### PR TITLE
Overlay sidebar

### DIFF
--- a/rnote-ui/data/ui/appwindow.ui
+++ b/rnote-ui/data/ui/appwindow.ui
@@ -25,7 +25,6 @@
                 <layout>
                   <property name="column">0</property>
                   <property name="row">0</property>
-                  <property name="column-span">3</property>
                 </layout>
               </object>
             </child>
@@ -34,7 +33,6 @@
                 <layout>
                   <property name="column">0</property>
                   <property name="row">1</property>
-                  <property name="column-span">3</property>
                 </layout>
               </object>
             </child>
@@ -44,70 +42,8 @@
                 <property name="vexpand">true</property>
                 <layout>
                   <property name="column">0</property>
-                  <property name="row">3</property>
+                  <property name="row">2</property>
                 </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSeparator" id="sidebar_sep">
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">3</property>
-                </layout>
-                <property name="orientation">horizontal</property>
-                <property name="hexpand">false</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkGrid" id="sidebar_box">
-                <layout>
-                  <property name="column">2</property>
-                  <property name="row">3</property>
-                </layout>
-                <property name="orientation">vertical</property>
-                <property name="hexpand">false</property>
-                <property name="margin-top">3</property>
-                <child>
-                  <object class="GtkScrolledWindow" id="sidebar_scroller">
-                    <property name="propagate-natural-width">true</property>
-                    <property name="propagate-natural-height">true</property>
-                    <property name="overlay-scrolling">true</property>
-                    <property name="hscrollbar-policy">never</property>
-                    <property name="vscrollbar-policy">automatic</property>
-                    <property name="hexpand">false</property>
-                    <property name="halign">fill</property>
-                    <property name="vexpand">true</property>
-                    <property name="valign">fill</property>
-                    <property name="min-content-height">240</property>
-                    <property name="window-placement">top-left</property>
-                    <child>
-                      <object class="PensSideBar" id="penssidebar"></object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkSeparator">
-                    <property name="orientation">vertical</property>
-                    <property name="vexpand">false</property>
-                    <property name="valign">end</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkToggleButton" id="flapreveal_toggle">
-                    <property name="hexpand">true</property>
-                    <property name="halign">fill</property>
-                    <property name="valign">end</property>
-                    <property name="icon_name">flap-symbolic</property>
-                    <property name="margin_top">6</property>
-                    <property name="margin_bottom">6</property>
-                    <property name="margin_start">6</property>
-                    <property name="margin_end">6</property>
-                    <property name="tooltip_text" translatable="yes">Reveal / hide flap</property>
-                    <style>
-                      <class name="flat" />
-                    </style>
-                  </object>
-                </child>
               </object>
             </child>
           </object>

--- a/rnote-ui/data/ui/mainheader.ui
+++ b/rnote-ui/data/ui/mainheader.ui
@@ -41,7 +41,7 @@
               <object class="GtkSeparator">
                 <property name="orientation">vertical</property>
                 <style>
-                  <class name="spacer"/>
+                  <class name="spacer" />
                 </style>
               </object>
             </child>
@@ -80,7 +80,8 @@
                     <child>
                       <object class="GtkButton">
                         <property name="icon_name">resize-to-fit-strokes-symbolic</property>
-                        <property name="tooltip_text" translatable="yes">Resize document to fit the strokes</property>
+                        <property name="tooltip_text" translatable="yes">Resize document to fit the
+                          strokes</property>
                         <property name="action-name">win.resize-to-fit-strokes</property>
                       </object>
                     </child>
@@ -98,6 +99,12 @@
                 <property name="tooltip-text" translatable="yes">Save document</property>
                 <property name="icon-name">doc-save-symbolic</property>
                 <property name="action-name">win.save-doc</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkToggleButton" id="flapreveal_toggle">
+                <property name="icon_name">flap-symbolic</property>
+                <property name="tooltip_text" translatable="yes">Reveal / hide flap</property>
               </object>
             </child>
             <child>

--- a/rnote-ui/data/ui/mainheader.ui
+++ b/rnote-ui/data/ui/mainheader.ui
@@ -29,12 +29,23 @@
         <property name="vexpand">false</property>
         <child type="start">
           <object class="GtkBox" id="quickactions_box">
-            <property name="spacing">6</property>
+            <property name="spacing">3</property>
             <child>
