### PR TITLE
Update BUILDING.md, Outdated dependencies on Fedora 36.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -70,7 +70,7 @@ If a native build on the host is wanted, meson can be called directly.
 
 ### Prerequisites
 
-Install all needed dependencies and build tools, e.g. for fedora 36:
+Install all needed dependencies and build tools, e.g. for fedora 37:
 ```bash
 sudo dnf install gcc gcc-c++ clang make automake cmake meson kernel-devel gtk4-devel libadwaita-devel poppler-glib-devel poppler-data alsa-lib-devel
 ```


### PR DESCRIPTION
Fedora 36 has gtk4 version 3.6.2 which is not recent enough to build rnote. Fedora 37 works AFAIK.