### PR TITLE
Stroke width picker with preset palette

### DIFF
--- a/rnote-ui/data/app.gschema.xml.in
+++ b/rnote-ui/data/app.gschema.xml.in
@@ -34,23 +34,23 @@
       <summary>the first brush stroke palette width</summary>
     </key>
     <key name="brush-width-2" type="d">
-      <default>2.0</default>
+      <default>6.0</default>
       <summary>the second brush stroke palette width</summary>
     </key>
     <key name="brush-width-3" type="d">
-      <default>6.0</default>
+      <default>12.0</default>
       <summary>the third brush stroke palette width</summary>
     </key>
     <key name="shaper-width-1" type="d">
-      <default>12.0</default>
+      <default>2.0</default>
       <summary>the first shaper stroke palette width</summary>
     </key>
     <key name="shaper-width-2" type="d">
-      <default>2.0</default>
+      <default>6.0</default>
       <summary>the second shaper stroke palette width</summary>
     </key>
     <key name="shaper-width-3" type="d">
-      <default>2.0</default>
+      <default>12.0</default>
       <summary>the third shaper stroke palette width</summary>
     </key>
     <key name="selected-workspace-index" type="u">

--- a/rnote-ui/data/app.gschema.xml.in
+++ b/rnote-ui/data/app.gschema.xml.in
@@ -29,6 +29,30 @@
         Use the color scheme in the application's UI and in the text area.
       </description>
     </key>
+    <key name="brush-width-1" type="d">
+      <default>2.0</default>
+      <summary>the first brush stroke palette width</summary>
+    </key>
+    <key name="brush-width-2" type="d">
+      <default>2.0</default>
+      <summary>the second brush stroke palette width</summary>
+    </key>
+    <key name="brush-width-3" type="d">
+      <default>6.0</default>
+      <summary>the third brush stroke palette width</summary>
+    </key>
+    <key name="shaper-width-1" type="d">
+      <default>12.0</default>
+      <summary>the first shaper stroke palette width</summary>
+    </key>
+    <key name="shaper-width-2" type="d">
+      <default>2.0</default>
+      <summary>the second shaper stroke palette width</summary>
+    </key>
+    <key name="shaper-width-3" type="d">
+      <default>2.0</default>
+      <summary>the third shaper stroke palette width</summary>
+    </key>
     <key name="selected-workspace-index" type="u">
       <default>0</default>
       <summary>the selected workspace index</summary>

--- a/rnote-ui/data/icons/scalable/actions/strokewidthsetter-symbolic.svg
+++ b/rnote-ui/data/icons/scalable/actions/strokewidthsetter-symbolic.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16.0px"
+   height="16.0px"
+   viewBox="0 0 16.0 16.0"
+   version="1.1"
+   id="SVGRoot"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs3351" />
+  <g
+     id="layer1">
+    <circle
+       style="fill:#212121;fill-opacity:1;stroke-width:0.53289"
+       id="path5403"
+       cx="8"
+       cy="8"
+       r="8" />
+  </g>
+</svg>

--- a/rnote-ui/data/resources.gresource.xml.in
+++ b/rnote-ui/data/resources.gresource.xml.in
@@ -17,6 +17,7 @@
         <file compressed="true" preprocess="xml-stripblanks">ui/workspacerow.ui</file>
         <file compressed="true" preprocess="xml-stripblanks">ui/unitentry.ui</file>
         <file compressed="true" preprocess="xml-stripblanks">ui/iconpicker.ui</file>
+        <file compressed="true" preprocess="xml-stripblanks">ui/strokewidthpicker.ui</file>
         <file compressed="true" preprocess="xml-stripblanks">ui/penshortcutrow.ui</file>
         <file compressed="true" preprocess="xml-stripblanks">ui/penssidebar/penssidebar.ui</file>
         <file compressed="true" preprocess="xml-stripblanks">ui/penssidebar/brushpage.ui</file>
@@ -82,6 +83,7 @@
         <file compressed="true">icons/scalable/actions/zoom-fit-width-symbolic.svg</file>
         <file compressed="true">icons/scalable/actions/stroke-color-symbolic.svg</file>
         <file compressed="true">icons/scalable/actions/fill-color-symbolic.svg</file>
+        <file compressed="true">icons/scalable/actions/strokewidthsetter-symbolic.svg</file>
         <file compressed="true">icons/scalable/actions/doc-save-symbolic.svg</file>
         <file compressed="true">icons/scalable/actions/selection-trash-symbolic.svg</file>
         <file compressed="true">icons/scalable/actions/selection-duplicate-symbolic.svg</file>

--- a/rnote-ui/data/ui/penssidebar/brushpage.ui
+++ b/rnote-ui/data/ui/penssidebar/brushpage.ui
@@ -27,6 +27,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon-name">pen-brush-style-solid-symbolic</property>
                 <property name="icon-size">large</property>
               </object>

--- a/rnote-ui/data/ui/penssidebar/brushpage.ui
+++ b/rnote-ui/data/ui/penssidebar/brushpage.ui
@@ -54,11 +54,7 @@
       </object>
     </child>
     <child>
-      <object class="GtkSpinButton" id="width_spinbutton">
-        <property name="orientation">vertical</property>
-        <property name="numeric">true</property>
-        <property name="digits">1</property>
-        <property name="climb-rate">0.5</property>
+      <object class="StrokeWidthPicker" id="stroke_width_picker">
       </object>
     </child>
 

--- a/rnote-ui/data/ui/penssidebar/eraserpage.ui
+++ b/rnote-ui/data/ui/penssidebar/eraserpage.ui
@@ -27,6 +27,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon_name">pen-eraser-trash-colliding-strokes-symbolic</property>
                 <property name="icon-size">large</property>
               </object>
@@ -43,6 +44,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon_name">pen-eraser-split-colliding-strokes-symbolic</property>
                 <property name="icon-size">large</property>
               </object>

--- a/rnote-ui/data/ui/penssidebar/selectorpage.ui
+++ b/rnote-ui/data/ui/penssidebar/selectorpage.ui
@@ -27,6 +27,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon_name">pen-selector-polygon-symbolic</property>
                 <property name="icon-size">large</property>
               </object>
@@ -43,6 +44,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon_name">pen-selector-rectangle-symbolic</property>
                 <property name="icon-size">large</property>
               </object>
