### PR TITLE
adding rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
When I tried to build rnote with meson, I got the following error:

```
--- entering build script ---

 --- DEVEL PROFILE ---

error: rustup could not choose a version of cargo to run, because one wasn't specified explicitly, and n
o default is configured.
help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
cp: cannot stat '/main/Programming/pull_requests/rnote/build/target/debug/rnote': No such file or directory
```

The reason was, that I was using the `nightly` channel. Adding this file and
rebuild everything worked aftewards.
