### PR TITLE
small fixes related to unsaved changes

### DIFF
--- a/rnote-ui/src/dialogs/mod.rs
+++ b/rnote-ui/src/dialogs/mod.rs
@@ -94,6 +94,24 @@ pub fn dialog_clear_doc(appwindow: &RnoteAppWindow) {
 }
 
 pub fn dialog_new_doc(appwindow: &RnoteAppWindow) {
+    let new_doc = |appwindow: &RnoteAppWindow| {
+        appwindow.canvas().engine().borrow_mut().clear();
+
+        appwindow.canvas().return_to_origin_page();
+        appwindow.canvas().engine().borrow_mut().resize_autoexpand();
+        appwindow.canvas().update_engine_rendering();
+
+        appwindow.canvas().set_unsaved_changes(false);
+        appwindow.canvas().set_empty(true);
+
+        appwindow.app().set_input_file(None);
+        appwindow.canvas().set_output_file(None);
+    };
+
+    if !appwindow.unsaved_changes() {
+        return new_doc(&appwindow);
+    }
+
     let builder = Builder::from_resource(
         (String::from(config::APP_IDPATH) + "ui/dialogs/dialogs.ui").as_str(),
     );
@@ -103,21 +121,7 @@ pub fn dialog_new_doc(appwindow: &RnoteAppWindow) {
     dialog_new_doc.connect_response(
         None,
         clone!(@weak appwindow => move |_dialog_new_doc, response| {
-        let new_doc = |appwindow: &RnoteAppWindow| {
-            appwindow.canvas().engine().borrow_mut().clear();
-
-            appwindow.canvas().return_to_origin_page();
-            appwindow.canvas().engine().borrow_mut().resize_autoexpand();
-            appwindow.canvas().update_engine_rendering();
-
-            appwindow.canvas().set_unsaved_changes(false);
-            appwindow.canvas().set_empty(true);
-
-            appwindow.app().set_input_file(None);
-            appwindow.canvas().set_output_file(None);
-        };
-
-        match response{
+        match response {
             "discard" => {
                 new_doc(&appwindow)
             },

--- a/rnote-ui/src/workspacebrowser/filerow/action/trash.rs
+++ b/rnote-ui/src/workspacebrowser/filerow/action/trash.rs
@@ -22,11 +22,13 @@ pub fn trash(filerow: &FileRow, appwindow: &RnoteAppWindow) -> gio::SimpleAction
                             // if the output file shares a sub-tree with the deleted directory, the output file has been deleted too and gets unset
                             if let Some(current_output_path) = current_output_file.path() {
                                 if current_output_path.starts_with(&current_path) {
+                                    appwindow.canvas().set_unsaved_changes(true);
                                     appwindow.canvas().set_output_file(None);
                                 }
                             }
                         } else if current_output_file.equal(&current_file) {
                             // if the output file is the current file, unset the output file
+                            appwindow.canvas().set_unsaved_changes(true);
                             appwindow.canvas().set_output_file(None);
                         }
                     }


### PR DESCRIPTION
- Set unsaved changes to `true` after deleting a file or one of its parent directories.
- Only show new file confirmation dialog if there are unsaved changes.