@@ -59,6 +61,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon_name">pen-selector-single-symbolic</property>
                 <property name="icon-size">large</property>
               </object>
@@ -75,6 +78,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon_name">pen-selector-intersectingpath-symbolic</property>
                 <property name="icon-size">large</property>
               </object>
@@ -104,6 +108,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon_name">selection-resize-lock-aspectratio-symbolic</property>
                 <property name="icon-size">large</property>
               </object>
@@ -122,6 +127,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon_name">selection-select-all-symbolic</property>
                 <property name="icon-size">large</property>
               </object>
@@ -140,6 +146,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon_name">selection-deselect-all-symbolic</property>
                 <property name="icon-size">large</property>
               </object>
@@ -158,6 +165,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon_name">selection-duplicate-symbolic</property>
                 <property name="icon-size">large</property>
               </object>
@@ -177,6 +185,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon_name">selection-trash-symbolic</property>
                 <property name="icon-size">large</property>
               </object>

--- a/rnote-ui/data/ui/penssidebar/shaperpage.ui
+++ b/rnote-ui/data/ui/penssidebar/shaperpage.ui
@@ -27,6 +27,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon-name">pen-shaper-style-smooth-symbolic</property>
                 <property name="icon-size">large</property>
               </object>
@@ -81,6 +82,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon-name">shapebuilder-line-symbolic</property>
                 <property name="icon-size">large</property>
               </object>

--- a/rnote-ui/data/ui/penssidebar/shaperpage.ui
+++ b/rnote-ui/data/ui/penssidebar/shaperpage.ui
@@ -54,11 +54,7 @@
       </object>
     </child>
     <child>
-      <object class="GtkSpinButton" id="width_spinbutton">
-        <property name="orientation">vertical</property>
-        <property name="numeric">true</property>
-        <property name="digits">1</property>
-        <property name="climb-rate">0.5</property>
+      <object class="StrokeWidthPicker" id="stroke_width_picker">
       </object>
     </child>
     <child>

--- a/rnote-ui/data/ui/penssidebar/toolspage.ui
+++ b/rnote-ui/data/ui/penssidebar/toolspage.ui
@@ -28,6 +28,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon-name">pen-tools-verticalspacetool-symbolic</property>
                 <property name="icon-size">large</property>
               </object>
@@ -47,6 +48,7 @@
                 <style>
                   <class name="sidebar_action_image" />
                 </style>
+                <property name="halign">center</property>
                 <property name="icon-name">pen-tools-offsetcameratool-symbolic</property>
                 <property name="icon-size">large</property>
               </object>

--- a/rnote-ui/data/ui/penssidebar/typewriterpage.ui
+++ b/rnote-ui/data/ui/penssidebar/typewriterpage.ui
@@ -24,6 +24,7 @@ or press Enter to select a new font)</property>
             <style>
               <class name="sidebar_action_image" />
             </style>
+            <property name="halign">center</property>
             <property name="icon-name">pen-typewriter-fontchooser-symbolic</property>
             <property name="icon-size">large</property>
           </object>
@@ -61,6 +62,7 @@ or press Enter to select a new font)</property>
             <style>
               <class name="sidebar_action_image" />
             </style>
+            <property name="halign">center</property>
             <property name="icon-name">emojichooser-symbolic</property>
             <property name="icon-size">large</property>
           </object>

--- a/rnote-ui/data/ui/strokewidthpicker.ui
+++ b/rnote-ui/data/ui/strokewidthpicker.ui
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="StrokeWidthPicker" parent="GtkWidget">
+    <property name="layout-manager">
+      <object class="GtkBoxLayout">
+        <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
+      </object>
+    </property>
+    <style>
+      <class name="strokewidthpicker" />
+    </style>
+    <child>
+      <object class="GtkAdjustment" id="adj">
+        <property name="lower">0.1</property>
+        <property name="upper">500</property>
+        <property name="value">2.0</property>
+      </object>
+      <object class="GtkSpinButton" id="spinbutton">
+        <property name="orientation">horizontal</property>
+        <property name="adjustment">adj</property>
+        <property name="numeric">true</property>
+        <property name="digits">1</property>
+        <property name="climb-rate">0.5</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox" id="setter_box">
+        <property name="orientation">vertical</property>
+        <property name="spacing">3</property>
+        <child>
+          <object class="StrokeWidthSetter" id="setter_1">
+            <style>
+              <class name="flat" />
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="StrokeWidthSetter" id="setter_2">
+            <property name="group">setter_1</property>
+            <style>
+              <class name="flat" />
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="StrokeWidthSetter" id="setter_3">
+            <property name="group">setter_1</property>
+            <style>
+              <class name="flat" />
+            </style>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/rnote-ui/data/ui/style.css
+++ b/rnote-ui/data/ui/style.css
@@ -106,6 +106,11 @@
     box-shadow: inset 0px -3px 0px 0px @colorsetter_fg_color;
 }
 
+.strokewidthsetter > image {
+    margin-left: -4px;
+    margin-right: -4px;
+}
+
 .quickaction-button {
     box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.2);
 }

--- a/rnote-ui/data/ui/style.css
+++ b/rnote-ui/data/ui/style.css
@@ -106,9 +106,8 @@
     box-shadow: inset 0px -3px 0px 0px @colorsetter_fg_color;
 }
 
