### PR TITLE
Pdf import preferences with dialog, add pdf page spacing pref

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2912,6 +2912,7 @@ dependencies = [
  "piet",
  "piet-cairo",
  "piet-svg",
+ "poppler-rs",
  "pretty_env_logger",
  "rand 0.8.5",
  "rand_distr",

--- a/rnote-engine/src/engine.rs
+++ b/rnote-engine/src/engine.rs
@@ -1,12 +1,11 @@
-use std::ops::Range;
 use std::path::PathBuf;
 
-use crate::document::{background, Background, Format, Layout};
+use crate::document::Layout;
+use crate::import::PdfImportPrefs;
 use crate::pens::penholder::PenStyle;
 use crate::pens::PenMode;
-use crate::store::{StoreSnapshot, StrokeKey};
+use crate::store::StrokeKey;
 use crate::strokes::strokebehaviour::GeneratedStrokeImages;
-use crate::strokes::{BitmapImage, Stroke, VectorImage};
 use crate::{render, AudioPlayer, DrawBehaviour, DrawOnDocBehaviour, WidgetFlags};
 use crate::{Camera, Document, PenHolder, StrokeStore};
 use gtk4::Snapshot;
@@ -15,9 +14,7 @@ use rnote_compose::helpers::{AABBHelpers, Vector2Helpers};
 use rnote_compose::penhelpers::{PenEvent, ShortcutKey};
 use rnote_compose::transform::TransformBehaviour;
 use rnote_fileformats::rnoteformat::RnotefileMaj0Min5;
-use rnote_fileformats::xoppformat;
-use rnote_fileformats::FileFormatLoader;
-use rnote_fileformats::FileFormatSaver;
+use rnote_fileformats::{xoppformat, FileFormatSaver};
 
 use anyhow::Context;
 use futures::channel::{mpsc, oneshot};
@@ -86,10 +83,8 @@ struct EngineConfig {
     document: serde_json::Value,
     #[serde(rename = "penholder")]
     penholder: serde_json::Value,
-    #[serde(rename = "pdf_import_width_perc")]
-    pdf_import_width_perc: serde_json::Value,
-    #[serde(rename = "pdf_import_as_vector")]
-    pdf_import_as_vector: serde_json::Value,
+    #[serde(rename = "pdf_import_prefs")]
+    pdf_import_prefs: serde_json::Value,
     #[serde(rename = "pen_sounds")]
     pen_sounds: serde_json::Value,
 }
@@ -102,8 +97,7 @@ impl Default for EngineConfig {
             document: serde_json::to_value(&engine.document).unwrap(),
             penholder: serde_json::to_value(&engine.penholder).unwrap(),
 
-            pdf_import_width_perc: serde_json::to_value(&engine.pdf_import_width_perc).unwrap(),
-            pdf_import_as_vector: serde_json::to_value(&engine.pdf_import_as_vector).unwrap(),
+            pdf_import_prefs: serde_json::to_value(&engine.pdf_import_prefs).unwrap(),
             pen_sounds: serde_json::to_value(&engine.pen_sounds).unwrap(),
         }
     }
