### PR TITLE
adjust setter_button CSS, closes #305

### DIFF
--- a/rnote-ui/data/ui/style.css
+++ b/rnote-ui/data/ui/style.css
@@ -41,13 +41,14 @@
 
 .setter_button {
     padding: 0 0 0 0;
+    margin-bottom: 1px;
     background-blend-mode: screen;
     background-image:
         linear-gradient(45deg, #11111188 25%, transparent 25%, transparent 75%, #11111188 75%, #11111188),
         linear-gradient(45deg, #11111188 25%, transparent 25%, transparent 75%, #11111188 75%, #11111188);
     background-size: 20px 20px;
     background-position: 0px 0px, 8px 8px;
-    border-color: @borders;
+    border-color: mix(@borders, @theme_fg_color, 0.25);
     border-style: solid;
     border-width: 1px;
     filter: brightness(100%);

--- a/rnote-ui/data/ui/style.css
+++ b/rnote-ui/data/ui/style.css
@@ -48,11 +48,9 @@
         linear-gradient(45deg, #11111188 25%, transparent 25%, transparent 75%, #11111188 75%, #11111188);
     background-size: 20px 20px;
     background-position: 0px 0px, 8px 8px;
-    border-color: mix(@borders, @theme_fg_color, 0.25);
     border-style: solid;
     border-width: 1px;
     filter: brightness(100%);
-    transition: border-radius 0.15s ease-out, filter 0.15s ease-out;
 }
 
 .setter_button:hover {

--- a/rnote-ui/src/colorpicker/colorsetter.rs
+++ b/rnote-ui/src/colorpicker/colorsetter.rs
@@ -180,7 +180,8 @@ mod imp {
 .setter_button {{
     margin{0}: 6px;
     background-color: rgba({3}, {4}, {5}, {6:.3});
-    transition: margin{0} 0.15s ease-out;
+    border-color: alpha(darker(rgba({3}, {4}, {5}, {6:.3})), 0.3);
+    transition: margin{0} 0.15s ease-out, border-radius 0.15s ease-out, filter 0.15s ease-out;
     {1}
 }}
 


### PR DESCRIPTION
The PR improves the contrast of the border around color buttons by mixing the default border color with the current foreground color. This fixes the issue mentioned in the first part of #305 - if you look closely, you can see that there is a border around the first button, but it is nearly identical to the current background color, making it look like an indentation issue.

dark theme             |  light theme
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/49598842/202189635-7388e121-d2cb-486a-9080-ac4a9dd2ac52.png)  |  ![](https://user-images.githubusercontent.com/49598842/202189702-6631491f-d250-47e0-a695-152b0f20ff1b.png)

The PR also adds `1px` of margin to the bottom of each button. This improves/fixes (?) the second issue mentioned in #305.

0px | 1px | 2px
:-------------------------:|:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/49598842/202190947-0ff8e639-5c87-4f61-9835-728677c642cf.png) |  ![](https://user-images.githubusercontent.com/49598842/202190994-79298278-c5ea-4d40-822b-54e28af39f88.png) | ![](https://user-images.githubusercontent.com/49598842/202191060-6e1bb00e-1606-4db1-8df1-d6a7422b4cce.png)

EDIT: The PR also fixes the border radius and brightness transitions when switching between or hovering over/clicking on colors.

---

TLDR:
- Closes #305.
- Fixes transition when hovering over & switching colors.