-              <object class="GtkButton">
-                <property name="icon-name">tab-new-filled-symbolic</property>
-                <property name="action-name">win.new-tab</property>
-                <property name="tooltip-text" translatable="yes">New tab</property>
+              <object class="GtkBox">
+                <property name="spacing">3</property>
+                <child>
+                  <object class="GtkToggleButton" id="left_flapreveal_toggle">
+                    <property name="icon_name">flap-symbolic</property>
+                    <property name="tooltip_text" translatable="yes">Reveal / hide flap</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton">
+                    <property name="icon-name">tab-new-filled-symbolic</property>
+                    <property name="action-name">win.new-tab</property>
+                    <property name="tooltip-text" translatable="yes">New tab</property>
+                  </object>
+                </child>
               </object>
             </child>
             <child>
@@ -102,7 +113,7 @@
               </object>
             </child>
             <child>
-              <object class="GtkToggleButton" id="flapreveal_toggle">
+              <object class="GtkToggleButton" id="right_flapreveal_toggle">
                 <property name="icon_name">flap-symbolic</property>
                 <property name="tooltip_text" translatable="yes">Reveal / hide flap</property>
               </object>

--- a/rnote-ui/data/ui/overlays.ui
+++ b/rnote-ui/data/ui/overlays.ui
@@ -26,29 +26,13 @@
           </object>
         </child>
         <child type="overlay">
-          <object class="ColorPicker" id="colorpicker">
-            <property name="hexpand">false</property>
-            <property name="vexpand">false</property>
-            <property name="halign">center</property>
-            <property name="valign">start</property>
-            <property name="margin-top">18</property>
-            <property name="margin-bottom">6</property>
-            <property name="margin-start">6</property>
-            <property name="margin-end">6</property>
-            <property name="position">top</property>
-            <style>
-              <class name="overlay-toolbar" />
-            </style>
-          </object>
-        </child>
-        <child type="overlay">
           <object class="GtkBox" id="pens_toggles_box">
             <property name="hexpand">false</property>
             <property name="vexpand">false</property>
             <property name="halign">center</property>
             <property name="valign">end</property>
             <property name="margin-top">6</property>
-            <property name="margin-bottom">6</property>
+            <property name="margin-bottom">18</property>
             <property name="margin-start">6</property>
             <property name="margin-end">6</property>
             <property name="width-request">400</property>
@@ -104,6 +88,58 @@
                 <property name="tooltip_text" translatable="yes">Tools</property>
                 <property name="hexpand">true</property>
                 <property name="group">brush_toggle</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="overlay">
+          <object class="ColorPicker" id="colorpicker">
+            <property name="hexpand">false</property>
+            <property name="vexpand">false</property>
+            <property name="halign">center</property>
+            <property name="valign">start</property>
+            <property name="margin-top">18</property>
+            <property name="margin-bottom">6</property>
+            <property name="margin-start">18</property>
+            <property name="margin-end">18</property>
+            <property name="position">top</property>
+            <style>
+              <class name="overlay-toolbar" />
+            </style>
+          </object>
+        </child>
+        <child type="overlay">
+          <object class="GtkBox" id="sidebar_box">
+            <property name="hexpand">false</property>
+            <property name="vexpand">false</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="margin-top">78</property>
+            <property name="margin-bottom">72</property>
+            <property name="margin-start">18</property>
+            <property name="margin-end">18</property>
+            <style>
+              <class name="overlay-toolbar" />
+            </style>
+            <child>
+              <object class="GtkScrolledWindow" id="sidebar_scroller">
+                <property name="propagate-natural-width">true</property>
+                <property name="propagate-natural-height">true</property>
+                <property name="overlay-scrolling">true</property>
+                <property name="hscrollbar-policy">never</property>
+                <property name="vscrollbar-policy">automatic</property>
+                <property name="hexpand">false</property>
+                <property name="halign">fill</property>
+                <property name="vexpand">true</property>
+                <property name="valign">fill</property>
+                <property name="min-content-height">240</property>
+                <property name="window-placement">top-left</property>
+                <child>
+                  <object class="PensSideBar" id="penssidebar">
+                    <property name="margin-top">3</property>
+                    <property name="margin-bottom">3</property>
+                  </object>
+                </child>
               </object>
             </child>
           </object>

