### PR TITLE
Flip vertical canvas scrollbar position in right-handed/left-handed modes

### DIFF
--- a/src/ui/appwindow/appwindowactions.rs
+++ b/src/ui/appwindow/appwindowactions.rs
@@ -285,7 +285,7 @@ impl RnoteAppWindow {
 
                     appwindow
                         .canvas_scroller()
-                        .set_window_placement(CornerType::BottomRight);
+                        .set_window_placement(CornerType::BottomLeft);
                     appwindow
                         .sidebar_scroller()
                         .set_window_placement(CornerType::TopRight);
@@ -372,7 +372,7 @@ impl RnoteAppWindow {
 
                     appwindow
                         .canvas_scroller()
-                        .set_window_placement(CornerType::BottomLeft);
+                        .set_window_placement(CornerType::BottomRight);
                     appwindow
                         .sidebar_scroller()
                         .set_window_placement(CornerType::TopLeft);


### PR DESCRIPTION
Hi! This is just a small tweak to get the hang of building and contributing to rnote. IMO having the canvas scrollbar on the same side of the window as the sidebar makes it difficult to tell if it's for the canvas or the sidebar. Primarily since this app is driven by mouse and touch events, it doesn't seem necessary to prioritize ease of reach to this scrollbar, esp. if we can more clearly communicate what it indicates by it moving out of the way.

Below, you can see the new canvas scrollbar position on the left while the app is in right-handed mode.
![Screenshot from 2022-02-06 17-34-54](https://user-images.githubusercontent.com/32315760/152706372-0395d1d9-0ff4-4c94-b6b7-545913c6f57e.png)