### PR TITLE
add file monitor to output file

### DIFF
--- a/rnote-ui/src/appwindow/imexport.rs
+++ b/rnote-ui/src/appwindow/imexport.rs
@@ -369,9 +369,8 @@ impl RnoteAppWindow {
                 .borrow()
                 .save_as_rnote_bytes(basename.to_string_lossy().to_string())?;
 
-            self.canvas().block_output_file_monitor();
+            self.canvas().set_output_file_expect_write(true);
             crate::utils::create_replace_file_future(rnote_bytes_receiver.await??, file).await?;
-            self.canvas().unblock_output_file_monitor();
 
             self.canvas().set_output_file(Some(file.to_owned()));
             self.canvas().set_unsaved_changes(false);

--- a/rnote-ui/src/appwindow/imexport.rs
+++ b/rnote-ui/src/appwindow/imexport.rs
@@ -76,7 +76,7 @@ impl RnoteAppWindow {
 
                     if let Ok((file_bytes, _)) = result {
                         if let Err(e) = appwindow.load_in_rnote_bytes(file_bytes.to_vec(), file.path()).await {
-                            adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening .rnote file failed.").to_variant()));
+                            appwindow.dispatch_toast_error(&gettext("Opening .rnote file failed."));
                             log::error!(
                                 "load_in_rnote_bytes() failed in load_in_file() with Err: {e:?}"
                             );
@@ -94,7 +94,7 @@ impl RnoteAppWindow {
 
                     if let Ok((file_bytes, _)) = result {
                         if let Err(e) = appwindow.load_in_vectorimage_bytes(file_bytes.to_vec(), target_pos).await {
-                            adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening vector image file failed.").to_variant()));
+                            appwindow.dispatch_toast_error(&gettext("Opening vector image file failed."));
                             log::error!(
                                 "load_in_rnote_bytes() failed in load_in_file() with Err: {e:?}"
                             );
@@ -112,7 +112,7 @@ impl RnoteAppWindow {
 
                     if let Ok((file_bytes, _)) = result {
                         if let Err(e) = appwindow.load_in_bitmapimage_bytes(file_bytes.to_vec(), target_pos).await {
-                            adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening bitmap image file failed.").to_variant()));
+                            appwindow.dispatch_toast_error(&gettext("Opening bitmap image file failed."));
                             log::error!(
                                 "load_in_rnote_bytes() failed in load_in_file() with Err: {e:?}"
                             );
@@ -130,7 +130,7 @@ impl RnoteAppWindow {
 
                     if let Ok((file_bytes, _)) = result {
                         if let Err(e) = appwindow.load_in_xopp_bytes(file_bytes.to_vec()) {
-                            adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening Xournal++ file failed.").to_variant()));
+                            appwindow.dispatch_toast_error(&gettext("Opening Xournal++ file failed."));
                             log::error!(
                                 "load_in_xopp_bytes() failed in load_in_file() with Err: {e:?}"
                             );
@@ -148,7 +148,7 @@ impl RnoteAppWindow {
 
                     if let Ok((file_bytes, _)) = result {
                         if let Err(e) = appwindow.load_in_pdf_bytes(file_bytes.to_vec(), target_pos, None).await {
-                            adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening PDF file failed.").to_variant()));
+                            appwindow.dispatch_toast_error(&gettext("Opening PDF file failed."));
                             log::error!(
                                 "load_in_rnote_bytes() failed in load_in_file() with Err: {e:?}"
                             );
@@ -161,20 +161,12 @@ impl RnoteAppWindow {
             crate::utils::FileType::Folder => {
                 self.app().set_input_file(None);
                 log::error!("tried to open a folder as a file.");
-                adw::prelude::ActionGroupExt::activate_action(
-                    self,
-                    "error-toast",
-                    Some(&gettext("Error: Tried opening folder as file").to_variant()),
-                );
+                self.dispatch_toast_error(&gettext("Error: Tried opening folder as file"));
             }
             crate::utils::FileType::Unsupported => {
                 self.app().set_input_file(None);
                 log::error!("tried to open a unsupported file type.");
-                adw::prelude::ActionGroupExt::activate_action(
-                    self,
-                    "error-toast",
-                    Some(&gettext("Failed to open file: Unsupported file type.").to_variant()),
-                );
+                self.dispatch_toast_error(&gettext("Failed to open file: Unsupported file type."));
             }
         }
 

--- a/rnote-ui/src/appwindow/imexport.rs
+++ b/rnote-ui/src/appwindow/imexport.rs
@@ -377,7 +377,9 @@ impl RnoteAppWindow {
                 .borrow()
                 .save_as_rnote_bytes(basename.to_string_lossy().to_string())?;
 
+            self.canvas().block_output_file_monitor();
             crate::utils::create_replace_file_future(rnote_bytes_receiver.await??, file).await?;
+            self.canvas().unblock_output_file_monitor();
 
             self.canvas().set_output_file(Some(file.to_owned()));
             self.canvas().set_unsaved_changes(false);

--- a/rnote-ui/src/appwindow/imexport.rs
+++ b/rnote-ui/src/appwindow/imexport.rs
@@ -200,6 +200,7 @@ impl RnoteAppWindow {
         app.set_input_file(None);
         if let Some(path) = path {
             let file = gio::File::for_path(path);
+            self.canvas().dismiss_output_file_modified_toast();
             self.canvas().set_output_file(Some(file));
         }
 
@@ -370,6 +371,8 @@ impl RnoteAppWindow {
                 .save_as_rnote_bytes(basename.to_string_lossy().to_string())?;
 
             self.canvas().set_output_file_expect_write(true);
+            self.canvas().dismiss_output_file_modified_toast();
+
             crate::utils::create_replace_file_future(rnote_bytes_receiver.await??, file).await?;
 
             self.canvas().set_output_file(Some(file.to_owned()));

--- a/rnote-ui/src/appwindow/mod.rs
+++ b/rnote-ui/src/appwindow/mod.rs
@@ -457,7 +457,7 @@ mod imp {
                             appwindow.canvas().set_output_file(None);
 
                             log::error!("saving document failed with error `{e:?}`");
-                            adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Saving document failed.").to_variant()));
+                            appwindow.dispatch_toast_error(&gettext("Saving document failed."));
                         }
                     }));
                 }

--- a/rnote-ui/src/canvas/mod.rs
+++ b/rnote-ui/src/canvas/mod.rs
@@ -57,9 +57,9 @@ mod imp {
         pub(crate) engine: Rc<RefCell<RnoteEngine>>,
 
         pub(crate) output_file: RefCell<Option<gio::File>>,
-        pub(crate) output_file_expect_write: RefCell<bool>,
         pub(crate) output_file_monitor: RefCell<Option<gio::FileMonitor>>,
         pub(crate) output_file_modified_toast_singleton: RefCell<Option<adw::Toast>>,
+        pub(crate) output_file_expect_write: Cell<bool>,
         pub(crate) unsaved_changes: Cell<bool>,
         pub(crate) empty: Cell<bool>,
 
@@ -146,9 +146,9 @@ mod imp {
                 engine: Rc::new(RefCell::new(engine)),
 
                 output_file: RefCell::new(None),
-                output_file_expect_write: RefCell::new(false),
                 output_file_monitor: RefCell::new(None),
                 output_file_modified_toast_singleton: RefCell::new(None),
+                output_file_expect_write: Cell::new(false),
                 unsaved_changes: Cell::new(false),
                 empty: Cell::new(true),
 
@@ -476,12 +476,12 @@ impl RnoteCanvas {
 
     #[allow(unused)]
     pub(crate) fn set_output_file_expect_write(&self, enable: bool) {
-        *self.imp().output_file_expect_write.borrow_mut() = enable;
+        self.imp().output_file_expect_write.set(enable);
     }
 
     #[allow(unused)]
     pub(crate) fn output_file_expect_write(&self) -> bool {
-        *self.imp().output_file_expect_write.borrow()
+        self.imp().output_file_expect_write.get()
     }
 
     #[allow(unused)]

--- a/rnote-ui/src/config.rs
+++ b/rnote-ui/src/config.rs
@@ -15,8 +15,8 @@ pub(crate) const APP_ISSUES_URL: &str = "https://github.com/flxzt/rnote/issues";
 pub(crate) const APP_SUPPORT_URL: &str = "https://github.com/flxzt/rnote/discussions";
 pub(crate) const APP_DONATE_URL: &str = "https://rnote.flxzt.net/donate/";
 pub(crate) const GETTEXT_PACKAGE: &str = "rnote";
-pub(crate) const LOCALEDIR: &str = "/app/share/locale";
+pub(crate) const LOCALEDIR: &str = "/usr/share/locale";
 
-pub(crate) const PKG_DATA_DIR: &str = "/app/share/rnote";
-pub(crate) const RESOURCES_FILE: &str = "/app/share/rnote/resources.gresource";
+pub(crate) const PKG_DATA_DIR: &str = "/usr/share/rnote";
+pub(crate) const RESOURCES_FILE: &str = "/usr/share/rnote/resources.gresource";
 pub(crate) const PROFILE: &str = "devel";

--- a/rnote-ui/src/config.rs
+++ b/rnote-ui/src/config.rs
@@ -15,8 +15,8 @@ pub(crate) const APP_ISSUES_URL: &str = "https://github.com/flxzt/rnote/issues";
 pub(crate) const APP_SUPPORT_URL: &str = "https://github.com/flxzt/rnote/discussions";
 pub(crate) const APP_DONATE_URL: &str = "https://rnote.flxzt.net/donate/";
 pub(crate) const GETTEXT_PACKAGE: &str = "rnote";
-pub(crate) const LOCALEDIR: &str = "/usr/share/locale";
+pub(crate) const LOCALEDIR: &str = "/app/share/locale";
 
-pub(crate) const PKG_DATA_DIR: &str = "/usr/share/rnote";
-pub(crate) const RESOURCES_FILE: &str = "/usr/share/rnote/resources.gresource";
+pub(crate) const PKG_DATA_DIR: &str = "/app/share/rnote";
+pub(crate) const RESOURCES_FILE: &str = "/app/share/rnote/resources.gresource";
 pub(crate) const PROFILE: &str = "devel";

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -65,9 +65,9 @@ pub(crate) fn filechooser_save_doc_as(appwindow: &RnoteAppWindow) {
                                 appwindow.canvas().set_output_file(None);
 
                                 log::error!("saving document failed with error `{e:?}`");
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Saving document failed.").to_variant()));
+                                appwindow.dispatch_toast_error(&gettext("Saving document failed."));
                             } else {
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "text-toast", Some(&gettext("Saved document successfully.").to_variant()));
+                                appwindow.dispatch_toast_text(&gettext("Saved document successfully."));
                             }
 
                             appwindow.finish_canvas_progressbar();
@@ -190,15 +190,15 @@ pub(crate) fn dialog_export_doc_w_prefs(appwindow: &RnoteAppWindow) {
 
                             if let Err(e) = appwindow.export_doc(&file, file_title, None).await {
                                 log::error!("exporting document failed with error `{e:?}`");
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Export document failed.").to_variant()));
+                                appwindow.dispatch_toast_error(&gettext("Export document failed."));
                             } else {
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "text-toast", Some(&gettext("Exported document successfully.").to_variant()));
+                                appwindow.dispatch_toast_text(&gettext("Exported document successfully."));
                             }
 
                             appwindow.finish_canvas_progressbar();
                         }));
                     } else {
-                        adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Export document failed, no file selected.").to_variant()));
+                        appwindow.dispatch_toast_error(&gettext("Export document failed, no file selected."));
                     }
                 }
                 _ => {}
@@ -465,15 +465,15 @@ pub(crate) fn dialog_export_doc_pages_w_prefs(appwindow: &RnoteAppWindow) {
 
                             if let Err(e) = appwindow.export_doc_pages(&dir, file_stem_name, None).await {
                                 log::error!("exporting document pages failed with error `{e:?}`");
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Export document pages failed.").to_variant()));
+                                appwindow.dispatch_toast_error(&gettext("Export document pages failed."));
                             } else {
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "text-toast", Some(&gettext("Exported document pages successfully.").to_variant()));
+                                appwindow.dispatch_toast_text(&gettext("Exported document pages successfully."));
                             }
 
                             appwindow.finish_canvas_progressbar();
                         }));
                     } else {
-                        adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Export document pages failed, no directory selected.").to_variant()));
+                        appwindow.dispatch_toast_error(&gettext("Export document pages failed, no directory selected."));
                     }
                 }
                 _ => {}
@@ -708,15 +708,15 @@ pub(crate) fn dialog_export_selection_w_prefs(appwindow: &RnoteAppWindow) {
 
                             if let Err(e) = appwindow.export_selection(&file, None).await {
                                 log::error!("exporting selection failed with error `{e:?}`");
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Export selection failed.").to_variant()));
+                                appwindow.dispatch_toast_error(&gettext("Export selection failed."));
                             } else {
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "text-toast", Some(&gettext("Exported selection successfully.").to_variant()));
+                                appwindow.dispatch_toast_text(&gettext("Exported selection successfully."));
                             }
 
                             appwindow.finish_canvas_progressbar();
                         }));
                     } else {
-                        adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Export selection failed, no file selected.").to_variant()));
+                        appwindow.dispatch_toast_error(&gettext("Export selection failed, no file selected."));
                     }
                 }
                 _ => {}
@@ -847,9 +847,9 @@ pub(crate) fn filechooser_export_engine_state(appwindow: &RnoteAppWindow) {
 
                             if let Err(e) = appwindow.export_engine_state(&file).await {
                                 log::error!("exporting engine state failed with error `{e:?}`");
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Export engine state failed.").to_variant()));
+                                appwindow.dispatch_toast_error(&gettext("Export engine state failed."));
                             } else {
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "text-toast", Some(&gettext("Exported engine state successfully.").to_variant()));
+                                appwindow.dispatch_toast_text(&gettext("Exported engine state successfully."));
                             }
 
                             appwindow.finish_canvas_progressbar();
@@ -911,9 +911,9 @@ pub(crate) fn filechooser_export_engine_config(appwindow: &RnoteAppWindow) {
 
                             if let Err(e) = appwindow.export_engine_config(&file).await {
                                 log::error!("exporting engine state failed with error `{e:?}`");
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Export engine config failed.").to_variant()));
+                                appwindow.dispatch_toast_error(&gettext("Export engine config failed."));
                             } else {
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "text-toast", Some(&gettext("Exported engine config successfully.").to_variant()));
+                                appwindow.dispatch_toast_text(&gettext("Exported engine config successfully."));
                             }
 
                             appwindow.finish_canvas_progressbar();

--- a/rnote-ui/src/dialogs/import.rs
+++ b/rnote-ui/src/dialogs/import.rs
@@ -26,7 +26,7 @@ pub(crate) fn dialog_open_overwrite(appwindow: &RnoteAppWindow) {
                 if let Some(input_file) = appwindow.app().input_file().as_ref() {
                     if let Err(e) = appwindow.load_in_file(input_file, None) {
                         log::error!("failed to load in input file, {e:?}");
-                        adw::prelude::ActionGroupExt::activate_action(appwindow, "error-toast", Some(&gettext("Opening file failed.").to_variant()));
+                        appwindow.dispatch_toast_error(&gettext("Opening file failed."));
                     }
                 }
             };
@@ -44,7 +44,7 @@ pub(crate) fn dialog_open_overwrite(appwindow: &RnoteAppWindow) {
                                 appwindow.canvas().set_output_file(None);
 
                                 log::error!("saving document failed with error `{e:?}`");
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Saving document failed.").to_variant()));
+                                appwindow.dispatch_toast_error(&gettext("Saving document failed."));
                             }
 
                             appwindow.finish_canvas_progressbar();
@@ -97,29 +97,29 @@ pub(crate) fn filechooser_open_doc(appwindow: &RnoteAppWindow) {
     }
 
     filechooser.connect_response(clone!(@weak appwindow => move |filechooser, responsetype| {
-            match responsetype {
-                ResponseType::Accept => {
-                    if let Some(file) = filechooser.file() {
-                        appwindow.app().set_input_file(Some(file));
+        match responsetype {
+            ResponseType::Accept => {
+                if let Some(file) = filechooser.file() {
+                    appwindow.app().set_input_file(Some(file));
 
-                        if !appwindow.unsaved_changes() {
-                            if let Some(input_file) = appwindow.app().input_file().as_ref() {
-                                if let Err(e) = appwindow.load_in_file(input_file, None) {
-                                    log::error!("failed to load in input file, {e:?}");
-                                    adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening file failed.").to_variant()));
-                                }
+                    if !appwindow.unsaved_changes() {
+                        if let Some(input_file) = appwindow.app().input_file().as_ref() {
+                            if let Err(e) = appwindow.load_in_file(input_file, None) {
+                                log::error!("failed to load in input file, {e:?}");
+                                appwindow.dispatch_toast_error(&gettext("Opening file failed."));
                             }
-                        } else {
-                            // Open a dialog to ask for overwriting the current doc
-                            dialog_open_overwrite(&appwindow);
                         }
+                    } else {
+                        // Open a dialog to ask for overwriting the current doc
+                        dialog_open_overwrite(&appwindow);
                     }
-                },
-                _ => {
                 }
+            },
+            _ => {
             }
+        }
 
-        }));
+    }));
 
     filechooser.show();
 
@@ -319,7 +319,7 @@ pub(crate) fn dialog_import_pdf_w_prefs(
 
                         if let Ok((file_bytes, _)) = result {
                             if let Err(e) = appwindow.load_in_pdf_bytes(file_bytes.to_vec(), target_pos, Some(page_range)).await {
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening PDF file failed.").to_variant()));
+                                appwindow.dispatch_toast_error(&gettext("Opening PDF file failed."));
                                 log::error!(
                                     "load_in_rnote_bytes() failed in dialog import pdf with Err: {e:?}"
                                 );
@@ -385,7 +385,7 @@ pub(crate) fn dialog_import_xopp_w_prefs(appwindow: &RnoteAppWindow) {
 
                         if let Ok((file_bytes, _)) = result {
                             if let Err(e) = appwindow.load_in_xopp_bytes(file_bytes.to_vec()) {
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening Xournal++ file failed.").to_variant()));
+                                appwindow.dispatch_toast_error(&gettext("Opening Xournal++ file failed."));
                                 log::error!(
                                     "load_in_xopp_bytes() failed in dialog import xopp with Err: {e:?}"
                                 );

--- a/rnote-ui/src/dialogs/mod.rs
+++ b/rnote-ui/src/dialogs/mod.rs
@@ -134,7 +134,7 @@ pub(crate) fn dialog_new_doc(appwindow: &RnoteAppWindow) {
                             appwindow.canvas().set_output_file(None);
 
                             log::error!("saving document failed with error `{e:?}`");
-                            adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Saving document failed.").to_variant()));
+                            appwindow.dispatch_toast_error(&gettext("Saving document failed."));
                         }
 
                         appwindow.finish_canvas_progressbar();
@@ -183,7 +183,7 @@ pub(crate) fn dialog_quit_save(appwindow: &RnoteAppWindow) {
                             if let Err(e) = appwindow.save_document_to_file(&output_file).await {
                                 appwindow.canvas().set_output_file(None);
 
-                                log::error!("saving document failed with error `{e:?}`");
+                                log::error!("saving document failed with error `{}`", e);
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Saving document failed.").to_variant()));
                             }
 

--- a/rnote-ui/src/dialogs/mod.rs
+++ b/rnote-ui/src/dialogs/mod.rs
@@ -183,8 +183,8 @@ pub(crate) fn dialog_quit_save(appwindow: &RnoteAppWindow) {
                             if let Err(e) = appwindow.save_document_to_file(&output_file).await {
                                 appwindow.canvas().set_output_file(None);
 
-                                log::error!("saving document failed with error `{}`", e);
-                                adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Saving document failed.").to_variant()));
+                                log::error!("saving document failed with error `{e:?}`");
+                                appwindow.dispatch_toast_error(&gettext("Saving document failed."));
                             }
 
                             appwindow.finish_canvas_progressbar();

--- a/rnote-ui/src/utils.rs
+++ b/rnote-ui/src/utils.rs
@@ -73,6 +73,18 @@ impl FileType {
 
         Self::Unsupported
     }
+
+    pub fn is_goutputstream_file(file: &gio::File) -> bool {
+        if let Some(path) = file.path() {
+            if let Some(file_name) = path.file_name() {
+                if String::from(file_name.to_string_lossy()).starts_with(".goutputstream-") {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }
 
 /// Translates a AABB to the coordinate space of the dest_widget. None if the widgets don't have a common ancestor

--- a/rnote-ui/src/utils.rs
+++ b/rnote-ui/src/utils.rs
@@ -74,7 +74,7 @@ impl FileType {
         Self::Unsupported
     }
 
-    pub fn is_goutputstream_file(file: &gio::File) -> bool {
+    pub(crate) fn is_goutputstream_file(file: &gio::File) -> bool {
         if let Some(path) = file.path() {
             if let Some(file_name) = path.file_name() {
                 if String::from(file_name.to_string_lossy()).starts_with(".goutputstream-") {

--- a/rnote-ui/src/workspacebrowser/filerow/action/trash.rs
+++ b/rnote-ui/src/workspacebrowser/filerow/action/trash.rs
@@ -1,37 +1,17 @@
 use gtk4::{gio, glib, glib::clone, prelude::FileExt};
 
-use crate::{workspacebrowser::FileRow, RnoteAppWindow};
+use crate::workspacebrowser::FileRow;
 
 /// Creates a new `trash` action
-pub(crate) fn trash(filerow: &FileRow, appwindow: &RnoteAppWindow) -> gio::SimpleAction {
+pub(crate) fn trash(filerow: &FileRow) -> gio::SimpleAction {
     let action_trash_file = gio::SimpleAction::new("trash-file", None);
-    action_trash_file.connect_activate(clone!(@weak filerow, @weak appwindow => move |_action_trash_file, _| {
+    action_trash_file.connect_activate(clone!(@weak filerow => move |_action_trash_file, _| {
         if let Some(current_file) = filerow.current_file() {
-            // directory check must happen before deleting the file or directory
-            let current_path = current_file.path().unwrap();
-            let is_directory = current_path.is_dir();
-
             current_file.trash_async(glib::PRIORITY_DEFAULT, None::<&gio::Cancellable>, clone!(@weak filerow, @weak current_file => move |res| {
                 if let Err(e) = res {
                     log::error!("filerow trash file failed with Err: {e:?}");
                 } else {
                     filerow.set_current_file(None);
-
-                    if let Some(current_output_file) = appwindow.canvas().output_file() {
-                        if is_directory {
-                            // if the output file shares a sub-tree with the deleted directory, the output file has been deleted too and gets unset
-                            if let Some(current_output_path) = current_output_file.path() {
-                                if current_output_path.starts_with(&current_path) {
-                                    appwindow.canvas().set_unsaved_changes(true);
-                                    appwindow.canvas().set_output_file(None);
-                                }
-                            }
-                        } else if current_output_file.equal(&current_file) {
-                            // if the output file is the current file, unset the output file
-                            appwindow.canvas().set_unsaved_changes(true);
-                            appwindow.canvas().set_output_file(None);
-                        }
-                    }
                 }
             }));
         }

--- a/rnote-ui/src/workspacebrowser/filerow/mod.rs
+++ b/rnote-ui/src/workspacebrowser/filerow/mod.rs
@@ -198,12 +198,8 @@ impl FileRow {
         self.imp()
             .action_group
             .add_action(&action::open(self, appwindow));
-        self.imp()
-            .action_group
-            .add_action(&action::rename(self, appwindow));
-        self.imp()
-            .action_group
-            .add_action(&action::trash(self, appwindow));
+        self.imp().action_group.add_action(&action::rename(self));
+        self.imp().action_group.add_action(&action::trash(self));
         self.imp()
             .action_group
             .add_action(&action::duplicate(self, appwindow));


### PR DESCRIPTION
* This PR implements a file monitor for the current output file, as discussed in #347.
* Uses toasts to indicate moves/deletions, renames, and modifications (with a button for reloading).
  * Updates the output file and unsaved changes flag accordingly.
* Refactors toasts and adds toasts with buttons.
* It makes special treatment for file row actions redundant, which is why it partially reverts #347 and fully reverts #343.

(For more details, see discussion below.)