--- a/rnote-ui/src/appwindow/appsettings.rs
+++ b/rnote-ui/src/appwindow/appsettings.rs
@@ -189,6 +189,7 @@ impl RnoteAppWindow {
             .bind(
                 "brush-width-1",
                 &self
+                    .overlays()
                     .penssidebar()
                     .brush_page()
                     .stroke_width_picker()
@@ -200,6 +201,7 @@ impl RnoteAppWindow {
             .bind(
                 "brush-width-2",
                 &self
+                    .overlays()
                     .penssidebar()
                     .brush_page()
                     .stroke_width_picker()
@@ -211,6 +213,7 @@ impl RnoteAppWindow {
             .bind(
                 "brush-width-3",
                 &self
+                    .overlays()
                     .penssidebar()
                     .brush_page()
                     .stroke_width_picker()
@@ -224,6 +227,7 @@ impl RnoteAppWindow {
             .bind(
                 "shaper-width-1",
                 &self
+                    .overlays()
                     .penssidebar()
                     .shaper_page()
                     .stroke_width_picker()
@@ -235,6 +239,7 @@ impl RnoteAppWindow {
             .bind(
                 "shaper-width-2",
                 &self
+                    .overlays()
                     .penssidebar()
                     .shaper_page()
                     .stroke_width_picker()
@@ -246,6 +251,7 @@ impl RnoteAppWindow {
             .bind(
                 "shaper-width-3",
                 &self
+                    .overlays()
                     .penssidebar()
                     .shaper_page()
                     .stroke_width_picker()

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -368,12 +368,12 @@ impl RnoteAppWindow {
             }
 
             // Update from / to the pen pages and settings panel
-            appwindow.penssidebar().brush_page().sync_ui_active_tab(&appwindow);
-            appwindow.penssidebar().shaper_page().sync_ui_active_tab(&appwindow);
-            appwindow.penssidebar().typewriter_page().sync_ui_active_tab(&appwindow);
-            appwindow.penssidebar().eraser_page().sync_ui_active_tab(&appwindow);
-            appwindow.penssidebar().selector_page().sync_ui_active_tab(&appwindow);
-            appwindow.penssidebar().tools_page().sync_ui_active_tab(&appwindow);
+            appwindow.overlays().penssidebar().brush_page().sync_ui_active_tab(&appwindow);
+            appwindow.overlays().penssidebar().shaper_page().sync_ui_active_tab(&appwindow);
+            appwindow.overlays().penssidebar().typewriter_page().sync_ui_active_tab(&appwindow);
+            appwindow.overlays().penssidebar().eraser_page().sync_ui_active_tab(&appwindow);
+            appwindow.overlays().penssidebar().selector_page().sync_ui_active_tab(&appwindow);
+            appwindow.overlays().penssidebar().tools_page().sync_ui_active_tab(&appwindow);
             appwindow.settings_panel().sync_state_active_tab(&appwindow);
             appwindow.handle_widget_flags(widget_flags, &canvas);
         }));
@@ -411,7 +411,7 @@ impl RnoteAppWindow {
             match pen_style {
                 PenStyle::Brush => {
                     appwindow.overlays().brush_toggle().set_active(true);
-                    appwindow.penssidebar().sidebar_stack().set_visible_child_name("brush_page");
+                    appwindow.overlays().penssidebar().sidebar_stack().set_visible_child_name("brush_page");
 
                     let style = canvas.engine().borrow().pens_config.brush_config.style;
                     match style {
@@ -435,7 +435,7 @@ impl RnoteAppWindow {
                 }
                 PenStyle::Shaper => {
                     appwindow.overlays().shaper_toggle().set_active(true);
-                    appwindow.penssidebar().sidebar_stack().set_visible_child_name("shaper_page");
+                    appwindow.overlays().penssidebar().sidebar_stack().set_visible_child_name("shaper_page");
 
                     let style = canvas.engine().borrow().pens_config.shaper_config.style;
                     match style {
@@ -455,31 +455,31 @@ impl RnoteAppWindow {
                 }
                 PenStyle::Typewriter => {
                     appwindow.overlays().typewriter_toggle().set_active(true);
-                    appwindow.penssidebar().sidebar_stack().set_visible_child_name("typewriter_page");
+                    appwindow.overlays().penssidebar().sidebar_stack().set_visible_child_name("typewriter_page");
 
                     let text_color = canvas.engine().borrow().pens_config.typewriter_config.text_style.color;
                     appwindow.overlays().colorpicker().set_stroke_color(gdk::RGBA::from_compose_color(text_color));
                 }
                 PenStyle::Eraser => {
                     appwindow.overlays().eraser_toggle().set_active(true);
-                    appwindow.penssidebar().sidebar_stack().set_visible_child_name("eraser_page");
+                    appwindow.overlays().penssidebar().sidebar_stack().set_visible_child_name("eraser_page");
                 }
                 PenStyle::Selector => {
                     appwindow.overlays().selector_toggle().set_active(true);
-                    appwindow.penssidebar().sidebar_stack().set_visible_child_name("selector_page");
+                    appwindow.overlays().penssidebar().sidebar_stack().set_visible_child_name("selector_page");
                 }
                 PenStyle::Tools => {
                     appwindow.overlays().tools_toggle().set_active(true);
-                    appwindow.penssidebar().sidebar_stack().set_visible_child_name("tools_page");
+                    appwindow.overlays().penssidebar().sidebar_stack().set_visible_child_name("tools_page");
                 }
             }
 
-            appwindow.penssidebar().brush_page().refresh_ui(&appwindow);
-            appwindow.penssidebar().shaper_page().refresh_ui(&appwindow);
-            appwindow.penssidebar().typewriter_page().refresh_ui(&appwindow);
-            appwindow.penssidebar().eraser_page().refresh_ui(&appwindow);
-            appwindow.penssidebar().selector_page().refresh_ui(&appwindow);
-            appwindow.penssidebar().tools_page().refresh_ui(&appwindow);
+            appwindow.overlays().penssidebar().brush_page().refresh_ui(&appwindow);
+            appwindow.overlays().penssidebar().shaper_page().refresh_ui(&appwindow);
+            appwindow.overlays().penssidebar().typewriter_page().refresh_ui(&appwindow);
+            appwindow.overlays().penssidebar().eraser_page().refresh_ui(&appwindow);
+            appwindow.overlays().penssidebar().selector_page().refresh_ui(&appwindow);
+            appwindow.overlays().penssidebar().tools_page().refresh_ui(&appwindow);
             appwindow.settings_panel().refresh_ui(&appwindow);
             appwindow.refresh_titles_active_tab();
         }));

--- a/rnote-ui/src/mainheader.rs
+++ b/rnote-ui/src/mainheader.rs
@@ -1,5 +1,7 @@
 use crate::{appmenu::AppMenu, appwindow::RnoteAppWindow, canvasmenu::CanvasMenu};
-use gtk4::{glib, prelude::*, subclass::prelude::*, Button, CompositeTemplate, Label, Widget};
+use gtk4::{
+    glib, prelude::*, subclass::prelude::*, Button, CompositeTemplate, Label, ToggleButton, Widget,
+};
 
 mod imp {
     use super::*;
@@ -21,6 +23,8 @@ mod imp {
         pub(crate) undo_button: TemplateChild<Button>,
         #[template_child]
         pub(crate) redo_button: TemplateChild<Button>,
+        #[template_child]
+        pub(crate) flapreveal_toggle: TemplateChild<ToggleButton>,
         #[template_child]
         pub(crate) menus_box: TemplateChild<gtk4::Box>,
         #[template_child]
@@ -88,6 +92,10 @@ impl MainHeader {
 
     pub(crate) fn fixedsize_quickactions_box(&self) -> gtk4::Box {
         self.imp().fixedsize_quickactions_box.get()
+    }
+
+    pub(crate) fn flapreveal_toggle(&self) -> ToggleButton {
+        self.imp().flapreveal_toggle.get()
     }
 
     pub(crate) fn undo_button(&self) -> Button {

--- a/rnote-ui/src/mainheader.rs
+++ b/rnote-ui/src/mainheader.rs
@@ -16,15 +16,15 @@ mod imp {
         #[template_child]
         pub(crate) main_title_unsaved_indicator: TemplateChild<Label>,
         #[template_child]
-        pub(crate) quickactions_box: TemplateChild<gtk4::Box>,
-        #[template_child]
         pub(crate) fixedsize_quickactions_box: TemplateChild<gtk4::Box>,
         #[template_child]
         pub(crate) undo_button: TemplateChild<Button>,
         #[template_child]
         pub(crate) redo_button: TemplateChild<Button>,
         #[template_child]
-        pub(crate) flapreveal_toggle: TemplateChild<ToggleButton>,
+        pub(crate) left_flapreveal_toggle: TemplateChild<ToggleButton>,
+        #[template_child]
+        pub(crate) right_flapreveal_toggle: TemplateChild<ToggleButton>,
         #[template_child]
         pub(crate) menus_box: TemplateChild<gtk4::Box>,
         #[template_child]
@@ -86,16 +86,16 @@ impl MainHeader {
         self.imp().main_title_unsaved_indicator.get()
     }
 
-    pub(crate) fn quickactions_box(&self) -> gtk4::Box {
-        self.imp().quickactions_box.get()
-    }
-
     pub(crate) fn fixedsize_quickactions_box(&self) -> gtk4::Box {
         self.imp().fixedsize_quickactions_box.get()
     }
 
-    pub(crate) fn flapreveal_toggle(&self) -> ToggleButton {
-        self.imp().flapreveal_toggle.get()
+    pub(crate) fn left_flapreveal_toggle(&self) -> ToggleButton {
+        self.imp().left_flapreveal_toggle.get()
+    }
+
+    pub(crate) fn right_flapreveal_toggle(&self) -> ToggleButton {
+        self.imp().right_flapreveal_toggle.get()
     }
 
     pub(crate) fn undo_button(&self) -> Button {

--- a/rnote-ui/src/overlays.rs
+++ b/rnote-ui/src/overlays.rs
@@ -1,6 +1,6 @@
 use gtk4::{
     glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate, Overlay, ProgressBar,
-    ToggleButton, Widget,
+    ScrolledWindow, ToggleButton, Widget,
 };
 use rnote_engine::engine::EngineViewMut;
 use rnote_engine::pens::{Pen, PenStyle};
@@ -8,6 +8,7 @@ use rnote_engine::utils::GdkRGBAHelpers;
 use std::cell::RefCell;
 
 use crate::canvaswrapper::RnoteCanvasWrapper;
+use crate::PensSideBar;
 use crate::{dialogs, ColorPicker, RnoteAppWindow};
 
 mod imp {
@@ -43,6 +44,12 @@ mod imp {
         pub(crate) colorpicker: TemplateChild<ColorPicker>,
         #[template_child]
         pub(crate) tabview: TemplateChild<adw::TabView>,
+        #[template_child]
+        pub(crate) sidebar_box: TemplateChild<gtk4::Box>,
+        #[template_child]
+        pub(crate) sidebar_scroller: TemplateChild<ScrolledWindow>,
+        #[template_child]
+        pub(crate) penssidebar: TemplateChild<PensSideBar>,
     }
 
     #[glib::object_subclass]
@@ -81,6 +88,8 @@ mod imp {
                 .set_measure_overlay(&*self.colorpicker, true);
             self.toolbar_overlay
                 .set_measure_overlay(&*self.pens_toggles_box, true);
+            self.toolbar_overlay
+                .set_measure_overlay(&*self.sidebar_box, true);
         }
     }
 }
@@ -141,7 +150,28 @@ impl RnoteOverlays {
         self.imp().tabview.get()
     }
 
+    pub(crate) fn sidebar_box(&self) -> gtk4::Box {
+        self.imp().sidebar_box.get()
+    }
+
+    pub(crate) fn sidebar_scroller(&self) -> ScrolledWindow {
+        self.imp().sidebar_scroller.get()
+    }
+
+    pub(crate) fn penssidebar(&self) -> PensSideBar {
+        self.imp().penssidebar.get()
+    }
+
     pub(crate) fn init(&self, appwindow: &RnoteAppWindow) {
+        let imp = self.imp();
+        imp.penssidebar.get().init(appwindow);
+        imp.penssidebar.get().brush_page().init(appwindow);
+        imp.penssidebar.get().shaper_page().init(appwindow);
+        imp.penssidebar.get().typewriter_page().init(appwindow);
+        imp.penssidebar.get().eraser_page().init(appwindow);
+        imp.penssidebar.get().selector_page().init(appwindow);
+        imp.penssidebar.get().tools_page().init(appwindow);
+
         self.setup_pens_toggles(appwindow);
         self.setup_colorpicker(appwindow);
         self.setup_tabview(appwindow);


### PR DESCRIPTION
This changes the sidebar into a floating one, like the others. Additionally the sidebar toggle is now in the headerbar, which is in line with other similar apps that have a collapsable sidebar.

addresses #367, at least partially.  
I am open to iterate further on this, this is not meant to be the definitive end state.