### PR TITLE
stroke path rendering as single closed shape

### DIFF
--- a/rnote-compose/src/style/smooth/mod.rs
+++ b/rnote-compose/src/style/smooth/mod.rs
@@ -141,11 +141,6 @@ impl Composer<SmoothOptions> for PenPath {
         for seg in self.segments.iter() {
             match seg {
                 Segment::LineTo { end } => {
-                    /*
-                                           let width_start = options
-                                               .pressure_curve
-                                               .apply(options.stroke_width, prev.pressure);
-                    */
                     let width_end = options
                         .pressure_curve
                         .apply(options.stroke_width, end.pressure);
@@ -318,14 +313,14 @@ fn draw_path_variable_width(
 
     // Draw
     cx.fill(bez_path.clone(), &fill_brush);
-
-    // debugging
-    //draw_debug_points(cx, path_points);
-    //let stroke_brush = cx.solid_brush(piet::Color::RED);
-    //cx.stroke(bez_path.clone(), &stroke_brush, 0.2);
-
     cx.fill(start_cap, &fill_brush);
     cx.fill(end_cap, &fill_brush);
+
+    // debugging
+    //draw_debug_path(cx, path_points);
+    //draw_debug_points(cx, path_points);
+    // outlines
+    //cx.stroke(bez_path.clone(), &piet::Color::RED, 0.2);
 }
 
 #[allow(unused)]
@@ -347,5 +342,21 @@ fn draw_debug_points(cx: &mut impl piet::RenderContext, points: &[(na::Vector2<f
             0.5 * (i as f64 * color_step + 2.0 * rgb_offset + color_offset).sin() + 0.5,
             1.0,
         )
+    }
+}
+
+#[allow(unused)]
+fn draw_debug_path(cx: &mut impl piet::RenderContext, points: &[(na::Vector2<f64>, f64)]) {
+    let mut points_iter = points
+        .into_iter()
+        .map(|p| kurbo::Point::new(p.0[0], p.0[1]));
+
+    if let Some(prev) = points_iter.next() {
+        let bez_path = kurbo::BezPath::from_iter(
+            std::iter::once(kurbo::PathEl::MoveTo(prev))
+                .chain(points_iter.map(|p| kurbo::PathEl::LineTo(p))),
+        );
+
+        cx.stroke(bez_path, &piet::Color::FUCHSIA, 1.0);
     }
 }

--- a/rnote-compose/src/style/smooth/mod.rs
+++ b/rnote-compose/src/style/smooth/mod.rs
@@ -6,116 +6,15 @@ pub use smoothoptions::SmoothOptions;
 use super::Composer;
 use crate::helpers::Vector2Helpers;
 use crate::penpath::Segment;
-use crate::shapes::CubicBezier;
-use crate::shapes::Ellipse;
 use crate::shapes::Line;
 use crate::shapes::QuadraticBezier;
 use crate::shapes::Rectangle;
 use crate::shapes::ShapeBehaviour;
+use crate::shapes::{cubbez, CubicBezier};
+use crate::shapes::{quadbez, Ellipse};
 use crate::PenPath;
 
-use kurbo::Shape;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
-
-// Composes lines with variable width. Must be drawn with only a fill
-fn compose_lines_variable_width(
-    lines: &[Line],
-    width_start: f64,
-    width_end: f64,
-    _options: &SmoothOptions,
-) -> kurbo::BezPath {
-    let mut bez_path = kurbo::BezPath::new();
-
-    if lines.is_empty() {
-        return bez_path;
-    }
-    let n_lines = lines.len() as u32;
-
-    let offset_coords = lines.iter().enumerate().map(|(i, line)| {
-        let line_start_width =
-            width_start + (width_end - width_start) * (f64::from(i as i32) / f64::from(n_lines));
-        let line_end_width = width_start
-            + (width_end - width_start) * (f64::from(i as i32 + 1) / f64::from(n_lines));
-
-        let direction_unit_norm = (line.end - line.start).orth_unit();
-
-        (
-            [
-                line.start + direction_unit_norm * line_start_width * 0.5,
-                line.end + direction_unit_norm * line_end_width * 0.5,
-            ],
-            [
-                line.start - direction_unit_norm * line_start_width * 0.5,
-                line.end - direction_unit_norm * line_end_width * 0.5,
-            ],
-        )
-    });
-
-    let mut pos_offset_coords = offset_coords
-        .clone()
-        .flat_map(|offset_coords| offset_coords.0)
-        .collect::<Vec<na::Vector2<f64>>>()
-        .into_iter();
-
-    let neg_offset_coords = offset_coords
-        .flat_map(|offset_coords| offset_coords.1)
-        .rev()
-        .collect::<Vec<na::Vector2<f64>>>()
-        .into_iter();
-
-    let start_offset_dist = width_start * 0.5;
-    let end_offset_dist = width_end * 0.5;
-
-    let first_line = lines.first().unwrap();
-    let last_line = lines.last().unwrap();
-
-    let start_arc_rotation = na::Vector2::y().angle_ahead(&(first_line.end - first_line.start));
-    let end_arc_rotation = na::Vector2::y().angle_ahead(&(last_line.end - last_line.start));
-
-    // Start cap
-    bez_path.extend(
-        kurbo::Arc {
-            center: first_line.start.to_kurbo_point(),
-            radii: kurbo::Vec2::new(start_offset_dist, start_offset_dist),
-            start_angle: 0.0,
-            sweep_angle: std::f64::consts::PI,
-            x_rotation: start_arc_rotation + std::f64::consts::PI,
-        }
-        .into_path(0.1)
-        .into_iter(),
-    );
-
-    // Positive offset path
-    if let Some(first_pos_offset_coord) = pos_offset_coords.next() {
-        bez_path.push(kurbo::PathEl::MoveTo(
-            first_pos_offset_coord.to_kurbo_point(),
-        ));
-
-        for pos_offset_coord in pos_offset_coords {
-            bez_path.push(kurbo::PathEl::LineTo(pos_offset_coord.to_kurbo_point()));
-        }
-    }
-
-    // Negative offset path (already reversed)
-    for pos_offset_coord in neg_offset_coords {
-        bez_path.push(kurbo::PathEl::LineTo(pos_offset_coord.to_kurbo_point()));
-    }
-
-    // End cap
-    bez_path.extend(
-        kurbo::Arc {
-            center: last_line.end.to_kurbo_point(),
-            radii: kurbo::Vec2::new(end_offset_dist, end_offset_dist),
-            start_angle: 0.0,
-            sweep_angle: std::f64::consts::PI,
-            x_rotation: end_arc_rotation,
-        }
-        .into_path(0.1)
-        .into_iter(),
-    );
-
-    bez_path
-}
 
 impl Composer<SmoothOptions> for Line {
     fn composed_bounds(&self, options: &SmoothOptions) -> Aabb {
@@ -230,97 +129,87 @@ impl Composer<SmoothOptions> for PenPath {
     fn draw_composed(&self, cx: &mut impl piet::RenderContext, options: &SmoothOptions) {
         cx.save().unwrap();
 
+        let start_point = (
+            self.start.pos,
+            options
+                .pressure_curve
+                .apply(options.stroke_width, self.start.pressure),
+        );
+        let mut path_points = vec![start_point];
+
         let mut prev = self.start;
         for seg in self.segments.iter() {
-            let bez_path = {
-                match seg {
-                    Segment::LineTo { end } => {
-                        let (width_start, width_end) = (
-                            options
-                                .pressure_curve
-                                .apply(options.stroke_width, prev.pressure),
-                            options
-                                .pressure_curve
-                                .apply(options.stroke_width, end.pressure),
-                        );
+            match seg {
+                Segment::LineTo { end } => {
+                    /*
+                                           let width_start = options
+                                               .pressure_curve
+                                               .apply(options.stroke_width, prev.pressure);
+                    */
+                    let width_end = options
+                        .pressure_curve
+                        .apply(options.stroke_width, end.pressure);
 
-                        let bez_path = compose_lines_variable_width(
-                            &[Line {
-                                start: prev.pos,
-                                end: end.pos,
-                            }],
-                            width_start,
-                            width_end,
-                            options,
-                        );
-
-                        prev = *end;
-                        bez_path
-                    }
-                    Segment::QuadBezTo { cp, end } => {
-                        let (width_start, width_end) = (
-                            options
-                                .pressure_curve
-                                .apply(options.stroke_width, prev.pressure),
-                            options
-                                .pressure_curve
-                                .apply(options.stroke_width, end.pressure),
-                        );
-
-                        let n_splits = 5;
-
-                        let quadbez = QuadraticBezier {
-                            start: prev.pos,
-                            cp: *cp,
-                            end: end.pos,
-                        };
-
-                        let lines = quadbez.approx_with_lines(n_splits);
-
-                        let bez_path =
-                            compose_lines_variable_width(&lines, width_start, width_end, options);
-
-                        prev = *end;
-                        bez_path
-                    }
-                    Segment::CubBezTo { cp1, cp2, end } => {
-                        let (width_start, width_end) = (
-                            options
-                                .pressure_curve
-                                .apply(options.stroke_width, prev.pressure),
-                            options
-                                .pressure_curve
-                                .apply(options.stroke_width, end.pressure),
-                        );
-
-                        let n_splits = 5;
-
-                        let cubbez = CubicBezier {
-                            start: prev.pos,
-                            cp1: *cp1,
-                            cp2: *cp2,
-                            end: end.pos,
-                        };
-                        let lines = cubbez.approx_with_lines(n_splits);
-
-                        let bez_path =
-                            compose_lines_variable_width(&lines, width_start, width_end, options);
-
-                        prev = *end;
-                        bez_path
-                    }
+                    path_points.append(&mut vec![(end.pos, width_end)]);
+                    prev = *end;
                 }
-            };
+                Segment::QuadBezTo { cp, end } => {
+                    let (width_start, width_end) = (
+                        options
+                            .pressure_curve
+                            .apply(options.stroke_width, prev.pressure),
+                        options
+                            .pressure_curve
+                            .apply(options.stroke_width, end.pressure),
+                    );
 
-            if let Some(fill_color) = options.stroke_color {
-                // Outlines for debugging
-                //let stroke_brush = cx.solid_brush(piet::Color::RED);
-                //cx.stroke(bez_path.clone(), &stroke_brush, 0.4);
+                    let n_splits = 5;
 
-                let fill_brush = cx.solid_brush(fill_color.into());
-                cx.fill(bez_path, &fill_brush);
+                    let mut quadbez_points = (1..n_splits)
+                        .map(|i| {
+                            let t = f64::from(i) / f64::from(n_splits);
+
+                            (
+                                quadbez::quadbez_calc(prev.pos, *cp, end.pos, t),
+                                width_start + (width_end - width_start) * t,
+                            )
+                        })
+                        .collect::<Vec<(na::Vector2<f64>, f64)>>();
+
+                    path_points.append(&mut quadbez_points);
+                    prev = *end;
+                }
+                Segment::CubBezTo { cp1, cp2, end } => {
+                    let (width_start, width_end) = (
+                        options
+                            .pressure_curve
+                            .apply(options.stroke_width, prev.pressure),
+                        options
+                            .pressure_curve
+                            .apply(options.stroke_width, end.pressure),
+                    );
+
+                    let n_splits = 5;
+
+                    let mut cubbez_points = (1..n_splits)
+                        .map(|i| {
+                            let t = f64::from(i) / f64::from(n_splits);
+
+                            (
+                                cubbez::cubbez_calc(prev.pos, *cp1, *cp2, end.pos, t),
+                                width_start + (width_end - width_start) * t,
+                            )
+                        })
+                        .collect::<Vec<(na::Vector2<f64>, f64)>>();
+
+                    path_points.append(&mut cubbez_points);
+                    prev = *end;
+                }
             }
         }
+
+        //debug_points(cx, &points_var_width);
+        draw_path_variable_width(cx, &path_points, options);
 
         cx.restore().unwrap();
     }
@@ -346,4 +235,106 @@ impl Composer<SmoothOptions> for crate::Shape {
             crate::Shape::CubicBezier(cubbez) => cubbez.draw_composed(cx, options),
         }
     }
+}
+
+#[allow(unused)]
+fn debug_points(cx: &mut impl piet::RenderContext, points: &[(na::Vector2<f64>, f64)]) {
+    for point in points {
+        let stroke_brush = cx.solid_brush(piet::Color::RED);
+
+        cx.fill(
+            kurbo::Circle::new(point.0.to_kurbo_point(), 1.0),
+            &piet::Color::RED,
+        );
+    }
+}
+
+// draws a path with variable width.
+fn draw_path_variable_width(
+    cx: &mut impl piet::RenderContext,
+    path_points: &[(na::Vector2<f64>, f64)],
+    options: &SmoothOptions,
+) {
+    let n_points = path_points.len();
+    let mut bez_path = kurbo::BezPath::new();
+
+    if n_points < 2 {
+        return;
+    }
+
+    let Some(color) = options.stroke_color else {
+        return;
+    };
+    let fill_brush = cx.solid_brush(color.into());
+
+    let first_point = *path_points.first().unwrap();
+    let second_point = *path_points.get(1).unwrap();
+    let last_point = *path_points.last().unwrap();
+
+    let start_unit_norm = (second_point.0 - first_point.0).orth_unit();
+
+    let mut pos_offset_coords = Vec::with_capacity(n_points);
+    let mut neg_offset_coords = Vec::with_capacity(n_points);
+
+    pos_offset_coords.push(first_point.0 + start_unit_norm * first_point.1 * 0.5);
+    neg_offset_coords.push(first_point.0 - start_unit_norm * first_point.1 * 0.5);
+
+    let mut points_iter = path_points.into_iter();
+    let mut prev = *points_iter.next().unwrap();
+    for point in points_iter {
+        let direction_unit_norm = (point.0 - prev.0).orth_unit();
+
+        pos_offset_coords.push(point.0 + direction_unit_norm * point.1 * 0.5);
+        neg_offset_coords.push(point.0 - direction_unit_norm * point.1 * 0.5);
+
+        prev = *point;
+    }
+
+    let start_arc_radius = first_point.1 * 0.5;
+    let end_arc_radius = last_point.1 * 0.5;
+
+    // Start cap
+    let start_cap = kurbo::Ellipse::new(
+        first_point.0.to_kurbo_point(),
+        kurbo::Vec2::new(start_arc_radius, start_arc_radius),
+        0.0,
+    );
+
+    let mut pos_offset_coords_iter = pos_offset_coords.into_iter();
+    let neg_offset_coords_iter = neg_offset_coords.into_iter().rev();
+
+    // Positive offset path
+    if let Some(first_pos_offset_coord) = pos_offset_coords_iter.next() {
+        bez_path.push(kurbo::PathEl::MoveTo(
+            first_pos_offset_coord.to_kurbo_point(),
+        ));
+
+        bez_path.extend(
+            pos_offset_coords_iter
+                .into_iter()
+                .map(|c| kurbo::PathEl::LineTo(c.to_kurbo_point())),
+        );
+    }
+
+    // Negative offset path (already reversed)
+    bez_path.extend(neg_offset_coords_iter.map(|c| kurbo::PathEl::LineTo(c.to_kurbo_point())));
+
+    bez_path.close_path();
+
+    // End cap
+    let end_cap = kurbo::Ellipse::new(
+        last_point.0.to_kurbo_point(),
+        kurbo::Vec2::new(end_arc_radius, end_arc_radius),
+        0.0,
+    );
+
+    // Draw
+    cx.fill(bez_path.clone(), &fill_brush);
+
+    // Outlines for debugging
+    //let stroke_brush = cx.solid_brush(piet::Color::RED);
+    //cx.stroke(bez_path.clone(), &stroke_brush, 0.2);
+
+    cx.fill(start_cap, &fill_brush);
+    cx.fill(end_cap, &fill_brush);
 }

--- a/rnote-compose/src/style/smooth/mod.rs
+++ b/rnote-compose/src/style/smooth/mod.rs
@@ -237,18 +237,6 @@ impl Composer<SmoothOptions> for crate::Shape {
     }
 }
 
-#[allow(unused)]
-fn debug_points(cx: &mut impl piet::RenderContext, points: &[(na::Vector2<f64>, f64)]) {
-    for point in points {
-        let stroke_brush = cx.solid_brush(piet::Color::RED);
-
-        cx.fill(
-            kurbo::Circle::new(point.0.to_kurbo_point(), 1.0),
-            &piet::Color::RED,
-        );
-    }
-}
-
 // draws a path with variable width.
 fn draw_path_variable_width(
     cx: &mut impl piet::RenderContext,
@@ -331,10 +319,33 @@ fn draw_path_variable_width(
     // Draw
     cx.fill(bez_path.clone(), &fill_brush);
 
-    // Outlines for debugging
+    // debugging
+    //draw_debug_points(cx, path_points);
     //let stroke_brush = cx.solid_brush(piet::Color::RED);
     //cx.stroke(bez_path.clone(), &stroke_brush, 0.2);
 
     cx.fill(start_cap, &fill_brush);
     cx.fill(end_cap, &fill_brush);
+}
+
+#[allow(unused)]
+fn draw_debug_points(cx: &mut impl piet::RenderContext, points: &[(na::Vector2<f64>, f64)]) {
+    let mut color = piet::Color::rgba(1.0, 1.0, 0.0, 1.0);
+    for (i, (point, _pressure)) in points.into_iter().enumerate() {
+        let stroke_brush = cx.solid_brush(piet::Color::RED);
+
+        cx.fill(kurbo::Circle::new(point.to_kurbo_point(), 0.5), &color);
+
+        // Shift the color so the point order becomes visible
+        let color_step = (2.0 * std::f64::consts::PI) / (8 as f64);
+        let rgb_offset = (2.0 / 3.0) * std::f64::consts::PI;
+        let color_offset = (5.0 / 4.0) * std::f64::consts::PI + 0.4;
+
+        color = piet::Color::rgba(
+            0.5 * (i as f64 * color_step + 0.0 * rgb_offset + color_offset).sin() + 0.5,
+            0.5 * (i as f64 * color_step + 1.0 * rgb_offset + color_offset).sin() + 0.5,
+            0.5 * (i as f64 * color_step + 2.0 * rgb_offset + color_offset).sin() + 0.5,
+            1.0,
+        )
+    }
 }


### PR DESCRIPTION
This changes the stroke rendering to be a single closed shape. At least for export and when the stroke is sufficiently small in the view, for larger zooms it is still split into segments, so the rendering for the entire path must still match the one for each segment.

This would reduce the export file sizes for SVG & PDF significantly ( ca. by factor 3 - 4 for stroke-only documents) but because there are some unresolved issues with cusps and start / end caps for most strokes this is still a draft.

