### PR TITLE
tab context menu

### DIFF
--- a/rnote-ui/data/ui/overlays.ui
+++ b/rnote-ui/data/ui/overlays.ui
@@ -149,6 +149,29 @@
               <object class="AdwTabView" id="tabview">
                 <property name="hexpand">true</property>
                 <property name="vexpand">true</property>
+                <property name="menu-model">tab_cx_menu_model</property>
+                <menu id="tab_cx_menu_model">
+                  <section>
+                    <item>
+                      <attribute name="label" translatable="yes">Move _left</attribute>
+                      <attribute name="action">win.active-tab-move-left</attribute>
+                    </item>
+                    <item>
+                      <attribute name="label" translatable="yes">Move _right</attribute>
+                      <attribute name="action">win.active-tab-move-right</attribute>
+                    </item>
+                  </section>
+                  <section>
+                    <item>
+                      <attribute name="label" translatable="yes">_Close all other tabs</attribute>
+                      <attribute name="action">win.other-tabs-close</attribute>
+                    </item>
+                    <item>
+                      <attribute name="label" translatable="yes">_Close</attribute>
+                      <attribute name="action">win.active-tab-close</attribute>
+                    </item>
+                  </section>
+                </menu>
               </object>
             </property>
           </object>

--- a/rnote-ui/po/rnote.pot
+++ b/rnote-ui/po/rnote.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rnote\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-27 16:32+0100\n"
+"POT-Creation-Date: 2023-01-28 20:19+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:16 rnote-ui/src/canvas/mod.rs:756
+#: rnote-ui/data/ui/dialogs/dialogs.ui:16 rnote-ui/src/canvas/mod.rs:757
 msgid "New Document"
 msgstr ""
 
@@ -1044,7 +1044,7 @@ msgstr ""
 msgid "New document"
 msgstr ""
 
-#: rnote-ui/data/ui/mainheader.ui:19 rnote-ui/src/canvas/mod.rs:758
+#: rnote-ui/data/ui/mainheader.ui:19 rnote-ui/src/canvas/mod.rs:759
 msgid "Draft"
 msgstr ""
 
@@ -1074,6 +1074,22 @@ msgstr ""
 
 #: rnote-ui/data/ui/mainheader.ui:109
 msgid "Save document"
+msgstr ""
+
+#: rnote-ui/data/ui/overlays.ui:156
+msgid "Move _left"
+msgstr ""
+
+#: rnote-ui/data/ui/overlays.ui:160
+msgid "Move _right"
+msgstr ""
+
+#: rnote-ui/data/ui/overlays.ui:166
+msgid "_Close all other tabs"
+msgstr ""
+
+#: rnote-ui/data/ui/overlays.ui:170
+msgid "_Close"
 msgstr ""
 
 #: rnote-ui/data/ui/penshortcutrow.ui:8
@@ -1484,79 +1500,79 @@ msgstr ""
 msgid "Edit selected workspace"
 msgstr ""
 
-#: rnote-ui/src/appwindow/mod.rs:523
+#: rnote-ui/src/appwindow/mod.rs:505
 msgid "Opening .rnote file failed."
 msgstr ""
 
-#: rnote-ui/src/appwindow/mod.rs:534
+#: rnote-ui/src/appwindow/mod.rs:516
 msgid "Opening vector image file failed."
 msgstr ""
 
-#: rnote-ui/src/appwindow/mod.rs:545
+#: rnote-ui/src/appwindow/mod.rs:527
 msgid "Opening bitmap image file failed."
 msgstr ""
 
-#: rnote-ui/src/appwindow/mod.rs:556 rnote-ui/src/dialogs/import.rs:394
+#: rnote-ui/src/appwindow/mod.rs:538 rnote-ui/src/dialogs/import.rs:394
 msgid "Opening Xournal++ file failed."
 msgstr ""
 
-#: rnote-ui/src/appwindow/mod.rs:567 rnote-ui/src/dialogs/import.rs:335
+#: rnote-ui/src/appwindow/mod.rs:549 rnote-ui/src/dialogs/import.rs:335
 msgid "Opening PDF file failed."
 msgstr ""
 
-#: rnote-ui/src/appwindow/mod.rs:576
+#: rnote-ui/src/appwindow/mod.rs:558
 msgid "Error: Tried opening folder as file"
 msgstr ""
 
-#: rnote-ui/src/appwindow/mod.rs:581
+#: rnote-ui/src/appwindow/mod.rs:563
 msgid "Failed to open file: Unsupported file type."
 msgstr ""
 
 #: rnote-ui/src/appwindow/imp.rs:272
-#: rnote-ui/src/appwindow/appwindowactions.rs:498
+#: rnote-ui/src/appwindow/appwindowactions.rs:525
 #: rnote-ui/src/dialogs/export.rs:71 rnote-ui/src/dialogs/import.rs:51
 #: rnote-ui/src/dialogs/mod.rs:147 rnote-ui/src/dialogs/mod.rs:200
 #: rnote-ui/src/dialogs/mod.rs:322
 msgid "Saving document failed."
 msgstr ""
 