-.strokewidthsetter > image {
-    margin-left: -4px;
-    margin-right: -4px;
+.strokewidthsetter {
+    padding: 5px;
 }
 
 .quickaction-button {

--- a/rnote-ui/po/POTFILES
+++ b/rnote-ui/po/POTFILES
@@ -16,6 +16,7 @@ rnote-ui/data/ui/appwindow.ui
 rnote-ui/data/ui/canvasmenu.ui
 rnote-ui/data/ui/canvaswrapper.ui
 rnote-ui/data/ui/colorpicker.ui
+rnote-ui/data/ui/strokewidthpicker.ui
 rnote-ui/data/ui/filerow.ui
 rnote-ui/data/ui/iconpicker.ui
 rnote-ui/data/ui/mainheader.ui

--- a/rnote-ui/src/app/mod.rs
+++ b/rnote-ui/src/app/mod.rs
@@ -10,10 +10,10 @@ use crate::{
     colorpicker::ColorPad, colorpicker::ColorSetter, config, penssidebar::BrushPage,
     penssidebar::EraserPage, penssidebar::SelectorPage, penssidebar::ShaperPage,
     penssidebar::ToolsPage, penssidebar::TypewriterPage, settingspanel::PenShortcutRow,
-    workspacebrowser::workspacesbar::WorkspaceRow, workspacebrowser::FileRow,
-    workspacebrowser::WorkspacesBar, AppMenu, CanvasMenu, ColorPicker, IconPicker, MainHeader,
-    PensSideBar, RnoteAppWindow, RnoteCanvas, RnoteCanvasWrapper, RnoteOverlays, SettingsPanel,
-    UnitEntry, WorkspaceBrowser,
+    strokewidthpicker::StrokeWidthSetter, workspacebrowser::workspacesbar::WorkspaceRow,
+    workspacebrowser::FileRow, workspacebrowser::WorkspacesBar, AppMenu, CanvasMenu, ColorPicker,
+    IconPicker, MainHeader, PensSideBar, RnoteAppWindow, RnoteCanvas, RnoteCanvasWrapper,
+    RnoteOverlays, SettingsPanel, StrokeWidthPicker, UnitEntry, WorkspaceBrowser,
 };
 
 mod imp {
@@ -127,6 +127,8 @@ mod imp {
             UnitEntry::static_type();
             IconPicker::static_type();
             PenShortcutRow::static_type();
+            StrokeWidthPicker::static_type();
+            StrokeWidthSetter::static_type();
 
             self.instance()
                 .set_resource_base_path(Some(config::APP_IDPATH));

--- a/rnote-ui/src/app/mod.rs
+++ b/rnote-ui/src/app/mod.rs
@@ -10,10 +10,11 @@ use crate::{
     colorpicker::ColorPad, colorpicker::ColorSetter, config, penssidebar::BrushPage,
     penssidebar::EraserPage, penssidebar::SelectorPage, penssidebar::ShaperPage,
     penssidebar::ToolsPage, penssidebar::TypewriterPage, settingspanel::PenShortcutRow,
-    strokewidthpicker::StrokeWidthSetter, workspacebrowser::workspacesbar::WorkspaceRow,
-    workspacebrowser::FileRow, workspacebrowser::WorkspacesBar, AppMenu, CanvasMenu, ColorPicker,
-    IconPicker, MainHeader, PensSideBar, RnoteAppWindow, RnoteCanvas, RnoteCanvasWrapper,
-    RnoteOverlays, SettingsPanel, StrokeWidthPicker, UnitEntry, WorkspaceBrowser,
+    strokewidthpicker::StrokeWidthPreview, strokewidthpicker::StrokeWidthSetter,
+    workspacebrowser::workspacesbar::WorkspaceRow, workspacebrowser::FileRow,
+    workspacebrowser::WorkspacesBar, AppMenu, CanvasMenu, ColorPicker, IconPicker, MainHeader,
+    PensSideBar, RnoteAppWindow, RnoteCanvas, RnoteCanvasWrapper, RnoteOverlays, SettingsPanel,
+    StrokeWidthPicker, UnitEntry, WorkspaceBrowser,
 };
 
 mod imp {
@@ -129,6 +130,7 @@ mod imp {
             PenShortcutRow::static_type();
             StrokeWidthPicker::static_type();
             StrokeWidthSetter::static_type();
+            StrokeWidthPreview::static_type();
 
             self.instance()
                 .set_resource_base_path(Some(config::APP_IDPATH));

--- a/rnote-ui/src/appwindow/appsettings.rs
+++ b/rnote-ui/src/appwindow/appsettings.rs
@@ -123,7 +123,7 @@ impl RnoteAppWindow {
             })
             .build();
 
-        // Brush stroke widths
+        // brush stroke widths
         self.app_settings()
             .bind(
                 "brush-width-1",
@@ -152,6 +152,41 @@ impl RnoteAppWindow {
                 &self
                     .penssidebar()
                     .brush_page()
+                    .stroke_width_picker()
+                    .setter_3(),
+                "stroke-width",
+            )
+            .build();
+
+        // shaper stroke widths
+        self.app_settings()
+            .bind(
+                "shaper-width-1",
+                &self
+                    .penssidebar()
+                    .shaper_page()
+                    .stroke_width_picker()
+                    .setter_1(),
+                "stroke-width",
+            )
+            .build();
+        self.app_settings()
+            .bind(
+                "shaper-width-2",
+                &self
+                    .penssidebar()
+                    .shaper_page()
+                    .stroke_width_picker()
+                    .setter_2(),
+                "stroke-width",
+            )
+            .build();
+        self.app_settings()
+            .bind(
+                "shaper-width-3",
+                &self
+                    .penssidebar()
+                    .shaper_page()
                     .stroke_width_picker()
                     .setter_3(),
                 "stroke-width",

--- a/rnote-ui/src/appwindow/appsettings.rs
+++ b/rnote-ui/src/appwindow/appsettings.rs
@@ -122,6 +122,41 @@ impl RnoteAppWindow {
                 Some(u32::from(val.get::<gdk::RGBA>().unwrap().into_compose_color()).to_variant())
             })
             .build();
+
+        // Brush stroke widths
+        self.app_settings()
+            .bind(
+                "brush-width-1",
+                &self
+                    .penssidebar()
+                    .brush_page()
+                    .stroke_width_picker()
+                    .setter_1(),
+                "stroke-width",
+            )
+            .build();
+        self.app_settings()
+            .bind(
+                "brush-width-2",
+                &self
+                    .penssidebar()
+                    .brush_page()
+                    .stroke_width_picker()
+                    .setter_2(),
+                "stroke-width",
+            )
+            .build();
+        self.app_settings()
+            .bind(
+                "brush-width-3",
+                &self
+                    .penssidebar()
+                    .brush_page()
+                    .stroke_width_picker()
+                    .setter_3(),
+                "stroke-width",
+            )
+            .build();
     }
 
     /// load settings at start that are not bound in setup_settings. Setting changes through gsettings / dconf might not be applied until app restarts

--- a/rnote-ui/src/appwindow/mod.rs
+++ b/rnote-ui/src/appwindow/mod.rs
@@ -28,6 +28,8 @@ use crate::{
 use rnote_engine::{engine::EngineTask, WidgetFlags};
 
 mod imp {
+    use gtk4::PositionType;
+
     use super::*;
 
     #[allow(missing_debug_implementations)]
@@ -536,6 +538,10 @@ mod imp {
                     .brushstyle_menubutton()
                     .set_direction(ArrowType::Right);
                 inst.penssidebar()
+                    .brush_page()
+                    .stroke_width_picker()
+                    .set_position(PositionType::Left);
+                inst.penssidebar()
                     .shaper_page()
                     .shaperstyle_menubutton()
                     .set_direction(ArrowType::Right);
@@ -607,6 +613,10 @@ mod imp {
                     .brush_page()
                     .brushstyle_menubutton()
                     .set_direction(ArrowType::Left);
+                inst.penssidebar()
+                    .brush_page()
+                    .stroke_width_picker()
+                    .set_position(PositionType::Right);
                 inst.penssidebar()
                     .shaper_page()
                     .shaperstyle_menubutton()

--- a/rnote-ui/src/appwindow/mod.rs
+++ b/rnote-ui/src/appwindow/mod.rs
@@ -557,6 +557,10 @@ mod imp {
                     .shaper_page()
                     .constraint_menubutton()
                     .set_direction(ArrowType::Right);
+                inst.penssidebar()
+                    .shaper_page()
+                    .stroke_width_picker()
+                    .set_position(PositionType::Left);
             } else {
                 inst.flap().set_flap_position(PackType::End);
                 inst.main_grid().remove(&inst.overlays());
@@ -633,6 +637,10 @@ mod imp {
                     .shaper_page()
                     .constraint_menubutton()
                     .set_direction(ArrowType::Left);
+                inst.penssidebar()
+                    .shaper_page()
+                    .stroke_width_picker()
+                    .set_position(PositionType::Right);
             }
         }
     }

--- a/rnote-ui/src/main.rs
+++ b/rnote-ui/src/main.rs
@@ -21,6 +21,7 @@ mod mainheader;
 mod overlays;
 pub(crate) mod penssidebar;
 mod settingspanel;
+pub(crate) mod strokewidthpicker;
 mod unitentry;
 mod workspacebrowser;
 
@@ -37,6 +38,7 @@ pub(crate) use mainheader::MainHeader;
 pub(crate) use overlays::RnoteOverlays;
 pub(crate) use penssidebar::PensSideBar;
 pub(crate) use settingspanel::SettingsPanel;
+pub(crate) use strokewidthpicker::StrokeWidthPicker;
 pub(crate) use unitentry::UnitEntry;
 pub(crate) use workspacebrowser::WorkspaceBrowser;
 

--- a/rnote-ui/src/meson.build
+++ b/rnote-ui/src/meson.build
@@ -65,6 +65,7 @@ rnote_ui_sources = files(
     'colorpicker/mod.rs',
     'strokewidthpicker/mod.rs',
     'strokewidthpicker/strokewidthsetter.rs',
+    'strokewidthpicker/strokewidthpreview.rs',
     'penssidebar/brushpage.rs',
     'penssidebar/eraserpage.rs',
     'penssidebar/mod.rs',

--- a/rnote-ui/src/meson.build
+++ b/rnote-ui/src/meson.build
@@ -63,6 +63,8 @@ rnote_ui_sources = files(
     'colorpicker/colorsetter.rs',
     'colorpicker/colorpad.rs',
     'colorpicker/mod.rs',
+    'strokewidthpicker/mod.rs',
+    'strokewidthpicker/strokewidthsetter.rs',
     'penssidebar/brushpage.rs',
     'penssidebar/eraserpage.rs',
     'penssidebar/mod.rs',

--- a/rnote-ui/src/penssidebar/brushpage.rs
+++ b/rnote-ui/src/penssidebar/brushpage.rs
@@ -232,12 +232,11 @@ impl BrushPage {
             .set_range(BrushConfig::STROKE_WIDTH_MIN, BrushConfig::STROKE_WIDTH_MAX);
         // set value after the range!
         imp.stroke_width_picker
-            .spinbutton()
-            .set_value(SolidOptions::default().stroke_width);
+            .set_stroke_width(SolidOptions::default().stroke_width);
 
         imp.stroke_width_picker.connect_notify_local(
             Some("stroke-width"),
-            clone!(@weak self as brushpage, @weak appwindow => move |picker, _pspec| {
+            clone!(@weak self as brushpage, @weak appwindow => move |picker, _| {
                 let stroke_width = picker.stroke_width();
                 let engine = appwindow.active_tab().canvas().engine();
                 let engine = &mut *engine.borrow_mut();
@@ -264,7 +263,6 @@ impl BrushPage {
             clone!(@weak self as brushpage, @weak appwindow => move |_, _| {
                 if let Some(brush_style) = brushpage.brush_style() {
                     appwindow.active_tab().canvas().engine().borrow_mut().pens_config.brush_config.style = brush_style;
-
                     brushpage.stroke_width_picker().deselect_setters();
 
                     match brush_style {

--- a/rnote-ui/src/penssidebar/brushpage.rs
+++ b/rnote-ui/src/penssidebar/brushpage.rs
@@ -10,7 +10,7 @@ use rnote_compose::builders::PenPathBuilderType;
 use rnote_compose::style::PressureCurve;
 use rnote_engine::pens::pensconfig::BrushConfig;
 
-use crate::appwindow::RnoteAppWindow;
+use crate::{RnoteAppWindow, StrokeWidthPicker};
 use rnote_compose::style::textured::{TexturedDotsDistribution, TexturedOptions};
 use rnote_engine::pens::pensconfig::brushconfig::{BrushStyle, SolidOptions};
 
@@ -24,8 +24,6 @@ mod imp {
         pub(crate) solid_stroke_width: Cell<f64>,
         pub(crate) textured_stroke_width: Cell<f64>,
 
-        #[template_child]
-        pub(crate) width_spinbutton: TemplateChild<SpinButton>,
         #[template_child]
         pub(crate) brushstyle_menubutton: TemplateChild<MenuButton>,
         #[template_child]
@@ -56,6 +54,8 @@ mod imp {
         pub(crate) texturedstyle_density_spinbutton: TemplateChild<SpinButton>,
         #[template_child]
         pub(crate) texturedstyle_distribution_row: TemplateChild<adw::ComboRow>,
+        #[template_child]
+        pub(crate) stroke_width_picker: TemplateChild<StrokeWidthPicker>,
     }
 
     #[glib::object_subclass]
@@ -219,21 +219,26 @@ impl BrushPage {
         self.imp().textured_stroke_width.set(stroke_width);
     }
 
+    pub(crate) fn stroke_width_picker(&self) -> StrokeWidthPicker {
+        self.imp().stroke_width_picker.get()
+    }
+
     pub(crate) fn init(&self, appwindow: &RnoteAppWindow) {
         let imp = self.imp();
 
         // Stroke width
-        imp.width_spinbutton.set_increments(0.1, 2.0);
-        imp.width_spinbutton
+        imp.stroke_width_picker
+            .spinbutton()
             .set_range(BrushConfig::STROKE_WIDTH_MIN, BrushConfig::STROKE_WIDTH_MAX);
         // set value after the range!
-        imp.width_spinbutton
-            .get()
+        imp.stroke_width_picker
+            .spinbutton()
             .set_value(SolidOptions::default().stroke_width);
 
-        imp.width_spinbutton.connect_value_changed(
-            clone!(@weak self as brushpage, @weak appwindow => move |brush_widthscale_spinbutton| {
-                let stroke_width = brush_widthscale_spinbutton.value();
+        imp.stroke_width_picker.connect_notify_local(
+            Some("stroke-width"),
+            clone!(@weak self as brushpage, @weak appwindow => move |picker, _pspec| {
+                let stroke_width = picker.stroke_width();
                 let engine = appwindow.active_tab().canvas().engine();
                 let engine = &mut *engine.borrow_mut();
 
@@ -260,23 +265,25 @@ impl BrushPage {
                 if let Some(brush_style) = brushpage.brush_style() {
                     appwindow.active_tab().canvas().engine().borrow_mut().pens_config.brush_config.style = brush_style;
 
+                    brushpage.stroke_width_picker().deselect_setters();
+
                     match brush_style {
                         BrushStyle::Marker => {
                             let stroke_width = appwindow.active_tab().canvas().engine().borrow_mut().pens_config.brush_config.marker_options.stroke_width;
                             brushpage.imp().marker_stroke_width.set(stroke_width);
-                            brushpage.imp().width_spinbutton.set_value(stroke_width);
+                            brushpage.imp().stroke_width_picker.set_stroke_width(stroke_width);
                             brushpage.imp().brushstyle_image.set_icon_name(Some("pen-brush-style-marker-symbolic"))
                         },
                         BrushStyle::Solid => {
                             let stroke_width = appwindow.active_tab().canvas().engine().borrow_mut().pens_config.brush_config.solid_options.stroke_width;
                             brushpage.imp().solid_stroke_width.set(stroke_width);
-                            brushpage.imp().width_spinbutton.set_value(stroke_width);
+                            brushpage.imp().stroke_width_picker.set_stroke_width(stroke_width);
                             brushpage.imp().brushstyle_image.set_icon_name(Some("pen-brush-style-solid-symbolic"))
                         },
                         BrushStyle::Textured => {
                             let stroke_width = appwindow.active_tab().canvas().engine().borrow_mut().pens_config.brush_config.textured_options.stroke_width;
                             brushpage.imp().textured_stroke_width.set(stroke_width);
-                            brushpage.imp().width_spinbutton.set_value(stroke_width);
+                            brushpage.imp().stroke_width_picker.set_stroke_width(stroke_width);
                             brushpage.imp().brushstyle_image.set_icon_name(Some("pen-brush-style-textured-symbolic"))
                         },
                     }
@@ -352,16 +359,16 @@ impl BrushPage {
 
         match brush_config.style {
             BrushStyle::Marker => {
-                imp.width_spinbutton
-                    .set_value(brush_config.marker_options.stroke_width);
+                imp.stroke_width_picker
+                    .set_stroke_width(brush_config.marker_options.stroke_width);
             }
             BrushStyle::Solid => {
-                imp.width_spinbutton
-                    .set_value(brush_config.solid_options.stroke_width);
+                imp.stroke_width_picker
+                    .set_stroke_width(brush_config.solid_options.stroke_width);
             }
             BrushStyle::Textured => {
-                imp.width_spinbutton
-                    .set_value(brush_config.textured_options.stroke_width);
+                imp.stroke_width_picker
+                    .set_stroke_width(brush_config.textured_options.stroke_width);
             }
         }
     }

--- a/rnote-ui/src/strokewidthpicker/mod.rs
+++ b/rnote-ui/src/strokewidthpicker/mod.rs
@@ -1,0 +1,259 @@
+mod strokewidthsetter;
+
+// Re-exports
+pub(crate) use strokewidthsetter::StrokeWidthSetter;
+
+// Imports
+use gtk4::{
+    glib, glib::clone, glib::translate::IntoGlib, prelude::*, subclass::prelude::*, BoxLayout,
+    CompositeTemplate, Orientation, PositionType, SpinButton, Widget,
+};
+use once_cell::sync::Lazy;
+use std::cell::Cell;
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug, CompositeTemplate)]
+    #[template(resource = "/com/github/flxzt/rnote/ui/strokewidthpicker.ui")]
+    pub(crate) struct StrokeWidthPicker {
+        pub(crate) position: Cell<PositionType>,
+        pub(crate) stroke_width: Cell<f64>,
+
+        #[template_child]
+        pub(crate) spinbutton: TemplateChild<SpinButton>,
+        #[template_child]
+        pub(crate) setter_box: TemplateChild<gtk4::Box>,
+        #[template_child]
+        pub(crate) setter_1: TemplateChild<StrokeWidthSetter>,
+        #[template_child]
+        pub(crate) setter_2: TemplateChild<StrokeWidthSetter>,
+        #[template_child]
+        pub(crate) setter_3: TemplateChild<StrokeWidthSetter>,
+    }
+
+    impl Default for StrokeWidthPicker {
+        fn default() -> Self {
+            Self {
+                position: Cell::new(PositionType::Right),
+                stroke_width: Cell::new(1.0),
+
+                spinbutton: TemplateChild::default(),
+                setter_box: TemplateChild::default(),
+                setter_1: TemplateChild::default(),
+                setter_2: TemplateChild::default(),
+                setter_3: TemplateChild::default(),
+            }
+        }
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for StrokeWidthPicker {
+        const NAME: &'static str = "StrokeWidthPicker";
+        type Type = super::StrokeWidthPicker;
+        type ParentType = Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for StrokeWidthPicker {
+        fn constructed(&self) {
+            self.parent_constructed();
+            let inst = self.instance();
+
+            self.spinbutton.set_increments(0.1, 2.0);
+
+            inst.bind_property("stroke-width", &*self.spinbutton, "value")
+                .sync_create()
+                .bidirectional()
+                .build();
+
+            self.setter_1.set_stroke_width(2.0);
+            self.setter_2.set_stroke_width(6.0);
+            self.setter_3.set_stroke_width(32.0);
+
+            self.setter_1.connect_clicked(
+                clone!(@weak inst as strokewidthpicker => move |setter| {
+                    strokewidthpicker.set_stroke_width(setter.stroke_width());
+                }),
+            );
+
+            self.setter_2.connect_clicked(
+                clone!(@weak inst as strokewidthpicker => move |setter| {
+                    strokewidthpicker.set_stroke_width(setter.stroke_width());
+                }),
+            );
+
+            self.setter_3.connect_clicked(
+                clone!(@weak inst as strokewidthpicker => move |setter| {
+                    strokewidthpicker.set_stroke_width(setter.stroke_width());
+                }),
+            );
+
+            self.spinbutton.connect_value_changed(
+                clone!(@weak inst as strokewidthpicker => move |spinbutton| {
+                    strokewidthpicker.set_active_setter_stroke_width(spinbutton.value());
+                }),
+            );
+        }
+
+        fn dispose(&self) {
+            while let Some(child) = self.instance().first_child() {
+                child.unparent();
+            }
+        }
+
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![
+                    glib::ParamSpecEnum::new(
+                        "position",
+                        "position",
+                        "position",
+                        PositionType::static_type(),
+                        PositionType::Right.into_glib(),
+                        glib::ParamFlags::READWRITE,
+                    ),
+                    glib::ParamSpecDouble::new(
+                        "stroke-width",
+                        "stroke-width",
+                        "stroke-width",
+                        0.0,
+                        500.0,
+                        1.0,
+                        glib::ParamFlags::READWRITE,
+                    ),
+                ]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "position" => self.position.get().to_value(),
+                "stroke-width" => self.stroke_width.get().to_value(),
+                _ => panic!("invalid property name"),
+            }
+        }
+
+        fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+            let inst = self.instance();
+
+            match pspec.name() {
+                "position" => {
+                    let position = value
+                        .get::<PositionType>()
+                        .expect("value not of type `PositionType`");
+                    self.position.replace(position);
+
+                    let layout_manager = inst
+                        .layout_manager()
+                        .unwrap()
+                        .downcast::<BoxLayout>()
+                        .unwrap();
+
+                    match position {
+                        PositionType::Left => {
+                            layout_manager.set_orientation(Orientation::Vertical);
+                            self.setter_box.set_orientation(Orientation::Vertical);
+                            self.spinbutton.set_orientation(Orientation::Vertical);
+                        }
+                        PositionType::Right => {
+                            layout_manager.set_orientation(Orientation::Vertical);
+                            self.setter_box.set_orientation(Orientation::Vertical);
+                            self.spinbutton.set_orientation(Orientation::Vertical);
+                        }
+                        PositionType::Top => {
+                            layout_manager.set_orientation(Orientation::Horizontal);
+                            self.setter_box.set_orientation(Orientation::Horizontal);
+                            self.spinbutton.set_orientation(Orientation::Horizontal);
+                        }
+                        PositionType::Bottom => {
+                            layout_manager.set_orientation(Orientation::Horizontal);
+                            self.setter_box.set_orientation(Orientation::Horizontal);
+                            self.spinbutton.set_orientation(Orientation::Horizontal);
+                        }
+                        _ => {}
+                    }
+                }
+                "stroke-width" => {
+                    self.stroke_width
+                        .set(value.get::<f64>().expect("value not of type `f64`"));
+                }
+                _ => panic!("invalid property name"),
+            }
+        }
+    }
+
+    impl WidgetImpl for StrokeWidthPicker {}
+
+    impl StrokeWidthPicker {}
+}
+
+glib::wrapper! {
+    pub(crate) struct StrokeWidthPicker(ObjectSubclass<imp::StrokeWidthPicker>)
+        @extends Widget,
+        @implements gtk4::Accessible, gtk4::Buildable, gtk4::ConstraintTarget;
+}
+
+impl Default for StrokeWidthPicker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StrokeWidthPicker {
+    pub(crate) fn new() -> Self {
+        glib::Object::new(&[])
+    }
+
+    #[allow(unused)]
+    pub(crate) fn position(&self) -> PositionType {
+        self.property::<PositionType>("position")
+    }
+
+    #[allow(unused)]
+    pub(crate) fn set_position(&self, position: PositionType) {
+        self.set_property("position", position.to_value());
+    }
+
+    #[allow(unused)]
+    pub(crate) fn stroke_width(&self) -> f64 {
+        self.property::<f64>("stroke-width")
+    }
+
+    #[allow(unused)]
+    pub(crate) fn set_stroke_width(&self, stroke_width: f64) {
+        self.set_property("stroke-width", stroke_width.to_value());
+    }
+
+    pub(crate) fn spinbutton(&self) -> SpinButton {
+        self.imp().spinbutton.get()
+    }
+
+    pub(crate) fn set_active_setter_stroke_width(&self, stroke_width: f64) {
+        let imp = self.imp();
+
+        if imp.setter_1.is_active() {
+            imp.setter_1.set_stroke_width(stroke_width);
+        } else if imp.setter_2.is_active() {
+            imp.setter_2.set_stroke_width(stroke_width);
+        } else if imp.setter_3.is_active() {
+            imp.setter_3.set_stroke_width(stroke_width);
+        }
+    }
+
+    pub(crate) fn deselect_setters(&self) {
+        let imp = self.imp();
+
+        imp.setter_1.set_active(false);
+        imp.setter_2.set_active(false);
+        imp.setter_3.set_active(false);
+    }
+}

--- a/rnote-ui/src/strokewidthpicker/mod.rs
+++ b/rnote-ui/src/strokewidthpicker/mod.rs
@@ -1,6 +1,8 @@
+mod strokewidthpreview;
 mod strokewidthsetter;
 
 // Re-exports
+pub(crate) use strokewidthpreview::StrokeWidthPreview;
 pub(crate) use strokewidthsetter::StrokeWidthSetter;
 
 // Imports

--- a/rnote-ui/src/strokewidthpicker/mod.rs
+++ b/rnote-ui/src/strokewidthpicker/mod.rs
@@ -237,6 +237,18 @@ impl StrokeWidthPicker {
         self.imp().spinbutton.get()
     }
 
+    pub(crate) fn setter_1(&self) -> StrokeWidthSetter {
+        self.imp().setter_1.get()
+    }
+
+    pub(crate) fn setter_2(&self) -> StrokeWidthSetter {
+        self.imp().setter_2.get()
+    }
+
+    pub(crate) fn setter_3(&self) -> StrokeWidthSetter {
+        self.imp().setter_3.get()
+    }
+
     pub(crate) fn set_active_setter_stroke_width(&self, stroke_width: f64) {
         let imp = self.imp();
 

--- a/rnote-ui/src/strokewidthpicker/strokewidthpreview.rs
+++ b/rnote-ui/src/strokewidthpicker/strokewidthpreview.rs
@@ -1,0 +1,156 @@
+// Imports
+use gtk4::{
+    glib, graphene, prelude::*, subclass::prelude::*, Orientation, Overflow, SizeRequestMode,
+    Widget,
+};
+use once_cell::sync::Lazy;
+use std::cell::Cell;
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug)]
+    pub(crate) struct StrokeWidthPreview {
+        stroke_width: Cell<f64>,
+    }
+
+    impl Default for StrokeWidthPreview {
+        fn default() -> Self {
+            Self {
+                stroke_width: Cell::new(1.0),
+            }
+        }
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for StrokeWidthPreview {
+        const NAME: &'static str = "StrokeWidthPreview";
+        type Type = super::StrokeWidthPreview;
+        type ParentType = Widget;
+    }
+
+    impl ObjectImpl for StrokeWidthPreview {
+        fn constructed(&self) {
+            self.parent_constructed();
+            let inst = self.instance();
+
+            inst.set_overflow(Overflow::Hidden);
+        }
+
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![glib::ParamSpecDouble::new(
+                    "stroke-width",
+                    "stroke-width",
+                    "stroke-width",
+                    0.1,
+                    500.0,
+                    1.0,
+                    glib::ParamFlags::READWRITE,
+                )]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+            let inst = self.instance();
+
+            match pspec.name() {
+                "stroke-width" => {
+                    let stroke_width = value.get::<f64>().expect("value not of type `f64`");
+                    self.stroke_width.set(stroke_width);
+                    inst.queue_draw();
+                }
+                _ => panic!("invalid property name"),
+            }
+        }
+
+        fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "stroke-width" => self.stroke_width.get().to_value(),
+                _ => panic!("invalid property name"),
+            }
+        }
+    }
+
+    impl WidgetImpl for StrokeWidthPreview {
+        fn request_mode(&self) -> SizeRequestMode {
+            SizeRequestMode::ConstantSize
+        }
+
+        fn measure(&self, orientation: Orientation, _for_size: i32) -> (i32, i32, i32, i32) {
+            match orientation {
+                Orientation::Horizontal => (0, 32, -1, -1),
+                Orientation::Vertical => (0, 32, -1, -1),
+                _ => todo!(),
+            }
+        }
+
+        fn snapshot(&self, snapshot: &gtk4::Snapshot) {
+            let inst = self.instance();
+            let size = (inst.width() as f32, inst.height() as f32);
+            let center = (size.0 * 0.5, size.1 * 0.5);
+            let stroke_width = self.stroke_width.get();
+
+            let window_fg_color = inst
+                .style_context()
+                .lookup_color("window_fg_color")
+                .unwrap();
+
+            // Intentionally a bit larger than half widget size, indicating that it is bigger than what can be displayed
+            const MAX_RADIUS: f64 = 22.0;
+
+            // Is asymptotic to MAX_RADIUS
+            let circle_radius =
+                (MAX_RADIUS * stroke_width * 0.5) / (MAX_RADIUS * 0.5 + stroke_width * 0.5);
+
+            let cairo_cx = snapshot.append_cairo(&graphene::Rect::new(0.0, 0.0, size.0, size.1));
+            cairo_cx.set_source_rgba(
+                window_fg_color.red() as f64,
+                window_fg_color.green() as f64,
+                window_fg_color.blue() as f64,
+                window_fg_color.alpha() as f64,
+            );
+            cairo_cx.arc(
+                center.0 as f64,
+                center.1 as f64,
+                circle_radius,
+                0.0,
+                std::f64::consts::PI * 2.0,
+            );
+            if let Err(e) = cairo_cx.fill() {
+                log::error!("failed to paint stroke width preview, fill returned Err: {e:?}");
+            }
+        }
+    }
+
+    impl StrokeWidthPreview {}
+}
+
+glib::wrapper! {
+    pub(crate) struct StrokeWidthPreview(ObjectSubclass<imp::StrokeWidthPreview>)
+        @extends Widget,
+        @implements gtk4::Accessible, gtk4::Buildable, gtk4::ConstraintTarget;
+}
+
+impl Default for StrokeWidthPreview {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StrokeWidthPreview {
+    pub(crate) fn new() -> Self {
+        glib::Object::new(&[])
+    }
+
+    #[allow(unused)]
+    pub(crate) fn stroke_width(&self) -> f64 {
+        self.property::<f64>("stroke-width")
+    }
+
+    #[allow(unused)]
+    pub(crate) fn set_stroke_width(&self, stroke_width: f64) {
+        self.set_property("stroke-width", stroke_width.to_value());
+    }
+}

--- a/rnote-ui/src/strokewidthpicker/strokewidthsetter.rs
+++ b/rnote-ui/src/strokewidthpicker/strokewidthsetter.rs
@@ -1,7 +1,6 @@
 // Imports
-use gtk4::{
-    glib, prelude::*, subclass::prelude::*, Align, Button, Image, Overflow, ToggleButton, Widget,
-};
+use super::StrokeWidthPreview;
+use gtk4::{glib, prelude::*, subclass::prelude::*, Align, Button, Overflow, ToggleButton, Widget};
 use once_cell::sync::Lazy;
 use std::cell::Cell;
 
@@ -10,14 +9,14 @@ mod imp {
 
     #[derive(Debug)]
     pub(crate) struct StrokeWidthSetter {
-        image: Image,
+        preview: StrokeWidthPreview,
         stroke_width: Cell<f64>,
     }
 
     impl Default for StrokeWidthSetter {
         fn default() -> Self {
             Self {
-                image: Image::default(),
+                preview: StrokeWidthPreview::default(),
                 stroke_width: Cell::new(1.0),
             }
         }
@@ -42,9 +41,11 @@ mod imp {
             inst.set_vexpand(false);
             inst.set_css_classes(&["strokewidthsetter"]);
 
-            self.image.add_css_class("strokewidthsetterimage");
-            self.image.set_icon_name(Some("strokewidthsetter-symbolic"));
-            inst.set_child(Some(&self.image));
+            inst.set_child(Some(&self.preview));
+
+            inst.bind_property("stroke-width", &self.preview, "stroke-width")
+                .sync_create()
+                .build();
 
             self.update_appearance(self.stroke_width.get());
         }
@@ -92,15 +93,6 @@ mod imp {
             let inst = self.instance();
 
             inst.set_tooltip_text(Some(&format!("{stroke_width:.1}")));
-
-            // The max size is 24
-            const IMAGE_MAX_SIZE: f64 = 24.0;
-
-            // Is asymptotic to IMAGE_MAX_SIZE
-            let pixel_size =
-                (IMAGE_MAX_SIZE * stroke_width) / (IMAGE_MAX_SIZE * 0.5 + stroke_width);
-            self.image
-                .set_pixel_size(pixel_size as i32 + pixel_size as i32 % 2);
         }
     }
 }

--- a/rnote-ui/src/strokewidthpicker/strokewidthsetter.rs
+++ b/rnote-ui/src/strokewidthpicker/strokewidthsetter.rs
@@ -1,0 +1,134 @@
+// Imports
+use gtk4::{
+    glib, prelude::*, subclass::prelude::*, Align, Button, Image, Overflow, ToggleButton, Widget,
+};
+use once_cell::sync::Lazy;
+use std::cell::Cell;
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug)]
+    pub(crate) struct StrokeWidthSetter {
+        image: Image,
+        stroke_width: Cell<f64>,
+    }
+
+    impl Default for StrokeWidthSetter {
+        fn default() -> Self {
+            Self {
+                image: Image::default(),
+                stroke_width: Cell::new(1.0),
+            }
+        }
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for StrokeWidthSetter {
+        const NAME: &'static str = "StrokeWidthSetter";
+        type Type = super::StrokeWidthSetter;
+        type ParentType = ToggleButton;
+    }
+
+    impl ObjectImpl for StrokeWidthSetter {
+        fn constructed(&self) {
+            self.parent_constructed();
+            let inst = self.instance();
+
+            inst.set_overflow(Overflow::Hidden);
+            inst.set_halign(Align::Center);
+            inst.set_valign(Align::Center);
+            inst.set_hexpand(false);
+            inst.set_vexpand(false);
+            inst.set_css_classes(&["strokewidthsetter"]);
+
+            self.image.add_css_class("strokewidthsetterimage");
+            self.image.set_icon_name(Some("strokewidthsetter-symbolic"));
+            inst.set_child(Some(&self.image));
+
+            self.update_appearance(self.stroke_width.get());
+        }
+
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![glib::ParamSpecDouble::new(
+                    "stroke-width",
+                    "stroke-width",
+                    "stroke-width",
+                    0.1,
+                    500.0,
+                    1.0,
+                    glib::ParamFlags::READWRITE,
+                )]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+            match pspec.name() {
+                "stroke-width" => {
+                    let stroke_width = value.get::<f64>().expect("value not of type `f64`");
+                    self.stroke_width.set(stroke_width);
+                    self.update_appearance(stroke_width);
+                }
+                _ => panic!("invalid property name"),
+            }
+        }
+
+        fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "stroke-width" => self.stroke_width.get().to_value(),
+                _ => panic!("invalid property name"),
+            }
+        }
+    }
+
+    impl WidgetImpl for StrokeWidthSetter {}
+    impl ButtonImpl for StrokeWidthSetter {}
+    impl ToggleButtonImpl for StrokeWidthSetter {}
+
+    impl StrokeWidthSetter {
+        fn update_appearance(&self, stroke_width: f64) {
+            let inst = self.instance();
+
+            inst.set_tooltip_text(Some(&format!("{stroke_width:.1}")));
+
+            // The max size is 24
+            const IMAGE_MAX_SIZE: f64 = 24.0;
+
+            // Is asymptotic to IMAGE_MAX_SIZE
+            let pixel_size =
+                (IMAGE_MAX_SIZE * stroke_width) / (IMAGE_MAX_SIZE * 0.5 + stroke_width);
+            self.image
+                .set_pixel_size(pixel_size as i32 + pixel_size as i32 % 2);
+        }
+    }
+}
+
+glib::wrapper! {
+    pub(crate) struct StrokeWidthSetter(ObjectSubclass<imp::StrokeWidthSetter>)
+        @extends ToggleButton, Button, Widget,
+        @implements gtk4::Accessible, gtk4::Buildable, gtk4::ConstraintTarget;
+}
+
+impl Default for StrokeWidthSetter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StrokeWidthSetter {
+    pub(crate) fn new() -> Self {
+        glib::Object::new(&[])
+    }
+
+    #[allow(unused)]
+    pub(crate) fn stroke_width(&self) -> f64 {
+        self.property::<f64>("stroke-width")
+    }
+
+    #[allow(unused)]
+    pub(crate) fn set_stroke_width(&self, stroke_width: f64) {
+        self.set_property("stroke-width", stroke_width.to_value());
+    }
+}


### PR DESCRIPTION
This introduces a stroke width palette to be able to save commonly used widths in presets. The widths are previewed as a circle with radius as stroke_width * 0.5.

![Bildschirmfoto vom 2023-01-18 23-07-26](https://user-images.githubusercontent.com/19841886/213305947-edbfece2-005d-49e5-a8ae-fd5280823946.png)


To be able to display all widths from 0.1 to 500.0, a conversion function is used that is asymptotic to a specified max size. For small widths this scales approximately linear, which should be the most common case.

fixes #302 when merged. @D0V4HKIIN already has a similar draft PR, but I thought it was easier to implement it myself, because the custom widget is tricky when not already familiar with gtk4 subclassing.