### PR TITLE
Refactoring penpath, segments

### DIFF
--- a/rnote-compose/src/builders/coordsystem2dbuilder.rs
+++ b/rnote-compose/src/builders/coordsystem2dbuilder.rs
@@ -9,7 +9,7 @@ use crate::shapes::Line;
 use crate::style::{drawhelpers, Composer};
 use crate::{Shape, Style};
 
-use super::shapebuilderbehaviour::{BuilderProgress, ShapeBuilderCreator};
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
 use super::{Constraints, ShapeBuilderBehaviour};
 
 /// 2D coordinate system builder
@@ -36,13 +36,13 @@ impl ShapeBuilderBehaviour for CoordSystem2DBuilder {
         event: PenEvent,
         _now: Instant,
         constraints: Constraints,
-    ) -> BuilderProgress {
+    ) -> ShapeBuilderProgress {
         match event {
             PenEvent::Down { element, .. } => {
                 self.tip_x = constraints.constrain(element.pos - self.tip_y) + self.tip_y;
             }
             PenEvent::Up { .. } => {
-                return BuilderProgress::Finished(
+                return ShapeBuilderProgress::Finished(
                     self.state_as_lines()
                         .iter()
                         .map(|&line| Shape::Line(line))
@@ -52,7 +52,7 @@ impl ShapeBuilderBehaviour for CoordSystem2DBuilder {
             _ => {}
         }
 
-        BuilderProgress::InProgress
+        ShapeBuilderProgress::InProgress
     }
 
     fn bounds(&self, style: &Style, zoom: f64) -> Option<AABB> {

--- a/rnote-compose/src/builders/coordsystem3dbuilder.rs
+++ b/rnote-compose/src/builders/coordsystem3dbuilder.rs
@@ -9,7 +9,7 @@ use crate::shapes::Line;
 use crate::style::{drawhelpers, Composer};
 use crate::{Shape, Style};
 
-use super::shapebuilderbehaviour::{BuilderProgress, ShapeBuilderCreator};
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
 use super::{Constraints, ShapeBuilderBehaviour};
 
 /// 3D coordinate system builder
@@ -36,13 +36,13 @@ impl ShapeBuilderBehaviour for CoordSystem3DBuilder {
         event: PenEvent,
         _now: Instant,
         constraints: Constraints,
-    ) -> BuilderProgress {
+    ) -> ShapeBuilderProgress {
         match event {
             PenEvent::Down { element, .. } => {
                 self.tip_y = constraints.constrain(element.pos - self.tip_z) + self.tip_z;
             }
             PenEvent::Up { .. } => {
-                return BuilderProgress::Finished(
+                return ShapeBuilderProgress::Finished(
                     self.state_as_lines()
                         .iter()
                         .map(|&line| Shape::Line(line))
@@ -52,7 +52,7 @@ impl ShapeBuilderBehaviour for CoordSystem3DBuilder {
             _ => {}
         }
 
-        BuilderProgress::InProgress
+        ShapeBuilderProgress::InProgress
     }
 
     fn bounds(&self, style: &Style, zoom: f64) -> Option<AABB> {

--- a/rnote-compose/src/builders/cubbezbuilder.rs
+++ b/rnote-compose/src/builders/cubbezbuilder.rs
@@ -9,7 +9,7 @@ use crate::shapes::CubicBezier;
 use crate::style::{drawhelpers, Composer};
 use crate::{Shape, Style};
 
-use super::shapebuilderbehaviour::{BuilderProgress, ShapeBuilderCreator};
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
 use super::{ConstraintRatio, Constraints, ShapeBuilderBehaviour};
 
 #[derive(Debug, Clone)]
@@ -67,7 +67,7 @@ impl ShapeBuilderBehaviour for CubBezBuilder {
         event: PenEvent,
         _now: Instant,
         mut constraints: Constraints,
-    ) -> BuilderProgress {
+    ) -> ShapeBuilderProgress {
         //log::debug!("state: {:?}, event: {:?}", &self.state, &event);
 
         // we always want to allow horizontal and vertical constraints while building a cubbez
@@ -119,7 +119,7 @@ impl ShapeBuilderBehaviour for CubBezBuilder {
                 },
                 PenEvent::Up { .. },
             ) => {
-                return BuilderProgress::Finished(vec![Shape::CubicBezier(CubicBezier {
+                return ShapeBuilderProgress::Finished(vec![Shape::CubicBezier(CubicBezier {
                     start: *start,
                     cp1: *cp1,
                     cp2: *cp2,
@@ -129,7 +129,7 @@ impl ShapeBuilderBehaviour for CubBezBuilder {
             (CubBezBuilderState::End { .. }, ..) => {}
         }
 
-        BuilderProgress::InProgress
+        ShapeBuilderProgress::InProgress
     }
 
     fn bounds(&self, style: &Style, zoom: f64) -> Option<AABB> {

--- a/rnote-compose/src/builders/ellipsebuilder.rs
+++ b/rnote-compose/src/builders/ellipsebuilder.rs
@@ -9,7 +9,7 @@ use crate::shapes::Ellipse;
 use crate::style::{drawhelpers, Composer};
 use crate::{Shape, Style, Transform};
 
-use super::shapebuilderbehaviour::{BuilderProgress, ShapeBuilderCreator};
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
 use super::{Constraints, ShapeBuilderBehaviour};
 
 /// ellipse builder
@@ -36,18 +36,20 @@ impl ShapeBuilderBehaviour for EllipseBuilder {
         event: PenEvent,
         _now: Instant,
         constraints: Constraints,
-    ) -> BuilderProgress {
+    ) -> ShapeBuilderProgress {
         match event {
             PenEvent::Down { element, .. } => {
                 self.current = constraints.constrain(element.pos - self.start) + self.start;
             }
             PenEvent::Up { .. } => {
-                return BuilderProgress::Finished(vec![Shape::Ellipse(self.state_as_ellipse())]);
+                return ShapeBuilderProgress::Finished(vec![Shape::Ellipse(
+                    self.state_as_ellipse(),
+                )]);
             }
             _ => {}
         }
 
-        BuilderProgress::InProgress
+        ShapeBuilderProgress::InProgress
     }
 
     fn bounds(&self, style: &crate::Style, zoom: f64) -> Option<AABB> {

--- a/rnote-compose/src/builders/fociellipsebuilder.rs
+++ b/rnote-compose/src/builders/fociellipsebuilder.rs
@@ -10,7 +10,7 @@ use crate::shapes::Ellipse;
 use crate::style::{drawhelpers, Composer};
 use crate::{Shape, Style};
 
-use super::shapebuilderbehaviour::{BuilderProgress, ShapeBuilderCreator};
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
 use super::{ConstraintRatio, Constraints, ShapeBuilderBehaviour};
 
 #[derive(Debug, Clone)]
@@ -50,7 +50,7 @@ impl ShapeBuilderBehaviour for FociEllipseBuilder {
         event: PenEvent,
         _now: Instant,
         mut constraints: Constraints,
-    ) -> BuilderProgress {
+    ) -> ShapeBuilderProgress {
         //log::debug!("state: {:?}, event: {:?}", &self.state, &event);
 
         match (&mut self.state, event) {
@@ -84,12 +84,12 @@ impl ShapeBuilderBehaviour for FociEllipseBuilder {
             (FociEllipseBuilderState::FociAndPoint { foci, point }, PenEvent::Up { .. }) => {
                 let shape = Ellipse::from_foci_and_point(*foci, *point);
 
-                return BuilderProgress::Finished(vec![Shape::Ellipse(shape)]);
+                return ShapeBuilderProgress::Finished(vec![Shape::Ellipse(shape)]);
             }
             (FociEllipseBuilderState::FociAndPoint { .. }, _) => {}
         }
 
-        BuilderProgress::InProgress
+        ShapeBuilderProgress::InProgress
     }
 
     fn bounds(&self, style: &Style, zoom: f64) -> Option<AABB> {

--- a/rnote-compose/src/builders/linebuilder.rs
+++ b/rnote-compose/src/builders/linebuilder.rs
@@ -9,7 +9,7 @@ use crate::shapes::Line;
 use crate::style::{drawhelpers, Composer};
 use crate::{Shape, Style};
 
-use super::shapebuilderbehaviour::{BuilderProgress, ShapeBuilderCreator};
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
 use super::{ConstraintRatio, Constraints, ShapeBuilderBehaviour};
 
 /// line builder
@@ -36,7 +36,7 @@ impl ShapeBuilderBehaviour for LineBuilder {
         event: PenEvent,
         _now: Instant,
         mut constraints: Constraints,
-    ) -> BuilderProgress {
+    ) -> ShapeBuilderProgress {
         // we always want to allow horizontal and vertical constraints while building a line
         constraints.ratios.insert(ConstraintRatio::Horizontal);
         constraints.ratios.insert(ConstraintRatio::Vertical);
@@ -46,12 +46,12 @@ impl ShapeBuilderBehaviour for LineBuilder {
                 self.current = constraints.constrain(element.pos - self.start) + self.start;
             }
             PenEvent::Up { .. } => {
-                return BuilderProgress::Finished(vec![Shape::Line(self.state_as_line())]);
+                return ShapeBuilderProgress::Finished(vec![Shape::Line(self.state_as_line())]);
             }
             _ => {}
         }
 
-        BuilderProgress::InProgress
+        ShapeBuilderProgress::InProgress
     }
 
     fn bounds(&self, style: &Style, zoom: f64) -> Option<AABB> {

--- a/rnote-compose/src/builders/mod.rs
+++ b/rnote-compose/src/builders/mod.rs
@@ -27,6 +27,7 @@ pub mod rectanglebuilder;
 /// shape builder behaviour
 pub mod shapebuilderbehaviour;
 
+use anyhow::Context;
 // Re-exports
 pub use coordsystem2dbuilder::CoordSystem2DBuilder;
 pub use coordsystem3dbuilder::CoordSystem3DBuilder;
@@ -95,12 +96,8 @@ impl TryFrom<u32> for ShapeBuilderType {
     type Error = anyhow::Error;
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
-        num_traits::FromPrimitive::from_u32(value).ok_or_else(|| {
-            anyhow::anyhow!(
-                "ShapeBuilderType try_from::<u32>() for value {} failed",
-                value
-            )
-        })
+        num_traits::FromPrimitive::from_u32(value)
+            .with_context(|| format!("ShapeBuilderType try_from::<u32>() for value {value} failed"))
     }
 }
 
@@ -131,11 +128,8 @@ impl TryFrom<u32> for PenPathBuilderType {
     type Error = anyhow::Error;
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
-        num_traits::FromPrimitive::from_u32(value).ok_or_else(|| {
-            anyhow::anyhow!(
-                "PenPathBuilderType try_from::<u32>() for value {} failed",
-                value
-            )
+        num_traits::FromPrimitive::from_u32(value).with_context(|| {
+            format!("PenPathBuilderType try_from::<u32>() for value {value} failed",)
         })
     }
 }

--- a/rnote-compose/src/builders/mod.rs
+++ b/rnote-compose/src/builders/mod.rs
@@ -10,6 +10,8 @@ pub mod ellipsebuilder;
 pub mod fociellipsebuilder;
 /// line builder
 pub mod linebuilder;
+/// pen path builder behaviour
+pub mod penpathbuilderbehaviour;
 /// the regular pen path builder, using bezier curves to interpolate between input elements.
 pub mod penpathcurvedbuilder;
 /// modeled pen path builder, uses ink-stroke-modeler for smooth paths with advanced algorithms and its predictor to reduce input latency
@@ -25,8 +27,6 @@ pub mod rectanglebuilder;
 /// shape builder behaviour
 pub mod shapebuilderbehaviour;
 
-use std::collections::HashSet;
-
 // Re-exports
 pub use coordsystem2dbuilder::CoordSystem2DBuilder;
 pub use coordsystem3dbuilder::CoordSystem3DBuilder;
@@ -34,6 +34,9 @@ pub use cubbezbuilder::CubBezBuilder;
 pub use ellipsebuilder::EllipseBuilder;
 pub use fociellipsebuilder::FociEllipseBuilder;
 pub use linebuilder::LineBuilder;
+pub use penpathbuilderbehaviour::PenPathBuilderBehaviour;
+pub use penpathbuilderbehaviour::PenPathBuilderCreator;
+pub use penpathbuilderbehaviour::PenPathBuilderProgress;
 pub use penpathcurvedbuilder::PenPathCurvedBuilder;
 pub use penpathmodeledbuilder::PenPathModeledBuilder;
 pub use penpathsimplebuilder::PenPathSimpleBuilder;
@@ -41,8 +44,11 @@ pub use quadbezbuilder::QuadBezBuilder;
 pub use quadrantcoordsystem2dbuilder::QuadrantCoordSystem2DBuilder;
 pub use rectanglebuilder::RectangleBuilder;
 pub use shapebuilderbehaviour::ShapeBuilderBehaviour;
+pub use shapebuilderbehaviour::ShapeBuilderCreator;
+pub use shapebuilderbehaviour::ShapeBuilderProgress;
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 #[derive(
     Copy, Clone, Debug, Serialize, Deserialize, num_derive::FromPrimitive, num_derive::ToPrimitive,

--- a/rnote-compose/src/builders/penpathbuilderbehaviour.rs
+++ b/rnote-compose/src/builders/penpathbuilderbehaviour.rs
@@ -3,31 +3,31 @@ use std::time::Instant;
 use p2d::bounding_volume::AABB;
 
 use crate::penhelpers::PenEvent;
-use crate::penpath::Element;
-use crate::{Shape, Style};
+use crate::penpath::{Element, Segment};
+use crate::Style;
 
 use super::Constraints;
 
 #[derive(Debug, Clone)]
 /// the builder progress
-pub enum ShapeBuilderProgress {
+pub enum PenPathBuilderProgress {
     /// in progress
     InProgress,
-    /// emits shapes, but continue
-    EmitContinue(Vec<Shape>),
+    /// emits new path segments, but continue
+    EmitContinue(Vec<Segment>),
     /// done building
-    Finished(Vec<Shape>),
+    Finished(Vec<Segment>),
 }
 
-/// Creates a shape builder (separate trait because we use the ShapeBuilderBehaviour as trait object, so we can't have a method returning Self there.)
-pub trait ShapeBuilderCreator {
+/// Creates a pen path builder
+pub trait PenPathBuilderCreator {
     /// Start the builder
     fn start(element: Element, now: Instant) -> Self;
 }
 
-/// Types that are shape builders.
-/// They receive pen events, and return built shapes. They usually are drawn while building the shape, and are state machines.
-pub trait ShapeBuilderBehaviour: std::fmt::Debug {
+/// Types that are pen path builders.
+/// They receive pen events, and return path segments. They usually are drawn while building the shape, and are state machines.
+pub trait PenPathBuilderBehaviour: std::fmt::Debug {
     /// handles a pen event.
     /// Returns the builder progress.
     fn handle_event(
@@ -35,7 +35,7 @@ pub trait ShapeBuilderBehaviour: std::fmt::Debug {
         event: PenEvent,
         now: Instant,
         constraints: Constraints,
-    ) -> ShapeBuilderProgress;
+    ) -> PenPathBuilderProgress;
 
     /// the bounds
     fn bounds(&self, style: &Style, zoom: f64) -> Option<AABB>;

--- a/rnote-compose/src/builders/penpathcurvedbuilder.rs
+++ b/rnote-compose/src/builders/penpathcurvedbuilder.rs
@@ -7,10 +7,10 @@ use crate::penhelpers::PenEvent;
 use crate::penpath::{Element, Segment};
 use crate::shapes::CubicBezier;
 use crate::style::Composer;
-use crate::{PenPath, Shape, Style};
+use crate::{PenPath, Style};
 
-use super::shapebuilderbehaviour::{BuilderProgress, ShapeBuilderCreator};
-use super::{Constraints, ShapeBuilderBehaviour};
+use super::penpathbuilderbehaviour::PenPathBuilderCreator;
+use super::{Constraints, PenPathBuilderBehaviour, PenPathBuilderProgress};
 
 #[derive(Debug, Clone)]
 pub(crate) enum PenPathCurvedBuilderState {
@@ -28,7 +28,7 @@ pub struct PenPathCurvedBuilder {
     i: usize,
 }
 
-impl ShapeBuilderCreator for PenPathCurvedBuilder {
+impl PenPathBuilderCreator for PenPathCurvedBuilder {
     fn start(element: Element, _now: Instant) -> Self {
         Self {
             state: PenPathCurvedBuilderState::Start,
@@ -38,13 +38,13 @@ impl ShapeBuilderCreator for PenPathCurvedBuilder {
     }
 }
 
-impl ShapeBuilderBehaviour for PenPathCurvedBuilder {
+impl PenPathBuilderBehaviour for PenPathCurvedBuilder {
     fn handle_event(
         &mut self,
         event: PenEvent,
         _now: Instant,
         _constraints: Constraints,
-    ) -> BuilderProgress {
+    ) -> PenPathBuilderProgress {
         /*         log::debug!(
             "event: {:?}; buffer.len(): {}, state: {:?}",
             event,
@@ -57,30 +57,35 @@ impl ShapeBuilderBehaviour for PenPathCurvedBuilder {
                 self.buffer.push(element);
 
                 match self.try_build_segments_start() {
-                    Some(shapes) => BuilderProgress::EmitContinue(shapes),
-                    None => BuilderProgress::InProgress,
+                    Some(segments) => {
+                        // Here we have enough elements to switch into during state
+
+                        self.state = PenPathCurvedBuilderState::During;
+                        PenPathBuilderProgress::EmitContinue(segments)
+                    }
+                    None => PenPathBuilderProgress::InProgress,
                 }
             }
             (PenPathCurvedBuilderState::During, PenEvent::Down { element, .. }) => {
                 self.buffer.push(element);
 
                 match self.try_build_segments_during() {
-                    Some(shapes) => BuilderProgress::EmitContinue(shapes),
-                    None => BuilderProgress::InProgress,
+                    Some(shapes) => PenPathBuilderProgress::EmitContinue(shapes),
+                    None => PenPathBuilderProgress::InProgress,
                 }
             }
             (_, PenEvent::Up { element, .. }) => {
                 self.buffer.push(element);
 
-                BuilderProgress::Finished(self.try_build_segments_end())
+                PenPathBuilderProgress::Finished(self.try_build_segments_end())
             }
             (_, PenEvent::Proximity { .. })
             | (_, PenEvent::KeyPressed { .. })
-            | (_, PenEvent::Text { .. }) => BuilderProgress::InProgress,
+            | (_, PenEvent::Text { .. }) => PenPathBuilderProgress::InProgress,
             (_, PenEvent::Cancel) => {
                 self.reset();
 
-                BuilderProgress::Finished(vec![])
+                PenPathBuilderProgress::Finished(vec![])
             }
         }
     }
@@ -109,43 +114,30 @@ impl ShapeBuilderBehaviour for PenPathCurvedBuilder {
 
         cx.save().unwrap();
 
-        let penpath = match &self.state {
-            PenPathCurvedBuilderState::Start => self.buffer[self.i..]
-                .iter()
-                .zip(self.buffer[self.i..].iter().skip(1))
-                .map(|(start, end)| Segment::Line {
-                    start: *start,
-                    end: *end,
-                })
-                .collect::<PenPath>(),
+        let pen_path = match &self.state {
+            PenPathCurvedBuilderState::Start => {
+                PenPath::try_from_elements(self.buffer[self.i..].into_iter().copied())
+            }
             // Skipping the first buffer element as that is the not drained by the segment builder and is the prev element in the "During" state
-            PenPathCurvedBuilderState::During => self.buffer[self.i..]
-                .iter()
-                .skip(1)
-                .zip(self.buffer[self.i..].iter().skip(2))
-                .map(|(start, end)| Segment::Line {
-                    start: *start,
-                    end: *end,
-                })
-                .collect::<PenPath>(),
+            PenPathCurvedBuilderState::During => {
+                PenPath::try_from_elements(self.buffer[self.i..].iter().skip(1).copied())
+            }
         };
 
-        penpath.draw_composed(cx, style);
+        if let Some(pen_path) = pen_path {
+            pen_path.draw_composed(cx, style);
+        }
 
         cx.restore().unwrap();
     }
 }
 
 impl PenPathCurvedBuilder {
-    fn try_build_segments_start(&mut self) -> Option<Vec<Shape>> {
-        if self.buffer.len().saturating_sub(1) >= self.i + 2 {
-            // Here we have enough elements to switch into during state
-            self.state = PenPathCurvedBuilderState::During;
-
-            let segment = Shape::Segment(Segment::Line {
-                start: self.buffer[self.i],
-                end: self.buffer[self.i + 1],
-            });
+    fn try_build_segments_start(&mut self) -> Option<Vec<Segment>> {
+        if self.buffer.len().saturating_sub(1) >= self.i + 1 {
+            let segment = Segment::LineTo {
+                end: self.buffer[self.i],
+            };
 
             Some(vec![segment])
         } else {
@@ -153,7 +145,7 @@ impl PenPathCurvedBuilder {
         }
     }
 
-    fn try_build_segments_during(&mut self) -> Option<Vec<Shape>> {
+    fn try_build_segments_during(&mut self) -> Option<Vec<Segment>> {
         if self.buffer.len().saturating_sub(1) < self.i + 3 {
             return None;
         }
@@ -167,27 +159,22 @@ impl PenPathCurvedBuilder {
                 self.buffer[self.i + 2].pos,
                 self.buffer[self.i + 3].pos,
             ) {
-                let segment = Shape::Segment(Segment::CubBez {
-                    start: Element {
-                        pos: cubbez.start,
-                        ..self.buffer[self.i + 1]
-                    },
+                let segment = Segment::CubBezTo {
                     cp1: cubbez.cp1,
                     cp2: cubbez.cp2,
                     end: Element {
                         pos: cubbez.end,
                         ..self.buffer[self.i + 2]
                     },
-                });
+                };
 
                 self.i += 1;
 
                 segments.push(segment);
             } else {
-                let segment = Shape::Segment(Segment::Line {
-                    start: self.buffer[self.i + 1],
+                let segment = Segment::LineTo {
                     end: self.buffer[self.i + 2],
-                });
+                };
 
                 self.i += 1;
 
@@ -198,65 +185,50 @@ impl PenPathCurvedBuilder {
         Some(segments)
     }
 
-    fn try_build_segments_end(&mut self) -> Vec<Shape> {
+    fn try_build_segments_end(&mut self) -> Vec<Segment> {
         let buffer_last_pos = self.buffer.len().saturating_sub(1);
-        let mut segments: Vec<Shape> = vec![];
+        let mut segments: Vec<Segment> = vec![];
 
-        while let Some(mut new_segments) = if buffer_last_pos >= self.i + 3 {
+        while let Some(mut new_segments) = if buffer_last_pos > self.i + 2 {
             if let Some(cubbez) = CubicBezier::new_w_catmull_rom(
                 self.buffer[self.i].pos,
                 self.buffer[self.i + 1].pos,
                 self.buffer[self.i + 2].pos,
                 self.buffer[self.i + 3].pos,
             ) {
-                let segment = Shape::Segment(Segment::CubBez {
-                    start: Element {
-                        pos: cubbez.start,
-                        ..self.buffer[self.i + 1]
-                    },
+                let segment = Segment::CubBezTo {
                     cp1: cubbez.cp1,
                     cp2: cubbez.cp2,
                     end: Element {
                         pos: cubbez.end,
                         ..self.buffer[self.i + 2]
                     },
-                });
+                };
 
                 self.i += 1;
 
                 Some(vec![segment])
             } else {
-                let segment = Shape::Segment(Segment::Line {
-                    start: self.buffer[self.i + 1],
+                let segment = Segment::LineTo {
                     end: self.buffer[self.i + 2],
-                });
+                };
 
                 self.i += 1;
 
                 Some(vec![segment])
             }
-        } else if buffer_last_pos > self.i + 2 {
-            let segment = Shape::Segment(Segment::Line {
-                start: self.buffer[self.i + 1],
-                end: self.buffer[self.i + 2],
-            });
-
-            self.i += 2;
-
-            Some(vec![segment])
         } else if buffer_last_pos > self.i + 1 {
-            let segment = Shape::Segment(Segment::Line {
-                start: self.buffer[self.i],
+            let segment = Segment::LineTo {
                 end: self.buffer[self.i + 1],
-            });
+            };
 
             self.i += 2;
 
             Some(vec![segment])
         } else if buffer_last_pos > self.i {
-            let segment = Shape::Segment(Segment::Dot {
-                element: self.buffer[self.i],
-            });
+            let segment = Segment::LineTo {
+                end: self.buffer[self.i],
+            };
 
             self.i += 1;
 

--- a/rnote-compose/src/builders/penpathcurvedbuilder.rs
+++ b/rnote-compose/src/builders/penpathcurvedbuilder.rs
@@ -116,7 +116,7 @@ impl PenPathBuilderBehaviour for PenPathCurvedBuilder {
 
         let pen_path = match &self.state {
             PenPathCurvedBuilderState::Start => {
-                PenPath::try_from_elements(self.buffer[self.i..].into_iter().copied())
+                PenPath::try_from_elements(self.buffer[self.i..].iter().copied())
             }
             // Skipping the first buffer element as that is the not drained by the segment builder and is the prev element in the "During" state
             PenPathCurvedBuilderState::During => {
@@ -134,7 +134,7 @@ impl PenPathBuilderBehaviour for PenPathCurvedBuilder {
 
 impl PenPathCurvedBuilder {
     fn try_build_segments_start(&mut self) -> Option<Vec<Segment>> {
-        if self.buffer.len().saturating_sub(1) >= self.i + 1 {
+        if self.buffer.len().saturating_sub(1) > self.i {
             let segment = Segment::LineTo {
                 end: self.buffer[self.i],
             };

--- a/rnote-compose/src/builders/penpathsimplebuilder.rs
+++ b/rnote-compose/src/builders/penpathsimplebuilder.rs
@@ -50,9 +50,10 @@ impl PenPathBuilderBehaviour for PenPathSimpleBuilder {
             }
             PenEvent::Up { element, .. } => {
                 self.buffer.push_back(element);
-                let segments = self.build_segments();
 
+                let segments = self.build_segments();
                 self.reset();
+
                 PenPathBuilderProgress::Finished(segments)
             }
             PenEvent::Proximity { .. } | PenEvent::KeyPressed { .. } | PenEvent::Text { .. } => {

--- a/rnote-compose/src/builders/penpathsimplebuilder.rs
+++ b/rnote-compose/src/builders/penpathsimplebuilder.rs
@@ -1,4 +1,4 @@
-use p2d::bounding_volume::{BoundingVolume, AABB};
+use p2d::bounding_volume::AABB;
 use piet::RenderContext;
 use std::collections::VecDeque;
 use std::time::Instant;
@@ -6,10 +6,12 @@ use std::time::Instant;
 use crate::penhelpers::PenEvent;
 use crate::penpath::{Element, Segment};
 use crate::style::Composer;
-use crate::{PenPath, Shape, Style};
+use crate::{PenPath, Style};
 
-use super::shapebuilderbehaviour::{BuilderProgress, ShapeBuilderCreator};
-use super::{Constraints, ShapeBuilderBehaviour};
+use super::penpathbuilderbehaviour::{
+    PenPathBuilderBehaviour, PenPathBuilderCreator, PenPathBuilderProgress,
+};
+use super::Constraints;
 
 #[derive(Debug, Clone)]
 /// The simple pen path builder
@@ -18,22 +20,21 @@ pub struct PenPathSimpleBuilder {
     pub buffer: VecDeque<Element>,
 }
 
-impl ShapeBuilderCreator for PenPathSimpleBuilder {
+impl PenPathBuilderCreator for PenPathSimpleBuilder {
     fn start(element: Element, _now: Instant) -> Self {
-        let mut buffer = VecDeque::new();
-        buffer.push_back(element);
+        let buffer = VecDeque::from_iter([element]);
 
         Self { buffer }
     }
 }
 
-impl ShapeBuilderBehaviour for PenPathSimpleBuilder {
+impl PenPathBuilderBehaviour for PenPathSimpleBuilder {
     fn handle_event(
         &mut self,
         event: PenEvent,
         _now: Instant,
         _constraints: Constraints,
-    ) -> BuilderProgress {
+    ) -> PenPathBuilderProgress {
         /*         log::debug!(
             "event: {:?}; buffer.len(): {}, state: {:?}",
             event,
@@ -45,85 +46,48 @@ impl ShapeBuilderBehaviour for PenPathSimpleBuilder {
             PenEvent::Down { element, .. } => {
                 self.buffer.push_back(element);
 
-                match self.try_build_segments() {
-                    Some(shapes) => BuilderProgress::EmitContinue(shapes),
-                    None => BuilderProgress::InProgress,
-                }
+                PenPathBuilderProgress::EmitContinue(self.build_segments())
             }
             PenEvent::Up { element, .. } => {
                 self.buffer.push_back(element);
-
-                let segment = self.try_build_segments().unwrap_or_default();
+                let segments = self.build_segments();
 
                 self.reset();
-
-                BuilderProgress::Finished(segment)
+                PenPathBuilderProgress::Finished(segments)
             }
             PenEvent::Proximity { .. } | PenEvent::KeyPressed { .. } | PenEvent::Text { .. } => {
-                BuilderProgress::InProgress
+                PenPathBuilderProgress::InProgress
             }
             PenEvent::Cancel => {
                 self.reset();
-
-                BuilderProgress::Finished(vec![])
+                PenPathBuilderProgress::Finished(vec![])
             }
         }
     }
 
     fn bounds(&self, style: &Style, _zoom: f64) -> Option<AABB> {
-        let penpath = self
-            .buffer
-            .iter()
-            .zip(self.buffer.iter().skip(1))
-            .map(|(start, end)| Segment::Line {
-                start: *start,
-                end: *end,
-            })
-            .collect::<PenPath>();
+        let pen_path = PenPath::try_from_elements(self.buffer.iter().copied())?;
 
-        if penpath.is_empty() {
-            return None;
-        }
-
-        Some(penpath.iter().fold(AABB::new_invalid(), |acc, x| {
-            acc.merged(&x.composed_bounds(style))
-        }))
+        Some(pen_path.composed_bounds(style))
     }
 
     fn draw_styled(&self, cx: &mut piet_cairo::CairoRenderContext, style: &Style, _zoom: f64) {
         cx.save().unwrap();
-        let penpath = self
-            .buffer
-            .iter()
-            .zip(self.buffer.iter().skip(1))
-            .map(|(start, end)| Segment::Line {
-                start: *start,
-                end: *end,
-            })
-            .collect::<PenPath>();
 
-        penpath.draw_composed(cx, style);
+        if let Some(pen_path) = PenPath::try_from_elements(self.buffer.iter().copied()) {
+            pen_path.draw_composed(cx, style);
+        }
+
         cx.restore().unwrap();
     }
 }
 
 impl PenPathSimpleBuilder {
-    fn try_build_segments(&mut self) -> Option<Vec<Shape>> {
-        if self.buffer.len() < 2 {
-            return None;
-        }
-        let mut segments = vec![];
-
-        while self.buffer.len() > 2 {
-            segments.push(Shape::Segment(Segment::Line {
-                start: self.buffer[0],
-                end: self.buffer[1],
-            }));
-
-            self.buffer.pop_front();
-        }
-
-        Some(segments)
+    fn build_segments(&mut self) -> Vec<Segment> {
+        self.buffer
+            .drain(..)
+            .map(|el| Segment::LineTo { end: el })
+            .collect()
     }
 
     fn reset(&mut self) {

--- a/rnote-compose/src/builders/quadbezbuilder.rs
+++ b/rnote-compose/src/builders/quadbezbuilder.rs
@@ -9,7 +9,7 @@ use crate::shapes::QuadraticBezier;
 use crate::style::{drawhelpers, Composer};
 use crate::{Shape, Style};
 
-use super::shapebuilderbehaviour::{BuilderProgress, ShapeBuilderCreator};
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
 use super::{ConstraintRatio, Constraints, ShapeBuilderBehaviour};
 
 #[derive(Debug, Clone)]
@@ -56,7 +56,7 @@ impl ShapeBuilderBehaviour for QuadBezBuilder {
         event: PenEvent,
         _now: Instant,
         mut constraints: Constraints,
-    ) -> BuilderProgress {
+    ) -> ShapeBuilderProgress {
         //log::debug!("state: {:?}, event: {:?}", &self.state, &event);
 
         // we always want to allow horizontal and vertical constraints while building a quadbez
@@ -88,16 +88,18 @@ impl ShapeBuilderBehaviour for QuadBezBuilder {
                 *end = constraints.constrain(element.pos - *cp) + *cp;
             }
             (QuadBezBuilderState::End { start, cp, end }, PenEvent::Up { .. }) => {
-                return BuilderProgress::Finished(vec![Shape::QuadraticBezier(QuadraticBezier {
-                    start: *start,
-                    cp: *cp,
-                    end: *end,
-                })]);
+                return ShapeBuilderProgress::Finished(vec![Shape::QuadraticBezier(
+                    QuadraticBezier {
+                        start: *start,
+                        cp: *cp,
+                        end: *end,
+                    },
+                )]);
             }
             (QuadBezBuilderState::End { .. }, ..) => {}
         }
 
-        BuilderProgress::InProgress
+        ShapeBuilderProgress::InProgress
     }
 
     fn bounds(&self, style: &Style, zoom: f64) -> Option<AABB> {

--- a/rnote-compose/src/builders/quadrantcoordsystem2dbuilder.rs
+++ b/rnote-compose/src/builders/quadrantcoordsystem2dbuilder.rs
@@ -9,7 +9,7 @@ use crate::shapes::Line;
 use crate::style::{drawhelpers, Composer};
 use crate::{Shape, Style};
 
-use super::shapebuilderbehaviour::{BuilderProgress, ShapeBuilderCreator};
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
 use super::{Constraints, ShapeBuilderBehaviour};
 
 /// 2D single quadrant coordinate system builder
@@ -36,13 +36,13 @@ impl ShapeBuilderBehaviour for QuadrantCoordSystem2DBuilder {
         event: PenEvent,
         _now: Instant,
         constraints: Constraints,
-    ) -> BuilderProgress {
+    ) -> ShapeBuilderProgress {
         match event {
             PenEvent::Down { element, .. } => {
                 self.tip_x = constraints.constrain(element.pos - self.tip_y) + self.tip_y;
             }
             PenEvent::Up { .. } => {
-                return BuilderProgress::Finished(
+                return ShapeBuilderProgress::Finished(
                     self.state_as_lines()
                         .iter()
                         .map(|&line| Shape::Line(line))
@@ -52,7 +52,7 @@ impl ShapeBuilderBehaviour for QuadrantCoordSystem2DBuilder {
             _ => {}
         }
 
-        BuilderProgress::InProgress
+        ShapeBuilderProgress::InProgress
     }
 
     fn bounds(&self, style: &Style, zoom: f64) -> Option<AABB> {

--- a/rnote-compose/src/builders/rectanglebuilder.rs
+++ b/rnote-compose/src/builders/rectanglebuilder.rs
@@ -10,7 +10,7 @@ use crate::shapes::Rectangle;
 use crate::style::{drawhelpers, Composer};
 use crate::{Shape, Style, Transform};
 
-use super::shapebuilderbehaviour::{BuilderProgress, ShapeBuilderCreator};
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
 use super::{Constraints, ShapeBuilderBehaviour};
 
 /// rect builder
@@ -37,18 +37,20 @@ impl ShapeBuilderBehaviour for RectangleBuilder {
         event: PenEvent,
         _now: Instant,
         constraints: Constraints,
-    ) -> BuilderProgress {
+    ) -> ShapeBuilderProgress {
         match event {
             PenEvent::Down { element, .. } => {
                 self.current = constraints.constrain(element.pos - self.start) + self.start;
             }
             PenEvent::Up { .. } => {
-                return BuilderProgress::Finished(vec![Shape::Rectangle(self.state_as_rect())]);
+                return ShapeBuilderProgress::Finished(vec![Shape::Rectangle(
+                    self.state_as_rect(),
+                )]);
             }
             _ => {}
         }
 
-        BuilderProgress::InProgress
+        ShapeBuilderProgress::InProgress
     }
 
     fn bounds(&self, style: &Style, zoom: f64) -> Option<AABB> {

--- a/rnote-compose/src/meson.build
+++ b/rnote-compose/src/meson.build
@@ -13,6 +13,7 @@ rnote_compose_sources = files(
     'builders/coordsystem3dbuilder.rs',
     'builders/quadrantcoordsystem2dbuilder.rs',
     'builders/shapebuilderbehaviour.rs',
+    'builders/penpathbuilderbehaviour.rs',
     'penpath/element.rs',
     'penpath/mod.rs',
     'penpath/segment.rs',

--- a/rnote-compose/src/penpath/mod.rs
+++ b/rnote-compose/src/penpath/mod.rs
@@ -3,63 +3,147 @@ mod segment;
 
 // Re exports
 pub use element::Element;
+use kurbo::Shape;
 pub use segment::Segment;
 
 use std::collections::VecDeque;
-use std::ops::{Deref, DerefMut};
 
 use p2d::bounding_volume::{BoundingVolume, AABB};
 use serde::{Deserialize, Serialize};
 
-use crate::shapes::ShapeBehaviour;
+use crate::helpers::KurboHelpers;
+use crate::shapes::{CubicBezier, Line, QuadraticBezier, ShapeBehaviour};
 use crate::transform::TransformBehaviour;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename = "pen_path")]
 /// a pen path, consisting of segments of pen input elements
-pub struct PenPath(VecDeque<Segment>);
-
-impl Deref for PenPath {
-    type Target = VecDeque<Segment>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for PenPath {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
+pub struct PenPath {
+    /// The path start
+    #[serde(rename = "start")]
+    pub start: Element,
+    /// The segments
+    #[serde(rename = "segments")]
+    pub segments: VecDeque<Segment>,
 }
 
 impl ShapeBehaviour for PenPath {
     fn bounds(&self) -> AABB {
-        self.iter()
-            .map(|segment| segment.bounds())
-            .fold(AABB::new_invalid(), |prev, next| prev.merged(&next))
+        let mut bounds = AABB::from_points(&[na::Point2::from(self.start.pos)]);
+
+        let mut prev = self.start;
+        for seg in self.segments.iter() {
+            match seg {
+                Segment::LineTo { end } => {
+                    bounds.take_point(na::Point2::from(end.pos));
+
+                    prev = *end;
+                }
+                Segment::QuadBezTo { cp, end } => {
+                    let quadbez = QuadraticBezier {
+                        start: prev.pos,
+                        cp: *cp,
+                        end: end.pos,
+                    };
+
+                    bounds.merge(&quadbez.to_kurbo().bounding_box().bounds_as_p2d_aabb());
+                    prev = *end;
+                }
+                Segment::CubBezTo { cp1, cp2, end } => {
+                    let cubbez = CubicBezier {
+                        start: prev.pos,
+                        cp1: *cp1,
+                        cp2: *cp2,
+                        end: end.pos,
+                    };
+
+                    bounds.merge(&cubbez.to_kurbo().bounding_box().bounds_as_p2d_aabb());
+                    prev = *end;
+                }
+            }
+        }
+
+        bounds
     }
 
     fn hitboxes(&self) -> Vec<AABB> {
-        self.iter().flat_map(|segment| segment.hitboxes()).collect()
+        let mut hitboxes = Vec::with_capacity(self.segments.len());
+
+        let mut prev = self.start;
+        for seg in self.segments.iter() {
+            match seg {
+                Segment::LineTo { end } => {
+                    let n_splits = hitbox_elems_for_segment_len((end.pos - prev.pos).magnitude());
+                    let line = Line {
+                        start: prev.pos,
+                        end: end.pos,
+                    };
+
+                    hitboxes.extend(line.split(n_splits).into_iter().map(|line| line.bounds()));
+                    prev = *end;
+                }
+                Segment::QuadBezTo { cp, end } => {
+                    let quadbez = QuadraticBezier {
+                        start: prev.pos,
+                        cp: *cp,
+                        end: end.pos,
+                    };
+
+                    // TODO: basing this off of the actual curve len
+                    let n_splits = hitbox_elems_for_segment_len(quadbez.to_kurbo().perimeter(0.1));
+
+                    hitboxes.extend(
+                        quadbez
+                            .approx_with_lines(n_splits)
+                            .into_iter()
+                            .map(|line| line.bounds()),
+                    );
+                    prev = *end;
+                }
+                Segment::CubBezTo { cp1, cp2, end } => {
+                    let cubbez = CubicBezier {
+                        start: prev.pos,
+                        cp1: *cp1,
+                        cp2: *cp2,
+                        end: end.pos,
+                    };
+
+                    // TODO: basing this off of the actual curve len
+                    let n_splits = hitbox_elems_for_segment_len(cubbez.to_kurbo().perimeter(0.1));
+
+                    hitboxes.extend(
+                        cubbez
+                            .approx_with_lines(n_splits)
+                            .into_iter()
+                            .map(|line| line.bounds()),
+                    );
+                    prev = *end;
+                }
+            }
+        }
+
+        hitboxes
     }
 }
 
 impl TransformBehaviour for PenPath {
     fn translate(&mut self, offset: nalgebra::Vector2<f64>) {
-        self.iter_mut().for_each(|segment| {
+        self.start.translate(offset);
+        self.segments.iter_mut().for_each(|segment| {
             segment.translate(offset);
         });
     }
 
     fn rotate(&mut self, angle: f64, center: nalgebra::Point2<f64>) {
-        self.iter_mut().for_each(|segment| {
+        self.start.rotate(angle, center);
+        self.segments.iter_mut().for_each(|segment| {
             segment.rotate(angle, center);
         });
     }
 
     fn scale(&mut self, scale: nalgebra::Vector2<f64>) {
-        self.iter_mut().for_each(|segment| {
+        self.start.scale(scale);
+        self.segments.iter_mut().for_each(|segment| {
             segment.scale(scale);
         });
     }
@@ -67,39 +151,88 @@ impl TransformBehaviour for PenPath {
 
 impl PenPath {
     /// A new pen path with a first dot segment
-    pub fn new_w_dot(element: Element) -> Self {
-        Self::new_w_segment(Segment::Dot { element })
+    pub fn new(start: Element) -> Self {
+        Self {
+            start,
+            segments: VecDeque::default(),
+        }
     }
 
-    /// A new pen path with a first segment
-    pub fn new_w_segment(segment: Segment) -> Self {
-        let mut segment_vec = VecDeque::with_capacity(1);
-        segment_vec.push_back(segment);
-
-        Self(segment_vec)
+    /// A new pen path with segments
+    pub fn new_w_segments(start: Element, segments: impl IntoIterator<Item = Segment>) -> Self {
+        Self {
+            start,
+            segments: segments.into_iter().collect(),
+        }
     }
 
     /// extracts the elements from the path. the path shape will be lost, as only the actual input elements are returned.
     pub fn into_elements(self) -> Vec<Element> {
-        self.0
-            .into_iter()
-            .flat_map(|segment| match segment {
-                Segment::Dot { element: pos } => vec![pos],
-                Segment::Line { start, end } => vec![start, end],
-                Segment::QuadBez { start, cp: _, end } => vec![start, end],
-                Segment::CubBez {
-                    start,
-                    cp1: _,
-                    cp2: _,
-                    end,
-                } => vec![start, end],
-            })
-            .collect()
+        let mut elements = vec![self.start];
+
+        elements.extend(self.segments.into_iter().map(|seg| match seg {
+            Segment::LineTo { end } => end,
+            Segment::QuadBezTo { end, .. } => end,
+            Segment::CubBezTo { end, .. } => end,
+        }));
+
+        elements
+    }
+
+    /// Try to create a pen path from the elements. the first element will be the start
+    pub fn try_from_elements(elements_iter: impl IntoIterator<Item = Element>) -> Option<Self> {
+        let mut elements_iter = elements_iter.into_iter();
+
+        let start = elements_iter.next()?;
+        let segments = elements_iter
+            .map(|el| Segment::LineTo { end: el })
+            .collect::<VecDeque<Segment>>();
+
+        Some(Self { start, segments })
+    }
+
+    /// Push front segment
+    pub fn push_front_segment(&mut self, segment: Segment) {
+        self.segments.push_front(segment);
+    }
+
+    /// Push back segment
+    pub fn push_back_segment(&mut self, segment: Segment) {
+        self.segments.push_back(segment);
+    }
+
+    /// Pop front segment
+    pub fn pop_front_segment(&mut self) -> Option<Segment> {
+        self.segments.pop_front()
+    }
+
+    /// Pop back segment
+    pub fn pop_back_segment(&mut self) -> Option<Segment> {
+        self.segments.pop_back()
+    }
+
+    /// Extends the pen path with the segments of the other.
+    pub fn extend_w_other(&mut self, other: Self) {
+        self.segments.extend(other.segments);
     }
 }
 
-impl std::iter::FromIterator<Segment> for PenPath {
-    fn from_iter<T: IntoIterator<Item = Segment>>(iter: T) -> Self {
-        Self(VecDeque::from_iter(iter))
+impl Extend<Segment> for PenPath {
+    fn extend<T: IntoIterator<Item = Segment>>(&mut self, iter: T) {
+        self.segments.extend(iter);
+    }
+}
+
+/// Calculates the number hitbox elems for the given length capped with a maximum no of hitbox elements
+fn hitbox_elems_for_segment_len(len: f64) -> i32 {
+    // Maximum hitbox diagonal ( below the threshold )
+    const MAX_HITBOX_DIAGONAL: f64 = 15.0;
+    const MAX_ELEMS: i32 = 6;
+
+    if len < MAX_HITBOX_DIAGONAL * f64::from(MAX_ELEMS) {
+        ((len / MAX_HITBOX_DIAGONAL).ceil() as i32).max(1)
+    } else {
+        // capping the no of elements for bigger len's, avoiding huge amounts of hitboxes for large strokes that are drawn when zoomed out
+        MAX_ELEMS
     }
 }

--- a/rnote-compose/src/penpath/mod.rs
+++ b/rnote-compose/src/penpath/mod.rs
@@ -142,13 +142,13 @@ impl PenPath {
         self.segments.extend(other.segments);
     }
 
-    /// Checks whether a bounds collides with the path. If it does, it returns the colliding segment
+    /// Checks whether a bounds collides with the path. If it does, it returns the index of the colliding segment
     pub fn hittest(&self, hit: &AABB) -> Option<usize> {
         for (i, seg_hitboxes) in self.hitboxes_priv() {
-            if seg_hitboxes.into_iter().any(|hitbox| {
-                // The hitboxes of the individual segments need to be loosened with the style stroke width
-                hitbox.intersects(&hit)
-            }) {
+            if seg_hitboxes
+                .into_iter()
+                .any(|hitbox| hitbox.intersects(hit))
+            {
                 return Some(i);
             }
         }

--- a/rnote-compose/src/penpath/segment.rs
+++ b/rnote-compose/src/penpath/segment.rs
@@ -1,40 +1,22 @@
-use crate::helpers::{AABBHelpers, KurboHelpers};
-use crate::shapes::{CubicBezier, Line, QuadraticBezier, ShapeBehaviour};
-use crate::transform::TransformBehaviour;
-
-use kurbo::Shape;
-use p2d::bounding_volume::{BoundingVolume, AABB};
 use serde::{Deserialize, Serialize};
 
 use super::Element;
+use crate::transform::TransformBehaviour;
 
-/// A single segment (usually of a path), containing elements to be able to being drawn with variable width
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// A single segment (usually of a path)
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename = "segment")]
 pub enum Segment {
-    #[serde(rename = "dot")]
-    /// A dot segment.
-    Dot {
-        #[serde(rename = "element")]
-        /// The element of the dot
-        element: Element,
-    },
-    #[serde(rename = "line")]
-    /// A line segment
-    Line {
-        #[serde(rename = "start")]
-        /// The line start
-        start: Element,
+    #[serde(rename = "lineto", alias = "line")]
+    /// A line to segment
+    LineTo {
         #[serde(rename = "end")]
         /// The line end
         end: Element,
     },
-    #[serde(rename = "quadbez")]
-    /// A quadratic bezier segment
-    QuadBez {
-        #[serde(rename = "start")]
-        /// The quadratic curve start
-        start: Element,
+    #[serde(rename = "quadbezto", alias = "quadbez")]
+    /// A quadratic bezier to segment
+    QuadBezTo {
         #[serde(rename = "cp")]
         /// The quadratic curve control point
         cp: na::Vector2<f64>,
@@ -42,12 +24,9 @@ pub enum Segment {
         /// The quadratic curve end
         end: Element,
     },
-    #[serde(rename = "cubbez")]
-    /// A cubic bezier segment.
-    CubBez {
-        #[serde(rename = "start")]
-        /// The cubic curve start
-        start: Element,
+    #[serde(rename = "cubbezto", alias = "cubbez")]
+    /// A cubic bezier to segment.
+    CubBezTo {
         #[serde(rename = "cp1")]
         /// The cubic curve first control point
         cp1: na::Vector2<f64>,
@@ -60,126 +39,17 @@ pub enum Segment {
     },
 }
 
-impl ShapeBehaviour for Segment {
-    fn bounds(&self) -> p2d::bounding_volume::AABB {
-        match self {
-            Self::Dot { element } => {
-                AABB::new_positive(na::Point2::from(element.pos), na::Point2::from(element.pos))
-                    .loosened(0.5)
-            }
-            Self::Line { start, end } => {
-                AABB::new_positive(na::Point2::from(start.pos), na::Point2::from(end.pos))
-            }
-            Self::QuadBez { start, cp, end } => {
-                let quadbez = QuadraticBezier {
-                    start: start.pos,
-                    cp: *cp,
-                    end: end.pos,
-                };
-
-                quadbez.to_kurbo().bounding_box().bounds_as_p2d_aabb()
-            }
-            Self::CubBez {
-                start,
-                cp1,
-                cp2,
-                end,
-            } => {
-                let cubbez = CubicBezier {
-                    start: start.pos,
-                    cp1: *cp1,
-                    cp2: *cp2,
-                    end: end.pos,
-                };
-
-                cubbez.to_kurbo().bounding_box().bounds_as_p2d_aabb()
-            }
-        }
-    }
-
-    fn hitboxes(&self) -> Vec<AABB> {
-        match self {
-            Segment::Dot { element } => vec![AABB::from_half_extents(
-                na::Point2::from(element.pos),
-                na::Vector2::repeat(0.5),
-            )],
-            Segment::Line { start, end } => {
-                let n_splits = hitbox_elems_for_segment_len((end.pos - start.pos).magnitude());
-
-                let line = Line {
-                    start: start.pos,
-                    end: end.pos,
-                };
-
-                line.split(n_splits)
-                    .into_iter()
-                    .map(|line| line.bounds())
-                    .collect()
-            }
-            Segment::QuadBez { start, cp, end } => {
-                let quadbez = QuadraticBezier {
-                    start: start.pos,
-                    cp: *cp,
-                    end: end.pos,
-                };
-
-                // TODO: basing this off of the actual curve len
-                let n_splits = hitbox_elems_for_segment_len(quadbez.to_kurbo().perimeter(0.1));
-
-                quadbez
-                    .approx_with_lines(n_splits)
-                    .into_iter()
-                    .map(|line| line.bounds())
-                    .collect()
-            }
-            Segment::CubBez {
-                start,
-                cp1,
-                cp2,
-                end,
-            } => {
-                let cubbez = CubicBezier {
-                    start: start.pos,
-                    cp1: *cp1,
-                    cp2: *cp2,
-                    end: end.pos,
-                };
-
-                // TODO: basing this off of the actual curve len
-                let n_splits = hitbox_elems_for_segment_len(cubbez.to_kurbo().perimeter(0.1));
-
-                cubbez
-                    .approx_with_lines(n_splits)
-                    .into_iter()
-                    .map(|line| line.bounds())
-                    .collect()
-            }
-        }
-    }
-}
-
 impl TransformBehaviour for Segment {
     fn translate(&mut self, offset: nalgebra::Vector2<f64>) {
         match self {
-            Self::Dot { element } => {
-                element.pos += offset;
-            }
-            Self::Line { start, end } => {
-                start.pos += offset;
+            Self::LineTo { end } => {
                 end.pos += offset;
             }
-            Self::QuadBez { start, cp, end } => {
-                start.pos += offset;
+            Self::QuadBezTo { cp, end } => {
                 *cp += offset;
                 end.pos += offset;
             }
-            Self::CubBez {
-                start,
-                cp1,
-                cp2,
-                end,
-            } => {
-                start.pos += offset;
+            Self::CubBezTo { cp1, cp2, end } => {
                 *cp1 += offset;
                 *cp2 += offset;
                 end.pos += offset;
@@ -192,25 +62,14 @@ impl TransformBehaviour for Segment {
         isometry.append_rotation_wrt_point_mut(&na::UnitComplex::new(angle), &center);
 
         match self {
-            Self::Dot { element } => {
-                element.pos = (isometry * na::Point2::from(element.pos)).coords;
-            }
-            Self::Line { start, end } => {
-                start.pos = (isometry * na::Point2::from(start.pos)).coords;
+            Self::LineTo { end } => {
                 end.pos = (isometry * na::Point2::from(end.pos)).coords;
             }
-            Self::QuadBez { start, cp, end } => {
-                start.pos = (isometry * na::Point2::from(start.pos)).coords;
+            Self::QuadBezTo { cp, end } => {
                 *cp = (isometry * na::Point2::from(*cp)).coords;
                 end.pos = (isometry * na::Point2::from(end.pos)).coords;
             }
-            Self::CubBez {
-                start,
-                cp1,
-                cp2,
-                end,
-            } => {
-                start.pos = (isometry * na::Point2::from(start.pos)).coords;
+            Self::CubBezTo { cp1, cp2, end } => {
                 *cp1 = (isometry * na::Point2::from(*cp1)).coords;
                 *cp2 = (isometry * na::Point2::from(*cp2)).coords;
                 end.pos = (isometry * na::Point2::from(end.pos)).coords;
@@ -220,25 +79,14 @@ impl TransformBehaviour for Segment {
 
     fn scale(&mut self, scale: nalgebra::Vector2<f64>) {
         match self {
-            Self::Dot { element } => {
-                element.pos = element.pos.component_mul(&scale);
-            }
-            Self::Line { start, end } => {
-                start.pos = start.pos.component_mul(&scale);
+            Self::LineTo { end } => {
                 end.pos = end.pos.component_mul(&scale);
             }
-            Self::QuadBez { start, cp, end } => {
-                start.pos = start.pos.component_mul(&scale);
+            Self::QuadBezTo { cp, end } => {
                 *cp = cp.component_mul(&scale);
                 end.pos = end.pos.component_mul(&scale);
             }
-            Self::CubBez {
-                start,
-                cp1,
-                cp2,
-                end,
-            } => {
-                start.pos = start.pos.component_mul(&scale);
+            Self::CubBezTo { cp1, cp2, end } => {
                 *cp1 = cp1.component_mul(&scale);
                 *cp2 = cp2.component_mul(&scale);
                 end.pos = end.pos.component_mul(&scale);
@@ -248,37 +96,12 @@ impl TransformBehaviour for Segment {
 }
 
 impl Segment {
-    /// All segment choices have a start
-    pub fn start(&self) -> Element {
-        match self {
-            Segment::Dot { element } => *element,
-            Segment::Line { start, .. } => *start,
-            Segment::QuadBez { start, .. } => *start,
-            Segment::CubBez { start, .. } => *start,
-        }
-    }
-
-    /// All segment choices have an end
+    /// All segments have an end
     pub fn end(&self) -> Element {
         match self {
-            Segment::Dot { element } => *element,
-            Segment::Line { end, .. } => *end,
-            Segment::QuadBez { end, .. } => *end,
-            Segment::CubBez { end, .. } => *end,
+            Segment::LineTo { end, .. } => *end,
+            Segment::QuadBezTo { end, .. } => *end,
+            Segment::CubBezTo { end, .. } => *end,
         }
-    }
-}
-
-/// Calculates the number hitbox elems for the given length capped with a maximum no of hitbox elements
-fn hitbox_elems_for_segment_len(len: f64) -> i32 {
-    // Maximum hitbox diagonal ( below the threshold )
-    const MAX_HITBOX_DIAGONAL: f64 = 15.0;
-    const MAX_ELEMS: i32 = 6;
-
-    if len < MAX_HITBOX_DIAGONAL * f64::from(MAX_ELEMS) {
-        ((len / MAX_HITBOX_DIAGONAL).ceil() as i32).max(1)
-    } else {
-        // capping the no of elements for bigger len's, avoiding huge amounts of hitboxes for large strokes that are drawn when zoomed out
-        MAX_ELEMS
     }
 }

--- a/rnote-compose/src/shapes/cubbez.rs
+++ b/rnote-compose/src/shapes/cubbez.rs
@@ -96,7 +96,7 @@ impl CubicBezier {
             end,
         };
 
-        // returnsing None when the cubbez does not have a length to prevent NaN when calculating the normals for segments with variable width
+        // returning None when the cubbez does not have a length to prevent NaN when calculating the normals for segments with variable width
         if (cubbez.end - cubbez.start).magnitude() == 0.0 {
             return None;
         }

--- a/rnote-compose/src/shapes/cubbez.rs
+++ b/rnote-compose/src/shapes/cubbez.rs
@@ -172,7 +172,7 @@ impl CubicBezier {
 }
 
 /// Calculates a point on a cubic curve given t ranging [0.0, 1.0]
-fn cubbez_calc(
+pub fn cubbez_calc(
     p0: na::Vector2<f64>,
     p1: na::Vector2<f64>,
     p2: na::Vector2<f64>,

--- a/rnote-compose/src/shapes/mod.rs
+++ b/rnote-compose/src/shapes/mod.rs
@@ -1,7 +1,9 @@
-mod cubbez;
+/// cubic bezier curves
+pub mod cubbez;
 mod ellipse;
 mod line;
-mod quadbez;
+/// quadratic bezier curves
+pub mod quadbez;
 mod rectangle;
 mod shape;
 mod shapebehaviour;

--- a/rnote-compose/src/shapes/quadbez.rs
+++ b/rnote-compose/src/shapes/quadbez.rs
@@ -155,7 +155,7 @@ fn quadbez_coeff_c(p0: na::Vector2<f64>) -> na::Vector2<f64> {
 
 /// calculating the value of a bezier curve with its support points, for t: between 0.0 and 1.0
 #[allow(dead_code)]
-fn quadbez_calc(
+pub fn quadbez_calc(
     p0: na::Vector2<f64>,
     p1: na::Vector2<f64>,
     p2: na::Vector2<f64>,
@@ -180,7 +180,7 @@ fn quadbez_derive_coeff_b(p0: na::Vector2<f64>, p1: na::Vector2<f64>) -> na::Vec
 
 #[allow(dead_code)]
 /// calculating the derivative of the bezier curve for t: between 0.0 and 1.0
-fn quadbez_derive_calc(
+pub fn quadbez_derive_calc(
     p0: na::Vector2<f64>,
     p1: na::Vector2<f64>,
     p2: na::Vector2<f64>,

--- a/rnote-compose/src/shapes/shape.rs
+++ b/rnote-compose/src/shapes/shape.rs
@@ -2,7 +2,6 @@ use p2d::bounding_volume::AABB;
 use serde::{Deserialize, Serialize};
 
 use super::{CubicBezier, Ellipse, Line, QuadraticBezier, Rectangle, ShapeBehaviour};
-use crate::penpath::Segment;
 use crate::transform::TransformBehaviour;
 
 // Container type to store shapes
@@ -25,9 +24,6 @@ pub enum Shape {
     #[serde(rename = "cubbez")]
     /// A cubic bezier curve shape
     CubicBezier(CubicBezier),
-    #[serde(rename = "segment")]
-    /// A segment
-    Segment(Segment),
 }
 
 impl Default for Shape {
@@ -54,9 +50,6 @@ impl TransformBehaviour for Shape {
             Self::CubicBezier(cubbez) => {
                 cubbez.translate(offset);
             }
-            Self::Segment(segment) => {
-                segment.translate(offset);
-            }
         }
     }
 
@@ -76,9 +69,6 @@ impl TransformBehaviour for Shape {
             }
             Self::CubicBezier(cubbez) => {
                 cubbez.rotate(angle, center);
-            }
-            Self::Segment(segment) => {
-                segment.rotate(angle, center);
             }
         }
     }
@@ -100,9 +90,6 @@ impl TransformBehaviour for Shape {
             Self::CubicBezier(cubbez) => {
                 cubbez.scale(scale);
             }
-            Self::Segment(segment) => {
-                segment.scale(scale);
-            }
         }
     }
 }
@@ -115,7 +102,6 @@ impl ShapeBehaviour for Shape {
             Self::Ellipse(ellipse) => ellipse.bounds(),
             Self::QuadraticBezier(quadbez) => quadbez.bounds(),
             Self::CubicBezier(cubbez) => cubbez.bounds(),
-            Self::Segment(segment) => segment.bounds(),
         }
     }
     fn hitboxes(&self) -> Vec<AABB> {
@@ -125,7 +111,6 @@ impl ShapeBehaviour for Shape {
             Self::Ellipse(ellipse) => ellipse.hitboxes(),
             Self::QuadraticBezier(quadbez) => quadbez.hitboxes(),
             Self::CubicBezier(cubbez) => cubbez.hitboxes(),
-            Self::Segment(segment) => segment.hitboxes(),
         }
     }
 }

--- a/rnote-compose/src/style/mod.rs
+++ b/rnote-compose/src/style/mod.rs
@@ -14,7 +14,6 @@ use self::smooth::SmoothOptions;
 use self::textured::TexturedOptions;
 pub use composer::Composer;
 
-use crate::penpath::Segment;
 use crate::shapes::{CubicBezier, Ellipse, Line, QuadraticBezier, Rectangle};
 use crate::{PenPath, Shape};
 use serde::{Deserialize, Serialize};
@@ -141,24 +140,6 @@ impl Composer<Style> for CubicBezier {
     }
 }
 
-impl Composer<Style> for Segment {
-    fn composed_bounds(&self, options: &Style) -> p2d::bounding_volume::AABB {
-        match options {
-            Style::Smooth(options) => self.composed_bounds(options),
-            Style::Rough(_) => unimplemented!(),
-            Style::Textured(options) => self.composed_bounds(options),
-        }
-    }
-
-    fn draw_composed(&self, cx: &mut impl piet::RenderContext, options: &Style) {
-        match options {
-            Style::Smooth(options) => self.draw_composed(cx, options),
-            Style::Rough(_) => unimplemented!(),
-            Style::Textured(options) => self.draw_composed(cx, options),
-        }
-    }
-}
-
 impl Composer<Style> for PenPath {
     fn composed_bounds(&self, options: &Style) -> p2d::bounding_volume::AABB {
         match options {
@@ -185,7 +166,6 @@ impl Composer<Style> for Shape {
             Shape::Ellipse(ellipse) => ellipse.composed_bounds(options),
             Shape::QuadraticBezier(quadratic_bezier) => quadratic_bezier.composed_bounds(options),
             Shape::CubicBezier(cubic_bezier) => cubic_bezier.composed_bounds(options),
-            Shape::Segment(segment) => segment.composed_bounds(options),
         }
     }
 
@@ -196,7 +176,6 @@ impl Composer<Style> for Shape {
             Shape::Ellipse(ellipse) => ellipse.draw_composed(cx, options),
             Shape::QuadraticBezier(quadratic_bezier) => quadratic_bezier.draw_composed(cx, options),
             Shape::CubicBezier(cubic_bezier) => cubic_bezier.draw_composed(cx, options),
-            Shape::Segment(segment) => segment.draw_composed(cx, options),
         }
     }
 }

--- a/rnote-compose/src/style/mod.rs
+++ b/rnote-compose/src/style/mod.rs
@@ -12,6 +12,7 @@ pub mod textured;
 use self::rough::RoughOptions;
 use self::smooth::SmoothOptions;
 use self::textured::TexturedOptions;
+use anyhow::Context;
 pub use composer::Composer;
 
 use crate::shapes::{CubicBezier, Ellipse, Line, QuadraticBezier, Rectangle};
@@ -230,8 +231,7 @@ impl TryFrom<u32> for PressureCurve {
     type Error = anyhow::Error;
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
-        num_traits::FromPrimitive::from_u32(value).ok_or_else(|| {
-            anyhow::anyhow!("PressureCurve try_from::<u32>() for value {} failed", value)
-        })
+        num_traits::FromPrimitive::from_u32(value)
+            .with_context(|| format!("PressureCurve try_from::<u32>() for value {value} failed"))
     }
 }

--- a/rnote-compose/src/style/rough/mod.rs
+++ b/rnote-compose/src/style/rough/mod.rs
@@ -163,7 +163,6 @@ impl Composer<RoughOptions> for crate::Shape {
             crate::Shape::Ellipse(ellipse) => ellipse.composed_bounds(options),
             crate::Shape::QuadraticBezier(quadbez) => quadbez.composed_bounds(options),
             crate::Shape::CubicBezier(cubbez) => cubbez.composed_bounds(options),
-            crate::Shape::Segment(_) => unimplemented!(),
         }
     }
 
@@ -174,7 +173,6 @@ impl Composer<RoughOptions> for crate::Shape {
             crate::Shape::Ellipse(ellipse) => ellipse.draw_composed(cx, options),
             crate::Shape::QuadraticBezier(quadbez) => quadbez.draw_composed(cx, options),
             crate::Shape::CubicBezier(cubbez) => cubbez.draw_composed(cx, options),
-            crate::Shape::Segment(_) => unimplemented!(),
         }
     }
 }

--- a/rnote-compose/src/style/rough/roughoptions.rs
+++ b/rnote-compose/src/style/rough/roughoptions.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
 use crate::Color;
@@ -134,8 +135,7 @@ impl TryFrom<u32> for FillStyle {
     type Error = anyhow::Error;
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
-        num_traits::FromPrimitive::from_u32(value).ok_or_else(|| {
-            anyhow::anyhow!("FillStyle try_from::<u32>() for value {} failed", value)
-        })
+        num_traits::FromPrimitive::from_u32(value)
+            .with_context(|| format!("FillStyle try_from::<u32>() for value {value} failed"))
     }
 }

--- a/rnote-compose/src/style/smooth/mod.rs
+++ b/rnote-compose/src/style/smooth/mod.rs
@@ -17,67 +17,6 @@ use crate::PenPath;
 use kurbo::Shape;
 use p2d::bounding_volume::{BoundingVolume, AABB};
 
-// Composes a line with variable width. Must be drawn with only a fill
-fn compose_line_variable_width(
-    line: Line,
-    width_start: f64,
-    width_end: f64,
-    _options: &SmoothOptions,
-) -> kurbo::BezPath {
-    let start_offset_dist = width_start * 0.5;
-    let end_offset_dist = width_end * 0.5;
-
-    let direction_unit_norm = (line.end - line.start).orth_unit();
-    let end_arc_rotation = na::Vector2::y().angle_ahead(&(line.end - line.start));
-
-    let mut bez_path = kurbo::BezPath::new();
-
-    bez_path.extend(
-        kurbo::Arc {
-            center: line.start.to_kurbo_point(),
-            radii: kurbo::Vec2::new(start_offset_dist, start_offset_dist),
-            start_angle: 0.0,
-            sweep_angle: std::f64::consts::PI,
-            x_rotation: end_arc_rotation + std::f64::consts::PI,
-        }
-        .into_path(0.1)
-        .into_iter(),
-    );
-
-    bez_path.extend(
-        [
-            kurbo::PathEl::MoveTo(
-                (line.start + direction_unit_norm * start_offset_dist).to_kurbo_point(),
-            ),
-            kurbo::PathEl::LineTo(
-                (line.start - direction_unit_norm * start_offset_dist).to_kurbo_point(),
-            ),
-            kurbo::PathEl::LineTo(
-                (line.end - direction_unit_norm * end_offset_dist).to_kurbo_point(),
-            ),
-            kurbo::PathEl::LineTo(
-                (line.end + direction_unit_norm * end_offset_dist).to_kurbo_point(),
-            ),
-            kurbo::PathEl::ClosePath,
-        ]
-        .into_iter(),
-    );
-
-    bez_path.extend(
-        kurbo::Arc {
-            center: line.end.to_kurbo_point(),
-            radii: kurbo::Vec2::new(end_offset_dist, end_offset_dist),
-            start_angle: 0.0,
-            sweep_angle: std::f64::consts::PI,
-            x_rotation: end_arc_rotation,
-        }
-        .into_path(0.1)
-        .into_iter(),
-    );
-
-    bez_path
-}
-
 // Composes lines with variable width. Must be drawn with only a fill
 fn compose_lines_variable_width(
     lines: &[Line],
@@ -283,7 +222,7 @@ impl Composer<SmoothOptions> for CubicBezier {
     }
 }
 
-impl Composer<SmoothOptions> for Segment {
+impl Composer<SmoothOptions> for PenPath {
     fn composed_bounds(&self, options: &SmoothOptions) -> AABB {
         self.bounds().loosened(options.stroke_width * 0.5)
     }
@@ -291,115 +230,98 @@ impl Composer<SmoothOptions> for Segment {
     fn draw_composed(&self, cx: &mut impl piet::RenderContext, options: &SmoothOptions) {
         cx.save().unwrap();
 
-        let bez_path = {
-            match self {
-                Segment::Dot { element } => {
-                    let radii = na::Vector2::from_element(
-                        options
-                            .pressure_curve
-                            .apply(options.stroke_width * 0.5, element.pressure),
-                    );
+        let mut prev = self.start;
+        for seg in self.segments.iter() {
+            let bez_path = {
+                match seg {
+                    Segment::LineTo { end } => {
+                        let (width_start, width_end) = (
+                            options
+                                .pressure_curve
+                                .apply(options.stroke_width, prev.pressure),
+                            options
+                                .pressure_curve
+                                .apply(options.stroke_width, end.pressure),
+                        );
 
-                    kurbo::Ellipse::new(element.pos.to_kurbo_point(), radii.to_kurbo_vec(), 0.0)
-                        .into_path(0.1)
-                }
-                Segment::Line { start, end } => {
-                    let (width_start, width_end) = (
-                        options
-                            .pressure_curve
-                            .apply(options.stroke_width, start.pressure),
-                        options
-                            .pressure_curve
-                            .apply(options.stroke_width, end.pressure),
-                    );
+                        let bez_path = compose_lines_variable_width(
+                            &[Line {
+                                start: prev.pos,
+                                end: end.pos,
+                            }],
+                            width_start,
+                            width_end,
+                            options,
+                        );
 
-                    compose_line_variable_width(
-                        Line {
-                            start: start.pos,
+                        prev = *end;
+                        bez_path
+                    }
+                    Segment::QuadBezTo { cp, end } => {
+                        let (width_start, width_end) = (
+                            options
+                                .pressure_curve
+                                .apply(options.stroke_width, prev.pressure),
+                            options
+                                .pressure_curve
+                                .apply(options.stroke_width, end.pressure),
+                        );
+
+                        let n_splits = 5;
+
+                        let quadbez = QuadraticBezier {
+                            start: prev.pos,
+                            cp: *cp,
                             end: end.pos,
-                        },
-                        width_start,
-                        width_end,
-                        options,
-                    )
+                        };
+
+                        let lines = quadbez.approx_with_lines(n_splits);
+
+                        let bez_path =
+                            compose_lines_variable_width(&lines, width_start, width_end, options);
+
+                        prev = *end;
+                        bez_path
+                    }
+                    Segment::CubBezTo { cp1, cp2, end } => {
+                        let (width_start, width_end) = (
+                            options
+                                .pressure_curve
+                                .apply(options.stroke_width, prev.pressure),
+                            options
+                                .pressure_curve
+                                .apply(options.stroke_width, end.pressure),
+                        );
+
+                        let n_splits = 5;
+
+                        let cubbez = CubicBezier {
+                            start: prev.pos,
+                            cp1: *cp1,
+                            cp2: *cp2,
+                            end: end.pos,
+                        };
+                        let lines = cubbez.approx_with_lines(n_splits);
+
+                        let bez_path =
+                            compose_lines_variable_width(&lines, width_start, width_end, options);
+
+                        prev = *end;
+                        bez_path
+                    }
                 }
-                Segment::QuadBez { start, cp, end } => {
-                    let (width_start, width_end) = (
-                        options
-                            .pressure_curve
-                            .apply(options.stroke_width, start.pressure),
-                        options
-                            .pressure_curve
-                            .apply(options.stroke_width, end.pressure),
-                    );
+            };
 
-                    let n_splits = 5;
+            if let Some(fill_color) = options.stroke_color {
+                // Outlines for debugging
+                //let stroke_brush = cx.solid_brush(piet::Color::RED);
+                //cx.stroke(bez_path.clone(), &stroke_brush, 0.4);
 
-                    let quadbez = QuadraticBezier {
-                        start: start.pos,
-                        cp: *cp,
-                        end: end.pos,
-                    };
-
-                    let lines = quadbez.approx_with_lines(n_splits);
-
-                    compose_lines_variable_width(&lines, width_start, width_end, options)
-                }
-                Segment::CubBez {
-                    start,
-                    cp1,
-                    cp2,
-                    end,
-                } => {
-                    let (width_start, width_end) = (
-                        options
-                            .pressure_curve
-                            .apply(options.stroke_width, start.pressure),
-                        options
-                            .pressure_curve
-                            .apply(options.stroke_width, end.pressure),
-                    );
-
-                    let n_splits = 5;
-
-                    let cubbez = CubicBezier {
-                        start: start.pos,
-                        cp1: *cp1,
-                        cp2: *cp2,
-                        end: end.pos,
-                    };
-                    let lines = cubbez.approx_with_lines(n_splits);
-
-                    compose_lines_variable_width(&lines, width_start, width_end, options)
-                }
+                let fill_brush = cx.solid_brush(fill_color.into());
+                cx.fill(bez_path, &fill_brush);
             }
-        };
-
-        if let Some(fill_color) = options.stroke_color {
-            // Outlines for debugging
-            //let stroke_brush = cx.solid_brush(piet::Color::RED);
-            //cx.stroke(bez_path.clone(), &stroke_brush, 0.4);
-
-            let fill_brush = cx.solid_brush(fill_color.into());
-            cx.fill(bez_path, &fill_brush);
         }
 
-        cx.restore().unwrap();
-    }
-}
-
-impl Composer<SmoothOptions> for PenPath {
-    fn composed_bounds(&self, options: &SmoothOptions) -> AABB {
-        self.iter()
-            .map(|segment| segment.composed_bounds(options))
-            .fold(AABB::new_invalid(), |acc, x| acc.merged(&x))
-    }
-
-    fn draw_composed(&self, cx: &mut impl piet::RenderContext, options: &SmoothOptions) {
-        cx.save().unwrap();
-        for segment in self.iter() {
-            segment.draw_composed(cx, options);
-        }
         cx.restore().unwrap();
     }
 }
@@ -412,7 +334,6 @@ impl Composer<SmoothOptions> for crate::Shape {
             crate::Shape::Ellipse(ellipse) => ellipse.composed_bounds(options),
             crate::Shape::QuadraticBezier(quadbez) => quadbez.composed_bounds(options),
             crate::Shape::CubicBezier(cubbez) => cubbez.composed_bounds(options),
-            crate::Shape::Segment(segment) => segment.composed_bounds(options),
         }
     }
 
@@ -423,7 +344,6 @@ impl Composer<SmoothOptions> for crate::Shape {
             crate::Shape::Ellipse(ellipse) => ellipse.draw_composed(cx, options),
             crate::Shape::QuadraticBezier(quadbez) => quadbez.draw_composed(cx, options),
             crate::Shape::CubicBezier(cubbez) => cubbez.draw_composed(cx, options),
-            crate::Shape::Segment(segment) => segment.draw_composed(cx, options),
         }
     }
 }

--- a/rnote-compose/src/style/textured/textureddotsdistribution.rs
+++ b/rnote-compose/src/style/textured/textureddotsdistribution.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 
+use anyhow::Context;
 use rand_distr::Distribution;
 use serde::{Deserialize, Serialize};
 
@@ -36,11 +37,8 @@ impl TryFrom<u32> for TexturedDotsDistribution {
     type Error = anyhow::Error;
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
-        num_traits::FromPrimitive::from_u32(value).ok_or_else(|| {
-            anyhow::anyhow!(
-                "TexturedDotsDistribution try_from::<u32>() for value {} failed",
-                value
-            )
+        num_traits::FromPrimitive::from_u32(value).with_context(|| {
+            format!("TexturedDotsDistribution try_from::<u32>() for value {value} failed",)
         })
     }
 }

--- a/rnote-compose/src/style/textured/texturedoptions.rs
+++ b/rnote-compose/src/style/textured/texturedoptions.rs
@@ -45,7 +45,7 @@ impl Default for TexturedOptions {
 
 impl TexturedOptions {
     /// The default width
-    pub const WIDTH_DEFAULT: f64 = 2.0;
+    pub const WIDTH_DEFAULT: f64 = 6.0;
     /// Density default
     pub const DENSITY_DEFAULT: f64 = 5.0;
     /// dots dadii default (without width weight)

--- a/rnote-compose/src/utils.rs
+++ b/rnote-compose/src/utils.rs
@@ -109,7 +109,7 @@ pub fn random_id_prefix() -> String {
         .collect::<String>()
 }
 
-/// returns a new seed by generating a random value seeded from the old seed using the Pcg algo
+/// returns a new seed by generating a random value seeded from the old seed using the Pcg algorithm
 pub fn seed_advance(seed: u64) -> u64 {
     let mut rng = rand_pcg::Pcg64::seed_from_u64(seed);
     rng.gen()

--- a/rnote-engine/src/audioplayer.rs
+++ b/rnote-engine/src/audioplayer.rs
@@ -215,9 +215,9 @@ fn load_sound_from_path(
 
         Ok(buffered)
     } else {
-        return Err(anyhow::Error::msg(format!(
+        Err(anyhow::Error::msg(format!(
             "failed to init audioplayer. File `{:?}` is missing.",
             resource_path
-        )));
+        )))
     }
 }

--- a/rnote-engine/src/audioplayer.rs
+++ b/rnote-engine/src/audioplayer.rs
@@ -118,7 +118,7 @@ impl AudioPlayer {
                 sink.detach();
             }
             Err(e) => log::error!(
-                "failed to create sink in play_random_marker_sound(), Err {}",
+                "failed to create sink in play_random_marker_sound(), Err {:?}",
                 e
             ),
         }
@@ -143,7 +143,7 @@ impl AudioPlayer {
                 self.brush_sink = Some(sink);
             }
             Err(e) => log::error!(
-                "failed to create sink in start_play_random_brush_sound(), Err {}",
+                "failed to create sink in start_play_random_brush_sound(), Err {:?}",
                 e
             ),
         }
@@ -189,7 +189,7 @@ impl AudioPlayer {
                 }
             },
             Err(e) => log::error!(
-                "failed to create sink in play_typewriter_sound(), Err {}",
+                "failed to create sink in play_typewriter_sound(), Err {:?}",
                 e
             ),
         }

--- a/rnote-engine/src/document/background.rs
+++ b/rnote-engine/src/document/background.rs
@@ -289,7 +289,7 @@ impl Background {
         }
 
         let svg_data = rnote_compose::utils::svg_node_to_string(&svg_group)
-            .map_err(|e| anyhow::anyhow!("node_to_string() failed for background, {}", e))?;
+            .context("svg_node_to_string() failed for background.")?;
 
         Ok(render::Svg { svg_data, bounds })
     }
@@ -339,7 +339,7 @@ impl Background {
             }
             Err(e) => {
                 log::error!(
-                    "gen_rendernode() failed in update_rendernode() of background with Err: {}",
+                    "gen_rendernode() failed in update_rendernode() of background with Err: {:?}",
                     e
                 );
             }

--- a/rnote-engine/src/document/format.rs
+++ b/rnote-engine/src/document/format.rs
@@ -217,7 +217,7 @@ impl Format {
 
         piet_cx.stroke(indicator_path, &PATH_COLOR, path_width);
 
-        piet_cx.finish().map_err(|e| anyhow::anyhow!("{}", e))?;
+        piet_cx.finish().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         Ok(cairo_node.upcast())
     }

--- a/rnote-engine/src/engine/export.rs
+++ b/rnote-engine/src/engine/export.rs
@@ -380,7 +380,7 @@ impl RnoteEngine {
                 .gen_svg(doc_bounds, doc_export_prefs.with_pattern)
                 .map_err(|e| {
                     log::error!(
-                        "background.gen_svg() failed in export_doc_as_pdf_bytes() with Err {}",
+                        "background.gen_svg() failed in export_doc_as_pdf_bytes() with Err {:?}",
                         e
                     )
                 })
@@ -436,7 +436,7 @@ impl RnoteEngine {
 
                         // Draw the strokes with piet
                         let mut piet_cx = piet_cairo::CairoRenderContext::new(&cairo_cx);
-                        piet_cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+                        piet_cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
                         piet_cx.transform(kurbo::Affine::translate(
                             -page_bounds.mins.coords.to_kurbo_vec(),
@@ -451,28 +451,24 @@ impl RnoteEngine {
 
                         cairo_cx.show_page().map_err(|e| {
                             anyhow::anyhow!(
-                                "show_page() failed when exporting page {} as pdf, Err {}",
-                                i,
-                                e
+                                "show_page() failed when exporting page {i} as pdf, Err: {e:?}"
                             )
                         })?;
 
-                        piet_cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+                        piet_cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
                     }
                 }
                 let data = *surface
                     .finish_output_stream()
                     .map_err(|e| {
                         anyhow::anyhow!(
-                            "finish_outputstream() failed in export_doc_as_pdf_bytes with Err {:?}",
-                            e
+                            "finish_outputstream() failed in export_doc_as_pdf_bytes with Err: {e:?}"
                         )
                     })?
                     .downcast::<Vec<u8>>()
                     .map_err(|e| {
                         anyhow::anyhow!(
-                            "downcast() finished output stream failed in export_doc_as_pdf_bytes with Err {:?}",
-                            e
+                            "downcast() finished output stream failed in export_doc_as_pdf_bytes with Err: {e:?}"
                         )
                     })?;
 

--- a/rnote-engine/src/engine/export.rs
+++ b/rnote-engine/src/engine/export.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use rnote_compose::helpers::Vector2Helpers;
 use rnote_compose::transform::TransformBehaviour;
-use rnote_fileformats::rnoteformat::RnotefileMaj0Min5;
+use rnote_fileformats::rnoteformat::Rnotefile;
 use rnote_fileformats::{xoppformat, FileFormatSaver};
 
 use crate::store::StrokeKey;
@@ -279,7 +279,7 @@ impl RnoteEngine {
 
         rayon::spawn(move || {
             let result = || -> anyhow::Result<Vec<u8>> {
-                let rnote_file = RnotefileMaj0Min5 {
+                let rnote_file = Rnotefile {
                     document: doc,
                     store_snapshot: serde_json::to_value(&*store_snapshot)?,
                 };

--- a/rnote-engine/src/engine/import.rs
+++ b/rnote-engine/src/engine/import.rs
@@ -139,8 +139,8 @@ impl RnoteEngine {
 
         rayon::spawn(move || {
             let result = || -> anyhow::Result<StoreSnapshot> {
-                Ok(serde_json::from_value(rnote_file.store_snapshot)
-                    .context("serde_json::from_value() for rnote_file.store_snapshot failed")?)
+                serde_json::from_value(rnote_file.store_snapshot)
+                    .context("serde_json::from_value() for rnote_file.store_snapshot failed")
             };
 
             if let Err(_data) = store_snapshot_sender.send(result()) {
@@ -237,7 +237,7 @@ impl RnoteEngine {
                         }
                         Err(e) => {
                             log::error!(
-                                "from_xoppstroke() failed in open_from_xopp_bytes() with Err {}",
+                                "from_xoppstroke() failed in open_from_xopp_bytes() with Err {:?}",
                                 e
                             );
                         }
@@ -252,7 +252,7 @@ impl RnoteEngine {
                         }
                         Err(e) => {
                             log::error!(
-                                "from_xoppimage() failed in open_from_xopp_bytes() with Err {}",
+                                "from_xoppimage() failed in open_from_xopp_bytes() with Err {:?}",
                                 e
                             );
                         }

--- a/rnote-engine/src/engine/import.rs
+++ b/rnote-engine/src/engine/import.rs
@@ -127,7 +127,7 @@ impl RnoteEngine {
         &mut self,
         bytes: Vec<u8>,
     ) -> anyhow::Result<oneshot::Receiver<anyhow::Result<StoreSnapshot>>> {
-        let rnote_file = rnoteformat::RnotefileMaj0Min5::load_from_bytes(&bytes)?;
+        let rnote_file = rnoteformat::Rnotefile::load_from_bytes(&bytes)?;
 
         self.document = serde_json::from_value(rnote_file.document)?;
 

--- a/rnote-engine/src/engine/import.rs
+++ b/rnote-engine/src/engine/import.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 
+use anyhow::Context;
 use futures::channel::oneshot;
 use rnote_fileformats::{rnoteformat, xoppformat, FileFormatLoader};
 use serde::{Deserialize, Serialize};
@@ -127,16 +128,19 @@ impl RnoteEngine {
         &mut self,
         bytes: Vec<u8>,
     ) -> anyhow::Result<oneshot::Receiver<anyhow::Result<StoreSnapshot>>> {
-        let rnote_file = rnoteformat::Rnotefile::load_from_bytes(&bytes)?;
+        let rnote_file = rnoteformat::Rnotefile::load_from_bytes(&bytes)
+            .context("RnoteFile load_from_bytes() failed.")?;
 
-        self.document = serde_json::from_value(rnote_file.document)?;
+        self.document = serde_json::from_value(rnote_file.document)
+            .context("serde_json::from_value() for rnote_file.document failed.")?;
 
         let (store_snapshot_sender, store_snapshot_receiver) =
             oneshot::channel::<anyhow::Result<StoreSnapshot>>();
 
         rayon::spawn(move || {
             let result = || -> anyhow::Result<StoreSnapshot> {
-                Ok(serde_json::from_value(rnote_file.store_snapshot)?)
+                Ok(serde_json::from_value(rnote_file.store_snapshot)
+                    .context("serde_json::from_value() for rnote_file.store_snapshot failed")?)
             };
 
             if let Err(_data) = store_snapshot_sender.send(result()) {

--- a/rnote-engine/src/engine/mod.rs
+++ b/rnote-engine/src/engine/mod.rs
@@ -210,7 +210,7 @@ impl RnoteEngine {
                     self.audioplayer = match AudioPlayer::new_init(data_dir) {
                         Ok(audioplayer) => Some(audioplayer),
                         Err(e) => {
-                            log::error!("creating a new audioplayer failed, Err {e}");
+                            log::error!("creating a new audioplayer failed, Err: {e:?}");
                             None
                         }
                     }
@@ -320,7 +320,7 @@ impl RnoteEngine {
         match task {
             EngineTask::UpdateStrokeWithImages { key, images } => {
                 if let Err(e) = self.store.replace_rendering_with_images(key, images) {
-                    log::error!("replace_rendering_with_images() in process_received_task() failed with Err {}", e);
+                    log::error!("replace_rendering_with_images() in process_received_task() failed with Err: {e:?}");
                 }
 
                 widget_flags.redraw = true;
@@ -328,8 +328,7 @@ impl RnoteEngine {
             EngineTask::AppendImagesToStroke { key, images } => {
                 if let Err(e) = self.store.append_rendering_images(key, images) {
                     log::error!(
-                        "append_rendering_images() in process_received_task() failed with Err {}",
-                        e
+                        "append_rendering_images() in process_received_task() failed with Err: {e:?}"
                     );
                 }
 
@@ -424,10 +423,7 @@ impl RnoteEngine {
 
         // Update background and strokes for the new viewport
         if let Err(e) = self.document.background.update_rendernodes(viewport) {
-            log::error!(
-                "failed to update background rendernodes on canvas resize with Err {}",
-                e
-            );
+            log::error!("failed to update background rendernodes on canvas resize with Err: {e:?}");
         }
     }
 
@@ -623,18 +619,18 @@ impl RnoteEngine {
                    // Transform to doc coordinate space
                    piet_cx.transform(self.camera.transform().to_kurbo());
 
-                   piet_cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+                   piet_cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
                    self.store
                        .draw_strokes_immediate_w_piet(&mut piet_cx, doc_bounds, viewport, zoom)?;
-                   piet_cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+                   piet_cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
-                   piet_cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+                   piet_cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
                    self.penholder
                        .draw_on_doc(&mut piet_cx, doc_bounds, &self.camera)?;
-                   piet_cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+                   piet_cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
-                   piet_cx.finish().map_err(|e| anyhow::anyhow!("{}", e))?;
+                   piet_cx.finish().map_err(|e| anyhow::anyhow!("{e:?}"))?;
                }
         */
         snapshot.save();

--- a/rnote-engine/src/engine/visual_debug.rs
+++ b/rnote-engine/src/engine/visual_debug.rs
@@ -158,7 +158,7 @@ pub fn draw_statistics_overlay(
             .alignment(piet::TextAlignment::End)
             .font(piet::FontFamily::MONOSPACE, 10.0)
             .build()
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         piet_cx.fill(
             Rectangle::from_p2d_aabb(text_bounds).to_kurbo(),
@@ -169,7 +169,7 @@ pub fn draw_statistics_overlay(
             &text_layout,
             (text_bounds.mins.coords + na::vector![20.0, 10.0]).to_kurbo_point(),
         );
-        piet_cx.finish().map_err(|e| anyhow::anyhow!("{}", e))?;
+        piet_cx.finish().map_err(|e| anyhow::anyhow!("{e:?}"))?;
     }
     Ok(())
 }

--- a/rnote-engine/src/pens/brush.rs
+++ b/rnote-engine/src/pens/brush.rs
@@ -224,7 +224,7 @@ impl PenBehaviour for Brush {
                         engine_view.camera.viewport(),
                         engine_view.camera.image_scale(),
                     ) {
-                        log::error!("regenerate_rendering_for_stroke() failed after inserting brush stroke, Err {}", e);
+                        log::error!("regenerate_rendering_for_stroke() failed after inserting brush stroke, Err: {e:?}");
                     }
 
                     self.state = BrushState::Drawing {
@@ -302,7 +302,7 @@ impl PenBehaviour for Brush {
                                 engine_view.camera.viewport(),
                                 engine_view.camera.image_scale(),
                             ) {
-                                log::error!("append_rendering_last_segments() for penevent down in brush failed with Err {}", e);
+                                log::error!("append_rendering_last_segments() for penevent down in brush failed with Err: {e:?}");
                             }
                         }
 
@@ -329,7 +329,7 @@ impl PenBehaviour for Brush {
                                 engine_view.camera.viewport(),
                                 engine_view.camera.image_scale(),
                             ) {
-                                log::error!("append_rendering_last_segments() for penevent down in brush failed with Err {}", e);
+                                log::error!("append_rendering_last_segments() for penevent down in brush failed with Err: {e:?}");
                             }
                         }
 
@@ -384,7 +384,7 @@ impl DrawOnDocBehaviour for Brush {
         cx: &mut piet_cairo::CairoRenderContext,
         engine_view: &EngineView,
     ) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         match &self.state {
             BrushState::Idle => {}
@@ -394,15 +394,17 @@ impl DrawOnDocBehaviour for Brush {
                         // Don't draw the marker, as the pen would render on top of other strokes, while the stroke itself would render underneath them.
                     }
                     BrushStyle::Solid | BrushStyle::Textured => {
-                        let mut style = self.style_for_current_options();
+                        let style = self.style_for_current_options();
 
-                        // Change color for debugging
-                        match &mut style {
-                            Style::Smooth(options) => {
-                                options.stroke_color = Some(rnote_compose::Color::RED)
-                            }
-                            Style::Rough(_) | Style::Textured(_) => {}
-                        }
+                        /*
+                                               // Change color for debugging
+                                               match &mut style {
+                                                   Style::Smooth(options) => {
+                                                       options.stroke_color = Some(rnote_compose::Color::RED)
+                                                   }
+                                                   Style::Rough(_) | Style::Textured(_) => {}
+                                               }
+                        */
 
                         path_builder.draw_styled(cx, &style, engine_view.camera.total_zoom());
                     }
@@ -410,7 +412,7 @@ impl DrawOnDocBehaviour for Brush {
             }
         }
 
-        cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 }

--- a/rnote-engine/src/pens/brush.rs
+++ b/rnote-engine/src/pens/brush.rs
@@ -193,7 +193,6 @@ impl PenBehaviour for Brush {
                     .filter_by_bounds(engine_view.doc.bounds().loosened(Self::INPUT_OVERSHOOT))
                 {
                     widget_flags.merge_with_other(engine_view.store.record());
-
                     Self::start_audio(style, engine_view.audioplayer);
 
                     // A new seed for a new brush stroke
@@ -395,7 +394,16 @@ impl DrawOnDocBehaviour for Brush {
                         // Don't draw the marker, as the pen would render on top of other strokes, while the stroke itself would render underneath them.
                     }
                     BrushStyle::Solid | BrushStyle::Textured => {
-                        let style = self.style_for_current_options();
+                        let mut style = self.style_for_current_options();
+
+                        // Change color for debugging
+                        match &mut style {
+                            Style::Smooth(options) => {
+                                options.stroke_color = Some(rnote_compose::Color::RED)
+                            }
+                            Style::Rough(_) | Style::Textured(_) => {}
+                        }
+
                         path_builder.draw_styled(cx, &style, engine_view.camera.total_zoom());
                     }
                 }

--- a/rnote-engine/src/pens/eraser.rs
+++ b/rnote-engine/src/pens/eraser.rs
@@ -101,7 +101,7 @@ impl PenBehaviour for Eraser {
                             engine_view.camera.viewport(),
                             engine_view.camera.image_scale(),
                         ) {
-                            log::error!("regenerate_rendering_for_strokes() failed while splitting colliding strokes, Err {}", e);
+                            log::error!("regenerate_rendering_for_strokes() failed while splitting colliding strokes, Err: {e:?}");
                         }
                     }
                 }
@@ -142,7 +142,7 @@ impl PenBehaviour for Eraser {
                             engine_view.camera.viewport(),
                             engine_view.camera.image_scale(),
                         ) {
-                            log::error!("regenerate_rendering_for_strokes() failed while splitting colliding strokes, Err {}", e);
+                            log::error!("regenerate_rendering_for_strokes() failed while splitting colliding strokes, Err: {e:?}");
                         }
                     }
                 }
@@ -173,7 +173,7 @@ impl PenBehaviour for Eraser {
                             engine_view.camera.viewport(),
                             engine_view.camera.image_scale(),
                         ) {
-                            log::error!("regenerate_rendering_for_strokes() failed while splitting colliding strokes, Err {}", e);
+                            log::error!("regenerate_rendering_for_strokes() failed while splitting colliding strokes, Err: {e:?}");
                         }
                     }
                 }
@@ -250,7 +250,7 @@ impl DrawOnDocBehaviour for Eraser {
         cx: &mut piet_cairo::CairoRenderContext,
         engine_view: &EngineView,
     ) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         static OUTLINE_COLOR: Lazy<piet::Color> =
             Lazy::new(|| color::GNOME_REDS[2].with_alpha(0.941));
@@ -281,7 +281,7 @@ impl DrawOnDocBehaviour for Eraser {
             }
         }
 
-        cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 }

--- a/rnote-engine/src/pens/penholder.rs
+++ b/rnote-engine/src/pens/penholder.rs
@@ -443,7 +443,7 @@ impl DrawOnDocBehaviour for PenHolder {
         cx: &mut piet_cairo::CairoRenderContext,
         engine_view: &EngineView,
     ) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         match self.current_style_w_override() {
             PenStyle::Brush => self.brush.draw_on_doc(cx, engine_view),
@@ -454,7 +454,7 @@ impl DrawOnDocBehaviour for PenHolder {
             PenStyle::Tools => self.tools.draw_on_doc(cx, engine_view),
         }?;
 
-        cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 }

--- a/rnote-engine/src/pens/selector.rs
+++ b/rnote-engine/src/pens/selector.rs
@@ -785,7 +785,7 @@ impl DrawOnDocBehaviour for Selector {
         cx: &mut piet_cairo::CairoRenderContext,
         engine_view: &EngineView,
     ) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         let total_zoom = engine_view.camera.total_zoom();
 
         match &self.state {
@@ -929,7 +929,7 @@ impl DrawOnDocBehaviour for Selector {
             }
         }
 
-        cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 }
@@ -1007,7 +1007,7 @@ impl Selector {
         modify_state: &ModifyState,
         camera: &Camera,
     ) -> anyhow::Result<()> {
-        piet_cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        piet_cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         let total_zoom = camera.total_zoom();
 
         let rotate_node_state = match modify_state {
@@ -1059,7 +1059,7 @@ impl Selector {
         // Selection rect
         let selection_rect = selection_bounds.to_kurbo_rect();
 
-        piet_cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        piet_cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         let mut clip_path = kurbo::BezPath::new();
         clip_path.extend(
@@ -1120,7 +1120,7 @@ impl Selector {
             Selector::SELECTION_OUTLINE_WIDTH / total_zoom,
         );
 
-        piet_cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        piet_cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         // Rotate Node
         drawhelpers::draw_circular_node(piet_cx, rotate_node_state, rotate_node_sphere, total_zoom);
@@ -1151,7 +1151,7 @@ impl Selector {
             total_zoom,
         );
 
-        piet_cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        piet_cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 
@@ -1162,7 +1162,7 @@ impl Selector {
         current_rotation_angle: f64,
         camera: &Camera,
     ) -> anyhow::Result<()> {
-        piet_cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        piet_cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         const CENTER_CROSS_COLOR: Color = Color {
             r: 0.964,
             g: 0.380,
@@ -1200,7 +1200,7 @@ impl Selector {
             &piet::Color::from(CENTER_CROSS_COLOR),
             center_cross_path_width,
         );
-        piet_cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        piet_cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         Ok(())
     }

--- a/rnote-engine/src/pens/shaper.rs
+++ b/rnote-engine/src/pens/shaper.rs
@@ -223,7 +223,7 @@ impl PenBehaviour for Shaper {
                                 engine_view.camera.viewport(),
                                 engine_view.camera.image_scale(),
                             ) {
-                                log::error!("regenerate_rendering_for_stroke() failed after inserting new line, Err {}", e);
+                                log::error!("regenerate_rendering_for_stroke() failed after inserting new line, Err: {e:?}");
                             }
                         }
 
@@ -259,7 +259,7 @@ impl PenBehaviour for Shaper {
                                 engine_view.camera.viewport(),
                                 engine_view.camera.image_scale(),
                             ) {
-                                log::error!("regenerate_rendering_for_stroke() failed after inserting new shape, Err {}", e);
+                                log::error!("regenerate_rendering_for_stroke() failed after inserting new shape, Err: {e:?}");
                             }
                         }
 
@@ -294,7 +294,7 @@ impl DrawOnDocBehaviour for Shaper {
         cx: &mut piet_cairo::CairoRenderContext,
         engine_view: &EngineView,
     ) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         let style = self.gen_style_for_current_options();
 
         match &self.state {
@@ -304,7 +304,7 @@ impl DrawOnDocBehaviour for Shaper {
             }
         }
 
-        cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 }

--- a/rnote-engine/src/pens/shaper.rs
+++ b/rnote-engine/src/pens/shaper.rs
@@ -9,7 +9,7 @@ use crate::{DrawOnDocBehaviour, WidgetFlags};
 use p2d::bounding_volume::AABB;
 use piet::RenderContext;
 use rand::{Rng, SeedableRng};
-use rnote_compose::builders::shapebuilderbehaviour::{BuilderProgress, ShapeBuilderCreator};
+use rnote_compose::builders::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
 use rnote_compose::builders::{Constraints, CubBezBuilder, QuadBezBuilder, ShapeBuilderType};
 use rnote_compose::builders::{
     CoordSystem2DBuilder, CoordSystem3DBuilder, EllipseBuilder, FociEllipseBuilder, LineBuilder,
@@ -200,12 +200,12 @@ impl PenBehaviour for Shaper {
                 };
 
                 match builder.handle_event(event, Instant::now(), constraints) {
-                    BuilderProgress::InProgress => {
+                    ShapeBuilderProgress::InProgress => {
                         widget_flags.redraw = true;
 
                         PenProgress::InProgress
                     }
-                    BuilderProgress::EmitContinue(shapes) => {
+                    ShapeBuilderProgress::EmitContinue(shapes) => {
                         let drawstyle = self.gen_style_for_current_options();
 
                         if !shapes.is_empty() {
@@ -232,7 +232,7 @@ impl PenBehaviour for Shaper {
 
                         PenProgress::InProgress
                     }
-                    BuilderProgress::Finished(shapes) => {
+                    ShapeBuilderProgress::Finished(shapes) => {
                         let drawstyle = self.gen_style_for_current_options();
 
                         if !shapes.is_empty() {

--- a/rnote-engine/src/pens/tools.rs
+++ b/rnote-engine/src/pens/tools.rs
@@ -63,7 +63,7 @@ impl DrawOnDocBehaviour for VerticalSpaceTool {
         cx: &mut piet_cairo::CairoRenderContext,
         engine_view: &EngineView,
     ) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         let viewport = engine_view.camera.viewport();
         let x = viewport.mins[0];
@@ -98,7 +98,7 @@ impl DrawOnDocBehaviour for VerticalSpaceTool {
             Self::OFFSET_LINE_WIDTH,
         );
 
-        cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 }
@@ -144,7 +144,7 @@ impl DrawOnDocBehaviour for OffsetCameraTool {
         cx: &mut piet_cairo::CairoRenderContext,
         engine_view: &EngineView,
     ) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         if let Some(bounds) = self.bounds_on_doc(engine_view) {
             cx.transform(kurbo::Affine::translate(bounds.mins.coords.to_kurbo_vec()));
@@ -160,7 +160,7 @@ impl DrawOnDocBehaviour for OffsetCameraTool {
             cx.fill(bez_path, &*OFFSETCAMERATOOL_FILL_COLOR);
         }
 
-        cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 }
@@ -399,7 +399,7 @@ impl DrawOnDocBehaviour for Tools {
         cx: &mut piet_cairo::CairoRenderContext,
         engine_view: &EngineView,
     ) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         match &self.style {
             ToolsStyle::VerticalSpace => {
@@ -410,7 +410,7 @@ impl DrawOnDocBehaviour for Tools {
             }
         }
 
-        cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 }

--- a/rnote-engine/src/pens/typewriter/mod.rs
+++ b/rnote-engine/src/pens/typewriter/mod.rs
@@ -121,7 +121,7 @@ impl DrawOnDocBehaviour for Typewriter {
         cx: &mut piet_cairo::CairoRenderContext,
         engine_view: &EngineView,
     ) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         static OUTLINE_COLOR: Lazy<piet::Color> =
             Lazy::new(|| color::GNOME_BRIGHTS[4].with_alpha(0.941));
@@ -340,7 +340,7 @@ impl DrawOnDocBehaviour for Typewriter {
             }
         }
 
-        cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 }
@@ -627,7 +627,7 @@ impl Typewriter {
                     engine_view.camera.viewport(),
                     engine_view.camera.image_scale(),
                 ) {
-                    log::error!("regenerate_rendering_for_stroke() after inserting a new textstroke from clipboard contents in typewriter paste_clipboard_contents() failed with Err {}", e);
+                    log::error!("regenerate_rendering_for_stroke() after inserting a new textstroke from clipboard contents in typewriter paste_clipboard_contents() failed with Err: {e:?}");
                 }
 
                 self.state = TypewriterState::Modifying {
@@ -667,7 +667,7 @@ impl Typewriter {
                     engine_view.camera.viewport(),
                     engine_view.camera.image_scale(),
                 ) {
-                    log::error!("regenerate_rendering_for_stroke() after inserting a new textstroke from clipboard contents in typewriter paste_clipboard_contents() failed with Err {}", e);
+                    log::error!("regenerate_rendering_for_stroke() after inserting a new textstroke from clipboard contents in typewriter paste_clipboard_contents() failed with Err: {e:?}");
                 }
 
                 self.state = TypewriterState::Modifying {
@@ -779,7 +779,7 @@ impl Typewriter {
                     engine_view.camera.viewport(),
                     engine_view.camera.image_scale(),
                 ) {
-                    log::error!("regenerate_rendering_for_stroke() failed with Err {}", e);
+                    log::error!("regenerate_rendering_for_stroke() failed with Err: {e:?}");
                 }
 
                 widget_flags.redraw = true;
@@ -810,7 +810,7 @@ impl Typewriter {
                     engine_view.camera.viewport(),
                     engine_view.camera.image_scale(),
                 ) {
-                    log::error!("regenerate_rendering_for_stroke() failed with Err {}", e);
+                    log::error!("regenerate_rendering_for_stroke() failed with Err: {e:?}");
                 }
 
                 widget_flags.redraw = true;
@@ -848,7 +848,7 @@ impl Typewriter {
                     engine_view.camera.viewport(),
                     engine_view.camera.image_scale(),
                 ) {
-                    log::error!("regenerate_rendering_for_stroke() failed with Err {}", e);
+                    log::error!("regenerate_rendering_for_stroke() failed with Err: {e:?}");
                 }
 
                 widget_flags.redraw = true;

--- a/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/rnote-engine/src/pens/typewriter/penevents.rs
@@ -225,7 +225,7 @@ impl Typewriter {
                         engine_view.camera.viewport(),
                         engine_view.camera.image_scale(),
                     ) {
-                        log::error!("regenerate_rendering_for_stroke() while translating textstroke failed with Err {}", e);
+                        log::error!("regenerate_rendering_for_stroke() while translating textstroke failed with Err: {e:?}");
                     }
 
                     *current_pos = element.pos;
@@ -260,7 +260,7 @@ impl Typewriter {
                     engine_view.camera.viewport(),
                     engine_view.camera.image_scale(),
                 ) {
-                    log::error!("regenerate_rendering_for_stroke() while adjusting text width textstroke failed with Err {}", e);
+                    log::error!("regenerate_rendering_for_stroke() while adjusting text width textstroke failed with Err: {e:?}");
                 }
 
                 *current_pos = element.pos;
@@ -309,7 +309,7 @@ impl Typewriter {
                     engine_view.camera.viewport(),
                     engine_view.camera.image_scale(),
                 ) {
-                    log::error!("regenerate_rendering_for_stroke() while translating textstroke failed with Err {}", e);
+                    log::error!("regenerate_rendering_for_stroke() while translating textstroke failed with Err: {e:?}");
                 }
 
                 self.state = TypewriterState::Modifying {
@@ -339,7 +339,7 @@ impl Typewriter {
                     engine_view.camera.viewport(),
                     engine_view.camera.image_scale(),
                 ) {
-                    log::error!("regenerate_rendering_for_stroke() while adjusting textstroke text width failed with Err {}", e);
+                    log::error!("regenerate_rendering_for_stroke() while adjusting textstroke text width failed with Err: {e:?}");
                 }
 
                 self.state = TypewriterState::Modifying {
@@ -427,7 +427,7 @@ impl Typewriter {
                             engine_view.camera.viewport(),
                             engine_view.camera.image_scale(),
                         ) {
-                            log::error!("regenerate_rendering_for_stroke() after inserting a new textstroke failed with Err {}", e);
+                            log::error!("regenerate_rendering_for_stroke() after inserting a new textstroke failed with Err: {e:?}");
                         }
 
                         self.state = TypewriterState::Modifying {
@@ -776,7 +776,7 @@ impl Typewriter {
                     engine_view.camera.viewport(),
                     engine_view.camera.image_scale(),
                 ) {
-                    log::error!("regenerate_rendering_for_stroke() after inserting a new textstroke failed with Err {}", e);
+                    log::error!("regenerate_rendering_for_stroke() after inserting a new textstroke failed with Err: {e:?}");
                 }
 
                 self.state = TypewriterState::Modifying {

--- a/rnote-engine/src/render.rs
+++ b/rnote-engine/src/render.rs
@@ -331,7 +331,9 @@ impl Image {
         Ok(transform_node)
     }
 
-    pub fn images_to_rendernodes(images: &[Self]) -> Result<Vec<gsk::RenderNode>, anyhow::Error> {
+    pub fn images_to_rendernodes<'a>(
+        images: impl IntoIterator<Item = &'a Self>,
+    ) -> Result<Vec<gsk::RenderNode>, anyhow::Error> {
         let mut rendernodes = vec![];
 
         for image in images {

--- a/rnote-engine/src/render.rs
+++ b/rnote-engine/src/render.rs
@@ -149,7 +149,7 @@ impl DrawBehaviour for Image {
     /// Expects image to be in rgba8-premultiplied format, else drawing will fail.
     /// image_scale has no meaning here, as the image pixels are already provided
     fn draw(&self, cx: &mut impl piet::RenderContext, _image_scale: f64) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         let piet_image_format = piet::ImageFormat::try_from(self.memory_format)?;
 
         let piet_image = cx
@@ -159,7 +159,7 @@ impl DrawBehaviour for Image {
                 &self.data,
                 piet_image_format,
             )
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         cx.transform(self.rect.transform.to_kurbo());
 
@@ -168,7 +168,7 @@ impl DrawBehaviour for Image {
             self.rect.cuboid.local_aabb().to_kurbo_rect(),
             piet::InterpolationMode::Bilinear,
         );
-        cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 }
@@ -404,10 +404,7 @@ impl Image {
             }
 
             piet_cx.finish().map_err(|e| {
-                anyhow::anyhow!(
-                    "piet_cx.finish() failed in image.gen_with_piet() with Err {}",
-                    e
-                )
+                anyhow::anyhow!("piet_cx.finish() failed in image.gen_with_piet() with Err: {e:?}")
             })?;
         }
         // Surface needs to be flushed before accessing its data
@@ -417,8 +414,7 @@ impl Image {
                    .data()
                    .map_err(|e| {
                        anyhow::Error::msg(format!(
-                   "accessing imagesurface data failed in strokebehaviour image.gen_with_piet() with Err {}",
-                   e
+                   "accessing imagesurface data failed in strokebehaviour image.gen_with_piet() with Err: {e:?}"
                ))
                    })?
                    .to_vec();
@@ -459,10 +455,7 @@ impl Image {
             )
             .map_err(|e| {
                 anyhow::anyhow!(
-                    "create ImageSurface with dimensions ({}, {}) failed in gen_image_from_svg_librsvg(), Err {}",
-                    width_scaled,
-                    height_scaled,
-                    e
+                    "create ImageSurface with dimensions ({width_scaled}, {height_scaled}) failed in gen_image_from_svg_librsvg(), Err: {e:?}"
                 )
             })?;
 
@@ -494,8 +487,7 @@ impl Image {
                     )
                     .map_err(|e| {
                         anyhow::Error::msg(format!(
-                            "librsvg render_document() failed in gen_image_from_svg_librsvg() with Err {}",
-                            e
+                            "librsvg render_document() failed in gen_image_from_svg_librsvg() with Err: {e:?}"
                         ))
                     })?;
         }
@@ -506,8 +498,7 @@ impl Image {
                 .data()
                 .map_err(|e| {
                     anyhow::Error::msg(format!(
-                        "accessing imagesurface data failed in gen_image_from_svg_librsvg() with Err {}",
-                        e
+                        "accessing imagesurface data failed in gen_image_from_svg_librsvg() with Err: {e:?}"
                     ))
                 })?
                 .to_vec();
@@ -562,10 +553,7 @@ impl Image {
             draw_func(&mut piet_cx)?;
 
             piet_cx.finish().map_err(|e| {
-                anyhow::anyhow!(
-                    "piet_cx.finish() failed in image.gen_with_piet() with Err {}",
-                    e
-                )
+                anyhow::anyhow!("piet_cx.finish() failed in image.gen_with_piet() with Err: {e:?}")
             })?;
         }
         // Surface needs to be flushed before accessing its data
@@ -575,8 +563,7 @@ impl Image {
                 .data()
                 .map_err(|e| {
                     anyhow::Error::msg(format!(
-                "accessing imagesurface data failed in strokebehaviour image.gen_with_piet() with Err {}",
-                e
+                "accessing imagesurface data failed in strokebehaviour image.gen_with_piet() with Err: {e:?}"
             ))
                 })?
                 .to_vec();
@@ -667,15 +654,14 @@ impl Svg {
 
             piet_cx.finish().map_err(|e| {
                 anyhow::anyhow!(
-                    "piet_cx.finish() failed in Svg gen_with_piet_cairo_backend() with Err {}",
-                    e
+                    "piet_cx.finish() failed in Svg gen_with_piet_cairo_backend() with Err: {e:?}"
                 )
             })?;
         }
 
         let file_content = svg_surface
             .finish_output_stream()
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         let svg_data = rnote_compose::utils::remove_xml_header(
             String::from_utf8(*file_content.downcast::<Vec<u8>>().map_err(|_e| {
@@ -730,8 +716,7 @@ impl Svg {
                 )
                 .map_err(|e| {
                     anyhow::Error::msg(format!(
-                    "librsvg render_document() failed in draw_svgs_to_cairo_context() with Err {}",
-                    e
+                    "librsvg render_document() failed in draw_svgs_to_cairo_context() with Err: {e:?}"
                 ))
                 })?;
         }

--- a/rnote-engine/src/store/render_comp.rs
+++ b/rnote-engine/src/store/render_comp.rs
@@ -304,13 +304,15 @@ impl StrokeStore {
         ) {
             match stroke.as_ref() {
                 Stroke::BrushStroke(brushstroke) => {
-                    let mut images =
-                        brushstroke.gen_images_for_last_segments(n_segments, image_scale)?;
+                    if let Some(image) =
+                        brushstroke.gen_image_for_last_segments(n_segments, image_scale)?
+                    {
+                        let mut rendernodes =
+                            render::Image::images_to_rendernodes(&[image.clone()])?;
 
-                    let mut rendernodes = render::Image::images_to_rendernodes(&images)?;
-
-                    render_comp.rendernodes.append(&mut rendernodes);
-                    render_comp.images.append(&mut images);
+                        render_comp.rendernodes.append(&mut rendernodes);
+                        render_comp.images.push(image);
+                    }
                 }
                 // regenerate everything for strokes that don't support generating svgs for the last added elements
                 Stroke::ShapeStroke(_)

--- a/rnote-engine/src/store/render_comp.rs
+++ b/rnote-engine/src/store/render_comp.rs
@@ -201,11 +201,11 @@ impl StrokeStore {
                             key,
                             images,
                         }).unwrap_or_else(|e| {
-                            log::error!("tasks_tx.send() UpdateStrokeWithImages failed in regenerate_rendering_for_stroke_threaded() for stroke with key {:?}, with Err, {}",key, e);
+                            log::error!("tasks_tx.send() UpdateStrokeWithImages failed in regenerate_rendering_for_stroke_threaded() for stroke with key {key:?}, with Err, {e:?}");
                         });
                 }
                 Err(e) => {
-                    log::debug!("stroke.gen_image() failed in regenerate_rendering_for_stroke_threaded() for stroke with key {:?}, with Err {}", key, e);
+                    log::debug!("stroke.gen_image() failed in regenerate_rendering_for_stroke_threaded() for stroke with key {key:?}, with Err: {e:?}");
                 }
             });
         }
@@ -277,11 +277,11 @@ impl StrokeStore {
                                 key,
                                 images,
                             }).unwrap_or_else(|e| {
-                                log::error!("tasks_tx.send() UpdateStrokeWithImages failed in regenerate_rendering_in_viewport_threaded() for stroke with key {:?}, with Err, {}",key, e);
+                                log::error!("tasks_tx.send() UpdateStrokeWithImages failed in regenerate_rendering_in_viewport_threaded() for stroke with key {key:?}, with Err, {e}");
                             });
                         }
                         Err(e) => {
-                            log::debug!("stroke.gen_image() failed in regenerate_rendering_in_viewport_threaded() for stroke with key {:?}, with Err {}", key, e);
+                            log::debug!("stroke.gen_image() failed in regenerate_rendering_in_viewport_threaded() for stroke with key {key:?}, with Err: {e:?}");
                         }
                     }
                 });
@@ -442,16 +442,15 @@ impl StrokeStore {
             .for_each(|key| {
                 if let Some(stroke) = self.stroke_components.get(key) {
                     if let Err(e) = || -> anyhow::Result<()> {
-                        piet_cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+                        piet_cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
                         stroke
                             .draw(piet_cx, image_scale)
-                            .map_err(|e| anyhow::anyhow!("{}", e))?;
-                        piet_cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+                            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+                        piet_cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
                         Ok(())
                     }() {
                         log::error!(
-                            "drawing stroke in draw_strokes_immediate_w_piet() failed with Err {}",
-                            e
+                            "drawing stroke in draw_strokes_immediate_w_piet() failed with Err: {e:?}"
                         );
                     }
                 }
@@ -473,16 +472,15 @@ impl StrokeStore {
             .for_each(|key| {
                 if let Some(stroke) = self.stroke_components.get(key) {
                     if let Err(e) = || -> anyhow::Result<()> {
-                        piet_cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+                        piet_cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
                         stroke
                             .draw(piet_cx, image_scale)
-                            .map_err(|e| anyhow::anyhow!("{}", e))?;
-                        piet_cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+                            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+                        piet_cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
                         Ok(())
                     }() {
                         log::error!(
-                            "drawing stroke in draw_selection_immediate_w_piet() failed with Err {}",
-                            e
+                            "drawing stroke in draw_selection_immediate_w_piet() failed with Err: {e:?}"
                         );
                     }
                 }

--- a/rnote-engine/src/store/render_comp.rs
+++ b/rnote-engine/src/store/render_comp.rs
@@ -294,7 +294,7 @@ impl StrokeStore {
         &mut self,
         tasks_tx: EngineTaskSender,
         key: StrokeKey,
-        n_segments: usize,
+        n_last_segments: usize,
         viewport: AABB,
         image_scale: f64,
     ) -> anyhow::Result<()> {
@@ -305,10 +305,9 @@ impl StrokeStore {
             match stroke.as_ref() {
                 Stroke::BrushStroke(brushstroke) => {
                     if let Some(image) =
-                        brushstroke.gen_image_for_last_segments(n_segments, image_scale)?
+                        brushstroke.gen_image_for_last_segments(n_last_segments, image_scale)?
                     {
-                        let mut rendernodes =
-                            render::Image::images_to_rendernodes(&[image.clone()])?;
+                        let mut rendernodes = render::Image::images_to_rendernodes([&image])?;
 
                         render_comp.rendernodes.append(&mut rendernodes);
                         render_comp.images.push(image);

--- a/rnote-engine/src/store/stroke_comp.rs
+++ b/rnote-engine/src/store/stroke_comp.rs
@@ -183,8 +183,7 @@ impl StrokeStore {
                         render_comp.rendernodes = rendernodes;
                     }
                     Err(e) => log::error!(
-                        "images_to_rendernode() failed in translate_strokes_images() with Err {}",
-                        e
+                        "images_to_rendernode() failed in translate_strokes_images() with Err: {e:?}"
                     ),
                 }
             }
@@ -227,8 +226,7 @@ impl StrokeStore {
                         render_comp.rendernodes = rendernodes;
                     }
                     Err(e) => log::error!(
-                        "images_to_rendernode() failed in rotate_strokes() with Err {}",
-                        e
+                        "images_to_rendernode() failed in rotate_strokes() with Err: {e:?}"
                     ),
                 }
             }
@@ -266,8 +264,7 @@ impl StrokeStore {
                         render_comp.rendernodes = rendernodes;
                     }
                     Err(e) => log::error!(
-                        "images_to_rendernode() failed in rotate_strokes() with Err {}",
-                        e
+                        "images_to_rendernode() failed in rotate_strokes() with Err: {e:?}"
                     ),
                 }
             }
@@ -369,8 +366,7 @@ impl StrokeStore {
                         render_comp.rendernodes = rendernodes;
                     }
                     Err(e) => log::error!(
-                        "images_to_rendernode() failed in resize_strokes() with Err {}",
-                        e
+                        "images_to_rendernode() failed in resize_strokes() with Err: {e:?}"
                     ),
                 }
             }

--- a/rnote-engine/src/store/trash_comp.rs
+++ b/rnote-engine/src/store/trash_comp.rs
@@ -157,6 +157,7 @@ impl StrokeStore {
                 let stroke_bounds = stroke.bounds();
 
                 match stroke {
+                    /*
                     Stroke::BrushStroke(brushstroke) => {
                         if eraser_bounds.intersects(&stroke_bounds) {
                             let stroke_width = brushstroke.style.stroke_width();
@@ -211,8 +212,8 @@ impl StrokeStore {
                                 }
                             }
                         }
-                    }
-                    Stroke::ShapeStroke(_) => {
+                    } */
+                    Stroke::BrushStroke(_) | Stroke::ShapeStroke(_) => {
                         if eraser_bounds.intersects(&stroke_bounds) {
                             for hitbox_elem in stroke.hitboxes().iter() {
                                 if eraser_bounds.intersects(hitbox_elem) {
@@ -221,15 +222,8 @@ impl StrokeStore {
                             }
                         }
                     }
-                    Stroke::TextStroke(_textstroke) => {
-                        // Ignore text strokes when trashing with the Eraser
-                    }
-                    Stroke::VectorImage(_vectorimage) => {
-                        // Ignore vector images when trashing with the Eraser
-                    }
-                    Stroke::BitmapImage(_bitmapimage) => {
-                        // Ignore bitmap images when trashing with the Eraser
-                    }
+                    // Ignore other strokes when trashing with the Eraser
+                    Stroke::TextStroke(_) | Stroke::VectorImage(_) | Stroke::BitmapImage(_) => {}
                 }
 
                 if trash_current_stroke {

--- a/rnote-engine/src/store/trash_comp.rs
+++ b/rnote-engine/src/store/trash_comp.rs
@@ -3,7 +3,6 @@ use crate::strokes::{BrushStroke, Stroke};
 use crate::WidgetFlags;
 
 use p2d::bounding_volume::{BoundingVolume, AABB};
-use rnote_compose::penpath::Segment;
 use rnote_compose::shapes::ShapeBehaviour;
 use rnote_compose::PenPath;
 use serde::{Deserialize, Serialize};
@@ -109,14 +108,8 @@ impl StrokeStore {
                                 }
                             }
                         }
-                        Stroke::TextStroke(_textstroke) => {
-                            // Ignore text strokes when trashing with the Eraser
-                        }
-                        Stroke::VectorImage(_vectorimage) => {
-                            // Ignore vector images when trashing with the Eraser
-                        }
-                        Stroke::BitmapImage(_bitmapimage) => {
-                            // Ignore bitmap images when trashing with the Eraser
+                        // Ignore other strokes when trashing with the Eraser
+                        Stroke::TextStroke(_) | Stroke::VectorImage(_) | Stroke::BitmapImage(_) => {
                         }
                     }
                 }
@@ -157,63 +150,68 @@ impl StrokeStore {
                 let stroke_bounds = stroke.bounds();
 
                 match stroke {
-                    /*
                     Stroke::BrushStroke(brushstroke) => {
                         if eraser_bounds.intersects(&stroke_bounds) {
-                            let stroke_width = brushstroke.style.stroke_width();
-                            brushstroke.path.make_contiguous();
+                            if let Some(split_at) = brushstroke.path.hittest(&eraser_bounds) {
+                                let (first_split, second_split) =
+                                    brushstroke.path.segments[..].split_at(split_at);
+                                let first_split = first_split.to_vec();
+                                // We want to exlude the colliding segment, so +1
+                                let second_split =
+                                    second_split[1.min(second_split.len())..].to_vec();
 
-                            let split_segments = brushstroke
-                                .path
-                                .as_slices()
-                                .0
-                                .split(|segment| {
-                                    segment.hitboxes().iter().any(|hitbox| {
-                                        // The hitboxes of the individual segments need to be loosened with the style stroke width
-                                        hitbox
-                                            .loosened(stroke_width * 0.5)
-                                            .intersects(&eraser_bounds)
-                                    })
-                                })
-                                .collect::<Vec<&[Segment]>>();
+                                let first_empty = first_split.is_empty();
+                                let second_empty = second_split.is_empty()
+                                    || split_at == second_split.len().saturating_sub(1);
 
-                            // If this is met, we intersect with the stroke but we cant form any new split strokes, so we trash it ( e.g. strokes that only have a single element )
-                            if split_segments.iter().all(|segments| segments.is_empty()) {
-                                trash_current_stroke = true;
-                            } else {
-                                // Filter out all empty paths
-                                let mut split_penpaths = split_segments
-                                    .into_iter()
-                                    .filter_map(|segments| {
-                                        let split_penpath =
-                                            PenPath::from_iter(segments.iter().cloned());
+                                //log::debug!("split stroke, first_empty: {first_empty}, second_empty: {second_empty}, split_i: {split_at}");
 
-                                        if split_penpath.is_empty() {
-                                            None
-                                        } else {
-                                            Some(split_penpath)
-                                        }
-                                    })
-                                    .collect::<Vec<PenPath>>();
+                                match (first_empty, second_empty) {
+                                    (false, false) => {
+                                        // the first split is the original path until the hit, so we only need to replace the segments and can keep start
+                                        let first_start = brushstroke.path.start;
+                                        let second_start = first_split.last().unwrap().end();
 
-                                if let Some(last_penpath) = split_penpaths.pop() {
-                                    for split_penpath in split_penpaths {
-                                        if let Some(new_brushstroke) = BrushStroke::from_penpath(
-                                            split_penpath,
-                                            brushstroke.style.clone(),
-                                        ) {
-                                            new_strokes.push(Stroke::BrushStroke(new_brushstroke));
-                                        }
+                                        let first_split = first_split.to_vec();
+                                        brushstroke.replace_path(PenPath::new_w_segments(
+                                            first_start,
+                                            first_split,
+                                        ));
+                                        modified_keys.push(key);
+
+                                        new_strokes.push(Stroke::BrushStroke(
+                                            BrushStroke::from_penpath(
+                                                PenPath::new_w_segments(
+                                                    second_start,
+                                                    second_split.to_vec(),
+                                                ),
+                                                brushstroke.style.clone(),
+                                            ),
+                                        ));
                                     }
-
-                                    // reusing the current brushstroke by replacing its path with the last new path
-                                    brushstroke.replace_path(last_penpath);
-                                    modified_keys.push(key);
+                                    (false, true) => {
+                                        brushstroke.replace_path(PenPath::new_w_segments(
+                                            brushstroke.path.start,
+                                            first_split.to_vec(),
+                                        ));
+                                        modified_keys.push(key);
+                                    }
+                                    (true, false) => {
+                                        let new_start = second_split.first().unwrap().end();
+                                        brushstroke.replace_path(PenPath::new_w_segments(
+                                            new_start,
+                                            second_split.to_vec(),
+                                        ));
+                                        modified_keys.push(key);
+                                    }
+                                    (true, true) => {
+                                        trash_current_stroke = true;
+                                    }
                                 }
                             }
                         }
-                    } */
-                    Stroke::BrushStroke(_) | Stroke::ShapeStroke(_) => {
+                    }
+                    Stroke::ShapeStroke(_) => {
                         if eraser_bounds.intersects(&stroke_bounds) {
                             for hitbox_elem in stroke.hitboxes().iter() {
                                 if eraser_bounds.intersects(hitbox_elem) {

--- a/rnote-engine/src/strokes/bitmapimage.rs
+++ b/rnote-engine/src/strokes/bitmapimage.rs
@@ -87,7 +87,7 @@ impl StrokeBehaviour for BitmapImage {
 
 impl DrawBehaviour for BitmapImage {
     fn draw(&self, cx: &mut impl piet::RenderContext, _image_scale: f64) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         let piet_image_format = piet::ImageFormat::try_from(self.image.memory_format)?;
 
@@ -100,12 +100,12 @@ impl DrawBehaviour for BitmapImage {
                 &self.image.data,
                 piet_image_format,
             )
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         let dest_rect = self.rectangle.cuboid.local_aabb().to_kurbo_rect();
         cx.draw_image(&piet_image, dest_rect, piet::InterpolationMode::Bilinear);
 
-        cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 }
@@ -245,7 +245,7 @@ impl BitmapImage {
                 match result() {
                     Ok(ret) => Some(ret),
                     Err(e) => {
-                        log::error!("bitmapimage import_from_pdf_bytes() failed with Err {}", e);
+                        log::error!("bitmapimage import_from_pdf_bytes() failed with Err: {e:?}");
                         None
                     }
                 }
@@ -261,7 +261,7 @@ impl BitmapImage {
                 ) {
                     Ok(bitmapimage) => Some(bitmapimage),
                     Err(e) => {
-                        log::error!("import_from_image_bytes() failed in bitmapimage import_from_pdf_bytes() with Err {}", e);
+                        log::error!("import_from_image_bytes() failed in bitmapimage import_from_pdf_bytes() with Err: {e:?}");
                         None
                     }
                 }

--- a/rnote-engine/src/strokes/brushstroke.rs
+++ b/rnote-engine/src/strokes/brushstroke.rs
@@ -264,7 +264,7 @@ impl BrushStroke {
 
     pub fn gen_image_for_last_segments(
         &self,
-        no_last_segments: usize,
+        n_last_segments: usize,
         image_scale: f64,
     ) -> Result<Option<render::Image>, anyhow::Error> {
         let image = match &self.style {
@@ -274,14 +274,14 @@ impl BrushStroke {
                 let start_el = self
                     .path
                     .segments
-                    .get(path_len.saturating_sub(no_last_segments).saturating_sub(1))
+                    .get(path_len.saturating_sub(n_last_segments).saturating_sub(1))
                     .map(|s| s.end())
-                    .unwrap_or_else(|| self.path.start);
+                    .unwrap_or(self.path.start);
 
                 let range_path = PenPath::new_w_segments(
                     start_el,
-                    self.path.segments[path_len.saturating_sub(no_last_segments)..]
-                        .into_iter()
+                    self.path.segments[path_len.saturating_sub(n_last_segments)..]
+                        .iter()
                         .copied(),
                 );
 
@@ -301,21 +301,21 @@ impl BrushStroke {
                 let mut options = options.clone();
                 let path_len = self.path.segments.len();
 
-                (0..path_len.saturating_sub(no_last_segments)).for_each(|_| {
+                (0..path_len.saturating_sub(n_last_segments)).for_each(|_| {
                     options.seed = options.seed.map(rnote_compose::utils::seed_advance)
                 });
 
                 let start_el = self
                     .path
                     .segments
-                    .get(path_len.saturating_sub(no_last_segments).saturating_sub(1))
+                    .get(path_len.saturating_sub(n_last_segments).saturating_sub(1))
                     .map(|s| s.end())
-                    .unwrap_or_else(|| self.path.start);
+                    .unwrap_or(self.path.start);
 
                 let range_path = PenPath::new_w_segments(
                     start_el,
-                    self.path.segments[path_len.saturating_sub(no_last_segments)..]
-                        .into_iter()
+                    self.path.segments[path_len.saturating_sub(n_last_segments)..]
+                        .iter()
                         .copied(),
                 );
 

--- a/rnote-engine/src/strokes/brushstroke.rs
+++ b/rnote-engine/src/strokes/brushstroke.rs
@@ -218,10 +218,11 @@ impl BrushStroke {
     pub fn new(start: Element, style: Style) -> Self {
         let path = PenPath::new(start);
 
-        Self::from_penpath(path, style).unwrap()
+        Self::from_penpath(path, style)
     }
 
-    pub fn from_penpath(path: PenPath, style: Style) -> Option<Self> {
+    /// New from pen path.
+    pub fn from_penpath(path: PenPath, style: Style) -> Self {
         let mut new_brushstroke = Self {
             path,
             style,
@@ -229,11 +230,11 @@ impl BrushStroke {
         };
         new_brushstroke.update_geometry();
 
-        Some(new_brushstroke)
+        new_brushstroke
     }
 
     pub fn push_segment(&mut self, segment: Segment) {
-        self.path.push_back_segment(segment);
+        self.path.segments.push(segment);
     }
 
     pub fn extend_w_segments(&mut self, segments: impl IntoIterator<Item = Segment>) {
@@ -279,9 +280,7 @@ impl BrushStroke {
 
                 let range_path = PenPath::new_w_segments(
                     start_el,
-                    self.path
-                        .segments
-                        .range(path_len.saturating_sub(no_last_segments)..)
+                    self.path.segments[path_len.saturating_sub(no_last_segments)..]
                         .into_iter()
                         .copied(),
                 );
@@ -315,9 +314,7 @@ impl BrushStroke {
 
                 let range_path = PenPath::new_w_segments(
                     start_el,
-                    self.path
-                        .segments
-                        .range(path_len.saturating_sub(no_last_segments)..)
+                    self.path.segments[path_len.saturating_sub(no_last_segments)..]
                         .into_iter()
                         .copied(),
                 );

--- a/rnote-engine/src/strokes/brushstroke.rs
+++ b/rnote-engine/src/strokes/brushstroke.rs
@@ -68,7 +68,7 @@ impl StrokeBehaviour for BrushStroke {
                     match image {
                         Ok(image) => vec![image],
                         Err(e) => {
-                            log::error!("gen_images() in brushstroke failed with Err {}", e);
+                            log::error!("gen_images() in brushstroke failed with Err: {e:?}");
                             vec![]
                         }
                     }
@@ -90,7 +90,7 @@ impl StrokeBehaviour for BrushStroke {
                     match image {
                         Ok(image) => vec![image],
                         Err(e) => {
-                            log::error!("gen_images() in brushstroke failed with Err {}", e);
+                            log::error!("gen_images() in brushstroke failed with Err: {e:?}");
                             vec![]
                         }
                     }
@@ -115,7 +115,7 @@ impl StrokeBehaviour for BrushStroke {
                         ) {
                             Ok(image) => images.push(image),
                             Err(e) => {
-                                log::error!("gen_images() in brushstroke failed with Err {}", e)
+                                log::error!("gen_images() in brushstroke failed with Err: {e:?}")
                             }
                         }
 
@@ -146,7 +146,7 @@ impl StrokeBehaviour for BrushStroke {
                         ) {
                             Ok(image) => images.push(image),
                             Err(e) => {
-                                log::error!("gen_images() in brushstroke failed with Err {}", e)
+                                log::error!("gen_images() in brushstroke failed with Err: {e:?}")
                             }
                         }
 
@@ -169,7 +169,7 @@ impl StrokeBehaviour for BrushStroke {
 
 impl DrawBehaviour for BrushStroke {
     fn draw(&self, cx: &mut impl piet::RenderContext, _image_scale: f64) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         match &self.style {
             Style::Smooth(options) => self.path.draw_composed(cx, options),
@@ -179,7 +179,7 @@ impl DrawBehaviour for BrushStroke {
             Style::Textured(options) => self.path.draw_composed(cx, options),
         };
 
-        cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 }

--- a/rnote-engine/src/strokes/brushstroke.rs
+++ b/rnote-engine/src/strokes/brushstroke.rs
@@ -14,26 +14,15 @@ use p2d::bounding_volume::{BoundingVolume, AABB};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default, rename = "brushstroke")]
+#[serde(rename = "brushstroke")]
 pub struct BrushStroke {
     #[serde(rename = "path")]
     pub path: PenPath,
-    #[serde(rename = "style")]
+    #[serde(default, rename = "style")]
     pub style: Style,
     #[serde(skip)]
     // since the path can have many hitboxes, we store them for faster queries and update them when the stroke geometry changes
     hitboxes: Vec<AABB>,
-}
-
-impl Default for BrushStroke {
-    fn default() -> Self {
-        Self::new(
-            Segment::Dot {
-                element: Element::default(),
-            },
-            Style::default(),
-        )
-    }
 }
 
 impl StrokeBehaviour for BrushStroke {
@@ -109,61 +98,63 @@ impl StrokeBehaviour for BrushStroke {
             }
         } else {
             match &self.style {
-                Style::Smooth(options) => self
-                    .path
-                    .iter()
-                    .filter_map(|segment| {
-                        let image = render::Image::gen_with_piet(
+                Style::Smooth(options) => {
+                    let mut images = Vec::with_capacity(self.path.segments.len());
+
+                    let mut prev = self.path.start;
+                    for seg in self.path.segments.iter() {
+                        let seg_path = PenPath::new_w_segments(prev, [*seg]);
+
+                        match render::Image::gen_with_piet(
                             |piet_cx| {
-                                segment.draw_composed(piet_cx, options);
+                                seg_path.draw_composed(piet_cx, options);
                                 Ok(())
                             },
-                            segment.composed_bounds(options),
+                            seg_path.composed_bounds(options),
                             image_scale,
-                        );
-
-                        match image {
-                            Ok(image) => Some(image),
+                        ) {
+                            Ok(image) => images.push(image),
                             Err(e) => {
-                                log::error!("gen_images() in brushstroke failed with Err {}", e);
-                                None
+                                log::error!("gen_images() in brushstroke failed with Err {}", e)
                             }
                         }
-                    })
-                    .collect::<Vec<render::Image>>(),
+
+                        prev = seg.end();
+                    }
+
+                    images
+                }
                 Style::Rough(_) => {
                     // Unsupported
                     vec![]
                 }
                 Style::Textured(options) => {
                     let mut options = options.clone();
+                    let mut images = Vec::with_capacity(self.path.segments.len());
 
-                    self.path
-                        .iter()
-                        .filter_map(|segment| {
-                            options.seed = options.seed.map(rnote_compose::utils::seed_advance);
+                    let mut prev = self.path.start;
+                    for seg in self.path.segments.iter() {
+                        let seg_path = PenPath::new_w_segments(prev, [*seg]);
 
-                            let image = render::Image::gen_with_piet(
-                                |piet_cx| {
-                                    segment.draw_composed(piet_cx, &options);
-                                    Ok(())
-                                },
-                                segment.composed_bounds(&options),
-                                image_scale,
-                            );
-
-                            match image {
-                                Ok(image) => Some(image),
-                                Err(e) => {
-                                    log::error!(
-                                        "gen_images() in brushstroke failed with Err {}",
-                                        e
-                                    );
-                                    None
-                                }
+                        match render::Image::gen_with_piet(
+                            |piet_cx| {
+                                seg_path.draw_composed(piet_cx, &options);
+                                Ok(())
+                            },
+                            seg_path.composed_bounds(&options),
+                            image_scale,
+                        ) {
+                            Ok(image) => images.push(image),
+                            Err(e) => {
+                                log::error!("gen_images() in brushstroke failed with Err {}", e)
                             }
-                        })
-                        .collect::<Vec<render::Image>>()
+                        }
+
+                        options.seed = options.seed.map(rnote_compose::utils::seed_advance);
+                        prev = seg.end();
+                    }
+
+                    images
                 }
             }
         };
@@ -224,16 +215,13 @@ impl BrushStroke {
     /// when one of the extents of the stroke is above this threshold, images are generated separately for each stroke segment (to avoid very large images)
     pub const IMAGES_SEGMENTS_THRESHOLD: f64 = 1000.0;
 
-    pub fn new(segment: Segment, style: Style) -> Self {
-        let path = PenPath::new_w_segment(segment);
+    pub fn new(start: Element, style: Style) -> Self {
+        let path = PenPath::new(start);
 
         Self::from_penpath(path, style).unwrap()
     }
 
     pub fn from_penpath(path: PenPath, style: Style) -> Option<Self> {
-        if path.is_empty() {
-            return None;
-        }
         let mut new_brushstroke = Self {
             path,
             style,
@@ -245,7 +233,11 @@ impl BrushStroke {
     }
 
     pub fn push_segment(&mut self, segment: Segment) {
-        self.path.push_back(segment);
+        self.path.push_back_segment(segment);
+    }
+
+    pub fn extend_w_segments(&mut self, segments: impl IntoIterator<Item = Segment>) {
+        self.path.extend(segments);
     }
 
     pub fn update_geometry(&mut self) {
@@ -263,82 +255,86 @@ impl BrushStroke {
         let stroke_width = self.style.stroke_width();
 
         self.path
-            .iter()
-            .flat_map(|segment| {
-                segment
-                    .hitboxes()
-                    .into_iter()
-                    .map(|hitbox| hitbox.loosened(stroke_width * 0.5))
-            })
+            .hitboxes()
+            .into_iter()
+            .map(|hb| hb.loosened(stroke_width * 0.5))
             .collect()
     }
 
-    pub fn gen_images_for_last_segments(
+    pub fn gen_image_for_last_segments(
         &self,
         no_last_segments: usize,
         image_scale: f64,
-    ) -> Result<Vec<render::Image>, anyhow::Error> {
-        let images = match &self.style {
-            Style::Smooth(options) => self
-                .path
-                .iter()
-                .rev()
-                .take(no_last_segments)
-                .rev()
-                .filter_map(|segment| {
-                    let image = render::Image::gen_with_piet(
-                        |piet_cx| {
-                            segment.draw_composed(piet_cx, options);
-                            Ok(())
-                        },
-                        segment.composed_bounds(options),
-                        image_scale,
-                    );
+    ) -> Result<Option<render::Image>, anyhow::Error> {
+        let image = match &self.style {
+            Style::Smooth(options) => {
+                let path_len = self.path.segments.len();
 
-                    match image {
-                        Ok(image) => Some(image),
-                        Err(e) => {
-                            log::error!("gen_images_for_last_segments() failed with Err {}", e);
-                            None
-                        }
-                    }
-                })
-                .collect::<Vec<render::Image>>(),
-            Style::Rough(_) => vec![],
-            Style::Textured(options) => self
-                .path
-                .iter()
-                .enumerate()
-                .rev()
-                .take(no_last_segments)
-                .rev()
-                .filter_map(|(i, segment)| {
-                    let mut options = options.clone();
+                let start_el = self
+                    .path
+                    .segments
+                    .get(path_len.saturating_sub(no_last_segments).saturating_sub(1))
+                    .map(|s| s.end())
+                    .unwrap_or_else(|| self.path.start);
 
-                    (0..=i).for_each(|_| {
-                        options.seed = options.seed.map(rnote_compose::utils::seed_advance)
-                    });
+                let range_path = PenPath::new_w_segments(
+                    start_el,
+                    self.path
+                        .segments
+                        .range(path_len.saturating_sub(no_last_segments)..)
+                        .into_iter()
+                        .copied(),
+                );
 
-                    let image = render::Image::gen_with_piet(
-                        |piet_cx| {
-                            segment.draw_composed(piet_cx, &options);
-                            Ok(())
-                        },
-                        segment.composed_bounds(&options),
-                        image_scale,
-                    );
+                let image = render::Image::gen_with_piet(
+                    |piet_cx| {
+                        range_path.draw_composed(piet_cx, options);
+                        Ok(())
+                    },
+                    range_path.composed_bounds(options),
+                    image_scale,
+                )?;
 
-                    match image {
-                        Ok(image) => Some(image),
-                        Err(e) => {
-                            log::error!("gen_images_for_last_segments() failed with Err {}", e);
-                            None
-                        }
-                    }
-                })
-                .collect::<Vec<render::Image>>(),
+                Some(image)
+            }
+            Style::Rough(_) => None,
+            Style::Textured(options) => {
+                let mut options = options.clone();
+                let path_len = self.path.segments.len();
+
+                (0..path_len.saturating_sub(no_last_segments)).for_each(|_| {
+                    options.seed = options.seed.map(rnote_compose::utils::seed_advance)
+                });
+
+                let start_el = self
+                    .path
+                    .segments
+                    .get(path_len.saturating_sub(no_last_segments).saturating_sub(1))
+                    .map(|s| s.end())
+                    .unwrap_or_else(|| self.path.start);
+
+                let range_path = PenPath::new_w_segments(
+                    start_el,
+                    self.path
+                        .segments
+                        .range(path_len.saturating_sub(no_last_segments)..)
+                        .into_iter()
+                        .copied(),
+                );
+
+                let image = render::Image::gen_with_piet(
+                    |piet_cx| {
+                        range_path.draw_composed(piet_cx, &options);
+                        Ok(())
+                    },
+                    range_path.composed_bounds(&options),
+                    image_scale,
+                )?;
+
+                Some(image)
+            }
         };
 
-        Ok(images)
+        Ok(image)
     }
 }

--- a/rnote-engine/src/strokes/shapestroke.rs
+++ b/rnote-engine/src/strokes/shapestroke.rs
@@ -72,11 +72,11 @@ impl StrokeBehaviour for ShapeStroke {
 
 impl DrawBehaviour for ShapeStroke {
     fn draw(&self, cx: &mut impl piet::RenderContext, _image_scale: f64) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         self.shape.draw_composed(cx, &self.style);
 
-        cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 }

--- a/rnote-engine/src/strokes/stroke.rs
+++ b/rnote-engine/src/strokes/stroke.rs
@@ -365,7 +365,7 @@ impl Stroke {
                 ) {
                     Ok(image_bytes) => image_bytes,
                     Err(e) => {
-                        log::error!("export_as_bytes() failed for shapestroke in stroke to_xopp() with Err `{}`", e);
+                        log::error!("export_as_bytes() failed for shapestroke in stroke to_xopp() with Err: {e:?}");
                         return None;
                     }
                 };
@@ -430,7 +430,7 @@ impl Stroke {
                 ) {
                     Ok(image_bytes) => image_bytes,
                     Err(e) => {
-                        log::error!("export_as_bytes() failed for vectorimage in stroke to_xopp() with Err `{}`", e);
+                        log::error!("export_as_bytes() failed for vectorimage in stroke to_xopp() with Err: {e:?}");
                         return None;
                     }
                 };
@@ -469,7 +469,7 @@ impl Stroke {
                 ) {
                     Ok(image_bytes) => image_bytes,
                     Err(e) => {
-                        log::error!("export_as_bytes() failed for vectorimage in stroke to_xopp() with Err `{}`", e);
+                        log::error!("export_as_bytes() failed for vectorimage in stroke to_xopp() with Err: {e:?}");
                         return None;
                     }
                 };
@@ -508,7 +508,7 @@ impl Stroke {
                 ) {
                     Ok(image_bytes) => image_bytes,
                     Err(e) => {
-                        log::error!("export_as_bytes() failed for bitmapimage in stroke to_xopp() with Err `{}`", e);
+                        log::error!("export_as_bytes() failed for bitmapimage in stroke to_xopp() with Err: {e:?}");
                         return None;
                     }
                 };

--- a/rnote-engine/src/strokes/stroke.rs
+++ b/rnote-engine/src/strokes/stroke.rs
@@ -248,10 +248,7 @@ impl Stroke {
             "from_xoppstroke() failed, failed to create pen path"
         ))?;
 
-        let brushstroke = BrushStroke::from_penpath(penpath, Style::Smooth(smooth_options))
-            .ok_or_else(|| {
-                anyhow::anyhow!("creating brushstroke from penpath in from_xoppstroke() failed.")
-            })?;
+        let brushstroke = BrushStroke::from_penpath(penpath, Style::Smooth(smooth_options));
 
         Ok((Stroke::BrushStroke(brushstroke), layer))
     }

--- a/rnote-engine/src/strokes/stroke.rs
+++ b/rnote-engine/src/strokes/stroke.rs
@@ -244,9 +244,7 @@ impl Stroke {
                 .zip(widths.into_iter())
                 .map(|(pos, pressure)| Element::new(pos + offset, pressure)),
         )
-        .ok_or(anyhow::anyhow!(
-            "from_xoppstroke() failed, failed to create pen path"
-        ))?;
+        .ok_or_else(|| anyhow::anyhow!("from_xoppstroke() failed, failed to create pen path"))?;
 
         let brushstroke = BrushStroke::from_penpath(penpath, Style::Smooth(smooth_options));
 

--- a/rnote-engine/src/strokes/textstroke.rs
+++ b/rnote-engine/src/strokes/textstroke.rs
@@ -317,7 +317,7 @@ impl TextStyle {
 
         text_layout_builder
             .build()
-            .map_err(|e| anyhow::anyhow!("{}", e))
+            .map_err(|e| anyhow::anyhow!("{e:?}"))
     }
 
     pub fn untransformed_size<T>(&self, piet_text: &mut T, text: String) -> Option<na::Vector2<f64>>
@@ -382,7 +382,7 @@ impl TextStyle {
     ) -> anyhow::Result<Vec<kurbo::Rect>> {
         let text_layout = self
             .build_text_layout(&mut piet_cairo::CairoText::new(), text)
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         let range = if selection_cursor.cur_cursor() >= cursor.cur_cursor() {
             cursor.cur_cursor()..selection_cursor.cur_cursor()
@@ -516,8 +516,7 @@ impl ShapeBehaviour for TextStroke {
             Ok(text_layout) => text_layout,
             Err(e) => {
                 log::error!(
-                    "build_text_layout() failed while calculating the hitboxes, Err {}",
-                    e
+                    "build_text_layout() failed while calculating the hitboxes, Err: {e:?}"
                 );
 
                 return vec![self.bounds()];
@@ -594,7 +593,7 @@ impl StrokeBehaviour for TextStroke {
 
 impl DrawBehaviour for TextStroke {
     fn draw(&self, cx: &mut impl RenderContext, _image_scale: f64) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         if let Ok(text_layout) = self
             .text_style
@@ -604,7 +603,7 @@ impl DrawBehaviour for TextStroke {
             cx.draw_text(&text_layout, kurbo::Point::new(0.0, 0.0))
         }
 
-        cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 }
@@ -630,7 +629,7 @@ impl TextStroke {
         let text_layout = self
             .text_style
             .build_text_layout(&mut piet_cairo::CairoText::new(), self.text.clone())
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
         let hit_test_point = text_layout.hit_test_point(
             (self.transform.affine.inverse() * na::Point2::from(coord))
                 .coords

--- a/rnote-engine/src/strokes/vectorimage.rs
+++ b/rnote-engine/src/strokes/vectorimage.rs
@@ -93,7 +93,7 @@ impl StrokeBehaviour for VectorImage {
 // There we use a svg renderer to generate pixel images. In this way we ensure to export an actual svg when calling gen_svgs(), but can also draw it onto piet.
 impl DrawBehaviour for VectorImage {
     fn draw(&self, cx: &mut impl piet::RenderContext, image_scale: f64) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         let mut image =
             render::Image::gen_image_from_svg(self.gen_svg()?, self.bounds(), image_scale)?;
@@ -103,7 +103,7 @@ impl DrawBehaviour for VectorImage {
         // image_scale does not have a meaning here, as the pixel image is already provided
         image.draw(cx, image_scale)?;
 
-        cx.restore().map_err(|e| anyhow::anyhow!("{}", e))?;
+        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
     }
 }
@@ -222,10 +222,9 @@ impl VectorImage {
                     cairo::SvgSurface::for_stream(intrinsic_size.0, intrinsic_size.1, svg_stream)
                         .map_err(|e| {
                         anyhow::anyhow!(
-                            "create SvgSurface with dimensions ({}, {}) failed in vectorimage import_from_pdf_bytes with Err {}",
+                            "create SvgSurface with dimensions ({}, {}) failed in vectorimage import_from_pdf_bytes with Err: {e:?}",
                             intrinsic_size.0,
-                            intrinsic_size.1,
-                            e
+                            intrinsic_size.1
                         )
                     })?;
 
@@ -235,8 +234,7 @@ impl VectorImage {
                 {
                     let cx = cairo::Context::new(&svg_surface).map_err(|e| {
                         anyhow::anyhow!(
-                            "new cairo::Context failed in vectorimage import_from_pdf_bytes() with Err {}",
-                            e
+                            "new cairo::Context failed in vectorimage import_from_pdf_bytes() with Err: {e:?}"
                         )
                     })?;
 
@@ -263,7 +261,7 @@ impl VectorImage {
 
                 let svg_content = String::from_utf8(
                     *svg_surface.finish_output_stream()
-                        .map_err(|e| anyhow::anyhow!("{}", e))?
+                        .map_err(|e| anyhow::anyhow!("{e:?}"))?
                         .downcast::<Vec<u8>>()
                         .map_err(|_e| anyhow::anyhow!("failed to downcast svg surface content in VectorImage import_from_pdf_bytes()"))?)?;
 
@@ -276,7 +274,7 @@ impl VectorImage {
                     bounds: AABB::new(na::point![x, y], na::point![x + width, y + height])
                 }),
                 Err(e) => {
-                    log::error!("importing page {} from pdf failed with Err {}", page, e);
+                    log::error!("importing page {page} from pdf failed with Err: {e:?}");
                     None
                 }
             }
@@ -292,7 +290,7 @@ impl VectorImage {
                 ) {
                     Ok(vectorimage) => Some(vectorimage),
                     Err(e) => {
-                        log::error!("import_from_svg_data() failed failed in vectorimage import_from_pdf_bytes() with Err {}", e);
+                        log::error!("import_from_svg_data() failed failed in vectorimage import_from_pdf_bytes() with Err: {e:?}");
                         None
                     }
                 }

--- a/rnote-fileformats/src/meson.build
+++ b/rnote-fileformats/src/meson.build
@@ -1,6 +1,7 @@
 # Specify sources
 rnote_fileformats_sources = files(
     'lib.rs',
-    'rnoteformat.rs',
+    'rnoteformat/mod.rs',
+    'rnoteformat/maj0min5patch8.rs',
     'xoppformat.rs',
 )

--- a/rnote-fileformats/src/rnoteformat/maj0min5patch8.rs
+++ b/rnote-fileformats/src/rnoteformat/maj0min5patch8.rs
@@ -8,9 +8,11 @@ impl TryFrom<RnoteFileMaj0Min5Patch8> for Rnotefile {
     fn try_from(mut file: RnoteFileMaj0Min5Patch8) -> Result<Self, Self::Error> {
         for value in file.store_snapshot["stroke_components"]
             .as_array_mut()
-            .ok_or(anyhow::anyhow!("failure"))?
+            .ok_or_else(|| anyhow::anyhow!("failure"))?
         {
-            let stroke = value.get_mut("value").ok_or(anyhow::anyhow!("failure"))?;
+            let stroke = value
+                .get_mut("value")
+                .ok_or_else(|| anyhow::anyhow!("failure"))?;
 
             if let Some(brushstroke) = stroke.get_mut("brushstroke") {
                 let brushstroke = brushstroke
@@ -25,8 +27,8 @@ impl TryFrom<RnoteFileMaj0Min5Patch8> for Rnotefile {
 
                 let mut path_upgraded = serde_json::Map::new();
 
-                let mut seg_iter = path.0.into_iter();
-                if let Some(start) = seg_iter.next() {
+                let mut seg_iter = path.0.into_iter().peekable();
+                if let Some(start) = seg_iter.peek() {
                     let start = match start {
                         SegmentMaj0Min5Patch8::Dot { element } => element,
                         SegmentMaj0Min5Patch8::Line { start, .. } => start,
@@ -86,7 +88,7 @@ impl TryFrom<RnoteFileMaj0Min5Patch8> for Rnotefile {
 
                     path_upgraded.insert(
                         String::from("segments"),
-                        serde_json::Value::Array(segments_upgraded.into()),
+                        serde_json::Value::Array(segments_upgraded),
                     );
                 }
 

--- a/rnote-fileformats/src/rnoteformat/maj0min5patch8.rs
+++ b/rnote-fileformats/src/rnoteformat/maj0min5patch8.rs
@@ -1,0 +1,163 @@
+use serde::{Deserialize, Serialize};
+
+use super::Rnotefile;
+
+impl TryFrom<RnoteFileMaj0Min5Patch8> for Rnotefile {
+    type Error = anyhow::Error;
+
+    fn try_from(mut file: RnoteFileMaj0Min5Patch8) -> Result<Self, Self::Error> {
+        for value in file.store_snapshot["stroke_components"]
+            .as_array_mut()
+            .ok_or(anyhow::anyhow!("failure"))?
+        {
+            let stroke = value.get_mut("value").ok_or(anyhow::anyhow!("failure"))?;
+
+            if let Some(brushstroke) = stroke.get_mut("brushstroke") {
+                let brushstroke = brushstroke
+                    .as_object_mut()
+                    .ok_or_else(|| anyhow::anyhow!("failure"))?;
+
+                let path = serde_json::from_value::<PenPathMaj0Min5Patch8>(
+                    brushstroke
+                        .remove("path")
+                        .ok_or_else(|| anyhow::anyhow!("failure"))?,
+                )?;
+
+                let mut path_upgraded = serde_json::Map::new();
+
+                let mut seg_iter = path.0.into_iter();
+                if let Some(start) = seg_iter.next() {
+                    let start = match start {
+                        SegmentMaj0Min5Patch8::Dot { element } => element,
+                        SegmentMaj0Min5Patch8::Line { start, .. } => start,
+                        SegmentMaj0Min5Patch8::QuadBez { start, .. } => start,
+                        SegmentMaj0Min5Patch8::CubBez { start, .. } => start,
+                    };
+
+                    path_upgraded.insert(String::from("start"), serde_json::to_value(start)?);
+
+                    let mut segments_upgraded = Vec::new();
+                    for seg in seg_iter {
+                        let mut segment_upgraded = serde_json::Map::new();
+
+                        match seg {
+                            SegmentMaj0Min5Patch8::Dot { element } => {
+                                let mut lineto = serde_json::Map::new();
+                                lineto.insert(String::from("end"), serde_json::to_value(element)?);
+
+                                segment_upgraded.insert(String::from("lineto"), lineto.into());
+                            }
+                            SegmentMaj0Min5Patch8::Line { start, end } => {
+                                let mut lineto = serde_json::Map::new();
+                                lineto.insert(String::from("start"), serde_json::to_value(start)?);
+                                lineto.insert(String::from("end"), serde_json::to_value(end)?);
+
+                                segment_upgraded.insert(String::from("lineto"), lineto.into());
+                            }
+                            SegmentMaj0Min5Patch8::QuadBez { start, cp, end } => {
+                                let mut quadbezto = serde_json::Map::new();
+                                quadbezto
+                                    .insert(String::from("start"), serde_json::to_value(start)?);
+                                quadbezto.insert(String::from("cp"), serde_json::to_value(cp)?);
+                                quadbezto.insert(String::from("end"), serde_json::to_value(end)?);
+
+                                segment_upgraded
+                                    .insert(String::from("quadbezto"), quadbezto.into());
+                            }
+                            SegmentMaj0Min5Patch8::CubBez {
+                                start,
+                                cp1,
+                                cp2,
+                                end,
+                            } => {
+                                let mut cubbezto = serde_json::Map::new();
+                                cubbezto
+                                    .insert(String::from("start"), serde_json::to_value(start)?);
+                                cubbezto.insert(String::from("cp1"), serde_json::to_value(cp1)?);
+                                cubbezto.insert(String::from("cp2"), serde_json::to_value(cp2)?);
+                                cubbezto.insert(String::from("end"), serde_json::to_value(end)?);
+
+                                segment_upgraded.insert(String::from("cubbezto"), cubbezto.into());
+                            }
+                        };
+
+                        segments_upgraded.push(segment_upgraded.into());
+                    }
+
+                    path_upgraded.insert(
+                        String::from("segments"),
+                        serde_json::Value::Array(segments_upgraded.into()),
+                    );
+                }
+
+                brushstroke.insert(String::from("path"), path_upgraded.into());
+            }
+        }
+
+        Ok(Self {
+            store_snapshot: file.store_snapshot,
+            document: file.document,
+        })
+    }
+}
+
+/// Rnote file in version: maj 0 min 5 patch 8
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RnoteFileMaj0Min5Patch8 {
+    /// the document
+    #[serde(rename = "document", alias = "sheet")]
+    pub document: serde_json::Value,
+    /// A snapshot of the store
+    #[serde(rename = "store_snapshot")]
+    pub store_snapshot: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename = "pen_path")]
+struct PenPathMaj0Min5Patch8(Vec<SegmentMaj0Min5Patch8>);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename = "segment")]
+enum SegmentMaj0Min5Patch8 {
+    #[serde(rename = "dot")]
+    Dot {
+        #[serde(rename = "element")]
+        element: ElementMaj0Min5Patch8,
+    },
+    #[serde(rename = "line")]
+    Line {
+        #[serde(rename = "start")]
+        start: ElementMaj0Min5Patch8,
+        #[serde(rename = "end")]
+        end: ElementMaj0Min5Patch8,
+    },
+    #[serde(rename = "quadbez")]
+    QuadBez {
+        #[serde(rename = "start")]
+        start: ElementMaj0Min5Patch8,
+        #[serde(rename = "cp")]
+        cp: na::Vector2<f64>,
+        #[serde(rename = "end")]
+        end: ElementMaj0Min5Patch8,
+    },
+    #[serde(rename = "cubbez")]
+    CubBez {
+        #[serde(rename = "start")]
+        start: ElementMaj0Min5Patch8,
+        #[serde(rename = "cp1")]
+        cp1: na::Vector2<f64>,
+        #[serde(rename = "cp2")]
+        cp2: na::Vector2<f64>,
+        #[serde(rename = "end")]
+        end: ElementMaj0Min5Patch8,
+    },
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename = "element")]
+struct ElementMaj0Min5Patch8 {
+    #[serde(rename = "pos")]
+    pub pos: na::Vector2<f64>,
+    #[serde(rename = "pressure")]
+    pub pressure: f64,
+}

--- a/rnote-fileformats/src/rnoteformat/mod.rs
+++ b/rnote-fileformats/src/rnoteformat/mod.rs
@@ -1,3 +1,11 @@
+//! The file format is expected only to break on minor versions in prelease (0.x.x) and on major versions after 1.0.0 release. (equivalent to API's conforming to the semver spec)
+//! Older formats can be added, with the naming scheme RnoteFileMaj<X>Min<Y>, where X: semver major, Y: semver minor version.
+//! Then TryFrom is implemented to allow conversions and chaining from older to newer versions.
+
+pub(crate) mod maj0min5patch8;
+
+use maj0min5patch8::RnoteFileMaj0Min5Patch8;
+
 use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
 
@@ -36,11 +44,11 @@ struct RnotefileWrapper {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// the Rnote file in format version 0.5.x. The actual (de-) serialization into strong types is happening in `rnote-engine`.
+/// the Rnote file in the newest format version. The actual (de-) serialization into strong types is happening in `rnote-engine`.
 /// This struct exists to allow for upgrading older versions before loading the file in.
 
-#[serde(rename = "rnotefile_maj0_min5")]
-pub struct RnotefileMaj0Min5 {
+#[serde(rename = "rnotefile")]
+pub struct Rnotefile {
     /// the document
     #[serde(rename = "document", alias = "sheet")]
     pub document: serde_json::Value,
@@ -49,32 +57,37 @@ pub struct RnotefileMaj0Min5 {
     pub store_snapshot: serde_json::Value,
 }
 
-impl FileFormatLoader for RnotefileMaj0Min5 {
-    fn load_from_bytes(bytes: &[u8]) -> anyhow::Result<RnotefileMaj0Min5> {
+impl FileFormatLoader for Rnotefile {
+    fn load_from_bytes(bytes: &[u8]) -> anyhow::Result<Rnotefile> {
         let decompressed = String::from_utf8(decompress_from_gzip(bytes)?)?;
 
         let wrapped_rnote_file = serde_json::from_str::<RnotefileWrapper>(decompressed.as_str())?;
 
         // Conversions for older file format versions happens here
-        if semver::VersionReq::parse(">=0.5.0")
+        if semver::Version::parse("0.5.8").unwrap() == wrapped_rnote_file.version {
+            Ok(Self::try_from(serde_json::from_value::<
+                RnoteFileMaj0Min5Patch8,
+            >(wrapped_rnote_file.data)?)?)
+        } else if semver::VersionReq::parse(">=0.5.0")
             .unwrap()
             .matches(&wrapped_rnote_file.version)
         {
-            Ok(serde_json::from_value::<RnotefileMaj0Min5>(
+            Ok(serde_json::from_value::<Rnotefile>(
                 wrapped_rnote_file.data,
             )?)
         } else {
             Err(anyhow::anyhow!(
-                "failed to load rnote file from bytes, unsupported version",
+                "failed to load rnote file from bytes, unsupported version: {}",
+                wrapped_rnote_file.version
             ))
         }
     }
 }
 
-impl FileFormatSaver for RnotefileMaj0Min5 {
+impl FileFormatSaver for Rnotefile {
     fn save_as_bytes(&self, file_name: &str) -> anyhow::Result<Vec<u8>> {
         let output = RnotefileWrapper {
-            version: semver::Version::parse("0.5.8").unwrap(),
+            version: semver::Version::parse("0.5.9").unwrap(),
             data: serde_json::to_value(self)?,
         };
 
@@ -83,12 +96,3 @@ impl FileFormatSaver for RnotefileMaj0Min5 {
         Ok(compressed)
     }
 }
-
-// The file format is expected only to break on minor versions in prelease (0.x.x) and on major versions after 1.0.0 release. (equivalent to API's conforming to the semver spec)
-// Older formats can be added here, with the naming scheme RnoteFileMaj<X>Min<Y>, where X: semver major, Y: semver minor version.
-// Then TryFrom is implemented to allow conversions and chaining from older to newer versions.
-
-/* #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RnoteFileMaj0Min4 {
-    doc: serde_json::Value,
-} */

--- a/rnote-fileformats/src/xoppformat.rs
+++ b/rnote-fileformats/src/xoppformat.rs
@@ -378,7 +378,7 @@ impl XmlLoadable for XoppBackground {
                 })?) {
                     Ok(s) => s,
                     Err(e) => {
-                        log::error!("failed to retrieve the XoppBackgroundSolidStyle from `style` attribute, {}", e);
+                        log::error!("failed to retrieve the XoppBackgroundSolidStyle from `style` attribute, {e:?}");
                         XoppBackgroundSolidStyle::Plain
                     }
                 };

--- a/rnote-ui/src/appwindow/appsettings.rs
+++ b/rnote-ui/src/appwindow/appsettings.rs
@@ -215,7 +215,7 @@ impl RnoteAppWindow {
                     if engine_config.is_empty() {
                         log::debug!("did not load `engine-config` from settings, was empty");
                     } else {
-                        log::error!("failed to load `engine-config` from settings, Err {}", e);
+                        log::error!("failed to load `engine-config` from settings, Err: {e:?}");
                     }
                     None
                 }

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -193,7 +193,7 @@ impl RnoteAppWindow {
         action_error_toast.connect_activate(
             clone!(@weak self as appwindow => move |_action_error_toast, parameter| {
                 let error_text = parameter.unwrap().get::<String>().unwrap();
-                log::error!("{}", error_text);
+                log::error!("{error_text}");
                 let error_toast = adw::Toast::builder().title(error_text.as_str()).priority(adw::ToastPriority::High).timeout(0).build();
 
                 appwindow.toast_overlay().add_toast(&error_toast);
@@ -266,7 +266,7 @@ impl RnoteAppWindow {
                         appwindow.canvas_fixedsize_quickactions_revealer().set_reveal_child(false);
                     }
                     invalid_str => {
-                        log::error!("action doc-layout failed, invalid str: {}", invalid_str);
+                        log::error!("action doc-layout failed, invalid str: {invalid_str}");
                         return;
                     }
                 }
@@ -323,7 +323,7 @@ impl RnoteAppWindow {
                         Some(PenStyle::Tools)
                     }
                     _ => {
-                        log::error!("invalid target for action_pen_style, `{}`", pen_style);
+                        log::error!("invalid target for action_pen_style, `{pen_style}`");
                         None
                     }
                 };
@@ -373,7 +373,7 @@ impl RnoteAppWindow {
                         Some(None)
                     }
                     _ => {
-                        log::error!("invalid target for action_pen_overwrite, `{}`", pen_style_override);
+                        log::error!("invalid target for action_pen_overwrite, `{pen_style_override}`");
                         None
                     }
                 };
@@ -638,7 +638,7 @@ impl RnoteAppWindow {
                     if let Err(e) = appwindow.save_document_to_file(&output_file).await {
                         appwindow.canvas().set_output_file(None);
 
-                        log::error!("saving document failed with error `{}`", e);
+                        log::error!("saving document failed with error `{e:?}`");
                         adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Saving document failed.").to_variant()));
                     }
 
@@ -675,8 +675,7 @@ impl RnoteAppWindow {
                     .gen_svg(doc_bounds, true)
                     .map_err(|e| {
                         log::error!(
-                            "background.gen_svg() failed in in the print document action, with Err {}",
-                            e
+                            "background.gen_svg() failed in in the print document action, with Err: {e:?}"
                         )
                     })
                     .ok()
@@ -746,9 +745,9 @@ impl RnoteAppWindow {
                         }
                     }
 
-                    piet_cx.finish().map_err(|e| anyhow::anyhow!("piet_cx finish() failed while printing page {}, with Err {}", page_no, e))
+                    piet_cx.finish().map_err(|e| anyhow::anyhow!("piet_cx finish() failed while printing page {page_no}, with Err: {e:?}"))
                 }() {
-                    log::error!("draw_page() failed while printing page: {}, Err {}", page_no, e);
+                    log::error!("draw_page() failed while printing page: {page_no}, Err: {e:?}");
                 }
             }));
 
@@ -764,7 +763,7 @@ impl RnoteAppWindow {
 
             // Run the print op
             if let Err(e) = print_op.run(PrintOperationAction::PrintDialog, Some(&appwindow)){
-                log::error!("print_op.run() failed with Err, {}", e);
+                log::error!("print_op.run() failed with Err, {e:?}");
                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Printing document failed").to_variant()));
             }
 
@@ -804,14 +803,14 @@ impl RnoteAppWindow {
                 let content = gdk::ContentProvider::for_bytes(mime_type.as_str(), &glib::Bytes::from_owned(data));
 
                 if let Err(e) = appwindow.clipboard().set_content(Some(&content)) {
-                    log::error!("clipboard set_content() failed in clipboard-copy action, Err {}", e);
+                    log::error!("clipboard set_content() failed in clipboard-copy action, Err: {e:?}");
                 }
             }
             Ok(None) => {
                 log::debug!("no data available to copy into clipboard.");
             }
             Err(e) => {
-                log::error!("fetch_clipboard_content() failed in clipboard-copy action, Err {}", e);
+                log::error!("fetch_clipboard_content() failed in clipboard-copy action, Err: {e:?}");
             }
         }
     }));
@@ -826,12 +825,12 @@ impl RnoteAppWindow {
                     match appwindow.clipboard().read_text_future().await {
                         Ok(Some(text)) => {
                                 if let Err(e) = appwindow.load_in_vectorimage_bytes(text.as_bytes().to_vec(), None).await {
-                                    log::error!("failed to paste clipboard as vector image, load_in_vectorimage_bytes() returned Err `{}`", e);
+                                    log::error!("failed to paste clipboard as vector image, load_in_vectorimage_bytes() returned Err: {e:?}");
                                 };
                         }
                         Ok(None) => {}
                         Err(e) => {
-                            log::debug!("could not load clipboard contents as svg, read_text() failed with Err `{}`", e);
+                            log::debug!("could not load clipboard contents as svg, read_text() failed with Err: {e:?}");
 
                         }
                     }
@@ -862,7 +861,7 @@ impl RnoteAppWindow {
                         }
                         Ok(None) => {}
                         Err(e) => {
-                            log::error!("failed to paste clipboard from path, read_text() failed with Err {}", e);
+                            log::error!("failed to paste clipboard from path, read_text() failed with Err: {e:?}");
 
                         }
                     }
@@ -884,12 +883,12 @@ impl RnoteAppWindow {
                         match appwindow.clipboard().read_texture_future().await {
                             Ok(Some(texture)) => {
                                 if let Err(e) = appwindow.load_in_bitmapimage_bytes(texture.save_to_png_bytes().to_vec(), None).await {
-                                    log::error!("failed to paste clipboard as {}, load_in_bitmapimage_bytes() returned Err {}", mime_type, e);
+                                    log::error!("failed to paste clipboard as {mime_type}, load_in_bitmapimage_bytes() returned Err: {e:?}");
                                 };
                             }
                             Ok(None) => {}
                             Err(e) => {
-                                log::error!("failed to paste clipboard as {}, read_texture_future() failed with Err {}", mime_type, e);
+                                log::error!("failed to paste clipboard as {mime_type}, read_texture_future() failed with Err: {e:?}");
                             }
                         };
                     }));
@@ -899,12 +898,12 @@ impl RnoteAppWindow {
                     match appwindow.clipboard().read_text_future().await {
                         Ok(Some(text)) => {
                             if let Err(e) = appwindow.load_in_text(text.to_string(), None) {
-                                log::error!("failed to paste clipboard text, Err `{e}`");
+                                log::error!("failed to paste clipboard text, Err: {e:?}");
                             }
                         }
                         Ok(None) => {}
                         Err(e) => {
-                            log::error!("failed to paste clipboard text, read_text() failed with Err {}", e);
+                            log::error!("failed to paste clipboard text, read_text() failed with Err: {e:?}");
 
                         }
                     }

--- a/rnote-ui/src/appwindow/imexport.rs
+++ b/rnote-ui/src/appwindow/imexport.rs
@@ -23,14 +23,13 @@ impl RnoteAppWindow {
                     dialogs::import::dialog_open_overwrite(self);
                 } else if let Err(e) = self.load_in_file(file, target_pos) {
                     log::error!(
-                        "failed to load in file with FileType::RnoteFile | FileType::XoppFile, {}",
-                        e
+                        "failed to load in file with FileType::RnoteFile | FileType::XoppFile, {e:?}"
                     );
                 }
             }
             crate::utils::FileType::VectorImageFile | crate::utils::FileType::BitmapImageFile => {
                 if let Err(e) = self.load_in_file(file, target_pos) {
-                    log::error!("failed to load in file with FileType::VectorImageFile / FileType::BitmapImageFile / FileType::Pdf, {}", e);
+                    log::error!("failed to load in file with FileType::VectorImageFile / FileType::BitmapImageFile / FileType::Pdf, {e:?}");
                 }
             }
             crate::utils::FileType::XoppFile => {
@@ -75,8 +74,7 @@ impl RnoteAppWindow {
                         if let Err(e) = appwindow.load_in_rnote_bytes(file_bytes.to_vec(), file.path()).await {
                             adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening .rnote file failed.").to_variant()));
                             log::error!(
-                                "load_in_rnote_bytes() failed in load_in_file() with Err {}",
-                                e
+                                "load_in_rnote_bytes() failed in load_in_file() with Err: {e:?}"
                             );
                         }
                     }
@@ -94,8 +92,7 @@ impl RnoteAppWindow {
                         if let Err(e) = appwindow.load_in_vectorimage_bytes(file_bytes.to_vec(), target_pos).await {
                             adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening vector image file failed.").to_variant()));
                             log::error!(
-                                "load_in_rnote_bytes() failed in load_in_file() with Err {}",
-                                e
+                                "load_in_rnote_bytes() failed in load_in_file() with Err: {e:?}"
                             );
                         }
                     }
@@ -113,8 +110,7 @@ impl RnoteAppWindow {
                         if let Err(e) = appwindow.load_in_bitmapimage_bytes(file_bytes.to_vec(), target_pos).await {
                             adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening bitmap image file failed.").to_variant()));
                             log::error!(
-                                "load_in_rnote_bytes() failed in load_in_file() with Err {}",
-                                e
+                                "load_in_rnote_bytes() failed in load_in_file() with Err: {e:?}"
                             );
                         }
                     }
@@ -132,8 +128,7 @@ impl RnoteAppWindow {
                         if let Err(e) = appwindow.load_in_xopp_bytes(file_bytes.to_vec()) {
                             adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening Xournal++ file failed.").to_variant()));
                             log::error!(
-                                "load_in_xopp_bytes() failed in load_in_file() with Err {}",
-                                e
+                                "load_in_xopp_bytes() failed in load_in_file() with Err: {e:?}"
                             );
                         }
                     }
@@ -151,8 +146,7 @@ impl RnoteAppWindow {
                         if let Err(e) = appwindow.load_in_pdf_bytes(file_bytes.to_vec(), target_pos, None).await {
                             adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening PDF file failed.").to_variant()));
                             log::error!(
-                                "load_in_rnote_bytes() failed in load_in_file() with Err {}",
-                                e
+                                "load_in_rnote_bytes() failed in load_in_file() with Err: {e:?}"
                             );
                         }
                     }

--- a/rnote-ui/src/appwindow/mod.rs
+++ b/rnote-ui/src/appwindow/mod.rs
@@ -456,7 +456,7 @@ mod imp {
                         if let Err(e) = appwindow.save_document_to_file(&output_file).await {
                             appwindow.canvas().set_output_file(None);
 
-                            log::error!("saving document failed with error `{}`", e);
+                            log::error!("saving document failed with error `{e:?}`");
                             adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Saving document failed.").to_variant()));
                         }
                     }));
@@ -911,8 +911,8 @@ impl RnoteAppWindow {
     /// Called to close the window
     pub fn close_force(&self) {
         // Saving all state
-        if let Err(err) = self.save_to_settings() {
-            log::error!("Failed to save appwindow to settings, with Err `{}`", &err);
+        if let Err(e) = self.save_to_settings() {
+            log::error!("Failed to save appwindow to settings, with Err: {e:?}");
         }
 
         // Closing the state tasks channel receiver
@@ -923,10 +923,7 @@ impl RnoteAppWindow {
             .tasks_tx()
             .unbounded_send(EngineTask::Quit)
         {
-            log::error!(
-                "failed to send StateTask::Quit on store tasks_tx, Err {}",
-                e
-            );
+            log::error!("failed to send StateTask::Quit on store tasks_tx, Err: {e:?}");
         }
 
         self.destroy();
@@ -1166,7 +1163,7 @@ impl RnoteAppWindow {
             glib::source::timeout_add_seconds_local(
                 Self::PERIODIC_CONFIGSAVE_INTERVAL, clone!(@strong self as appwindow => @default-return glib::source::Continue(false), move || {
                     if let Err(e) = appwindow.save_engine_config() {
-                        log::error!("saving engine config in periodic task failed with Err `{e}`");
+                        log::error!("saving engine config in periodic task failed with Err: {e:?}");
                     }
 
                     glib::source::Continue(true)

--- a/rnote-ui/src/canvas/mod.rs
+++ b/rnote-ui/src/canvas/mod.rs
@@ -399,7 +399,7 @@ mod imp {
                 snapshot.pop();
                 Ok(())
             }() {
-                log::error!("canvas snapshot() failed with Err {}", e);
+                log::error!("canvas snapshot() failed with Err: {e:?}");
             }
         }
     }
@@ -901,7 +901,7 @@ impl RnoteCanvas {
                     return true;
                 } else if value.is::<String>() {
                     if let Err(e) = appwindow.load_in_text(value.get::<String>().unwrap(), Some(pos)) {
-                        log::error!("failed to insert dropped in text, Err `{e}`");
+                        log::error!("failed to insert dropped in text, Err: {e:?}");
                     }
                 }
 
@@ -1081,7 +1081,7 @@ impl RnoteCanvas {
             .background
             .regenerate_pattern(viewport, image_scale)
         {
-            log::error!("failed to regenerate background, {}", e)
+            log::error!("failed to regenerate background, {e:?}")
         };
 
         self.queue_draw();

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -33,14 +33,14 @@ pub fn filechooser_save_doc_as(appwindow: &RnoteAppWindow) {
     // Set the output file as default, else at least the current workspace directory
     if let Some(output_file) = appwindow.canvas().output_file() {
         if let Err(e) = filechooser.set_file(&output_file) {
-            log::error!("set_file() for dialog_save_doc_as failed with Err `{e}`");
+            log::error!("set_file() for dialog_save_doc_as failed with Err: {e:?}");
         }
     } else {
         if let Some(current_workspace_dir) = appwindow.workspacebrowser().selected_workspace_dir() {
             if let Err(e) =
                 filechooser.set_current_folder(Some(&gio::File::for_path(current_workspace_dir)))
             {
-                log::error!("set_current_folder() for dialog_save_doc_as failed with Err `{e}`");
+                log::error!("set_current_folder() for dialog_save_doc_as failed with Err: {e:?}");
             }
         }
 
@@ -64,7 +64,7 @@ pub fn filechooser_save_doc_as(appwindow: &RnoteAppWindow) {
                             if let Err(e) = appwindow.save_document_to_file(&file).await {
                                 appwindow.canvas().set_output_file(None);
 
-                                log::error!("saving document failed with error `{}`", e);
+                                log::error!("saving document failed with error `{e:?}`");
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Saving document failed.").to_variant()));
                             } else {
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "text-toast", Some(&gettext("Saved document successfully.").to_variant()));
@@ -189,7 +189,7 @@ pub fn dialog_export_doc_w_prefs(appwindow: &RnoteAppWindow) {
                             let file_title = file.basename().and_then(|b| Some(b.file_stem()?.to_string_lossy().to_string())).unwrap_or_else(|| appwindow::OUTPUT_FILE_NEW_TITLE.clone());
 
                             if let Err(e) = appwindow.export_doc(&file, file_title, None).await {
-                                log::error!("exporting document failed with error `{}`", e);
+                                log::error!("exporting document failed with error `{e:?}`");
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Export document failed.").to_variant()));
                             } else {
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "text-toast", Some(&gettext("Exported document successfully.").to_variant()));
@@ -227,7 +227,7 @@ fn create_filechooser_export_doc(appwindow: &RnoteAppWindow) -> FileChooserNativ
         if let Err(e) =
             filechooser.set_current_folder(Some(&gio::File::for_path(current_workspace_dir)))
         {
-            log::error!("set_current_folder() for dialog_export_doc failed with Err `{e}`");
+            log::error!("set_current_folder() for dialog_export_doc failed with Err: {e:?}");
         }
     }
 
@@ -464,7 +464,7 @@ pub fn dialog_export_doc_pages_w_prefs(appwindow: &RnoteAppWindow) {
                             let file_stem_name = export_files_stemname_entryrow.text().to_string();
 
                             if let Err(e) = appwindow.export_doc_pages(&dir, file_stem_name, None).await {
-                                log::error!("exporting document pages failed with error `{}`", e);
+                                log::error!("exporting document pages failed with error `{e:?}`");
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Export document pages failed.").to_variant()));
                             } else {
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "text-toast", Some(&gettext("Exported document pages successfully.").to_variant()));
@@ -502,7 +502,7 @@ fn create_filechooser_export_doc_pages(appwindow: &RnoteAppWindow) -> FileChoose
         if let Err(e) =
             filechooser.set_current_folder(Some(&gio::File::for_path(current_workspace_dir)))
         {
-            log::error!("set_current_folder() for dialog_export_doc_pages failed with Err `{e}`");
+            log::error!("set_current_folder() for dialog_export_doc_pages failed with Err: {e:?}");
         }
     }
 
@@ -707,7 +707,7 @@ pub fn dialog_export_selection_w_prefs(appwindow: &RnoteAppWindow) {
                             appwindow.start_pulsing_canvas_progressbar();
 
                             if let Err(e) = appwindow.export_selection(&file, None).await {
-                                log::error!("exporting selection failed with error `{}`", e);
+                                log::error!("exporting selection failed with error `{e:?}`");
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Export selection failed.").to_variant()));
                             } else {
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "text-toast", Some(&gettext("Exported selection successfully.").to_variant()));
@@ -745,7 +745,7 @@ fn create_filechooser_export_selection(appwindow: &RnoteAppWindow) -> FileChoose
         if let Err(e) =
             filechooser.set_current_folder(Some(&gio::File::for_path(current_workspace_dir)))
         {
-            log::error!("set_current_folder() for dialog_export_selection failed with Err `{e}`");
+            log::error!("set_current_folder() for dialog_export_selection failed with Err: {e:?}");
         }
     }
 
@@ -824,7 +824,7 @@ pub fn filechooser_export_engine_state(appwindow: &RnoteAppWindow) {
             filechooser.set_current_folder(Some(&gio::File::for_path(current_workspace_dir)))
         {
             log::error!(
-                "set_current_folder() for dialog_export_engine_state failed with Err `{e}`"
+                "set_current_folder() for dialog_export_engine_state failed with Err: {e:?}"
             );
         }
     }
@@ -846,7 +846,7 @@ pub fn filechooser_export_engine_state(appwindow: &RnoteAppWindow) {
                             appwindow.start_pulsing_canvas_progressbar();
 
                             if let Err(e) = appwindow.export_engine_state(&file).await {
-                                log::error!("exporting engine state failed with error `{}`", e);
+                                log::error!("exporting engine state failed with error `{e:?}`");
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Export engine state failed.").to_variant()));
                             } else {
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "text-toast", Some(&gettext("Exported engine state successfully.").to_variant()));
@@ -888,7 +888,7 @@ pub fn filechooser_export_engine_config(appwindow: &RnoteAppWindow) {
             filechooser.set_current_folder(Some(&gio::File::for_path(current_workspace_dir)))
         {
             log::error!(
-                "set_current_folder() for dialog_export_engine_config failed with Err `{e}`"
+                "set_current_folder() for dialog_export_engine_config failed with Err: {e:?}"
             );
         }
     }
@@ -910,7 +910,7 @@ pub fn filechooser_export_engine_config(appwindow: &RnoteAppWindow) {
                             appwindow.start_pulsing_canvas_progressbar();
 
                             if let Err(e) = appwindow.export_engine_config(&file).await {
-                                log::error!("exporting engine state failed with error `{}`", e);
+                                log::error!("exporting engine state failed with error `{e:?}`");
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Export engine config failed.").to_variant()));
                             } else {
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "text-toast", Some(&gettext("Exported engine config successfully.").to_variant()));

--- a/rnote-ui/src/dialogs/import.rs
+++ b/rnote-ui/src/dialogs/import.rs
@@ -25,7 +25,7 @@ pub fn dialog_open_overwrite(appwindow: &RnoteAppWindow) {
             let open_overwrite = |appwindow: &RnoteAppWindow| {
                 if let Some(input_file) = appwindow.app().input_file().as_ref() {
                     if let Err(e) = appwindow.load_in_file(input_file, None) {
-                        log::error!("failed to load in input file, {}", e);
+                        log::error!("failed to load in input file, {e:?}");
                         adw::prelude::ActionGroupExt::activate_action(appwindow, "error-toast", Some(&gettext("Opening file failed.").to_variant()));
                     }
                 }
@@ -43,7 +43,7 @@ pub fn dialog_open_overwrite(appwindow: &RnoteAppWindow) {
                             if let Err(e) = appwindow.save_document_to_file(&output_file).await {
                                 appwindow.canvas().set_output_file(None);
 
-                                log::error!("saving document failed with error `{}`", e);
+                                log::error!("saving document failed with error `{e:?}`");
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Saving document failed.").to_variant()));
                             }
 
@@ -92,7 +92,7 @@ pub fn filechooser_open_doc(appwindow: &RnoteAppWindow) {
         if let Err(e) =
             filechooser.set_current_folder(Some(&gio::File::for_path(current_workspace_dir)))
         {
-            log::error!("set_current_folder() for dialog_open_doc failed with Err `{e}`");
+            log::error!("set_current_folder() for dialog_open_doc failed with Err: {e:?}");
         }
     }
 
@@ -105,7 +105,7 @@ pub fn filechooser_open_doc(appwindow: &RnoteAppWindow) {
                         if !appwindow.unsaved_changes() {
                             if let Some(input_file) = appwindow.app().input_file().as_ref() {
                                 if let Err(e) = appwindow.load_in_file(input_file, None) {
-                                    log::error!("failed to load in input file, {}", e);
+                                    log::error!("failed to load in input file, {e:?}");
                                     adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening file failed.").to_variant()));
                                 }
                             }
@@ -158,7 +158,7 @@ pub fn filechooser_import_file(appwindow: &RnoteAppWindow) {
         if let Err(e) =
             filechooser.set_current_folder(Some(&gio::File::for_path(current_workspace_dir)))
         {
-            log::error!("set_current_folder() for dialog_import_file failed with Err `{e}`");
+            log::error!("set_current_folder() for dialog_import_file failed with Err: {e:?}");
         }
     }
 
@@ -318,8 +318,7 @@ pub fn dialog_import_pdf_w_prefs(appwindow: &RnoteAppWindow, target_pos: Option<
                             if let Err(e) = appwindow.load_in_pdf_bytes(file_bytes.to_vec(), target_pos, Some(page_range)).await {
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening PDF file failed.").to_variant()));
                                 log::error!(
-                                    "load_in_rnote_bytes() failed in dialog import pdf with Err {}",
-                                    e
+                                    "load_in_rnote_bytes() failed in dialog import pdf with Err: {e:?}"
                                 );
                             }
                         }
@@ -385,8 +384,7 @@ pub fn dialog_import_xopp_w_prefs(appwindow: &RnoteAppWindow) {
                             if let Err(e) = appwindow.load_in_xopp_bytes(file_bytes.to_vec()) {
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Opening Xournal++ file failed.").to_variant()));
                                 log::error!(
-                                    "load_in_xopp_bytes() failed in dialog import xopp with Err {}",
-                                    e
+                                    "load_in_xopp_bytes() failed in dialog import xopp with Err: {e:?}"
                                 );
                             }
                         }

--- a/rnote-ui/src/dialogs/mod.rs
+++ b/rnote-ui/src/dialogs/mod.rs
@@ -133,7 +133,7 @@ pub fn dialog_new_doc(appwindow: &RnoteAppWindow) {
                         if let Err(e) = appwindow.save_document_to_file(&output_file).await {
                             appwindow.canvas().set_output_file(None);
 
-                            log::error!("saving document failed with error `{}`", e);
+                            log::error!("saving document failed with error `{e:?}`");
                             adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Saving document failed.").to_variant()));
                         }
 
@@ -183,7 +183,7 @@ pub fn dialog_quit_save(appwindow: &RnoteAppWindow) {
                             if let Err(e) = appwindow.save_document_to_file(&output_file).await {
                                 appwindow.canvas().set_output_file(None);
 
-                                log::error!("saving document failed with error `{}`", e);
+                                log::error!("saving document failed with error `{e:?}`");
                                 adw::prelude::ActionGroupExt::activate_action(&appwindow, "error-toast", Some(&gettext("Saving document failed.").to_variant()));
                             }
 
@@ -252,7 +252,7 @@ pub fn dialog_edit_workspace(appwindow: &RnoteAppWindow) {
         if let Err(e) =
             filechooser_change_workspace_dir.set_file(&gio::File::for_path(&row.entry().dir()))
         {
-            log::error!("set file in change workspace dialog failed with Err {}", e);
+            log::error!("set file in change workspace dialog failed with Err: {e:?}");
         }
 
         // set initial dialog UI on popup

--- a/rnote-ui/src/utils.rs
+++ b/rnote-ui/src/utils.rs
@@ -104,8 +104,7 @@ pub async fn create_replace_file_future(bytes: Vec<u8>, file: &gio::File) -> any
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "file replace_future() failed in create_replace_file_future(), Err {}",
-                e
+                "file replace_future() failed in create_replace_file_future(), Err: {e:?}"
             )
         })?;
 
@@ -114,8 +113,7 @@ pub async fn create_replace_file_future(bytes: Vec<u8>, file: &gio::File) -> any
         .await
         .map_err(|(_, e)| {
             anyhow::anyhow!(
-                "output_stream write_all_future() failed in create_replace_file_future(), Err {}",
-                e
+                "output_stream write_all_future() failed in create_replace_file_future(), Err: {e:?}"
             )
         })?;
     output_stream
@@ -123,8 +121,7 @@ pub async fn create_replace_file_future(bytes: Vec<u8>, file: &gio::File) -> any
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "output_stream close_future() failed in create_replace_file_future(), Err {}",
-                e
+                "output_stream close_future() failed in create_replace_file_future(), Err: {e:?}"
             )
         })?;
 

--- a/rnote-ui/src/workspacebrowser/filerow/action/duplicate.rs
+++ b/rnote-ui/src/workspacebrowser/filerow/action/duplicate.rs
@@ -68,8 +68,8 @@ fn duplicate_file(source_path: PathBuf) {
 
         log::debug!("Duplicate source: {}", source.display());
         log::debug!("Duplicate destination: {}", destination.display());
-        if let Err(err) = std::fs::copy(source, destination) {
-            log::error!("Couldn't duplicate file: {}", err);
+        if let Err(e) = std::fs::copy(source, destination) {
+            log::error!("Couldn't duplicate file: {e:?}");
         }
     }
     log::info!("Destination-file for duplication not found.");
@@ -88,10 +88,10 @@ where
 
         log::debug!("Duplicate source: {}", source.display());
         log::debug!("Duplicate destination: {}", destination.display());
-        if let Err(err) =
+        if let Err(e) =
             copy_items_with_progress(&[source], destination, &options, process_evaluator)
         {
-            log::error!("Couldn't copy items: {}", err);
+            log::error!("Couldn't copy items: {e:?}");
         }
     }
 }

--- a/rnote-ui/src/workspacebrowser/filerow/action/rename.rs
+++ b/rnote-ui/src/workspacebrowser/filerow/action/rename.rs
@@ -92,13 +92,13 @@ fn connect_apply_button(
 
         if new_file.query_exists(None::<&gio::Cancellable>) {
             // Should have been caught earlier, but making sure
-            log::error!("file already exists");
+            log::error!("file already exists.");
         } else {
             // directory check must happen before moving the file or directory
             let is_directory = current_path.is_dir();
 
             if let Err(e) = current_file.move_(&new_file, gio::FileCopyFlags::NONE, None::<&gio::Cancellable>, None) {
-                log::error!("rename file failed with Err {}", e);
+                log::error!("rename file failed with Err: {e:?}");
             } else if let Some(current_output_file) = appwindow.canvas().output_file() {
                 if is_directory {
                     // if the output file shares a sub-tree with the renamed directory, rename the directory in the output file's path too

--- a/rnote-ui/src/workspacebrowser/filerow/action/trash.rs
+++ b/rnote-ui/src/workspacebrowser/filerow/action/trash.rs
@@ -13,7 +13,7 @@ pub fn trash(filerow: &FileRow, appwindow: &RnoteAppWindow) -> gio::SimpleAction
 
             current_file.trash_async(glib::PRIORITY_DEFAULT, None::<&gio::Cancellable>, clone!(@weak filerow, @weak current_file => move |res| {
                 if let Err(e) = res {
-                    log::error!("filerow trash file failed with Err {}", e);
+                    log::error!("filerow trash file failed with Err: {e:?}");
                 } else {
                     filerow.set_current_file(None);
 

--- a/rnote-ui/src/workspacebrowser/mod.rs
+++ b/rnote-ui/src/workspacebrowser/mod.rs
@@ -257,17 +257,14 @@ impl WorkspaceBrowser {
 
     pub fn save_workspaces_to_settings(&self, settings: &gio::Settings) {
         if let Err(e) = settings.set("workspace-list", &self.imp().workspace_list) {
-            log::error!("saving `workspace-list` to settings failed with Err {}", e);
+            log::error!("saving `workspace-list` to settings failed with Err: {e:?}");
         }
 
         if let Err(e) = settings.set(
             "current-workspace-index",
             &self.selected_workspace_index().unwrap_or(0),
         ) {
-            log::error!(
-                "saving `current-workspace-index` to settings failed with Err {}",
-                e
-            );
+            log::error!("saving `current-workspace-index` to settings failed with Err: {e:?}");
         }
     }
 

--- a/rnote-ui/src/workspacebrowser/workspace_action/create_folder.rs
+++ b/rnote-ui/src/workspacebrowser/workspace_action/create_folder.rs
@@ -84,7 +84,7 @@ fn connect_apply_button(
             log::error!("Couldn't create new folder wit name `{}`, it already exists.", entry.text().as_str());
         } else {
             if let Err(e) = fs_extra::dir::create(new_folder_path, false) {
-                log::error!("Couldn't create folder: {}", e);
+                log::error!("Couldn't create folder: {e:?}");
             }
 
             popover.popdown();


### PR DESCRIPTION
This refactors the pen path and its segments to something that makes more sense conceptually, and reduces file sizes.

To keep compatibility there is a conversion function that converts all pen paths from files with version `>=0.5.8` to the new representation.

While in the process of writing this I also noticed that the error messages used throughout the app were not ideal, I refactored to make them more consistent and to display more verbose error messages by using `:?`