### PR TITLE
CI: include rustc hash in cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
         run: |
           sudo dnf upgrade --refresh -y
           sudo dnf install -y gcc gcc-c++ clang make cmake meson kernel-devel gtk4-devel libadwaita-devel poppler-glib-devel poppler-data alsa-lib-devel libappstream-glib desktop-file-utils
+      - name: Install toolchain
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt, clippy
+          override: true
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -29,15 +37,8 @@ jobs:
             _mesonbuild/cargo-home/registry/cache/
             _mesonbuild/cargo-home/git/db/
             _mesonbuild/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: rustfmt, clippy
-          override: true
+          key: cargo-${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}
       - name: Configure
         run: |
           meson setup --prefix=/usr _mesonbuild


### PR DESCRIPTION
The CI cache is currently not rebuilt when the rustc version changes. This explains the unusually long durations of the last three workflows:

![Unbenannt](https://user-images.githubusercontent.com/49598842/212124311-4eeb2f6b-c19f-4323-83cc-2bb5684466d1.png)

This PR adds the rustc version hash provided by the [`actions-rs/toolchain` step](https://github.com/actions-rs/toolchain#Outputs) to the cache key and restore key. The latter is done because the whole app has to be rebuilt, regardless of the old cache, so we can save the time it takes to download it.

`cargo` was moved to the front of the cache (restore) key for consistency purposes (all variables are behind it now). It's a good idea to include it in this PR because all caches will be invalidated by it anyway :P