@@ -126,10 +120,8 @@ pub struct RnoteEngine {
     #[serde(rename = "camera")]
     pub camera: Camera,
 
-    #[serde(rename = "pdf_import_width_perc")]
-    pub pdf_import_width_perc: f64,
-    #[serde(rename = "pdf_import_as_vector")]
-    pub pdf_import_as_vector: bool,
+    #[serde(rename = "pdf_import_prefs")]
+    pub pdf_import_prefs: PdfImportPrefs,
     #[serde(rename = "pen_sounds")]
     pub pen_sounds: bool,
 
@@ -151,8 +143,6 @@ impl Default for RnoteEngine {
 }
 
 impl RnoteEngine {
-    /// The default width of imported PDF's in percentage to the document width
-    pub const PDF_IMPORT_WIDTH_PERC_DEFAULT: f64 = 50.0;
     /// The used image scale factor on export
     pub const EXPORT_IMAGE_SCALE: f64 = 1.5;
 
@@ -183,8 +173,7 @@ impl RnoteEngine {
             store: StrokeStore::default(),
             camera: Camera::default(),
 
-            pdf_import_width_perc: Self::PDF_IMPORT_WIDTH_PERC_DEFAULT,
-            pdf_import_as_vector: true,
+            pdf_import_prefs: PdfImportPrefs::default(),
             pen_sounds,
 
             audioplayer,
@@ -610,8 +599,7 @@ impl RnoteEngine {
 
         self.document = serde_json::from_value(engine_config.document)?;
         self.penholder = serde_json::from_value(engine_config.penholder)?;
-        self.pdf_import_width_perc = serde_json::from_value(engine_config.pdf_import_width_perc)?;
-        self.pdf_import_as_vector = serde_json::from_value(engine_config.pdf_import_as_vector)?;
+        self.pdf_import_prefs = serde_json::from_value(engine_config.pdf_import_prefs)?;
         self.pen_sounds = serde_json::from_value(engine_config.pen_sounds)?;
 
         // Set the pen sounds to update the audioplayer
@@ -625,50 +613,11 @@ impl RnoteEngine {
         let engine_config = EngineConfig {
             document: serde_json::to_value(&self.document)?,
             penholder: serde_json::to_value(&self.penholder)?,
-            pdf_import_width_perc: serde_json::to_value(&self.pdf_import_width_perc)?,
-            pdf_import_as_vector: serde_json::to_value(&self.pdf_import_as_vector)?,
+            pdf_import_prefs: serde_json::to_value(&self.pdf_import_prefs)?,
             pen_sounds: serde_json::to_value(&self.pen_sounds)?,
         };
 
         Ok(serde_json::to_string(&engine_config)?)
-    }
-
-    /// opens a .rnote file. We need to split this into two methods,
-    /// because we can't have it as a async function and await when the engine is wrapped in a refcell without causing panics :/
-    pub fn open_from_rnote_bytes_p1(
-        &mut self,
-        bytes: Vec<u8>,
-    ) -> anyhow::Result<oneshot::Receiver<anyhow::Result<StoreSnapshot>>> {
-        let rnote_file = RnotefileMaj0Min5::load_from_bytes(&bytes)?;
-
-        self.document = serde_json::from_value(rnote_file.document)?;
-
-        let (store_snapshot_sender, store_snapshot_receiver) =
-            oneshot::channel::<anyhow::Result<StoreSnapshot>>();
-
-        rayon::spawn(move || {
-            let result = || -> anyhow::Result<StoreSnapshot> {
-                Ok(serde_json::from_value(rnote_file.store_snapshot)?)
-            };
-
-            if let Err(_data) = store_snapshot_sender.send(result()) {
-                log::error!("sending result to receiver in open_from_rnote_bytes() failed. Receiver already dropped.");
-            }
-        });
-
-        Ok(store_snapshot_receiver)
-    }
-
-    // Part two for opening a file. imports the store snapshot.
-    pub fn open_from_store_snapshot_p2(
-        &mut self,
-        store_snapshot: &StoreSnapshot,
-    ) -> anyhow::Result<()> {
-        self.store.import_snapshot(store_snapshot);
-
-        self.update_pens_states();
-
-        Ok(())
     }
 
     /// Saves the current state as a .rnote file.
@@ -704,225 +653,6 @@ impl RnoteEngine {
     /// Only use for debugging
     pub fn export_state_as_json(&self) -> anyhow::Result<String> {
         Ok(serde_json::to_string_pretty(self)?)
-    }
-
-    /// Opens a  Xournal++ .xopp file, and replaces the current state with it.
-    pub fn open_from_xopp_bytes(&mut self, bytes: Vec<u8>) -> anyhow::Result<()> {
-        let xopp_file = xoppformat::XoppFile::load_from_bytes(&bytes)?;
-
-        // Extract the largest width of all pages, add together all heights
-        let (doc_width, doc_height) = xopp_file
-            .xopp_root
-            .pages
-            .iter()
-            .map(|page| (page.width, page.height))
-            .fold((0_f64, 0_f64), |prev, next| {
-                // Max of width, sum heights
-                (prev.0.max(next.0), prev.1 + next.1)
-            });
-        let no_pages = xopp_file.xopp_root.pages.len() as u32;
-
-        let mut doc = Document::default();
-        let mut format = Format::default();
-        let mut background = Background::default();
-        let mut store = StrokeStore::default();
-        // We set the doc dpi to the hardcoded xournal++ dpi, so no need to convert values or coordinates anywhere
-        doc.format.dpi = xoppformat::XoppFile::DPI;
-
-        doc.x = 0.0;
-        doc.y = 0.0;
-        doc.width = doc_width;
-        doc.height = doc_height;
-
-        format.width = doc_width;
-        format.height = doc_height / f64::from(no_pages);
-
-        if let Some(first_page) = xopp_file.xopp_root.pages.get(0) {
-            if let xoppformat::XoppBackgroundType::Solid {
-                color: _color,
-                style: _style,
-            } = &first_page.background.bg_type
-            {
-                // Background styles would not align with Rnotes background patterns, so everything is plain
-                background.pattern = background::PatternStyle::None;
-            }
-        }
-
-        // Offsetting as rnote has one global coordinate space
-        let mut offset = na::Vector2::<f64>::zeros();
-
-        for (_page_i, page) in xopp_file.xopp_root.pages.into_iter().enumerate() {
-            for layers in page.layers.into_iter() {
-                // import strokes
-                for new_xoppstroke in layers.strokes.into_iter() {
-                    match Stroke::from_xoppstroke(new_xoppstroke, offset) {
-                        Ok(new_stroke) => {
-                            store.insert_stroke(new_stroke);
-                        }
-                        Err(e) => {
-                            log::error!(
-                                "from_xoppstroke() failed in open_from_xopp_bytes() with Err {}",
-                                e
-                            );
-                        }
-                    }
-                }
-
-                // import images
-                for new_xoppimage in layers.images.into_iter() {
-                    match Stroke::from_xoppimage(new_xoppimage, offset) {
-                        Ok(new_image) => {
-                            store.insert_stroke(new_image);
-                        }
-                        Err(e) => {
-                            log::error!(
-                                "from_xoppimage() failed in open_from_xopp_bytes() with Err {}",
-                                e
-                            );
-                        }
-                    }
-                }
-            }
-
-            // Only add to y offset, results in vertical pages
-            offset[1] += page.height;
-        }
-
-        doc.background = background;
-        doc.format = format;
-
-        // Import into engine
-        self.document = doc;
-        self.store.import_snapshot(&*store.take_store_snapshot());
-
-        self.update_pens_states();
-
-        Ok(())
-    }
-
-    //// generates a vectorimage for the bytes ( from a SVG file )
-    pub fn generate_vectorimage_from_bytes(
-        &self,
-        pos: na::Vector2<f64>,
-        bytes: Vec<u8>,
-    ) -> oneshot::Receiver<anyhow::Result<VectorImage>> {
-        let (oneshot_sender, oneshot_receiver) = oneshot::channel::<anyhow::Result<VectorImage>>();
-
-        rayon::spawn(move || {
-            let result = || -> anyhow::Result<VectorImage> {
-                let svg_str = String::from_utf8(bytes)?;
-
-                VectorImage::import_from_svg_data(&svg_str, pos, None)
-            };
-
-            if let Err(_data) = oneshot_sender.send(result()) {
-                log::error!("sending result to receiver in generate_vectorimage_from_bytes() failed. Receiver already dropped.");
-            }
-        });
-
-        oneshot_receiver
-    }
-
-    //// generates a bitmapimage for the bytes ( from a bitmap image file (PNG, JPG) )
-    pub fn generate_bitmapimage_from_bytes(
-        &self,
-        pos: na::Vector2<f64>,
-        bytes: Vec<u8>,
-    ) -> oneshot::Receiver<anyhow::Result<BitmapImage>> {
-        let (oneshot_sender, oneshot_receiver) = oneshot::channel::<anyhow::Result<BitmapImage>>();
-
-        rayon::spawn(move || {
-            let result = || -> anyhow::Result<BitmapImage> {
-                BitmapImage::import_from_image_bytes(&bytes, pos)
-            };
-
-            if let Err(_data) = oneshot_sender.send(result()) {
-                log::error!("sending result to receiver in generate_bitmapimage_from_bytes() failed. Receiver already dropped.");
-            }
-        });
-
-        oneshot_receiver
-    }
-
-    //// generates strokes for each page for the bytes ( from a PDF file )
-    pub fn generate_strokes_from_pdf_bytes(
-        &self,
-        bytes: Vec<u8>,
-        pos: na::Vector2<f64>,
-        page_range: Option<Range<u32>>,
-    ) -> oneshot::Receiver<anyhow::Result<Vec<Stroke>>> {
-        let (oneshot_sender, oneshot_receiver) = oneshot::channel::<anyhow::Result<Vec<Stroke>>>();
-
-        let page_width =
-            (self.document.format.width * (self.pdf_import_width_perc / 100.0)).round() as i32;
-
-        let pdf_import_as_vector = self.pdf_import_as_vector;
-
-        rayon::spawn(move || {
-            let result = || -> anyhow::Result<Vec<Stroke>> {
-                if pdf_import_as_vector {
-                    let vectorimages = VectorImage::import_from_pdf_bytes(
-                        &bytes,
-                        pos,
-                        Some(page_width),
-                        page_range,
-                    )?
-                    .into_iter()
-                    .map(Stroke::VectorImage)
-                    .collect::<Vec<Stroke>>();
-                    Ok(vectorimages)
-                } else {
-                    let bitmapimages = BitmapImage::import_from_pdf_bytes(
-                        &bytes,
-                        pos,
-                        Some(page_width),
-                        page_range,
-                    )?
-                    .into_iter()
-                    .map(Stroke::BitmapImage)
-                    .collect::<Vec<Stroke>>();
-                    Ok(bitmapimages)
-                }
-            };
-
-            if let Err(_data) = oneshot_sender.send(result()) {
-                log::error!("sending result to receiver in import_pdf_bytes() failed. Receiver already dropped.");
-            }
-        });
-
-        oneshot_receiver
-    }
-
-    /// Imports the generated strokes into the store
-    pub fn import_generated_strokes(&mut self, strokes: Vec<Stroke>) -> WidgetFlags {
-        let mut widget_flags = self.store.record();
-
-        let all_strokes = self.store.keys_unordered();
-        self.store.set_selected_keys(&all_strokes, false);
-
-        widget_flags.merge_with_other(self.change_pen_style(PenStyle::Selector));
-
-        let inserted = strokes
-            .into_iter()
-            .map(|stroke| self.store.insert_stroke(stroke))
-            .collect::<Vec<StrokeKey>>();
-
-        // after inserting the strokes, but before set the inserted strokes selected
-        self.resize_to_fit_strokes();
-
-        inserted.into_iter().for_each(|key| {
-            self.store.set_selected(key, true);
-        });
-
-        self.update_pens_states();
-        self.update_rendering_current_viewport();
-
-        widget_flags.redraw = true;
-        widget_flags.resize = true;
-        widget_flags.indicate_changed_store = true;
-        widget_flags.refresh_ui = true;
-
-        widget_flags
     }
 
     /// generates the doc svg.

--- a/rnote-engine/src/import.rs
+++ b/rnote-engine/src/import.rs
@@ -1,0 +1,307 @@
+use std::ops::Range;
+
+use futures::channel::oneshot;
+use rnote_fileformats::{rnoteformat, xoppformat, FileFormatLoader};
+use serde::{Deserialize, Serialize};
+
+use crate::document::{background, Background, Format};
+use crate::pens::penholder::PenStyle;
+use crate::store::{StoreSnapshot, StrokeKey};
+use crate::strokes::{BitmapImage, Stroke, VectorImage};
+use crate::{Document, RnoteEngine, StrokeStore, WidgetFlags};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename = "pdf_import_pages_type")]
+pub enum PdfImportPagesType {
+    #[serde(rename = "bitmap")]
+    Bitmap,
+    #[serde(rename = "vector")]
+    Vector,
+}
+
+impl Default for PdfImportPagesType {
+    fn default() -> Self {
+        Self::Vector
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename = "pdf_import_prefs")]
+pub struct PdfImportPrefs {
+    /// The pdf pages type
+    #[serde(rename = "pages_type")]
+    pub pages_type: PdfImportPagesType,
+    /// The pdf page width in percentage to the format width
+    #[serde(rename = "page_width_perc")]
+    pub page_width_perc: f64,
+}
+
+impl Default for PdfImportPrefs {
+    fn default() -> Self {
+        Self {
+            pages_type: PdfImportPagesType::default(),
+            page_width_perc: 50.0,
+        }
+    }
+}
+
+impl RnoteEngine {
+    /// opens a .rnote file. We need to split this into two methods,
+    /// because we can't have it as a async function and await when the engine is wrapped in a refcell without causing panics :/
+    pub fn open_from_rnote_bytes_p1(
+        &mut self,
+        bytes: Vec<u8>,
+    ) -> anyhow::Result<oneshot::Receiver<anyhow::Result<StoreSnapshot>>> {
+        let rnote_file = rnoteformat::RnotefileMaj0Min5::load_from_bytes(&bytes)?;
+
+        self.document = serde_json::from_value(rnote_file.document)?;
+
+        let (store_snapshot_sender, store_snapshot_receiver) =
+            oneshot::channel::<anyhow::Result<StoreSnapshot>>();
+
+        rayon::spawn(move || {
+            let result = || -> anyhow::Result<StoreSnapshot> {
+                Ok(serde_json::from_value(rnote_file.store_snapshot)?)
+            };
+
+            if let Err(_data) = store_snapshot_sender.send(result()) {
+                log::error!("sending result to receiver in open_from_rnote_bytes() failed. Receiver already dropped.");
+            }
+        });
+
+        Ok(store_snapshot_receiver)
+    }
+
+    // Part two for opening a file. imports the store snapshot.
+    pub fn open_from_store_snapshot_p2(
+        &mut self,
+        store_snapshot: &StoreSnapshot,
+    ) -> anyhow::Result<()> {
+        self.store.import_snapshot(store_snapshot);
+
+        self.update_pens_states();
+
+        Ok(())
+    }
+
+    /// Opens a  Xournal++ .xopp file, and replaces the current state with it.
+    pub fn open_from_xopp_bytes(&mut self, bytes: Vec<u8>) -> anyhow::Result<()> {
+        let xopp_file = xoppformat::XoppFile::load_from_bytes(&bytes)?;
+
+        // Extract the largest width of all pages, add together all heights
+        let (doc_width, doc_height) = xopp_file
+            .xopp_root
+            .pages
+            .iter()
+            .map(|page| (page.width, page.height))
+            .fold((0_f64, 0_f64), |prev, next| {
+                // Max of width, sum heights
+                (prev.0.max(next.0), prev.1 + next.1)
+            });
+        let no_pages = xopp_file.xopp_root.pages.len() as u32;
+
+        let mut doc = Document::default();
+        let mut format = Format::default();
+        let mut background = Background::default();
+        let mut store = StrokeStore::default();
+        // We set the doc dpi to the hardcoded xournal++ dpi, so no need to convert values or coordinates anywhere
+        doc.format.dpi = xoppformat::XoppFile::DPI;
+
+        doc.x = 0.0;
+        doc.y = 0.0;
+        doc.width = doc_width;
+        doc.height = doc_height;
+
+        format.width = doc_width;
+        format.height = doc_height / f64::from(no_pages);
+
+        if let Some(first_page) = xopp_file.xopp_root.pages.get(0) {
+            if let xoppformat::XoppBackgroundType::Solid {
+                color: _color,
+                style: _style,
+            } = &first_page.background.bg_type
+            {
+                // Background styles would not align with Rnotes background patterns, so everything is plain
+                background.pattern = background::PatternStyle::None;
+            }
+        }
+
+        // Offsetting as rnote has one global coordinate space
+        let mut offset = na::Vector2::<f64>::zeros();
+
+        for (_page_i, page) in xopp_file.xopp_root.pages.into_iter().enumerate() {
+            for layers in page.layers.into_iter() {
+                // import strokes
+                for new_xoppstroke in layers.strokes.into_iter() {
+                    match Stroke::from_xoppstroke(new_xoppstroke, offset) {
+                        Ok(new_stroke) => {
+                            store.insert_stroke(new_stroke);
+                        }
+                        Err(e) => {
+                            log::error!(
+                                "from_xoppstroke() failed in open_from_xopp_bytes() with Err {}",
+                                e
+                            );
+                        }
+                    }
+                }
+
+                // import images
+                for new_xoppimage in layers.images.into_iter() {
+                    match Stroke::from_xoppimage(new_xoppimage, offset) {
+                        Ok(new_image) => {
+                            store.insert_stroke(new_image);
+                        }
+                        Err(e) => {
+                            log::error!(
+                                "from_xoppimage() failed in open_from_xopp_bytes() with Err {}",
+                                e
+                            );
+                        }
+                    }
+                }
+            }
+
+            // Only add to y offset, results in vertical pages
+            offset[1] += page.height;
+        }
+
+        doc.background = background;
+        doc.format = format;
+
+        // Import into engine
+        self.document = doc;
+        self.store.import_snapshot(&*store.take_store_snapshot());
+
+        self.update_pens_states();
+
+        Ok(())
+    }
+
+    //// generates a vectorimage for the bytes ( from a SVG file )
+    pub fn generate_vectorimage_from_bytes(
+        &self,
+        pos: na::Vector2<f64>,
+        bytes: Vec<u8>,
+    ) -> oneshot::Receiver<anyhow::Result<VectorImage>> {
+        let (oneshot_sender, oneshot_receiver) = oneshot::channel::<anyhow::Result<VectorImage>>();
+
+        rayon::spawn(move || {
+            let result = || -> anyhow::Result<VectorImage> {
+                let svg_str = String::from_utf8(bytes)?;
+
+                VectorImage::import_from_svg_data(&svg_str, pos, None)
+            };
+
+            if let Err(_data) = oneshot_sender.send(result()) {
+                log::error!("sending result to receiver in generate_vectorimage_from_bytes() failed. Receiver already dropped.");
+            }
+        });
+
+        oneshot_receiver
+    }
+
+    //// generates a bitmapimage for the bytes ( from a bitmap image file (PNG, JPG) )
+    pub fn generate_bitmapimage_from_bytes(
+        &self,
+        pos: na::Vector2<f64>,
+        bytes: Vec<u8>,
+    ) -> oneshot::Receiver<anyhow::Result<BitmapImage>> {
+        let (oneshot_sender, oneshot_receiver) = oneshot::channel::<anyhow::Result<BitmapImage>>();
+
+        rayon::spawn(move || {
+            let result = || -> anyhow::Result<BitmapImage> {
+                BitmapImage::import_from_image_bytes(&bytes, pos)
+            };
+
+            if let Err(_data) = oneshot_sender.send(result()) {
+                log::error!("sending result to receiver in generate_bitmapimage_from_bytes() failed. Receiver already dropped.");
+            }
+        });
+
+        oneshot_receiver
+    }
+
+    //// generates strokes for each page for the bytes ( from a PDF file )
+    pub fn generate_strokes_from_pdf_bytes(
+        &self,
+        bytes: Vec<u8>,
+        pos: na::Vector2<f64>,
+        page_range: Option<Range<u32>>,
+    ) -> oneshot::Receiver<anyhow::Result<Vec<Stroke>>> {
+        let (oneshot_sender, oneshot_receiver) = oneshot::channel::<anyhow::Result<Vec<Stroke>>>();
+        let pdf_import_prefs = self.pdf_import_prefs;
+
+        let page_width = (self.document.format.width * (pdf_import_prefs.page_width_perc / 100.0))
+            .round() as i32;
+
+        rayon::spawn(move || {
+            let result = || -> anyhow::Result<Vec<Stroke>> {
+                match pdf_import_prefs.pages_type {
+                    PdfImportPagesType::Bitmap => {
+                        let bitmapimages = BitmapImage::import_from_pdf_bytes(
+                            &bytes,
+                            pos,
+                            Some(page_width),
+                            page_range,
+                        )?
+                        .into_iter()
+                        .map(Stroke::BitmapImage)
+                        .collect::<Vec<Stroke>>();
+                        Ok(bitmapimages)
+                    }
+                    PdfImportPagesType::Vector => {
+                        let vectorimages = VectorImage::import_from_pdf_bytes(
+                            &bytes,
+                            pos,
+                            Some(page_width),
+                            page_range,
+                        )?
+                        .into_iter()
+                        .map(Stroke::VectorImage)
+                        .collect::<Vec<Stroke>>();
+                        Ok(vectorimages)
+                    }
+                }
+            };
+
+            if let Err(_data) = oneshot_sender.send(result()) {
+                log::error!("sending result to receiver in import_pdf_bytes() failed. Receiver already dropped.");
+            }
+        });
+
+        oneshot_receiver
+    }
+
+    /// Imports the generated strokes into the store
+    pub fn import_generated_strokes(&mut self, strokes: Vec<Stroke>) -> WidgetFlags {
+        let mut widget_flags = self.store.record();
+
+        let all_strokes = self.store.keys_unordered();
+        self.store.set_selected_keys(&all_strokes, false);
+
+        widget_flags.merge_with_other(self.change_pen_style(PenStyle::Selector));
+
+        let inserted = strokes
+            .into_iter()
+            .map(|stroke| self.store.insert_stroke(stroke))
+            .collect::<Vec<StrokeKey>>();
+
+        // after inserting the strokes, but before set the inserted strokes selected
+        self.resize_to_fit_strokes();
+
+        inserted.into_iter().for_each(|key| {
+            self.store.set_selected(key, true);
+        });
+
+        self.update_pens_states();
+        self.update_rendering_current_viewport();
+
+        widget_flags.redraw = true;
+        widget_flags.resize = true;
+        widget_flags.indicate_changed_store = true;
+        widget_flags.refresh_ui = true;
+
+        widget_flags
+    }
+}

--- a/rnote-engine/src/lib.rs
+++ b/rnote-engine/src/lib.rs
@@ -17,6 +17,8 @@ pub mod store;
 pub mod strokes;
 pub mod utils;
 pub mod widgetflags;
+/// module concerned with importing data into the engine
+pub mod import;
 
 // Re-exports
 pub use audioplayer::AudioPlayer;

--- a/rnote-engine/src/meson.build
+++ b/rnote-engine/src/meson.build
@@ -8,6 +8,7 @@ rnote_engine_sources = files(
     'widgetflags.rs',
     'camera.rs',
     'audioplayer.rs',
+    'import.rs',
     'pens/mod.rs',
     'pens/penbehaviour.rs',
     'pens/penholder.rs',

--- a/rnote-engine/src/strokes/vectorimage.rs
+++ b/rnote-engine/src/strokes/vectorimage.rs
@@ -185,8 +185,8 @@ impl VectorImage {
         let doc = poppler::Document::from_bytes(&glib::Bytes::from(to_be_read), None)?;
         let page_range = page_range.unwrap_or(0..doc.n_pages() as u32);
 
-        let svgs = page_range.enumerate().filter_map(|(i, page)| {
-            let page = doc.page(page as i32)?;
+        let svgs = page_range.enumerate().filter_map(|(i, page_i)| {
+            let page = doc.page(page_i as i32)?;
                 let (intrinsic_width, intrinsic_height) = (page.size().0, page.size().1);
 
                 let (width, height) = if let Some(page_width) = page_width {
@@ -261,7 +261,7 @@ impl VectorImage {
                         bounds: AABB::new(na::point![x, y], na::point![x + width, y + height])
                     }),
                     Err(e) => {
-                        log::error!("importing page {} from pdf failed with Err {}", i, e);
+                        log::error!("importing page {} from pdf failed with Err {}", page, e);
                         None
                     }
                 }

--- a/rnote-engine/src/strokes/vectorimage.rs
+++ b/rnote-engine/src/strokes/vectorimage.rs
@@ -2,6 +2,8 @@ use std::ops::Range;
 
 use super::strokebehaviour::GeneratedStrokeImages;
 use super::StrokeBehaviour;
+use crate::document::Format;
+use crate::import::{PdfImportPageSpacing, PdfImportPrefs};
 use crate::{render, DrawBehaviour};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rnote_compose::color;
@@ -178,93 +180,109 @@ impl VectorImage {
 
     pub fn import_from_pdf_bytes(
         to_be_read: &[u8],
-        pos: na::Vector2<f64>,
-        page_width: Option<i32>,
+        pdf_import_prefs: PdfImportPrefs,
+        insert_pos: na::Vector2<f64>,
         page_range: Option<Range<u32>>,
+        format: &Format,
     ) -> Result<Vec<Self>, anyhow::Error> {
         let doc = poppler::Document::from_bytes(&glib::Bytes::from(to_be_read), None)?;
         let page_range = page_range.unwrap_or(0..doc.n_pages() as u32);
 
+        let page_width = format.width * (pdf_import_prefs.page_width_perc / 100.0);
+
         let svgs = page_range.enumerate().filter_map(|(i, page_i)| {
             let page = doc.page(page_i as i32)?;
-                let (intrinsic_width, intrinsic_height) = (page.size().0, page.size().1);
+            let intrinsic_size = page.size();
 
-                let (width, height) = if let Some(page_width) = page_width {
-                    let zoom = f64::from(page_width) / intrinsic_width;
+            let (width, height, _zoom) = {
+                let zoom = page_width / intrinsic_size.0;
 
-                    (f64::from(page_width), (intrinsic_height * zoom))
-                } else {
-                    (intrinsic_width, intrinsic_height)
-                };
+                (
+                    page_width.round(),
+                    intrinsic_size.1 * zoom,
+                    zoom,
+                )
+            };
 
-                let x = pos[0];
-                let y = pos[1] + f64::from(i as u32) * (height + Self::IMPORT_OFFSET_DEFAULT[1] * 0.5);
-
-                let res = || -> anyhow::Result<String> {
-                    let svg_stream: Vec<u8> = vec![];
-
-                    let mut svg_surface =
-                        cairo::SvgSurface::for_stream(intrinsic_width, intrinsic_height, svg_stream)
-                            .map_err(|e| {
-                            anyhow::anyhow!(
-                                "create SvgSurface with dimensions ({}, {}) failed in vectorimage import_from_pdf_bytes with Err {}",
-                                intrinsic_width,
-                                intrinsic_height,
-                                e
-                            )
-                        })?;
-
-                    // Popplers page units are in points ( ^= 1 / 72 inch )
-                    svg_surface.set_document_unit(cairo::SvgUnit::Pt);
-
-                    {
-                        let cx = cairo::Context::new(&svg_surface).map_err(|e| {
-                            anyhow::anyhow!(
-                                "new cairo::Context failed in vectorimage import_from_pdf_bytes() with Err {}",
-                                e
-                            )
-                        })?;
-
-                        // Set margin to white
-                        cx.set_source_rgba(1.0, 1.0, 1.0, 1.0);
-                        cx.paint()?;
-
-                        // Render the poppler page
-                        page.render(&cx);
-
-                        // Draw outline around page
-                        cx.set_source_rgba(color::GNOME_REDS[4].as_rgba().0, color::GNOME_REDS[4].as_rgba().1, color::GNOME_REDS[4].as_rgba().2, 1.0);
-
-                        let line_width = 1.0;
-                        cx.set_line_width(line_width);
-                        cx.rectangle(
-                            line_width * 0.5,
-                            line_width * 0.5,
-                            intrinsic_width - line_width,
-                            intrinsic_height - line_width,
-                        );
-                        cx.stroke()?;
-                    }
-
-                    let svg_content = String::from_utf8(
-                        *svg_surface.finish_output_stream()
-                            .map_err(|e| anyhow::anyhow!("{}", e))?
-                            .downcast::<Vec<u8>>()
-                            .map_err(|_e| anyhow::anyhow!("failed to downcast svg surface content in VectorImage import_from_pdf_bytes()"))?)?;
-
-                    Ok(svg_content)
-                };
-
-                match res() {
-                    Ok(svg_data) => Some(render::Svg {
-                        svg_data,
-                        bounds: AABB::new(na::point![x, y], na::point![x + width, y + height])
-                    }),
-                    Err(e) => {
-                        log::error!("importing page {} from pdf failed with Err {}", page, e);
-                        None
-                    }
+            let x = insert_pos[0];
+            let y = match pdf_import_prefs.page_spacing {
+                PdfImportPageSpacing::Continuous => {
+                    insert_pos[1]
+                        + f64::from(i as u32)
+                            * (f64::from(height) + Self::IMPORT_OFFSET_DEFAULT[1] * 0.5)
                 }
+                PdfImportPageSpacing::OnePdfPagePerPage => {
+                    insert_pos[1]
+                        + f64::from(i as u32) *  format.height
+                }
+            };
+
+
+            let res = || -> anyhow::Result<String> {
+                let svg_stream: Vec<u8> = vec![];
+
+                let mut svg_surface =
+                    cairo::SvgSurface::for_stream(intrinsic_size.0, intrinsic_size.1, svg_stream)
+                        .map_err(|e| {
+                        anyhow::anyhow!(
+                            "create SvgSurface with dimensions ({}, {}) failed in vectorimage import_from_pdf_bytes with Err {}",
+                            intrinsic_size.0,
+                            intrinsic_size.1,
+                            e
+                        )
+                    })?;
+
+                // Popplers page units are in points ( ^= 1 / 72 inch )
+                svg_surface.set_document_unit(cairo::SvgUnit::Pt);
+
+                {
+                    let cx = cairo::Context::new(&svg_surface).map_err(|e| {
+                        anyhow::anyhow!(
+                            "new cairo::Context failed in vectorimage import_from_pdf_bytes() with Err {}",
+                            e
+                        )
+                    })?;
+
+                    // Set margin to white
+                    cx.set_source_rgba(1.0, 1.0, 1.0, 1.0);
+                    cx.paint()?;
+
+                    // Render the poppler page
+                    page.render(&cx);
+
+                    // Draw outline around page
+                    cx.set_source_rgba(color::GNOME_REDS[4].as_rgba().0, color::GNOME_REDS[4].as_rgba().1, color::GNOME_REDS[4].as_rgba().2, 1.0);
+
+                    let line_width = 1.0;
+                    cx.set_line_width(line_width);
+                    cx.rectangle(
+                        line_width * 0.5,
+                        line_width * 0.5,
+                        intrinsic_size.0 - line_width,
+                        intrinsic_size.1 - line_width,
+                    );
+                    cx.stroke()?;
+                }
+
+                let svg_content = String::from_utf8(
+                    *svg_surface.finish_output_stream()
+                        .map_err(|e| anyhow::anyhow!("{}", e))?
+                        .downcast::<Vec<u8>>()
+                        .map_err(|_e| anyhow::anyhow!("failed to downcast svg surface content in VectorImage import_from_pdf_bytes()"))?)?;
+
+                Ok(svg_content)
+            };
+
+            match res() {
+                Ok(svg_data) => Some(render::Svg {
+                    svg_data,
+                    bounds: AABB::new(na::point![x, y], na::point![x + width, y + height])
+                }),
+                Err(e) => {
+                    log::error!("importing page {} from pdf failed with Err {}", page, e);
+                    None
+                }
+            }
         }).collect::<Vec<render::Svg>>();
 
         Ok(svgs

--- a/rnote-ui/Cargo.toml
+++ b/rnote-ui/Cargo.toml
@@ -28,6 +28,7 @@ parry2d-f64 = { version = "0.9.0", features = ["serde-serialize"] }
 gtk4 = {version = "0.4.7", features = ["v4_6"]}
 adw = {version = "0.1.1", package="libadwaita"}
 cairo-rs = {version = "0.15.10", features = ["png", "svg", "pdf"]}
+poppler-rs = {version = "0.19.0", features = ["v20_9"] }
 svg = "0.10.0"
 image = "0.23.14"
 gettext-rs = { version = "0.7.0", features = ["gettext-system"] }

--- a/rnote-ui/data/app.metainfo.xml.in.in
+++ b/rnote-ui/data/app.metainfo.xml.in.in
@@ -70,6 +70,7 @@
         <ul>
           <li>A new app icon and symbolic! (based on @bertob's design and with his help. Thanks a ton!)</li>
           <li>long awaited: write and edit text with the typewriter</li>
+          <li>option to import pdfs aligned with the document pages ( one pdf page per document page )</li>
           <li>import bitmap images (e.g. screenshots) from the clipboard (thanks @RickStanley!)</li>
           <li>proportial shapes / input constraints (thanks @sei0o!)</li>
         </ul>

--- a/rnote-ui/data/ui/dialogs.ui
+++ b/rnote-ui/data/ui/dialogs.ui
@@ -101,7 +101,7 @@
   <object class="GtkDialog" id="dialog_import_pdf_w_prefs">
     <property name="use-header-bar">1</property>
     <property name="modal">true</property>
-    <property name="title">PDF import preferences</property>
+    <property name="title" translatable="yes">Import PDF</property>
     <child type="action">
       <object class="GtkButton" id="import_pdf_button_cancel">
         <property name="label" translatable="yes">Cancel</property>
@@ -120,80 +120,139 @@
       <action-widget response="apply" default="true">import_pdf_button_confirm</action-widget>
     </action-widgets>
     <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <property name="spacing">24</property>
-        <property name="margin-start">12</property>
-        <property name="margin-end">12</property>
-        <property name="margin-top">12</property>
-        <property name="margin-bottom">12</property>
-        <style>
-          <class name="background" />
-        </style>
+      <object class="AdwClamp">
+        <property name="maximum-size">800</property>
+        <property name="tightening-threshold">600</property>
+        <property name="hexpand">true</property>
+        <property name="vexpand">false</property>
+        <property name="valign">fill</property>
+        <property name="halign">fill</property>
         <child>
           <object class="GtkBox">
             <property name="orientation">vertical</property>
-            <property name="halign">fill</property>
-            <property name="spacing">12</property>
+            <property name="spacing">24</property>
+            <property name="margin-start">12</property>
+            <property name="margin-end">12</property>
+            <property name="margin-top">12</property>
+            <property name="margin-bottom">12</property>
             <style>
-              <class name="card" />
+              <class name="background" />
             </style>
             <child>
-              <object class="GtkLabel">
-                <property name="margin-start">24</property>
-                <property name="margin-end">24</property>
-                <property name="margin-top">12</property>
+              <object class="GtkBox">
+                <property name="orientation">vertical</property>
+                <property name="halign">fill</property>
+                <property name="spacing">12</property>
                 <style>
-                  <class name="title-4" />
+                  <class name="card" />
+                  <class name="view" />
                 </style>
-                <property name="label">Info</property>
-                <property name="halign">center</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="pdf_info_label">
-                <property name="halign">start</property>
-                <property name="margin-start">24</property>
-                <property name="margin-end">24</property>
-                <property name="margin-bottom">12</property>
-                <property name="use-markup">true</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkListBox">
-            <property name="selection-mode">none</property>
-            <property name="halign">fill</property>
-            <style>
-              <class name="boxed-list" />
-            </style>
-            <child>
-              <object class="AdwActionRow">
-                <property name="title">PDF page start</property>
-                <child type="suffix">
-                  <object class="GtkSpinButton" id="pdf_page_start_spinbutton">
-                    <property name="valign">center</property>
-                    <property name="margin_start">12</property>
-                    <property name="orientation">horizontal</property>
-                    <property name="numeric">true</property>
-                    <property name="digits">0</property>
-                    <property name="climb-rate">1</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="margin-start">24</property>
+                    <property name="margin-end">24</property>
+                    <property name="margin-top">12</property>
+                    <style>
+                      <class name="title-4" />
+                    </style>
+                    <property name="label">Info</property>
+                    <property name="halign">center</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="pdf_info_label">
+                    <property name="halign">start</property>
+                    <property name="margin-start">24</property>
+                    <property name="margin-end">24</property>
+                    <property name="margin-bottom">12</property>
+                    <property name="use-markup">true</property>
+                    <property name="ellipsize">end</property>
                   </object>
                 </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
-                <property name="title">PDF page end</property>
-                <child type="suffix">
-                  <object class="GtkSpinButton" id="pdf_page_end_spinbutton">
-                    <property name="valign">center</property>
-                    <property name="margin_start">12</property>
-                    <property name="orientation">horizontal</property>
-                    <property name="numeric">true</property>
-                    <property name="digits">0</property>
-                    <property name="climb-rate">1</property>
+              <object class="AdwPreferencesGroup">
+                <property name="title" translatable="yes">PDF import preferences</property>
+                <property name="halign">fill</property>
+                <child>
+                  <object class="AdwActionRow">
+                    <property name="title">PDF page start</property>
+                    <child type="suffix">
+                      <object class="GtkSpinButton" id="pdf_page_start_spinbutton">
+                        <property name="valign">center</property>
+                        <property name="margin_start">12</property>
+                        <property name="orientation">horizontal</property>
+                        <property name="numeric">true</property>
+                        <property name="digits">0</property>
+                        <property name="climb-rate">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwActionRow">
+                    <property name="title">PDF page end</property>
+                    <child type="suffix">
+                      <object class="GtkSpinButton" id="pdf_page_end_spinbutton">
+                        <property name="valign">center</property>
+                        <property name="margin_start">12</property>
+                        <property name="orientation">horizontal</property>
+                        <property name="numeric">true</property>
+                        <property name="digits">0</property>
+                        <property name="climb-rate">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwActionRow" id="pdf_import_width_row">
+                    <property name="title" translatable="yes">PDF import width (%)</property>
+                    <property name="subtitle" translatable="yes">Set the width of imported PDF's in percentage to the format width</property>
+                    <child type="suffix">
+                      <object class="GtkAdjustment" id="pdf_import_width_perc_adj">
+                        <property name="step-increment">1</property>
+                        <property name="upper">100</property>
+                        <property name="lower">1</property>
+                        <property name="value">50</property>
+                      </object>
+                      <object class="GtkSpinButton" id="pdf_import_width_perc_spinbutton">
+                        <property name="adjustment">pdf_import_width_perc_adj</property>
+                        <property name="orientation">horizontal</property>
+                        <property name="vexpand">false</property>
+                        <property name="valign">center</property>
+                        <property name="digits">0</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwActionRow" id="pdf_import_pages_type_row">
+                    <property name="title" translatable="yes">PDF import pages type</property>
+                    <property name="subtitle" translatable="yes">Set wether PDFs should be imported as vector or bitmap images</property>
+                    <child type="suffix">
+                      <object class="GtkBox">
+                        <property name="orientation">horizontal</property>
+                        <property name="homogeneous">true</property>
+                        <property name="vexpand">false</property>
+                        <property name="valign">center</property>
+                        <style>
+                          <class name="linked" />
+                        </style>
+                        <child>
+                          <object class="GtkToggleButton" id="pdf_import_as_vector_toggle">
+                            <property name="label" translatable="yes">Vector</property>
+                            <property name="active">true</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkToggleButton" id="pdf_import_as_bitmap_toggle">
+                            <property name="group">pdf_import_as_vector_toggle</property>
+                            <property name="label" translatable="yes">Bitmap</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/rnote-ui/data/ui/dialogs.ui
+++ b/rnote-ui/data/ui/dialogs.ui
@@ -98,6 +98,112 @@
     </action-widgets>
   </object>
 
+  <object class="GtkDialog" id="dialog_import_pdf_w_prefs">
+    <property name="use-header-bar">1</property>
+    <property name="modal">true</property>
+    <property name="title">PDF import preferences</property>
+    <child type="action">
+      <object class="GtkButton" id="import_pdf_button_cancel">
+        <property name="label" translatable="yes">Cancel</property>
+      </object>
+    </child>
+    <child type="action">
+      <object class="GtkButton" id="import_pdf_button_confirm">
+        <property name="label" translatable="yes">Import</property>
+        <style>
+          <class name="suggested-action" />
+        </style>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="cancel">import_pdf_button_cancel</action-widget>
+      <action-widget response="apply" default="true">import_pdf_button_confirm</action-widget>
+    </action-widgets>
+    <child>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <property name="spacing">24</property>
+        <property name="margin-start">12</property>
+        <property name="margin-end">12</property>
+        <property name="margin-top">12</property>
+        <property name="margin-bottom">12</property>
+        <style>
+          <class name="background" />
+        </style>
+        <child>
+          <object class="GtkBox">
+            <property name="orientation">vertical</property>
+            <property name="halign">fill</property>
+            <property name="spacing">12</property>
+            <style>
+              <class name="card" />
+            </style>
+            <child>
+              <object class="GtkLabel">
+                <property name="margin-start">24</property>
+                <property name="margin-end">24</property>
+                <property name="margin-top">12</property>
+                <style>
+                  <class name="title-4" />
+                </style>
+                <property name="label">Info</property>
+                <property name="halign">center</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="pdf_info_label">
+                <property name="halign">start</property>
+                <property name="margin-start">24</property>
+                <property name="margin-end">24</property>
+                <property name="margin-bottom">12</property>
+                <property name="use-markup">true</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkListBox">
+            <property name="selection-mode">none</property>
+            <property name="halign">fill</property>
+            <style>
+              <class name="boxed-list" />
+            </style>
+            <child>
+              <object class="AdwActionRow">
+                <property name="title">PDF page start</property>
+                <child type="suffix">
+                  <object class="GtkSpinButton" id="pdf_page_start_spinbutton">
+                    <property name="valign">center</property>
+                    <property name="margin_start">12</property>
+                    <property name="orientation">horizontal</property>
+                    <property name="numeric">true</property>
+                    <property name="digits">0</property>
+                    <property name="climb-rate">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="AdwActionRow">
+                <property name="title">PDF page end</property>
+                <child type="suffix">
+                  <object class="GtkSpinButton" id="pdf_page_end_spinbutton">
+                    <property name="valign">center</property>
+                    <property name="margin_start">12</property>
+                    <property name="orientation">horizontal</property>
+                    <property name="numeric">true</property>
+                    <property name="digits">0</property>
+                    <property name="climb-rate">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+
   <object class="GtkMessageDialog" id="dialog_clear_doc">
     <property name="modal">true</property>
     <property name="title" translatable="yes">Clear document</property>

--- a/rnote-ui/data/ui/dialogs.ui
+++ b/rnote-ui/data/ui/dialogs.ui
@@ -255,6 +255,20 @@
                     </child>
                   </object>
                 </child>
+                <child>
+                  <object class="AdwComboRow" id="pdf_import_page_spacing_row">
+                    <property name="title" translatable="yes">PDF page spacing</property>
+                    <property name="subtitle" translatable="yes">Set how PDF pages are spaced</property>
+                    <property name="model">
+                      <object class="GtkStringList">
+                        <items>
+                          <item translatable="yes">Continuous</item>
+                          <item translatable="yes">One PDF page per document page</item>
+                        </items>
+                      </object>
+                    </property>
+                  </object>
+                </child>
               </object>
             </child>
           </object>

--- a/rnote-ui/data/ui/settingspanel.ui
+++ b/rnote-ui/data/ui/settingspanel.ui
@@ -72,56 +72,6 @@
                       </object>
                     </child>
                     <child>
-                      <object class="AdwActionRow" id="general_pdf_import_width_row">
-                        <property name="title" translatable="yes">PDF import width (%)</property>
-                        <property name="subtitle" translatable="yes">Set the width of imported PDF's in percentage to the format width</property>
-                        <child type="suffix">
-                          <object class="GtkAdjustment" id="general_pdf_import_width_adj">
-                            <property name="step-increment">1</property>
-                            <property name="upper">100</property>
-                            <property name="lower">1</property>
-                            <property name="value">50</property>
-                          </object>
-                          <object class="GtkSpinButton" id="general_pdf_import_width_spinbutton">
-                            <property name="adjustment">general_pdf_import_width_adj</property>
-                            <property name="orientation">horizontal</property>
-                            <property name="vexpand">false</property>
-                            <property name="valign">center</property>
-                            <property name="digits">0</property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="AdwActionRow" id="general_pdf_import_image_type_row">
-                        <property name="title" translatable="yes">PDF import image type</property>
-                        <property name="subtitle" translatable="yes">Set wether PDFs should be imported as vector or bitmap images</property>
-                        <child type="suffix">
-                          <object class="GtkBox">
-                            <property name="orientation">horizontal</property>
-                            <property name="homogeneous">true</property>
-                            <property name="vexpand">false</property>
-                            <property name="valign">center</property>
-                            <style>
-                              <class name="linked" />
-                            </style>
-                            <child>
-                              <object class="GtkToggleButton" id="general_pdf_import_as_vector_toggle">
-                                <property name="label" translatable="yes">Vector</property>
-                                <property name="active">true</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkToggleButton" id="general_pdf_import_as_bitmap_toggle">
-                                <property name="group">general_pdf_import_as_vector_toggle</property>
-                                <property name="label" translatable="yes">Bitmap</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
                       <object class="AdwActionRow" id="general_format_border_color_row">
                         <property name="title" translatable="yes">Format border color</property>
                         <property name="subtitle" translatable="yes">Set the format border color</property>

--- a/rnote-ui/src/appwindow/mod.rs
+++ b/rnote-ui/src/appwindow/mod.rs
@@ -1,6 +1,7 @@
 mod appsettings;
 mod appwindowactions;
 
+use std::ops::Range;
 use std::{
     cell::{Cell, RefCell},
     path::Path,
@@ -1285,7 +1286,7 @@ impl RnoteAppWindow {
         let app = self.application().unwrap().downcast::<RnoteApp>().unwrap();
         match utils::FileType::lookup_file_type(file) {
             utils::FileType::RnoteFile | utils::FileType::XoppFile => {
-                // Setting input file to hand it to the open overwrite dialog
+                // Set as input file to hand it to the dialog
                 app.set_input_file(Some(file.clone()));
 
                 if self.unsaved_changes() {
@@ -1297,12 +1298,16 @@ impl RnoteAppWindow {
                     );
                 }
             }
-            utils::FileType::VectorImageFile
-            | utils::FileType::BitmapImageFile
-            | utils::FileType::PdfFile => {
+            utils::FileType::VectorImageFile | utils::FileType::BitmapImageFile => {
                 if let Err(e) = self.load_in_file(file, target_pos) {
                     log::error!("failed to load in file with FileType::VectorImageFile / FileType::BitmapImageFile / FileType::Pdf, {}", e);
                 }
+            }
+            utils::FileType::PdfFile => {
+                // Set as input file to hand it to the dialog
+                app.set_input_file(Some(file.clone()));
+
+                dialogs::dialog_import_pdf_w_prefs(self);
             }
             utils::FileType::Folder => {
                 if let Some(path) = file.path() {
@@ -1409,7 +1414,7 @@ impl RnoteAppWindow {
                     let result = file.load_bytes_future().await;
 
                     if let Ok((file_bytes, _)) = result {
-                        if let Err(e) = appwindow.load_in_pdf_bytes(file_bytes.to_vec(), target_pos).await {
+                        if let Err(e) = appwindow.load_in_pdf_bytes(file_bytes.to_vec(), target_pos, None).await {
                             adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening PDF file failed.").to_variant()));
                             log::error!(
                                 "load_in_rnote_bytes() failed in load_in_file() with Err {}",
@@ -1591,6 +1596,7 @@ impl RnoteAppWindow {
         bytes: Vec<u8>,
         // In the coordinate space of the doc
         target_pos: Option<na::Vector2<f64>>,
+        page_range: Option<Range<u32>>,
     ) -> anyhow::Result<()> {
         let app = self.application().unwrap().downcast::<RnoteApp>().unwrap();
 
@@ -1604,7 +1610,7 @@ impl RnoteAppWindow {
             .canvas()
             .engine()
             .borrow_mut()
-            .generate_strokes_from_pdf_bytes(pos, bytes);
+            .generate_strokes_from_pdf_bytes(bytes, pos, page_range);
         let strokes = strokes_receiver.await??;
 
         let widget_flags = self

--- a/rnote-ui/src/appwindow/mod.rs
+++ b/rnote-ui/src/appwindow/mod.rs
@@ -1307,7 +1307,7 @@ impl RnoteAppWindow {
                 // Set as input file to hand it to the dialog
                 app.set_input_file(Some(file.clone()));
 
-                dialogs::dialog_import_pdf_w_prefs(self);
+                dialogs::dialog_import_pdf_w_prefs(self, target_pos);
             }
             utils::FileType::Folder => {
                 if let Some(path) = file.path() {

--- a/rnote-ui/src/dialogs.rs
+++ b/rnote-ui/src/dialogs.rs
@@ -214,6 +214,10 @@ pub fn dialog_import_pdf_w_prefs(appwindow: &RnoteAppWindow, target_pos: Option<
     pdf_page_start_spinbutton.set_increments(1.0, 2.0);
     pdf_page_end_spinbutton.set_increments(1.0, 2.0);
 
+    pdf_page_start_spinbutton
+        .bind_property("value", &pdf_page_end_spinbutton.adjustment(), "lower")
+        .flags(glib::BindingFlags::SYNC_CREATE | glib::BindingFlags::DEFAULT)
+        .build();
     pdf_page_end_spinbutton
         .bind_property("value", &pdf_page_start_spinbutton.adjustment(), "upper")
         .flags(glib::BindingFlags::SYNC_CREATE | glib::BindingFlags::DEFAULT)

--- a/rnote-ui/src/dialogs.rs
+++ b/rnote-ui/src/dialogs.rs
@@ -1,9 +1,9 @@
 use gettextrs::gettext;
-use gtk4::{glib, glib::clone, prelude::*, Builder};
 use gtk4::{
-    AboutDialog, FileChooserAction, FileChooserNative, FileFilter, MessageDialog, ResponseType,
-    ShortcutsWindow,
+    gio, AboutDialog, Dialog, FileChooserAction, FileChooserNative, FileFilter, Label,
+    MessageDialog, ResponseType, ShortcutsWindow, SpinButton,
 };
+use gtk4::{glib, glib::clone, prelude::*, Builder};
 
 use crate::appwindow::RnoteAppWindow;
 use crate::{app::RnoteApp, config};
@@ -181,6 +181,126 @@ pub fn dialog_open_overwrite(appwindow: &RnoteAppWindow) {
     dialog_open_input_file.show();
 }
 
+pub fn dialog_import_pdf_w_prefs(appwindow: &RnoteAppWindow) {
+    let builder =
+        Builder::from_resource((String::from(config::APP_IDPATH) + "ui/dialogs.ui").as_str());
+    let dialog_import_pdf: Dialog = builder.object("dialog_import_pdf_w_prefs").unwrap();
+    let pdf_page_start_spinbutton: SpinButton =
+        builder.object("pdf_page_start_spinbutton").unwrap();
+    let pdf_page_end_spinbutton: SpinButton = builder.object("pdf_page_end_spinbutton").unwrap();
+    let pdf_info_label: Label = builder.object("pdf_info_label").unwrap();
+
+    pdf_page_start_spinbutton.set_increments(1.0, 2.0);
+    pdf_page_end_spinbutton.set_increments(1.0, 2.0);
+
+    pdf_page_end_spinbutton
+        .bind_property("value", &pdf_page_start_spinbutton.adjustment(), "upper")
+        .flags(glib::BindingFlags::SYNC_CREATE | glib::BindingFlags::DEFAULT)
+        .build();
+
+    dialog_import_pdf.set_transient_for(Some(appwindow));
+
+    if let Some(input_file) = appwindow
+        .application()
+        .unwrap()
+        .downcast::<RnoteApp>()
+        .unwrap()
+        .input_file()
+    {
+        if let Ok(poppler_doc) =
+            poppler::Document::from_gfile(&input_file, None, None::<&gio::Cancellable>)
+        {
+            let file_name = input_file
+                .basename()
+                .map_or_else(|| gettext("- no file name -"), |s| s.to_string_lossy().to_string());
+            let title = poppler_doc
+                .title()
+                .map_or_else(|| gettext("- no title -"), |s| s.to_string());
+            let author = poppler_doc
+                .author()
+                .map_or_else(|| gettext("- no author -"), |s| s.to_string());
+            let mod_date = poppler_doc
+                .mod_datetime()
+                .and_then(|dt| dt.format("%F").ok())
+                .map_or_else(|| gettext("- no date -"), |s| s.to_string());
+            let n_pages = poppler_doc.n_pages();
+
+            // pdf info
+            pdf_info_label.set_label(
+                (String::from("")
+                    + "<b>"
+                    + &gettext("File name:")
+                    + "  </b>"
+                    + &format!("{file_name}\n")
+                    + "<b>"
+                    + &gettext("Title:")
+                    + "  </b>"
+                    + &format!("{title}\n")
+                    + "<b>"
+                    + &gettext("Author:")
+                    + "  </b>"
+                    + &format!("{author}\n")
+                    + "<b>"
+                    + &gettext("Modification date:")
+                    + "  </b>"
+                    + &format!("{mod_date}\n")
+                    + "<b>"
+                    + &gettext("Pages:")
+                    + "  </b>"
+                    + &format!("{n_pages}\n"))
+                    .as_str(),
+            );
+
+            // Configure pages spinners
+            pdf_page_start_spinbutton.set_range(1.into(), n_pages.into());
+            pdf_page_start_spinbutton.set_value(1.into());
+
+            pdf_page_end_spinbutton
+                .adjustment()
+                .set_upper(n_pages.into());
+            pdf_page_end_spinbutton.set_value(n_pages.into());
+        }
+
+        dialog_import_pdf.connect_response(
+        clone!(@weak appwindow => move |dialog_import_pdf, responsetype| {
+            match responsetype {
+                ResponseType::Apply => {
+                    dialog_import_pdf.close();
+
+                    let page_range = (pdf_page_start_spinbutton.value() as u32 - 1)..pdf_page_end_spinbutton.value() as u32;
+
+                    glib::MainContext::default().spawn_local(clone!(@strong input_file, @strong appwindow => async move {
+                        let result = input_file.load_bytes_future().await;
+
+                        if let Ok((file_bytes, _)) = result {
+                            if let Err(e) = appwindow.load_in_pdf_bytes(file_bytes.to_vec(), None, Some(page_range)).await {
+                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening PDF file failed.").to_variant()));
+                                log::error!(
+                                    "load_in_rnote_bytes() failed in dialog import pdf with Err {}",
+                                    e
+                                );
+                            }
+                        }
+                    }));
+                }
+                ResponseType::Cancel => {
+                    dialog_import_pdf.close();
+
+                    appwindow.application().unwrap().downcast::<RnoteApp>().unwrap().set_input_file(None);
+                }
+                _ => {
+                    dialog_import_pdf.close();
+
+                    appwindow.application().unwrap().downcast::<RnoteApp>().unwrap().set_input_file(None);
+                }
+            }
+        }),
+    );
+
+        dialog_import_pdf.show();
+    }
+}
+
 // FileChooserNative Dialogs
 
 pub fn dialog_open_doc(appwindow: &RnoteAppWindow) {
@@ -339,10 +459,7 @@ pub fn dialog_import_file(appwindow: &RnoteAppWindow) {
             match responsetype {
                 ResponseType::Accept => {
                     if let Some(file) = dialog_import_file.file() {
-                        if let Err(e) = appwindow.load_in_file(&file, None) {
-                            log::error!("load_in_file() failed while import file, Err {}", e);
-                            adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Importing file failed.").to_variant()));
-                        }
+                        appwindow.open_file_w_dialogs(&file, None);
                     }
                 }
                 _ => {

--- a/rnote-ui/src/settingspanel/mod.rs
+++ b/rnote-ui/src/settingspanel/mod.rs
@@ -36,12 +36,6 @@ mod imp {
         #[template_child]
         pub general_autosave_interval_secs_spinbutton: TemplateChild<SpinButton>,
         #[template_child]
-        pub general_pdf_import_width_adj: TemplateChild<Adjustment>,
-        #[template_child]
-        pub general_pdf_import_as_vector_toggle: TemplateChild<ToggleButton>,
-        #[template_child]
-        pub general_pdf_import_as_bitmap_toggle: TemplateChild<ToggleButton>,
-        #[template_child]
         pub general_format_border_color_choosebutton: TemplateChild<ColorButton>,
         #[template_child]
         pub format_predefined_formats_row: TemplateChild<adw::ComboRow>,
@@ -431,18 +425,6 @@ impl SettingsPanel {
         self.imp().settings_scroller.clone()
     }
 
-    pub fn general_pdf_import_width_adj(&self) -> Adjustment {
-        self.imp().general_pdf_import_width_adj.clone()
-    }
-
-    pub fn general_pdf_import_as_vector_toggle(&self) -> ToggleButton {
-        self.imp().general_pdf_import_as_vector_toggle.clone()
-    }
-
-    pub fn general_pdf_import_as_bitmap_toggle(&self) -> ToggleButton {
-        self.imp().general_pdf_import_as_bitmap_toggle.clone()
-    }
-
     pub fn general_format_border_color_choosebutton(&self) -> ColorButton {
         self.imp().general_format_border_color_choosebutton.clone()
     }
@@ -487,8 +469,6 @@ impl SettingsPanel {
     }
 
     pub fn load_general(&self, appwindow: &RnoteAppWindow) {
-        let pdf_import_as_vector = appwindow.canvas().engine().borrow().pdf_import_as_vector;
-        let pdf_import_width_perc = appwindow.canvas().engine().borrow().pdf_import_width_perc;
         let format_border_color = appwindow
             .canvas()
             .engine()
@@ -497,12 +477,6 @@ impl SettingsPanel {
             .format
             .border_color;
 
-        self.general_pdf_import_as_vector_toggle()
-            .set_active(pdf_import_as_vector);
-        self.general_pdf_import_as_bitmap_toggle()
-            .set_active(!pdf_import_as_vector);
-        self.general_pdf_import_width_adj()
-            .set_value(pdf_import_width_perc);
         self.general_format_border_color_choosebutton()
             .set_rgba(&gdk::RGBA::from_compose_color(format_border_color));
     }
@@ -621,28 +595,6 @@ impl SettingsPanel {
             .transform_from(|_, value| Some(f64::from(value.get::<u32>().unwrap()).to_value()))
             .flags(glib::BindingFlags::SYNC_CREATE | glib::BindingFlags::BIDIRECTIONAL)
             .build();
-
-        // Pdf import width
-        self.imp()
-            .general_pdf_import_width_adj
-            .get()
-            .connect_value_changed(clone!(@weak appwindow => move |general_pdf_import_width_adj| {
-                adw::prelude::ActionGroupExt::activate_action(&appwindow, "pdf-import-width-perc", Some(&general_pdf_import_width_adj.value().to_variant()));
-            }));
-
-        self.imp()
-            .general_pdf_import_as_vector_toggle
-            .get()
-            .connect_active_notify(clone!(@weak appwindow => move |general_pdf_import_as_vector_toggle| {
-                adw::prelude::ActionGroupExt::activate_action(&appwindow, "pdf-import-as-vector", Some(&general_pdf_import_as_vector_toggle.is_active().to_variant()));
-            }));
-
-        self.imp()
-            .general_pdf_import_as_bitmap_toggle
-            .get()
-            .connect_active_notify(clone!(@weak appwindow => move |general_pdf_import_as_bitmap_toggle| {
-                adw::prelude::ActionGroupExt::activate_action(&appwindow, "pdf-import-as-vector", Some(&(!general_pdf_import_as_bitmap_toggle.is_active()).to_variant()));
-            }));
 
         // revert format
         self.imp().format_revert_button.get().connect_clicked(


### PR DESCRIPTION
Adds a dialog that is popped up whenever a PDF is imported. The existing import preferences are moved into the dialog,
and a new "pdf page spacing" pref is added to align imported pdf pages with the document pages (meaning: allows one pdf page per document page ).

This partially addresses #153