### PR TITLE
skip saving when already in progress

### DIFF
--- a/rnote-ui/src/canvas/imexport.rs
+++ b/rnote-ui/src/canvas/imexport.rs
@@ -175,6 +175,12 @@ impl RnoteCanvas {
     }
 
     pub(crate) async fn save_document_to_file(&self, file: &gio::File) -> anyhow::Result<()> {
+        // skip saving when it is already in progress
+        if self.output_file_expect_write() {
+            log::debug!("saving file already in progress.");
+            return Ok(());
+        }
+
         let basename = file.basename().ok_or_else(|| {
             anyhow::anyhow!(
                 "save_document_to_file() failed, could not retreive basename for file: {file:?}"

--- a/rnote-ui/src/canvas/imexport.rs
+++ b/rnote-ui/src/canvas/imexport.rs
@@ -187,12 +187,20 @@ impl RnoteCanvas {
             )
         })?;
 
-        let rnote_bytes_receiver = self
+        self.set_output_file_expect_write(true);
+
+        let rnote_bytes_receiver = match self
             .engine()
             .borrow()
-            .save_as_rnote_bytes(basename.to_string_lossy().to_string())?;
+            .save_as_rnote_bytes(basename.to_string_lossy().to_string())
+        {
+            Ok(r) => r,
+            Err(e) => {
+                self.set_output_file_expect_write(false);
+                return Err(e);
+            }
+        };
 
-        self.set_output_file_expect_write(true);
         self.dismiss_output_file_modified_toast();
 
         crate::utils::create_replace_file_future(rnote_bytes_receiver.await??, file).await?;

--- a/rnote-ui/src/canvas/imexport.rs
+++ b/rnote-ui/src/canvas/imexport.rs
@@ -174,11 +174,15 @@ impl RnoteCanvas {
         Ok(())
     }
 
-    pub(crate) async fn save_document_to_file(&self, file: &gio::File) -> anyhow::Result<()> {
+    /// Saves the document to the given file.
+    ///
+    /// Returns Ok(true) if saved successfully, Ok(false) when a save is already in progress and no file operatiosn were executed,
+    /// Err(e) when saving failed in any way.
+    pub(crate) async fn save_document_to_file(&self, file: &gio::File) -> anyhow::Result<bool> {
         // skip saving when it is already in progress
         if self.output_file_expect_write() {
             log::debug!("saving file already in progress.");
-            return Ok(());
+            return Ok(false);
         }
 
         let basename = file.basename().ok_or_else(|| {
@@ -208,7 +212,7 @@ impl RnoteCanvas {
         self.set_output_file(Some(file.to_owned()));
         self.set_unsaved_changes(false);
 
-        Ok(())
+        Ok(true)
     }
 
     pub(crate) async fn export_doc(

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -57,13 +57,19 @@ pub(crate) fn filechooser_save_doc_as(appwindow: &RnoteAppWindow, canvas: &Rnote
                         glib::MainContext::default().spawn_local(clone!(@weak canvas, @weak appwindow => async move {
                             appwindow.overlays().start_pulsing_progressbar();
 
-                            if let Err(e) = canvas.save_document_to_file(&file).await {
-                                canvas.set_output_file(None);
+                            match canvas.save_document_to_file(&file).await {
+                                Ok(true) => {
+                                    appwindow.overlays().dispatch_toast_text(&gettext("Saved document successfully."));
+                                }
+                                Ok(false) => {
+                                    // Saving was already in progress
+                                }
+                                Err(e) => {
+                                    canvas.set_output_file(None);
 
-                                log::error!("saving document failed with error `{e:?}`");
-                                appwindow.overlays().dispatch_toast_error(&gettext("Saving document failed."));
-                            } else {
-                                appwindow.overlays().dispatch_toast_text(&gettext("Saved document successfully."));
+                                    log::error!("saving document failed with error `{e:?}`");
+                                    appwindow.overlays().dispatch_toast_error(&gettext("Saving document failed."));
+                                }
                             }
 
                             appwindow.overlays().finish_progressbar();

--- a/rnote-ui/src/dialogs/mod.rs
+++ b/rnote-ui/src/dialogs/mod.rs
@@ -130,7 +130,6 @@ pub(crate) fn dialog_new_doc(appwindow: &RnoteAppWindow, canvas: &RnoteCanvas) {
                 new_doc(&appwindow, &canvas);
             },
             "save" => {
-
                 glib::MainContext::default().spawn_local(clone!(@weak canvas, @weak appwindow => async move {
                     if let Some(output_file) = canvas.output_file() {
                         appwindow.overlays().start_pulsing_progressbar();


### PR DESCRIPTION
This skips saving the document when it is alerady in progress, and should fix #432 .

@Kneemund Just to double-check, does this look like a reasonable fix to you by using `expect_write` here?