### PR TITLE
Show .xopp files in workspace browser

### DIFF
--- a/src/ui/workspacebrowser/mod.rs
+++ b/src/ui/workspacebrowser/mod.rs
@@ -252,6 +252,7 @@ impl WorkspaceBrowser {
         });
         let filefilter = FileFilter::new();
         filefilter.add_pattern("*.rnote");
+        filefilter.add_pattern("*.xopp");
         filefilter.add_pattern("*.svg");
         filefilter.add_mime_type("image/svg+xml");
         filefilter.add_mime_type("image/png");


### PR DESCRIPTION
Added `.xopp` files to the `FileFilter` for the workspace browser.