-#: rnote-ui/src/appwindow/appwindowactions.rs:616
+#: rnote-ui/src/appwindow/appwindowactions.rs:643
 msgid "Printed document successfully"
 msgstr ""
 
-#: rnote-ui/src/appwindow/appwindowactions.rs:625
+#: rnote-ui/src/appwindow/appwindowactions.rs:652
 msgid "Printing document failed"
 msgstr ""
 
-#: rnote-ui/src/appwindow/appwindowactions.rs:653
+#: rnote-ui/src/appwindow/appwindowactions.rs:680
 msgid "Export selection failed, nothing selected."
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:961
+#: rnote-ui/src/canvas/mod.rs:994
 msgid "- invalid file name -"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:974
+#: rnote-ui/src/canvas/mod.rs:1007
 msgid "- invalid folder path -"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:998
+#: rnote-ui/src/canvas/mod.rs:1031
 msgid "Opened file was modified on disk."
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:999
+#: rnote-ui/src/canvas/mod.rs:1032
 msgid "Reload"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:1005
+#: rnote-ui/src/canvas/mod.rs:1038
 msgid "Reloading .rnote file from disk failed."
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:1054
+#: rnote-ui/src/canvas/mod.rs:1087
 msgid "Opened file was renamed on disk."
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:1067
+#: rnote-ui/src/canvas/mod.rs:1100
 msgid "Opened file was moved or deleted on disk."
 msgstr ""
 

--- a/rnote-ui/src/appwindow/mod.rs
+++ b/rnote-ui/src/appwindow/mod.rs
@@ -235,14 +235,14 @@ impl RnoteAppWindow {
         }
     }
 
-    /// Get the active (selected) tab page, or create one if there is None.
-    /// (should never be the the case, since we add a initial page on startup and the last tab cannot be closed in the UI. But making sure)
+    /// Get the active (selected) tab page.
+    /// Panics if there is none (but should never be the case, since we add one initially and the UI hides closing the last tab)
     pub(crate) fn active_tab_page(&self) -> adw::TabPage {
         self.imp()
             .overlays
             .tabview()
             .selected_page()
-            .unwrap_or_else(|| self.new_tab())
+            .expect("there must always be one active tab")
     }
 
     /// Get the active (selected) tab page child.
@@ -300,17 +300,6 @@ impl RnoteAppWindow {
         self.overlays().tabview().set_selected_page(&page);
 
         page
-    }
-
-    /// Requests to close the active tab, or if only one tab is left, the active appwindow
-    pub(crate) fn close_active_tab(&self) {
-        let active_tab_page = self.active_tab_page();
-        if self.overlays().tabview().n_pages() <= 1 {
-            // If there is only one tab left, request to close the entire window.
-            self.close();
-        } else {
-            self.overlays().tabview().close_page(&active_tab_page);
-        }
     }
 
     pub(crate) fn tab_pages_snapshot(&self) -> Vec<adw::TabPage> {

--- a/rnote-ui/src/overlays.rs
+++ b/rnote-ui/src/overlays.rs
@@ -1,6 +1,6 @@
 use gtk4::{
-    glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate, Overlay, ProgressBar,
-    ScrolledWindow, ToggleButton, Widget,
+    gio, glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate, Overlay,
+    ProgressBar, ScrolledWindow, ToggleButton, Widget,
 };
 use rnote_engine::engine::EngineViewMut;
 use rnote_engine::pens::{Pen, PenStyle};
@@ -344,6 +344,22 @@ impl RnoteOverlays {
                 true
             }),
         );
+
+        imp.tabview.connect_setup_menu(clone!(@weak appwindow => move |tabview, page| {
+            if let Some(page) = page {
+                let action_active_tab_move_left = appwindow.lookup_action("active-tab-move-left").unwrap().downcast::<gio::SimpleAction>().unwrap();
+                let action_active_tab_move_right = appwindow.lookup_action("active-tab-move-right").unwrap().downcast::<gio::SimpleAction>().unwrap();
+                let action_active_tab_close = appwindow.lookup_action("active-tab-close").unwrap().downcast::<gio::SimpleAction>().unwrap();
+
+                tabview.set_selected_page(page);
+
+                let n_pages = tabview.n_pages();
+                let pos = tabview.page_position(page);
+                action_active_tab_move_left.set_enabled(pos > 0);
+                action_active_tab_move_right.set_enabled(pos + 1 < n_pages);
+                action_active_tab_close.set_enabled(n_pages > 1);
+            }
+        }));
     }
 
     pub(crate) fn start_pulsing_progressbar(&self) {


### PR DESCRIPTION
this adds a (basic) context menu to the tab pages. For now "move left / right", "close other" and "close active tab" entries are added.

One thing to note: When popping up the menu, `Gtk-WARNING **: 20:26:15.039: Broken accounting of active state for widget 0x5647bbcc5cf0(GtkPopoverMenu)` gets emitted. Since this also happens in the adwaita-demo I assume this is something that would need fixing in libadwaita.