### PR TITLE
Fix output monitor missing events for new or changed files

### DIFF
--- a/rnote-ui/src/canvas/imexport.rs
+++ b/rnote-ui/src/canvas/imexport.rs
@@ -220,7 +220,8 @@ impl RnoteCanvas {
             }
         }
 
-        // this **must** come before actually saving the file to disk, else the event might not be catched by the monitor for new or changed files
+        // this **must** come before actually saving the file to disk,
+        // else the event might not be catched by the monitor for new or changed files
         if !skip_set_output_file {
             self.set_output_file(Some(file.to_owned()));
         }

--- a/rnote-ui/src/canvas/imexport.rs
+++ b/rnote-ui/src/canvas/imexport.rs
@@ -197,21 +197,10 @@ impl RnoteCanvas {
             )
         })?;
 
-        self.set_output_file_expect_write(true);
-
-        let rnote_bytes_receiver = match self
+        let rnote_bytes_receiver = self
             .engine()
             .borrow()
-            .save_as_rnote_bytes(basename.to_string_lossy().to_string())
-        {
-            Ok(r) => r,
-            Err(e) => {
-                self.set_output_file_expect_write(false);
-                return Err(e);
-            }
-        };
-
-        self.dismiss_output_file_modified_toast();
+            .save_as_rnote_bytes(basename.to_string_lossy().to_string())?;
 
         let mut skip_set_output_file = false;
         if let Some(current_file_path) = self.output_file().and_then(|f| f.path()) {
@@ -225,6 +214,9 @@ impl RnoteCanvas {
         if !skip_set_output_file {
             self.set_output_file(Some(file.to_owned()));
         }
+
+        self.dismiss_output_file_modified_toast();
+        self.set_output_file_expect_write(true);
 
         let res = async move {
             crate::utils::create_replace_file_future(rnote_bytes_receiver.await??, file).await

--- a/rnote-ui/src/canvas/mod.rs
+++ b/rnote-ui/src/canvas/mod.rs
@@ -1256,6 +1256,8 @@ impl RnoteCanvas {
 
     /// This disconnects all handlers with references to external objects, to prepare moving the widget to another appwindow.
     pub(crate) fn disconnect_handlers(&self, _appwindow: &RnoteAppWindow) {
+        self.clear_output_file_monitor();
+
         let mut handlers = self.imp().handlers.borrow_mut();
         if let Some(old) = handlers.appwindow_output_file.take() {
             self.disconnect(old);

--- a/rnote-ui/src/canvas/mod.rs
+++ b/rnote-ui/src/canvas/mod.rs
@@ -1052,10 +1052,14 @@ impl RnoteCanvas {
             }),
         );
 
-        self.imp()
+        if let Some(old) = self
+            .imp()
             .output_file_monitor
             .borrow_mut()
-            .replace(output_file_monitor);
+            .replace(output_file_monitor)
+        {
+            old.cancel();
+        }
     }
 
     /// Replaces and installs a new file monitor when there is an output file present

--- a/rnote-ui/src/canvas/mod.rs
+++ b/rnote-ui/src/canvas/mod.rs
@@ -1065,6 +1065,8 @@ impl RnoteCanvas {
     fn reinstall_output_file_monitor(&self, appwindow: &RnoteAppWindow) {
         if let Some(output_file) = self.output_file() {
             self.create_output_file_monitor(&output_file, appwindow);
+        } else {
+            self.clear_output_file_monitor();
         }
     }
 


### PR DESCRIPTION
This fixes multiple issues found related to the output monitor:

---

There was an ordering issue where the output monitor was recreated (by `set_output_file()` ) **after** actually saving to disk, causing sometimes missed file events when initially saving a new or a changed file, which then causes missing clearing `expect_write` so we end up in the state where saving is not possible anymore.

#434 *might* be related, but I can't think the sequence that would trigger that right now. Would need testing and more debugging.

Edit: we might want to do that before merging, because if we don't and this is indeed the fix, we won't have the certainty to close that issue

( 1a401e98ddd1a12b4d90b28b7ec94c93956e90a8 )

---

the output monitor is now cleared in `reinstall_output_file_monitor()` when output_file is none

( a1378b5e6d1426a622593d8d8e2210117f510e5b )

---

fixed panics when clicking `reload` in the reload toast after closing the tab that emitted it

( ced60af3932bbacff9c5486e28aeb0dab9030619 )

---

Also: did some code clean up like early returns 

(9dd0635064eb690e461d42a5630d4600318fbde1 )

---

@Kneemund thoughts?