### PR TITLE
Automate installing the build on Windows

### DIFF
--- a/build-aux/meson_post_install.py
+++ b/build-aux/meson_post_install.py
@@ -6,11 +6,24 @@ from subprocess import call
 if not environ.get('DESTDIR', ''):
     PREFIX = environ.get('MESON_INSTALL_PREFIX', '/usr/local')
     DATA_DIR = path.join(PREFIX, 'share')
-    print('Updating icon cache...')
-    call(['gtk-update-icon-cache', '-qtf', path.join(DATA_DIR, 'icons/hicolor')])
-    print("Compiling new schemas...")
-    call(["glib-compile-schemas", path.join(DATA_DIR, 'glib-2.0/schemas')])
-    print("Updating desktop database...")
-    call(["update-desktop-database", path.join(DATA_DIR, 'applications')])
-    print("Updating MIME-type database...")
-    call(["update-mime-database", path.join(DATA_DIR, 'mime')])
+
+    if sys.platform.startswith('linux'):
+        print('Updating icon cache...')
+        call(['gtk-update-icon-cache', '-qtf', path.join(DATA_DIR, 'icons/hicolor')])
+        print("Compiling new schemas...")
+        call(["glib-compile-schemas", path.join(DATA_DIR, 'glib-2.0/schemas')])
+        print("Updating desktop database...")
+        call(["update-desktop-database", path.join(DATA_DIR, 'applications')])
+        print("Updating MIME-type database...")
+        call(["update-mime-database", path.join(DATA_DIR, 'mime')])
+    elif sys.platform == "win32" or sys.platform == "cygwin":
+        print('Updating icon cache...')
+        call(['gtk-update-icon-cache-3.0.exe', '-qtf', path.join(DATA_DIR, 'icons/hicolor')])
+        print("Compiling new schemas...")
+        call(["glib-compile-schemas.exe", path.join(DATA_DIR, 'glib-2.0/schemas')])
+        print("Updating desktop database...")
+        call(["update-desktop-database.exe", path.join(DATA_DIR, 'applications')])
+        print("Updating MIME-type database...")
+        call(["update-mime-database.exe", path.join(DATA_DIR, 'mime')])
+    else:
+        print(f"[WARNING] \"meson_post_install.py\" does not work on {sys.platform}")

--- a/misc/building/rnote-windows-build.md
+++ b/misc/building/rnote-windows-build.md
@@ -26,28 +26,7 @@ git clone https://github.com/flxzt/rnote
 git submodule update --init --recursive
 ```
 
-in the repo `build-aux/meson_post_install.py` must be overwritten with ( renaming the executables ):
-```
-#!/usr/bin/env python3
-
-from os import environ, path
-from subprocess import call
-
-if not environ.get('DESTDIR', ''):
-    PREFIX = environ.get('MESON_INSTALL_PREFIX', '/usr/local')
-    DATA_DIR = path.join(PREFIX, 'share')
-    print('Updating icon cache...')
-    call(['gtk-update-icon-cache-3.0.exe', '-qtf', path.join(DATA_DIR, 'icons/hicolor')])
-    print("Compiling new schemas...")
-    call(["glib-compile-schemas.exe", path.join(DATA_DIR, 'glib-2.0/schemas')])
-    print("Updating desktop database...")
-    call(["update-desktop-database.exe", path.join(DATA_DIR, 'applications')])
-    print("Updating MIME-type database...")
-    call(["update-mime-database.exe", path.join(DATA_DIR, 'mime')])
-
-```
-
-then Rnote can built with meson inside a **mingw64 shell**:
+Rnote can be built with meson inside a **mingw64 shell**:
 ```
 meson setup --prefix=C:/gnome _mesonbuild
 meson compile -C _mesonbuild


### PR DESCRIPTION
**Description**
This PR automates installing the build on Windows so that there is limited manual work to be done. This is needed to simplify the script which will create the Windows installer.

**Additional Notes**
Not sure on the best method of automating the renaming of ``rnote.exe``. This will need to be worked out at somepoint.