### PR TITLE
Added duplicate selection shortcut

### DIFF
--- a/rnote-engine/src/pens/selector/penevents.rs
+++ b/rnote-engine/src/pens/selector/penevents.rs
@@ -565,6 +565,13 @@ impl Selector {
 
                         PenProgress::InProgress
                     }
+                    KeyboardKey::Unicode('d') => {
+                        //Duplicate selection
+                        if shortcut_keys.contains(&ShortcutKey::KeyboardCtrl) {
+                            engine_view.store.duplicate_selection();
+                        }
+                        PenProgress::Finished
+                    }
                     KeyboardKey::Delete | KeyboardKey::BackSpace => {
                         engine_view.store.set_trashed_keys(selection, true);
                         self.state = SelectorState::Idle;

--- a/rnote-ui/data/ui/shortcuts.ui
+++ b/rnote-ui/data/ui/shortcuts.ui
@@ -192,6 +192,12 @@
                 </child>
                 <child>
                   <object class="GtkShortcutsShortcut">
+                    <property name="title" context="shortcut window" translatable="yes">Duplicate selection</property>
+                    <property name="accelerator">&lt;ctrl&gt;d</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkShortcutsShortcut">
                     <property name="title" context="shortcut window" translatable="yes">Undo</property>
                     <property name="accelerator">&lt;ctrl&gt;z</property>
                   </object>


### PR DESCRIPTION
This allows duplicating selection without need to click on the menu button.
The shortcut is CTRL+D.