### PR TITLE
Stroke layers

### DIFF
--- a/rnote-engine/src/document/mod.rs
+++ b/rnote-engine/src/document/mod.rs
@@ -185,8 +185,7 @@ impl Document {
         let padding_horizontal = self.format.width * 2.0;
         let padding_vertical = self.format.height * 2.0;
 
-        let mut keys = store.stroke_keys_as_rendered();
-        keys.append(&mut store.selection_keys_as_rendered());
+        let keys = store.stroke_keys_as_rendered();
 
         let new_bounds = if let Some(new_bounds) = store.bounds_for_strokes(&keys) {
             new_bounds.extend_by(na::vector![padding_horizontal, padding_vertical])

--- a/rnote-engine/src/engine.rs
+++ b/rnote-engine/src/engine.rs
@@ -454,8 +454,7 @@ impl RnoteEngine {
     // Generates bounds for each page on the document which contains content
     pub fn pages_bounds_w_content(&self) -> Vec<AABB> {
         let doc_bounds = self.document.bounds();
-        let mut keys = self.store.stroke_keys_as_rendered();
-        keys.extend(self.store.selection_keys_as_rendered());
+        let keys = self.store.stroke_keys_as_rendered();
 
         let strokes_bounds = self.store.strokes_bounds(&keys);
 
@@ -664,8 +663,7 @@ impl RnoteEngine {
     pub fn gen_doc_svg(&self, with_background: bool) -> Result<render::Svg, anyhow::Error> {
         let doc_bounds = self.document.bounds();
 
-        let mut strokes = self.store.stroke_keys_as_rendered();
-        strokes.extend(self.store.selection_keys_as_rendered());
+        let strokes = self.store.stroke_keys_as_rendered();
 
         let mut doc_svg = if with_background {
             let mut background_svg = self.document.background.gen_svg(doc_bounds)?;
@@ -736,13 +734,9 @@ impl RnoteEngine {
             }
         };
 
-        let mut strokes_in_viewport = self
+        let strokes_in_viewport = self
             .store
             .stroke_keys_as_rendered_intersecting_bounds(viewport);
-        strokes_in_viewport.extend(
-            self.store
-                .selection_keys_as_rendered_intersecting_bounds(viewport),
-        );
 
         doc_svg.merge([render::Svg::gen_with_piet_cairo_backend(
             |piet_cx| {
@@ -915,13 +909,9 @@ impl RnoteEngine {
             .pages_bounds_w_content()
             .iter()
             .map(|&page_bounds| {
-                let mut page_keys = self
+                let page_keys = self
                     .store
                     .stroke_keys_as_rendered_intersecting_bounds(page_bounds);
-                page_keys.extend(
-                    self.store
-                        .selection_keys_as_rendered_intersecting_bounds(page_bounds),
-                );
 
                 let strokes = self.store.clone_strokes(&page_keys);
 
@@ -1038,13 +1028,9 @@ impl RnoteEngine {
             .pages_bounds_w_content()
             .into_iter()
             .map(|page_bounds| {
-                let mut strokes_in_viewport = self
+                let strokes_in_viewport = self
                     .store
                     .stroke_keys_as_rendered_intersecting_bounds(page_bounds);
-                strokes_in_viewport.extend(
-                    self.store
-                        .selection_keys_as_rendered_intersecting_bounds(page_bounds),
-                );
 
                 (page_bounds, strokes_in_viewport)
             })
@@ -1156,9 +1142,7 @@ impl RnoteEngine {
             .draw(snapshot, doc_bounds, &self.camera)?;
 
         self.store
-            .draw_strokes_snapshot(snapshot, doc_bounds, viewport);
-        self.store
-            .draw_selection_snapshot(snapshot, doc_bounds, viewport);
+            .draw_strokes_to_snapshot(snapshot, doc_bounds, viewport);
 
         snapshot.restore();
 

--- a/rnote-engine/src/pens/brush.rs
+++ b/rnote-engine/src/pens/brush.rs
@@ -1,7 +1,7 @@
 use super::penbehaviour::{PenBehaviour, PenProgress};
 use crate::engine::{EngineView, EngineViewMut};
-use crate::store::StrokeKey;
 use crate::store::chrono_comp::StrokeLayer;
+use crate::store::StrokeKey;
 use crate::strokes::BrushStroke;
 use crate::strokes::Stroke;
 use crate::AudioPlayer;
@@ -185,7 +185,9 @@ impl PenBehaviour for Brush {
                         Segment::Dot { element },
                         self.style_for_current_options(),
                     ));
-                    let current_stroke_key = engine_view.store.insert_stroke(brushstroke, Some(self.layer_for_current_options()));
+                    let current_stroke_key = engine_view
+                        .store
+                        .insert_stroke(brushstroke, Some(self.layer_for_current_options()));
 
                     let path_builder = PenPathBuilder::start(element);
 
@@ -399,8 +401,7 @@ impl Brush {
     pub fn layer_for_current_options(&self) -> StrokeLayer {
         match &self.style {
             BrushStyle::Marker => StrokeLayer::Highlighter,
-            BrushStyle::Solid |
-            BrushStyle::Textured => StrokeLayer::UserLayer(0),
+            BrushStyle::Solid | BrushStyle::Textured => StrokeLayer::UserLayer(0),
         }
     }
 

--- a/rnote-engine/src/pens/brush.rs
+++ b/rnote-engine/src/pens/brush.rs
@@ -362,8 +362,15 @@ impl DrawOnDocBehaviour for Brush {
         match &self.state {
             BrushState::Idle => {}
             BrushState::Drawing { path_builder, .. } => {
-                let style = self.style_for_current_options();
-                path_builder.draw_styled(cx, &style, engine_view.camera.total_zoom());
+                match self.style {
+                    BrushStyle::Marker => {
+                        // Don't draw the marker, as the pen would render on top of other strokes, while the stroke itself would render underneath them.
+                    }
+                    BrushStyle::Solid | BrushStyle::Textured => {
+                        let style = self.style_for_current_options();
+                        path_builder.draw_styled(cx, &style, engine_view.camera.total_zoom());
+                    }
+                }
             }
         }
 

--- a/rnote-engine/src/pens/selector.rs
+++ b/rnote-engine/src/pens/selector.rs
@@ -145,9 +145,7 @@ impl PenBehaviour for Selector {
                 widget_flags.merge_with_other(engine_view.store.record());
 
                 // Deselect on start
-                let selection_keys = engine_view
-                    .store
-                    .selection_keys_as_rendered_intersecting_bounds(engine_view.camera.viewport());
+                let selection_keys = engine_view.store.selection_keys_as_rendered();
                 engine_view.store.set_selected_keys(&selection_keys, false);
 
                 self.state = SelectorState::Selecting {
@@ -252,16 +250,13 @@ impl PenBehaviour for Selector {
                     }
                     SelectorStyle::Apiece => {
                         if let Some(last) = path.last() {
-                            engine_view
-                                .store
-                                .stroke_hitboxes_contain_coord(
-                                    engine_view.camera.viewport(),
-                                    last.pos,
-                                )
-                                .map(|stroke_key| {
-                                    engine_view.store.set_selected(stroke_key, true);
-                                    vec![stroke_key]
-                                })
+                            let new_keys = engine_view.store.stroke_hitboxes_contain_coord(
+                                engine_view.camera.viewport(),
+                                last.pos,
+                            );
+
+                            engine_view.store.set_selected_keys(&new_keys, true);
+                            Some(new_keys)
                         } else {
                             None
                         }
@@ -352,9 +347,7 @@ impl PenBehaviour for Selector {
                 self.state = SelectorState::Idle;
 
                 // Deselect on cancel
-                let selection_keys = engine_view
-                    .store
-                    .selection_keys_as_rendered_intersecting_bounds(engine_view.camera.viewport());
+                let selection_keys = engine_view.store.selection_keys_as_rendered();
                 engine_view.store.set_selected_keys(&selection_keys, false);
 
                 widget_flags.redraw = true;
@@ -380,30 +373,30 @@ impl PenBehaviour for Selector {
                     ModifyState::Up => {
                         widget_flags.merge_with_other(engine_view.store.record());
 
-                        if let Some(key_to_add) = engine_view
+                        // If we click on another, not-already selected stroke while in apiece style or while pressing Shift, we add it to the selection
+                        let keys_to_add = engine_view
                             .store
                             .stroke_hitboxes_contain_coord(
                                 engine_view.camera.viewport(),
                                 element.pos,
                             )
-                            .and_then(|key_to_add| {
-                                if self.style == SelectorStyle::Apiece
-                                    || shortcut_keys.contains(&ShortcutKey::KeyboardShift)
-                                {
-                                    Some(key_to_add)
-                                } else {
-                                    None
-                                }
-                            })
-                        {
-                            // If we click on another stroke while in apiece style or while pressing Shift, we add it to the selection
-                            engine_view.store.set_selected(key_to_add, true);
+                            .into_iter();
 
-                            selection.push(key_to_add);
-                            engine_view
-                                .store
-                                .bounds_for_strokes(selection)
-                                .map(|new_bounds| *selection_bounds = new_bounds);
+                        if (self.style == SelectorStyle::Apiece
+                            || shortcut_keys.contains(&ShortcutKey::KeyboardShift))
+                            && keys_to_add
+                                .clone()
+                                .any(|key| !engine_view.store.selected(key).unwrap_or(false))
+                        {
+                            for key_to_add in keys_to_add {
+                                engine_view.store.set_selected(key_to_add, true);
+
+                                selection.push(key_to_add);
+                                engine_view
+                                    .store
+                                    .bounds_for_strokes(selection)
+                                    .map(|new_bounds| *selection_bounds = new_bounds);
+                            }
                         } else if Self::rotate_node_sphere(*selection_bounds, engine_view.camera)
                             .contains_local_point(&na::Point2::from(element.pos))
                         {

--- a/rnote-engine/src/pens/shaper.rs
+++ b/rnote-engine/src/pens/shaper.rs
@@ -180,9 +180,10 @@ impl PenBehaviour for Shaper {
                         }
 
                         for shape in shapes {
-                            let key = engine_view.store.insert_stroke(Stroke::ShapeStroke(
-                                ShapeStroke::new(shape, drawstyle.clone()),
-                            ));
+                            let key = engine_view.store.insert_stroke(
+                                Stroke::ShapeStroke(ShapeStroke::new(shape, drawstyle.clone())),
+                                None,
+                            );
                             if let Err(e) = engine_view.store.regenerate_rendering_for_stroke(
                                 key,
                                 engine_view.camera.viewport(),
@@ -215,9 +216,10 @@ impl PenBehaviour for Shaper {
                         }
 
                         for shape in shapes {
-                            let key = engine_view.store.insert_stroke(Stroke::ShapeStroke(
-                                ShapeStroke::new(shape, drawstyle.clone()),
-                            ));
+                            let key = engine_view.store.insert_stroke(
+                                Stroke::ShapeStroke(ShapeStroke::new(shape, drawstyle.clone())),
+                                None,
+                            );
                             if let Err(e) = engine_view.store.regenerate_rendering_for_stroke(
                                 key,
                                 engine_view.camera.viewport(),

--- a/rnote-engine/src/pens/typewriter.rs
+++ b/rnote-engine/src/pens/typewriter.rs
@@ -430,7 +430,7 @@ impl PenBehaviour for Typewriter {
 
                         let stroke_key = engine_view
                             .store
-                            .insert_stroke(Stroke::TextStroke(textstroke));
+                            .insert_stroke(Stroke::TextStroke(textstroke), None);
 
                         if let Err(e) = engine_view.store.regenerate_rendering_for_stroke(
                             stroke_key,
@@ -1357,7 +1357,7 @@ impl Typewriter {
 
                 let stroke_key = engine_view
                     .store
-                    .insert_stroke(Stroke::TextStroke(textstroke));
+                    .insert_stroke(Stroke::TextStroke(textstroke), None);
 
                 if let Err(e) = engine_view.store.regenerate_rendering_for_stroke(
                     stroke_key,

--- a/rnote-engine/src/pens/typewriter.rs
+++ b/rnote-engine/src/pens/typewriter.rs
@@ -359,9 +359,10 @@ impl PenBehaviour for Typewriter {
                 let mut refresh_state = false;
                 let mut new_state = TypewriterState::Start(element.pos);
 
-                if let Some(stroke_key) = engine_view
+                if let Some(&stroke_key) = engine_view
                     .store
                     .stroke_hitboxes_contain_coord(engine_view.camera.viewport(), element.pos)
+                    .last()
                 {
                     // When clicked on a textstroke, we start modifying it
                     if let Some(Stroke::TextStroke(textstroke)) =

--- a/rnote-engine/src/store/chrono_comp.rs
+++ b/rnote-engine/src/store/chrono_comp.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::sync::Arc;
 
 use p2d::bounding_volume::AABB;
@@ -6,22 +7,79 @@ use serde::{Deserialize, Serialize};
 
 use super::{StrokeKey, StrokeStore};
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq)]
+#[serde(rename = "stroke_layer")]
+pub enum StrokeLayer {
+    UserLayer(u32),
+    Highlighter,
+    Image,
+    Document,
+}
+
+impl Default for StrokeLayer {
+    fn default() -> Self {
+        Self::UserLayer(0)
+    }
+}
+
+impl PartialEq for StrokeLayer {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::UserLayer(l0), Self::UserLayer(r0)) => l0 == r0,
+            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+        }
+    }
+}
+
+impl PartialOrd for StrokeLayer {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for StrokeLayer {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match (self, other) {
+            (StrokeLayer::UserLayer(this_ul), StrokeLayer::UserLayer(other_ul)) => {
+                this_ul.cmp(other_ul)
+            }
+            (StrokeLayer::UserLayer(_), _) => Ordering::Greater,
+            (StrokeLayer::Highlighter, StrokeLayer::UserLayer(_)) => Ordering::Less,
+            (StrokeLayer::Highlighter, StrokeLayer::Highlighter) => Ordering::Equal,
+            (StrokeLayer::Highlighter, _) => Ordering::Greater,
+            (StrokeLayer::Image, StrokeLayer::UserLayer(_) | StrokeLayer::Highlighter) => {
+                Ordering::Less
+            }
+            (StrokeLayer::Image, StrokeLayer::Image) => Ordering::Equal,
+            (StrokeLayer::Image, StrokeLayer::Document) => Ordering::Greater,
+            (StrokeLayer::Document, StrokeLayer::Document) => Ordering::Equal,
+            (StrokeLayer::Document, _) => Ordering::Less,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
 #[serde(default, rename = "chrono_component")]
 pub struct ChronoComponent {
     #[serde(rename = "t")]
     t: u32,
+    /// layers are split into two groups: positive are user layers and modifyable, system layers are negative. By default the layer is 0.
+    #[serde(rename = "layer")]
+    pub layer: StrokeLayer,
 }
 
 impl Default for ChronoComponent {
     fn default() -> Self {
-        Self { t: 0 }
+        Self {
+            t: 0,
+            layer: StrokeLayer::default(),
+        }
     }
 }
 
 impl ChronoComponent {
-    pub fn new(t: u32) -> Self {
-        Self { t }
+    pub fn new(t: u32, layer: StrokeLayer) -> Self {
+        Self { t, layer }
     }
 }
 
@@ -49,7 +107,13 @@ impl StrokeStore {
             if let (Some(first_chrono), Some(second_chrono)) =
                 (chrono_components.get(first), chrono_components.get(second))
             {
-                first_chrono.t.cmp(&second_chrono.t)
+                let layer_order = first_chrono.layer.cmp(&second_chrono.layer);
+
+                if layer_order != std::cmp::Ordering::Equal {
+                    layer_order
+                } else {
+                    first_chrono.t.cmp(&second_chrono.t)
+                }
             } else {
                 std::cmp::Ordering::Equal
             }
@@ -67,7 +131,13 @@ impl StrokeStore {
             if let (Some(first_chrono), Some(second_chrono)) =
                 (chrono_components.get(first), chrono_components.get(second))
             {
-                first_chrono.t.cmp(&second_chrono.t)
+                let layer_order = first_chrono.layer.cmp(&second_chrono.layer);
+
+                if layer_order != std::cmp::Ordering::Equal {
+                    layer_order
+                } else {
+                    first_chrono.t.cmp(&second_chrono.t)
+                }
             } else {
                 std::cmp::Ordering::Equal
             }

--- a/rnote-engine/src/store/mod.rs
+++ b/rnote-engine/src/store/mod.rs
@@ -21,6 +21,8 @@ use rnote_compose::shapes::ShapeBehaviour;
 use serde::{Deserialize, Serialize};
 use slotmap::{HopSlotMap, SecondaryMap};
 
+use self::chrono_comp::StrokeLayer;
+
 slotmap::new_key_type! {
     pub struct StrokeKey;
 }
@@ -425,10 +427,11 @@ impl StrokeStore {
         self.history_pos = None;
     }
 
-    /// inserts a new stroke into the store
+    /// inserts a new stroke into the store. Optionally a desired layer can be specified, or the default stroke layer is used.
     /// stroke then needs to update its rendering
-    pub fn insert_stroke(&mut self, stroke: Stroke) -> StrokeKey {
+    pub fn insert_stroke(&mut self, stroke: Stroke, layer: Option<StrokeLayer>) -> StrokeKey {
         let bounds = stroke.bounds();
+        let layer = layer.unwrap_or(stroke.extract_default_layer());
 
         let key = Arc::make_mut(&mut self.stroke_components).insert(Arc::new(stroke));
         self.key_tree.insert_with_key(key, bounds);
@@ -438,7 +441,7 @@ impl StrokeStore {
         Arc::make_mut(&mut self.selection_components)
             .insert(key, Arc::new(SelectionComponent::default()));
         Arc::make_mut(&mut self.chrono_components)
-            .insert(key, Arc::new(ChronoComponent::new(self.chrono_counter)));
+            .insert(key, Arc::new(ChronoComponent::new(self.chrono_counter, layer)));
         self.render_components
             .insert(key, RenderComponent::default());
 

--- a/rnote-engine/src/store/mod.rs
+++ b/rnote-engine/src/store/mod.rs
@@ -440,8 +440,10 @@ impl StrokeStore {
         Arc::make_mut(&mut self.trash_components).insert(key, Arc::new(TrashComponent::default()));
         Arc::make_mut(&mut self.selection_components)
             .insert(key, Arc::new(SelectionComponent::default()));
-        Arc::make_mut(&mut self.chrono_components)
-            .insert(key, Arc::new(ChronoComponent::new(self.chrono_counter, layer)));
+        Arc::make_mut(&mut self.chrono_components).insert(
+            key,
+            Arc::new(ChronoComponent::new(self.chrono_counter, layer)),
+        );
         self.render_components
             .insert(key, RenderComponent::default());
 

--- a/rnote-engine/src/store/selection_comp.rs
+++ b/rnote-engine/src/store/selection_comp.rs
@@ -103,7 +103,8 @@ impl StrokeStore {
         let new_selected = old_selected
             .iter()
             .filter_map(|&key| {
-                let new_key = self.insert_stroke((**self.stroke_components.get(key)?).clone(), None);
+                let new_key =
+                    self.insert_stroke((**self.stroke_components.get(key)?).clone(), None);
                 self.set_selected(new_key, true);
                 Some(new_key)
             })

--- a/rnote-engine/src/store/selection_comp.rs
+++ b/rnote-engine/src/store/selection_comp.rs
@@ -103,7 +103,7 @@ impl StrokeStore {
         let new_selected = old_selected
             .iter()
             .filter_map(|&key| {
-                let new_key = self.insert_stroke((**self.stroke_components.get(key)?).clone());
+                let new_key = self.insert_stroke((**self.stroke_components.get(key)?).clone(), None);
                 self.set_selected(new_key, true);
                 Some(new_key)
             })

--- a/rnote-engine/src/store/stroke_comp.rs
+++ b/rnote-engine/src/store/stroke_comp.rs
@@ -508,7 +508,7 @@ impl StrokeStore {
             .collect()
     }
 
-    /// returns the strokes where the given coord is inside at least one of the stroke hitboxes
+    /// returns the strokes for the given coord is inside at least one of the stroke hitboxes
     pub fn stroke_hitboxes_contain_coord(
         &self,
         viewport: AABB,

--- a/rnote-engine/src/store/stroke_comp.rs
+++ b/rnote-engine/src/store/stroke_comp.rs
@@ -56,34 +56,27 @@ impl StrokeStore {
         self.key_tree.keys_intersecting_bounds(bounds)
     }
 
-    /// All stroke keys unordered, excluding selected or trashed keys
+    /// All stroke keys, unordered.
     pub fn stroke_keys_unordered(&self) -> Vec<StrokeKey> {
         self.stroke_components
             .keys()
-            .filter(|&key| {
-                !(self.trashed(key).unwrap_or(false)) && !(self.selected(key).unwrap_or(false))
-            })
+            .filter(|&key| !(self.trashed(key).unwrap_or(false)))
             .collect()
     }
 
-    /// Returns the stroke keys in the order that they should be rendered. Exluding selected or trashed keys.
+    /// Returns the stroke keys in the order that they should be rendered.
     pub fn stroke_keys_as_rendered(&self) -> Vec<StrokeKey> {
         self.keys_sorted_chrono()
             .into_iter()
-            .filter(|&key| {
-                !(self.trashed(key).unwrap_or(false)) && !(self.selected(key).unwrap_or(false))
-            })
+            .filter(|&key| !(self.trashed(key).unwrap_or(false)))
             .collect::<Vec<StrokeKey>>()
     }
 
     /// Returns the stroke keys in the order that they should be rendered, intersecting the given bounds.
-    /// Exluding selected or trashed keys.
     pub fn stroke_keys_as_rendered_intersecting_bounds(&self, bounds: AABB) -> Vec<StrokeKey> {
         self.keys_sorted_chrono_intersecting_bounds(bounds)
             .into_iter()
-            .filter(|&key| {
-                !(self.trashed(key).unwrap_or(false)) && !(self.selected(key).unwrap_or(false))
-            })
+            .filter(|&key| !(self.trashed(key).unwrap_or(false)))
             .collect::<Vec<StrokeKey>>()
     }
 
@@ -129,7 +122,6 @@ impl StrokeStore {
         let strokes_iter = self
             .stroke_keys_unordered()
             .into_iter()
-            .chain(self.selection_keys_unordered())
             .filter_map(|key| self.stroke_components.get(key));
 
         let strokes_min_y = strokes_iter
@@ -516,15 +508,15 @@ impl StrokeStore {
             .collect()
     }
 
-    /// returns the key if coord is inside at least one of the stroke hitboxes
+    /// returns the strokes where the given coord is inside at least one of the stroke hitboxes
     pub fn stroke_hitboxes_contain_coord(
         &self,
         viewport: AABB,
         coord: na::Vector2<f64>,
-    ) -> Option<StrokeKey> {
+    ) -> Vec<StrokeKey> {
         self.stroke_keys_as_rendered_intersecting_bounds(viewport)
             .into_iter()
-            .find(|&key| {
+            .filter(|&key| {
                 if let Some(stroke) = self.stroke_components.get(key) {
                     stroke
                         .hitboxes()
@@ -534,6 +526,7 @@ impl StrokeStore {
                     false
                 }
             })
+            .collect()
     }
 
     /// Returns all keys below the y_pos

--- a/rnote-engine/src/store/trash_comp.rs
+++ b/rnote-engine/src/store/trash_comp.rs
@@ -234,7 +234,7 @@ impl StrokeStore {
         modified_keys.append(
             &mut new_strokes
                 .into_iter()
-                .map(|new_stroke| self.insert_stroke(new_stroke))
+                .map(|new_stroke| self.insert_stroke(new_stroke, None))
                 .collect(),
         );
 

--- a/rnote-ui/data/app.metainfo.xml.in.in
+++ b/rnote-ui/data/app.metainfo.xml.in.in
@@ -77,6 +77,7 @@
           <li>proportial shapes / input constraints (thanks @sei0o!)</li>
           <li>additional selector modes: apiece, intersecting path</li>
           <li>improved workspace browser, added sidebar to select between different workspaces (inspired by the `Paper` app)</li>
+          <li>mark underneath other strokes with the 'Marker' brush style</li>
           <li>bug fixes</li>
         </ul>
       </description>

--- a/rnote-ui/data/ui/penssidebar/brushpage.ui
+++ b/rnote-ui/data/ui/penssidebar/brushpage.ui
@@ -73,6 +73,7 @@
               <child>
                 <object class="AdwActionRow" id="brushstyle_marker_row">
                   <property name="title" translatable="yes">Marker</property>
+                  <property name="tooltip-text">Mark under another brush stroke</property>
                   <child type="prefix">
                     <object class="GtkImage">
                       <property name="icon-name">pen-brush-style-marker-symbolic</property>
@@ -84,6 +85,7 @@
               <child>
                 <object class="AdwActionRow" id="brushstyle_solid_row">
                   <property name="title" translatable="yes">Solid</property>
+                  <property name="tooltip-text">Draw solid color strokes</property>
                   <child type="prefix">
                     <object class="GtkImage">
                       <property name="icon-name">pen-brush-style-solid-symbolic</property>
@@ -95,6 +97,7 @@
               <child>
                 <object class="AdwActionRow" id="brushstyle_textured_row">
                   <property name="title" translatable="yes">Textured</property>
+                  <property name="tooltip-text">Draw textured strokes</property>
                   <child type="prefix">
                     <object class="GtkImage">
                       <property name="icon-name">pen-brush-style-textured-symbolic</property>

--- a/rnote-ui/data/ui/penssidebar/brushpage.ui
+++ b/rnote-ui/data/ui/penssidebar/brushpage.ui
@@ -73,7 +73,7 @@
               <child>
                 <object class="AdwActionRow" id="brushstyle_marker_row">
                   <property name="title" translatable="yes">Marker</property>
-                  <property name="tooltip-text">Mark under another brush stroke</property>
+                  <property name="tooltip-text">Mark underneath other brush strokes</property>
                   <child type="prefix">
                     <object class="GtkImage">
                       <property name="icon-name">pen-brush-style-marker-symbolic</property>

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -8,7 +8,7 @@ use piet::RenderContext;
 use rnote_compose::helpers::Vector2Helpers;
 use rnote_engine::document::Layout;
 use rnote_engine::pens::penholder::PenStyle;
-use rnote_engine::{render, Camera, DrawBehaviour, RnoteEngine, Document};
+use rnote_engine::{render, Camera, Document, DrawBehaviour, RnoteEngine};
 
 use gettextrs::gettext;
 use gtk4::{gdk, gio, glib, glib::clone, prelude::*, PrintOperation, PrintOperationAction, Unit};
@@ -714,13 +714,9 @@ impl RnoteAppWindow {
                 if let Err(e) = || -> anyhow::Result<()> {
                     let page_bounds = pages_bounds[page_no as usize];
 
-                    let mut page_strokes = appwindow.canvas().engine().borrow()
+                    let page_strokes = appwindow.canvas().engine().borrow()
                         .store
                         .stroke_keys_as_rendered_intersecting_bounds(page_bounds);
-                    page_strokes.extend(
-                        appwindow.canvas().engine().borrow().store
-                            .selection_keys_as_rendered_intersecting_bounds(page_bounds),
-                    );
 
                     let print_zoom = {
                         let width_scale = print_cx.width() / format_size[0];

--- a/rnote-ui/src/appwindow/mod.rs
+++ b/rnote-ui/src/appwindow/mod.rs
@@ -1617,7 +1617,7 @@ impl RnoteAppWindow {
             .canvas()
             .engine()
             .borrow_mut()
-            .import_generated_strokes(vec![Stroke::VectorImage(vectorimage)]);
+            .import_generated_strokes(vec![(Stroke::VectorImage(vectorimage), None)]);
         self.handle_widget_flags(widget_flags);
 
         app.set_input_file(None);
@@ -1651,7 +1651,7 @@ impl RnoteAppWindow {
             .canvas()
             .engine()
             .borrow_mut()
-            .import_generated_strokes(vec![Stroke::BitmapImage(bitmapimage)]);
+            .import_generated_strokes(vec![(Stroke::BitmapImage(bitmapimage), None)]);
         self.handle_widget_flags(widget_flags);
 
         app.set_input_file(None);


### PR DESCRIPTION
This implements stroke layers.

There are several dedicated layers: documents (pdfs), images (bitmap / vector), highlighter and user layers. They get rendered in this order.
The marker brush style now saves into the highlighter layer which is drawn under the "regular" brush layer, making it possible to mark text without obstructing it. Fixes #106, fixes #183 when merged.

When selecting strokes, they are also no longer resurfaced to the top, but now stay in their layer.

The brush now saves the individual options for each style and the brush width switches and is remembered when changing between the styles.