### PR TITLE
use header-capitalization appropriately

### DIFF
--- a/rnote-ui/data/ui/appmenu.ui
+++ b/rnote-ui/data/ui/appmenu.ui
@@ -21,43 +21,43 @@
         </section>
         <section>
           <submenu>
-            <attribute name="label" translatable="yes">Co_lor scheme</attribute>
+            <attribute name="label" translatable="yes">Co_lor Scheme</attribute>
             <item>
-              <attribute name="label" translatable="yes">Use _system colors</attribute>
+              <attribute name="label" translatable="yes">Use _System Colors</attribute>
               <attribute name="action">app.color-scheme</attribute>
               <attribute name="target">default</attribute>
             </item>
             <item>
-              <attribute name="label" translatable="yes">Use _light colors</attribute>
+              <attribute name="label" translatable="yes">Use _Light Colors</attribute>
               <attribute name="action">app.color-scheme</attribute>
               <attribute name="target">force-light</attribute>
             </item>
             <item>
-              <attribute name="label" translatable="yes">Use _dark colors</attribute>
+              <attribute name="label" translatable="yes">Use _Dark Colors</attribute>
               <attribute name="action">app.color-scheme</attribute>
               <attribute name="target">force-dark</attribute>
             </item>
           </submenu>
           <item>
-            <attribute name="label" translatable="yes">De_veloper mode</attribute>
+            <attribute name="label" translatable="yes">De_veloper Mode</attribute>
             <attribute name="toggle" />
             <attribute name="action">win.devel-mode</attribute>
           </item>
           <submenu>
-            <attribute name="label" translatable="yes">Developer _menu</attribute>
+            <attribute name="label" translatable="yes">Developer _Menu</attribute>
             <attribute name="action">win.devel-menu</attribute>
             <attribute name="hidden-when">action-disabled</attribute>
             <section>
               <item>
-                <attribute name="label" translatable="yes">Visual _debugging</attribute>
+                <attribute name="label" translatable="yes">Visual _Debugging</attribute>
                 <attribute name="action">win.visual-debug</attribute>
               </item>
               <item>
-                <attribute name="label" translatable="yes">Export engine _state</attribute>
+                <attribute name="label" translatable="yes">Export Engine _State</attribute>
                 <attribute name="action">win.debug-export-engine-state</attribute>
               </item>
               <item>
-                <attribute name="label" translatable="yes">Export engine _config</attribute>
+                <attribute name="label" translatable="yes">Export Engine _Config</attribute>
                 <attribute name="action">win.debug-export-engine-config</attribute>
               </item>
             </section>
@@ -77,7 +77,7 @@
             <attribute name="action">win.save-doc</attribute>
           </item>
           <item>
-            <attribute name="label" translatable="yes">Save _as</attribute>
+            <attribute name="label" translatable="yes">Save _As</attribute>
             <attribute name="action">win.save-doc-as</attribute>
           </item>
         </section>
@@ -87,7 +87,7 @@
             <attribute name="action">win.print-doc</attribute>
           </item>
           <item>
-            <attribute name="label" translatable="yes">_Import file</attribute>
+            <attribute name="label" translatable="yes">_Import File</attribute>
             <attribute name="action">win.import-file</attribute>
           </item>
           <submenu>
@@ -108,15 +108,15 @@
           <submenu>
             <attribute name="label" translatable="yes">_Export…</attribute>
             <item>
-              <attribute name="label" translatable="yes">Export _document</attribute>
+              <attribute name="label" translatable="yes">Export _Document</attribute>
               <attribute name="action">win.export-doc</attribute>
             </item>
             <item>
-              <attribute name="label" translatable="yes">Export document _pages</attribute>
+              <attribute name="label" translatable="yes">Export Document _Pages</attribute>
               <attribute name="action">win.export-doc-pages</attribute>
             </item>
             <item>
-              <attribute name="label" translatable="yes">Export _selection</attribute>
+              <attribute name="label" translatable="yes">Export _Selection</attribute>
               <attribute name="action">win.export-selection</attribute>
             </item>
           </submenu>
@@ -127,7 +127,7 @@
             <attribute name="action">win.open-settings</attribute>
           </item>
           <item>
-            <attribute name="label" translatable="yes">_Keyboard shortcuts</attribute>
+            <attribute name="label" translatable="yes">_Keyboard Shortcuts</attribute>
             <attribute name="action">win.keyboard-shortcuts</attribute>
           </item>
           <item>
@@ -166,7 +166,7 @@
                   <child>
                     <object class="GtkToggleButton" id="righthanded_toggle">
                       <property name="icon_name">dock-left-symbolic</property>
-                      <property name="tooltip_text" translatable="yes">Sidebar on the left side</property>
+                      <property name="tooltip_text" translatable="yes">Sidebar on the Left Side</property>
                       <property name="hexpand">true</property>
                     </object>
                   </child>
@@ -175,7 +175,7 @@
                       <property name="group">righthanded_toggle</property>
                       <property name="active">true</property>
                       <property name="icon_name">dock-right-symbolic</property>
-                      <property name="tooltip_text" translatable="yes">Sidebar on the right side</property>
+                      <property name="tooltip_text" translatable="yes">Sidebar on the Right Side</property>
                       <property name="hexpand">true</property>
                     </object>
                   </child>
@@ -185,7 +185,7 @@
                 <object class="GtkButton" id="fullscreen_toggle">
                   <property name="hexpand">false</property>
                   <property name="icon_name">appwindow-fullscreen-symbolic</property>
-                  <property name="tooltip_text" translatable="yes">Toggle fullscreen</property>
+                  <property name="tooltip_text" translatable="yes">Toggle Fullscreen</property>
                   <property name="action-name">win.fullscreen</property>
                 </object>
               </child>

--- a/rnote-ui/data/ui/appwindow.ui
+++ b/rnote-ui/data/ui/appwindow.ui
@@ -106,7 +106,7 @@
                     <child type="start">
                       <object class="GtkButton" id="flap_close_button">
                         <property name="icon_name">right-symbolic</property>
-                        <property name="tooltip_text" translatable="yes">Close the folded flap</property>
+                        <property name="tooltip_text" translatable="yes">Close the Folded Flap</property>
                       </object>
                     </child>
                     <child type="end">

--- a/rnote-ui/data/ui/canvasmenu.ui
+++ b/rnote-ui/data/ui/canvasmenu.ui
@@ -21,20 +21,20 @@
         </section>
         <section>
           <submenu>
-            <attribute name="label" translatable="yes">_Document layout</attribute>
+            <attribute name="label" translatable="yes">_Document Layout</attribute>
             <section>
               <item>
-                <attribute name="label" translatable="yes">_Fixed size</attribute>
+                <attribute name="label" translatable="yes">_Fixed Size</attribute>
                 <attribute name="action">win.doc-layout</attribute>
                 <attribute name="target">fixed-size</attribute>
               </item>
               <item>
-                <attribute name="label" translatable="yes">_Continuous vertical</attribute>
+                <attribute name="label" translatable="yes">_Continuous Vertical</attribute>
                 <attribute name="action">win.doc-layout</attribute>
                 <attribute name="target">continuous-vertical</attribute>
               </item>
               <item>
-                <attribute name="label" translatable="yes">_Semi infinite</attribute>
+                <attribute name="label" translatable="yes">_Semi Infinite</attribute>
                 <attribute name="action">win.doc-layout</attribute>
                 <attribute name="target">semi-infinite</attribute>
               </item>
@@ -46,28 +46,28 @@
             </section>
           </submenu>
           <item>
-            <attribute name="label" translatable="yes">Show _format borders</attribute>
+            <attribute name="label" translatable="yes">Show _Format Borders</attribute>
             <attribute name="toggle" />
             <attribute name="action">win.format-borders</attribute>
           </item>
           <item>
-            <attribute name="label" translatable="yes">Draw with _touch input</attribute>
+            <attribute name="label" translatable="yes">Draw With _Touch Input</attribute>
             <attribute name="toggle" />
             <attribute name="action">win.touch-drawing</attribute>
           </item>
           <item>
-            <attribute name="label" translatable="yes">_Pen sounds</attribute>
+            <attribute name="label" translatable="yes">_Pen Sounds</attribute>
             <attribute name="toggle" />
             <attribute name="action">win.pen-sounds</attribute>
           </item>
         </section>
         <section>
           <item>
-            <attribute name="label" translatable="yes">C_lear document</attribute>
+            <attribute name="label" translatable="yes">C_lear Document</attribute>
             <attribute name="action">win.clear-doc</attribute>
           </item>
           <item>
-            <attribute name="label" translatable="yes">_Return to origin page</attribute>
+            <attribute name="label" translatable="yes">_Return to Origin Page</attribute>
             <attribute name="action">win.return-origin-page</attribute>
           </item>
         </section>
@@ -106,7 +106,7 @@
                   <child>
                     <object class="GtkButton" id="zoom_reset_button">
                       <property name="action-name">win.zoom-reset</property>
-                      <property name="tooltip_text" translatable="yes">Reset the zoom</property>
+                      <property name="tooltip_text" translatable="yes">Reset the Zoom</property>
                       <property name="hexpand">true</property>
                     </object>
                   </child>
@@ -125,7 +125,7 @@
                 <object class="GtkButton" id="zoom_fit_width_button">
                   <property name="hexpand">false</property>
                   <property name="icon_name">zoom-fit-width-symbolic</property>
-                  <property name="tooltip_text" translatable="yes">Zoom to fit page width</property>
+                  <property name="tooltip_text" translatable="yes">Zoom to Fit Page Width</property>
                   <property name="action-name">win.zoom-fit-width</property>
                 </object>
               </child>

--- a/rnote-ui/data/ui/colorpicker.ui
+++ b/rnote-ui/data/ui/colorpicker.ui
@@ -16,14 +16,14 @@
         <child>
           <object class="RnColorPad" id="stroke_color_pad">
             <property name="icon_name">stroke-color-symbolic</property>
-            <property name="tooltip-text" translatable="yes">Stroke color</property>
+            <property name="tooltip-text" translatable="yes">Stroke Color</property>
             <property name="active">true</property>
           </object>
         </child>
         <child>
           <object class="RnColorPad" id="fill_color_pad">
             <property name="icon_name">fill-color-symbolic</property>
-            <property name="tooltip-text" translatable="yes">Fill color</property>
+            <property name="tooltip-text" translatable="yes">Fill Color</property>
             <property name="group">stroke_color_pad</property>
           </object>
         </child>

--- a/rnote-ui/data/ui/dialogs/dialogs.ui
+++ b/rnote-ui/data/ui/dialogs/dialogs.ui
@@ -2,7 +2,7 @@
 <!-- misc dialogs -->
 <interface>
   <object class="AdwMessageDialog" id="dialog_clear_doc">
-    <property name="heading" translatable="yes">Clear document</property>
+    <property name="heading" translatable="yes">Clear Document</property>
     <property name="body" translatable="yes">This clears the entire document. Please confirm.</property>
     <property name="default-response">clear</property>
     <property name="close-response">cancel</property>
@@ -26,7 +26,7 @@ Do you want to save the current document?</property>
   </object>
 
   <object class="AdwMessageDialog" id="dialog_close_tab">
-    <property name="heading" translatable="yes">Close tab</property>
+    <property name="heading" translatable="yes">Close Tab</property>
     <property name="body" translatable="yes">This tab contains unsaved changes. Changes which are not saved will be permanently lost.</property>
     <property name="default-response">save</property>
     <property name="close-response">cancel</property>
@@ -38,18 +38,18 @@ Do you want to save the current document?</property>
   </object>
 
   <object class="AdwMessageDialog" id="dialog_close_window">
-    <property name="heading" translatable="yes">Close window</property>
+    <property name="heading" translatable="yes">Close Window</property>
     <property name="body" translatable="yes">Some opened files contain unsaved changes. Changes which are not saved will be permanently lost.</property>
     <property name="default-response">save</property>
     <property name="close-response">cancel</property>
     <property name="extra-child">
       <object class="AdwPreferencesGroup" id="close_window_files_group">
-        <property name="title" translatable="yes">Unsaved documents</property>
+        <property name="title" translatable="yes">Unsaved Documents</property>
       </object>
     </property>
     <responses>
       <response id="cancel" translatable="yes">Cancel</response>
-      <response id="discard" appearance="destructive" translatable="yes">Discard all</response>
+      <response id="discard" appearance="destructive" translatable="yes">Discard All</response>
       <response id="save" appearance="suggested" translatable="yes">Save</response>
     </responses>
   </object>
@@ -57,7 +57,7 @@ Do you want to save the current document?</property>
   <object class="GtkDialog" id="dialog_edit_selected_workspace">
     <property name="use-header-bar">1</property>
     <property name="modal">true</property>
-    <property name="title" translatable="yes">Edit workspace</property>
+    <property name="title" translatable="yes">Edit Workspace</property>
     <child type="action">
       <object class="GtkButton" id="edit_selected_workspace_button_cancel">
         <property name="label" translatable="yes">Cancel</property>

--- a/rnote-ui/data/ui/dialogs/export.ui
+++ b/rnote-ui/data/ui/dialogs/export.ui
@@ -4,7 +4,7 @@
   <object class="GtkDialog" id="dialog_export_doc_w_prefs">
     <property name="use-header-bar">1</property>
     <property name="modal">true</property>
-    <property name="title" translatable="yes">Export document</property>
+    <property name="title" translatable="yes">Export Document</property>
     <child type="action">
       <object class="GtkButton" id="export_doc_button_cancel">
         <property name="label" translatable="yes">Cancel</property>
@@ -46,7 +46,7 @@
               <object class="AdwPreferencesGroup">
                 <child>
                   <object class="AdwActionRow">
-                    <property name="title" translatable="yes">Export file</property>
+                    <property name="title" translatable="yes">Export File</property>
                     <property name="subtitle" translatable="yes">Select the export file</property>
                     <child type="suffix">
                       <object class="GtkBox">
@@ -80,11 +80,11 @@
             </child>
             <child>
               <object class="AdwPreferencesGroup">
-                <property name="title" translatable="yes">Export preferences</property>
+                <property name="title" translatable="yes">Export Preferences</property>
                 <property name="halign">fill</property>
                 <child>
                   <object class="AdwActionRow" id="export_doc_with_background_row">
-                    <property name="title" translatable="yes">With background</property>
+                    <property name="title" translatable="yes">With Background</property>
                     <property name="subtitle" translatable="yes">Set whether the background should be exported</property>
                     <child type="suffix">
                       <object class="GtkSwitch" id="export_doc_with_background_switch">
@@ -95,7 +95,7 @@
                 </child>
                 <child>
                   <object class="AdwActionRow" id="export_doc_with_pattern_row">
-                    <property name="title" translatable="yes">With pattern</property>
+                    <property name="title" translatable="yes">With Pattern</property>
                     <property name="subtitle" translatable="yes">Set whether the background pattern should be exported</property>
                     <child type="suffix">
                       <object class="GtkSwitch" id="export_doc_with_pattern_switch">
@@ -106,7 +106,7 @@
                 </child>
                 <child>
                   <object class="AdwComboRow" id="export_doc_export_format_row">
-                    <property name="title" translatable="yes">Export format</property>
+                    <property name="title" translatable="yes">Export Format</property>
                     <property name="subtitle" translatable="yes">The export format</property>
                     <property name="model">
                       <object class="GtkStringList">
@@ -130,7 +130,7 @@
   <object class="GtkDialog" id="dialog_export_doc_pages_w_prefs">
     <property name="use-header-bar">1</property>
     <property name="modal">true</property>
-    <property name="title" translatable="yes">Export document pages</property>
+    <property name="title" translatable="yes">Export Document Pages</property>
     <child type="action">
       <object class="GtkButton" id="export_doc_pages_button_cancel">
         <property name="label" translatable="yes">Cancel</property>
@@ -189,7 +189,7 @@
                     <child>
                       <object class="GtkLabel">
                         <property name="margin-end">12</property>
-                        <property name="label" translatable="yes">Page files naming:</property>
+                        <property name="label" translatable="yes">Page Files Naming:</property>
                       </object>
                     </child>
                     <child>
@@ -210,7 +210,7 @@
               <object class="AdwPreferencesGroup">
                 <child>
                   <object class="AdwActionRow">
-                    <property name="title" translatable="yes">Export directory</property>
+                    <property name="title" translatable="yes">Export Directory</property>
                     <property name="subtitle" translatable="yes">Select the export directory</property>
                     <child type="suffix">
                       <object class="GtkBox">
@@ -242,18 +242,18 @@
                 </child>
                 <child>
                   <object class="AdwEntryRow" id="export_doc_pages_export_files_stemname_entryrow">
-                    <property name="title" translatable="yes">Export files stem name</property>
+                    <property name="title" translatable="yes">Export Files Stem Name</property>
                   </object>
                 </child>
               </object>
             </child>
             <child>
               <object class="AdwPreferencesGroup">
-                <property name="title" translatable="yes">Export preferences</property>
+                <property name="title" translatable="yes">Export Preferences</property>
                 <property name="halign">fill</property>
                 <child>
                   <object class="AdwActionRow" id="export_doc_pages_with_background_row">
-                    <property name="title" translatable="yes">With background</property>
+                    <property name="title" translatable="yes">With Background</property>
                     <property name="subtitle" translatable="yes">Set whether the background should be exported</property>
                     <child type="suffix">
                       <object class="GtkSwitch" id="export_doc_pages_with_background_switch">
@@ -264,7 +264,7 @@
                 </child>
                 <child>
                   <object class="AdwActionRow" id="export_doc_pages_with_pattern_row">
-                    <property name="title" translatable="yes">With pattern</property>
+                    <property name="title" translatable="yes">With Pattern</property>
                     <property name="subtitle" translatable="yes">Set whether the background pattern should be exported</property>
                     <child type="suffix">
                       <object class="GtkSwitch" id="export_doc_pages_with_pattern_switch">
@@ -275,7 +275,7 @@
                 </child>
                 <child>
                   <object class="AdwComboRow" id="export_doc_pages_export_format_row">
-                    <property name="title" translatable="yes">Export format</property>
+                    <property name="title" translatable="yes">Export Format</property>
                     <property name="subtitle" translatable="yes">The export format</property>
                     <property name="model">
                       <object class="GtkStringList">
@@ -290,7 +290,7 @@
                 </child>
                 <child>
                   <object class="AdwActionRow" id="export_doc_pages_bitmap_scalefactor_row">
-                    <property name="title" translatable="yes">Bitmap scale factor</property>
+                    <property name="title" translatable="yes">Bitmap Scale-Factor</property>
                     <property name="subtitle" translatable="yes">Set the bitmap scale factor in relation
 to the actual size on the document</property>
                     <child type="suffix">
@@ -312,7 +312,7 @@ to the actual size on the document</property>
                 </child>
                 <child>
                   <object class="AdwActionRow" id="export_doc_pages_jpeg_quality_row">
-                    <property name="title" translatable="yes">Jpeg quality</property>
+                    <property name="title" translatable="yes">Jpeg Quality</property>
                     <property name="subtitle" translatable="yes">Set the quality of the Jpeg image (1 - 100)</property>
                     <child type="suffix">
                       <object class="GtkAdjustment" id="export_doc_pages_jpeg_quality_adj">
@@ -342,7 +342,7 @@ to the actual size on the document</property>
   <object class="GtkDialog" id="dialog_export_selection_w_prefs">
     <property name="use-header-bar">1</property>
     <property name="modal">true</property>
-    <property name="title" translatable="yes">Export selection</property>
+    <property name="title" translatable="yes">Export Selection</property>
     <child type="action">
       <object class="GtkButton" id="export_selection_button_cancel">
         <property name="label" translatable="yes">Cancel</property>
@@ -384,7 +384,7 @@ to the actual size on the document</property>
               <object class="AdwPreferencesGroup">
                 <child>
                   <object class="AdwActionRow">
-                    <property name="title" translatable="yes">Export file</property>
+                    <property name="title" translatable="yes">Export File</property>
                     <property name="subtitle" translatable="yes">Select the export file</property>
                     <child type="suffix">
                       <object class="GtkBox">
@@ -418,11 +418,11 @@ to the actual size on the document</property>
             </child>
             <child>
               <object class="AdwPreferencesGroup">
-                <property name="title" translatable="yes">Export preferences</property>
+                <property name="title" translatable="yes">Export Preferences</property>
                 <property name="halign">fill</property>
                 <child>
                   <object class="AdwActionRow" id="export_selection_with_background_row">
-                    <property name="title" translatable="yes">With background</property>
+                    <property name="title" translatable="yes">With Background</property>
                     <property name="subtitle" translatable="yes">Set whether the background should be exported</property>
                     <child type="suffix">
                       <object class="GtkSwitch" id="export_selection_with_background_switch">
@@ -433,7 +433,7 @@ to the actual size on the document</property>
                 </child>
                 <child>
                   <object class="AdwActionRow" id="export_selection_with_pattern_row">
-                    <property name="title" translatable="yes">With pattern</property>
+                    <property name="title" translatable="yes">With Pattern</property>
                     <property name="subtitle" translatable="yes">Set whether the background pattern should be exported</property>
                     <child type="suffix">
                       <object class="GtkSwitch" id="export_selection_with_pattern_switch">
@@ -444,7 +444,7 @@ to the actual size on the document</property>
                 </child>
                 <child>
                   <object class="AdwComboRow" id="export_selection_export_format_row">
-                    <property name="title" translatable="yes">Export format</property>
+                    <property name="title" translatable="yes">Export Format</property>
                     <property name="subtitle" translatable="yes">The export image format</property>
                     <property name="model">
                       <object class="GtkStringList">
@@ -459,7 +459,7 @@ to the actual size on the document</property>
                 </child>
                 <child>
                   <object class="AdwActionRow" id="export_selection_bitmap_scalefactor_row">
-                    <property name="title" translatable="yes">Bitmap scale factor</property>
+                    <property name="title" translatable="yes">Bitmap Scale-Factor</property>
                     <property name="subtitle" translatable="yes">Set the bitmap scale factor in relation
 to the actual size on the document</property>
                     <child type="suffix">
@@ -481,7 +481,7 @@ to the actual size on the document</property>
                 </child>
                 <child>
                   <object class="AdwActionRow" id="export_selection_jpeg_quality_row">
-                    <property name="title" translatable="yes">Jpeg quality</property>
+                    <property name="title" translatable="yes">Jpeg Quality</property>
                     <property name="subtitle" translatable="yes">Set the quality of the Jpeg image (1 - 100)</property>
                     <child type="suffix">
                       <object class="GtkAdjustment" id="export_selection_jpeg_quality_adj">

--- a/rnote-ui/data/ui/dialogs/import.ui
+++ b/rnote-ui/data/ui/dialogs/import.ui
@@ -88,11 +88,11 @@
             </child>
             <child>
               <object class="AdwPreferencesGroup">
-                <property name="title" translatable="yes">PDF import preferences</property>
+                <property name="title" translatable="yes">PDF Import Preferences</property>
                 <property name="halign">fill</property>
                 <child>
                   <object class="AdwActionRow">
-                    <property name="title" translatable="yes">Start page</property>
+                    <property name="title" translatable="yes">Start Page</property>
                     <child type="suffix">
                       <object class="GtkSpinButton" id="pdf_page_start_spinbutton">
                         <property name="valign">center</property>
@@ -107,7 +107,7 @@
                 </child>
                 <child>
                   <object class="AdwActionRow">
-                    <property name="title" translatable="yes">End page</property>
+                    <property name="title" translatable="yes">End Page</property>
                     <child type="suffix">
                       <object class="GtkSpinButton" id="pdf_page_end_spinbutton">
                         <property name="valign">center</property>
@@ -122,7 +122,7 @@
                 </child>
                 <child>
                   <object class="AdwActionRow" id="pdf_import_width_row">
-                    <property name="title" translatable="yes">Page width (%)</property>
+                    <property name="title" translatable="yes">Page Width (%)</property>
                     <property name="subtitle" translatable="yes">Set the width of imported PDF's in percentage to the format width</property>
                     <child type="suffix">
                       <object class="GtkAdjustment" id="pdf_import_width_perc_adj">
@@ -143,13 +143,13 @@
                 </child>
                 <child>
                   <object class="AdwComboRow" id="pdf_import_page_spacing_row">
-                    <property name="title" translatable="yes">Page spacing</property>
+                    <property name="title" translatable="yes">Page Spacing</property>
                     <property name="subtitle" translatable="yes">How PDF pages are spaced</property>
                     <property name="model">
                       <object class="GtkStringList">
                         <items>
                           <item translatable="yes">Continuous</item>
-                          <item translatable="yes">One per document page</item>
+                          <item translatable="yes">One per Document Page</item>
                         </items>
                       </object>
                     </property>
@@ -157,7 +157,7 @@
                 </child>
                 <child>
                   <object class="AdwActionRow" id="pdf_import_pages_type_row">
-                    <property name="title" translatable="yes">Pages type</property>
+                    <property name="title" translatable="yes">Pages Type</property>
                     <property name="subtitle" translatable="yes">Set whether PDFs should be imported as vector or bitmap images</property>
                     <child type="suffix">
                       <object class="GtkBox">
@@ -186,7 +186,7 @@
                 </child>
                 <child>
                   <object class="AdwActionRow" id="pdf_import_bitmap_scalefactor_row">
-                    <property name="title" translatable="yes">Bitmap scale factor</property>
+                    <property name="title" translatable="yes">Bitmap Scale-Factor</property>
                     <property name="subtitle" translatable="yes">Set the bitmap scale factor in relation
 to the actual size on the document</property>
                     <child type="suffix">
@@ -217,7 +217,7 @@ to the actual size on the document</property>
   <object class="GtkDialog" id="dialog_import_xopp_w_prefs">
     <property name="use-header-bar">1</property>
     <property name="modal">true</property>
-    <property name="title" translatable="yes">Import Xournal++ file</property>
+    <property name="title" translatable="yes">Import Xournal++ File</property>
     <child type="action">
       <object class="GtkButton" id="import_xopp_button_cancel">
         <property name="label" translatable="yes">Cancel</property>
@@ -256,7 +256,7 @@ to the actual size on the document</property>
             </style>
             <child>
               <object class="AdwPreferencesGroup">
-                <property name="title" translatable="yes">Xournal++ file import preferences</property>
+                <property name="title" translatable="yes">Xournal++ File Import Preferences</property>
                 <property name="halign">fill</property>
                 <child>
                   <object class="AdwActionRow" id="xopp_import_dpi_row">

--- a/rnote-ui/data/ui/filerow.ui
+++ b/rnote-ui/data/ui/filerow.ui
@@ -63,7 +63,7 @@
             <attribute name="action">filerow.rename-file</attribute>
           </item>
           <item>
-            <attribute name="label" translatable="yes">Move into trash</attribute>
+            <attribute name="label" translatable="yes">Move Into Trash</attribute>
             <attribute name="action">filerow.trash-file</attribute>
           </item>
           <item>

--- a/rnote-ui/data/ui/mainheader.ui
+++ b/rnote-ui/data/ui/mainheader.ui
@@ -15,7 +15,7 @@
         </child>
         <child>
           <object class="AdwWindowTitle" id="main_title">
-            <property name="title" translatable="yes">New document</property>
+            <property name="title" translatable="yes">New Document</property>
             <property name="subtitle" translatable="yes">Draft</property>
             <style>
               <class name="main_title" />
@@ -36,14 +36,14 @@
                 <child>
                   <object class="GtkToggleButton" id="left_flapreveal_toggle">
                     <property name="icon_name">flap-symbolic</property>
-                    <property name="tooltip_text" translatable="yes">Reveal / hide flap</property>
+                    <property name="tooltip_text" translatable="yes">Reveal / Hide Flap</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkButton">
                     <property name="icon-name">tab-new-filled-symbolic</property>
                     <property name="action-name">win.new-tab</property>
-                    <property name="tooltip-text" translatable="yes">New tab</property>
+                    <property name="tooltip-text" translatable="yes">New Tab</property>
                   </object>
                 </child>
               </object>
@@ -84,14 +84,14 @@
                     <child>
                       <object class="GtkButton">
                         <property name="icon_name">add-page-symbolic</property>
-                        <property name="tooltip_text" translatable="yes">Add page</property>
+                        <property name="tooltip_text" translatable="yes">Add Page</property>
                         <property name="action-name">win.add-page-to-doc</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkButton">
                         <property name="icon_name">resize-to-fit-strokes-symbolic</property>
-                        <property name="tooltip_text" translatable="yes">Resize document to fit the strokes</property>
+                        <property name="tooltip_text" translatable="yes">Resize Document to Fit Strokes</property>
                         <property name="action-name">win.resize-to-fit-strokes</property>
                       </object>
                     </child>
@@ -106,7 +106,7 @@
             <property name="spacing">3</property>
             <child>
               <object class="GtkButton">
-                <property name="tooltip-text" translatable="yes">Save document</property>
+                <property name="tooltip-text" translatable="yes">Save Document</property>
                 <property name="icon-name">doc-save-symbolic</property>
                 <property name="action-name">win.save-doc</property>
               </object>
@@ -114,7 +114,7 @@
             <child>
               <object class="GtkToggleButton" id="right_flapreveal_toggle">
                 <property name="icon_name">flap-symbolic</property>
-                <property name="tooltip_text" translatable="yes">Reveal / hide flap</property>
+                <property name="tooltip_text" translatable="yes">Reveal / Hide Flap</property>
               </object>
             </child>
             <child>

--- a/rnote-ui/data/ui/overlays.ui
+++ b/rnote-ui/data/ui/overlays.ui
@@ -148,11 +148,11 @@
                 <menu id="tab_cx_menu_model">
                   <section>
                     <item>
-                      <attribute name="label" translatable="yes">Move _left</attribute>
+                      <attribute name="label" translatable="yes">Move _Left</attribute>
                       <attribute name="action">win.active-tab-move-left</attribute>
                     </item>
                     <item>
-                      <attribute name="label" translatable="yes">Move _right</attribute>
+                      <attribute name="label" translatable="yes">Move _Right</attribute>
                       <attribute name="action">win.active-tab-move-right</attribute>
                     </item>
                   </section>

--- a/rnote-ui/data/ui/penssidebar/brushpage.ui
+++ b/rnote-ui/data/ui/penssidebar/brushpage.ui
@@ -15,7 +15,7 @@
         <child>
           <object class="GtkMenuButton" id="brushstyle_menubutton">
             <property name="direction">left</property>
-            <property name="tooltip_text" translatable="yes">Brush style</property>
+            <property name="tooltip_text" translatable="yes">Brush Style</property>
             <property name="popover">brushstyle_popover</property>
             <property name="icon-name">pen-brush-style-solid-symbolic</property>
             <style>
@@ -30,7 +30,7 @@
             <property name="hexpand">true</property>
             <property name="halign">fill</property>
             <property name="direction">left</property>
-            <property name="tooltip_text" translatable="yes">Brush configuration</property>
+            <property name="tooltip_text" translatable="yes">Brush Configuration</property>
             <property name="popover">brushconfig_popover</property>
             <style>
               <class name="flat" />
@@ -59,7 +59,7 @@
           <property name="spacing">12</property>
           <child>
             <object class="GtkLabel">
-              <property name="label" translatable="yes">Brush styles</property>
+              <property name="label" translatable="yes">Brush Styles</property>
               <property name="halign">center</property>
               <property name="margin-bottom">12</property>
               <style>
@@ -129,7 +129,7 @@
           <property name="spacing">12</property>
           <child>
             <object class="GtkLabel">
-              <property name="label" translatable="yes">Brush configuration</property>
+              <property name="label" translatable="yes">Brush Configuration</property>
               <property name="halign">center</property>
               <style>
                 <class name="title-3" />
@@ -138,7 +138,7 @@
           </child>
           <child>
             <object class="GtkLabel">
-              <property name="label" translatable="yes">Path modelling</property>
+              <property name="label" translatable="yes">Path Modelling</property>
               <property name="margin-top">12</property>
               <property name="halign">start</property>
               <style>
@@ -180,10 +180,10 @@ Results in the best looking handwriting.</property>
           <child>
             <!-- Solid options -->
             <object class="AdwPreferencesGroup">
-              <property name="title" translatable="yes">Solid style</property>
+              <property name="title" translatable="yes">Solid Style</property>
               <child>
                 <object class="AdwComboRow" id="solidstyle_pressure_curves_row">
-                  <property name="title" translatable="yes">Pressure curve</property>
+                  <property name="title" translatable="yes">Pressure Curve</property>
                   <property name="subtitle" translatable="yes">Choose a pressure curve</property>
                   <property name="model">
                     <object class="GtkStringList">
@@ -204,7 +204,7 @@ Results in the best looking handwriting.</property>
           <child>
             <!-- Textured options -->
             <object class="AdwPreferencesGroup">
-              <property name="title" translatable="yes">Textured style</property>
+              <property name="title" translatable="yes">Textured Style</property>
               <child>
                 <object class="AdwActionRow">
                   <property name="title" translatable="yes">Density</property>
@@ -223,7 +223,7 @@ Results in the best looking handwriting.</property>
               </child>
               <child>
                 <object class="AdwComboRow" id="texturedstyle_distribution_row">
-                  <property name="title" translatable="yes">Stroke dots position distribution</property>
+                  <property name="title" translatable="yes">Stroke Dots Position Distribution</property>
                   <property name="subtitle" translatable="yes">Choose a dots position probability distribution</property>
                   <property name="model">
                     <object class="GtkStringList">

--- a/rnote-ui/data/ui/penssidebar/eraserpage.ui
+++ b/rnote-ui/data/ui/penssidebar/eraserpage.ui
@@ -18,7 +18,7 @@
         </style>
         <child>
           <object class="GtkToggleButton" id="eraserstyle_trash_colliding_strokes_toggle">
-            <property name="tooltip_text" translatable="yes">Trash strokes</property>
+            <property name="tooltip_text" translatable="yes">Trash Strokes</property>
             <property name="icon_name">pen-eraser-trash-colliding-strokes-symbolic</property>
             <style>
               <class name="sidebar_action_button" />
@@ -28,7 +28,7 @@
         <child>
           <object class="GtkToggleButton" id="eraserstyle_split_colliding_strokes_toggle">
             <property name="group">eraserstyle_trash_colliding_strokes_toggle</property>
-            <property name="tooltip_text" translatable="yes">Split strokes</property>
+            <property name="tooltip_text" translatable="yes">Split Strokes</property>
             <property name="icon_name">pen-eraser-split-colliding-strokes-symbolic</property>
             <style>
               <class name="sidebar_action_button" />

--- a/rnote-ui/data/ui/penssidebar/selectorpage.ui
+++ b/rnote-ui/data/ui/penssidebar/selectorpage.ui
@@ -19,7 +19,7 @@
         </style>
         <child>
           <object class="GtkToggleButton" id="selectorstyle_polygon_toggle">
-            <property name="tooltip_text" translatable="yes">Select with a polygon</property>
+            <property name="tooltip_text" translatable="yes">Select With a Polygon</property>
             <property name="icon_name">pen-selector-polygon-symbolic</property>
             <style>
               <class name="sidebar_action_button" />
@@ -29,7 +29,7 @@
         <child>
           <object class="GtkToggleButton" id="selectorstyle_rect_toggle">
             <property name="group">selectorstyle_polygon_toggle</property>
-            <property name="tooltip_text" translatable="yes">Select with a rectangle</property>
+            <property name="tooltip_text" translatable="yes">Select With a Rectangle</property>
             <property name="icon_name">pen-selector-rectangle-symbolic</property>
             <style>
               <class name="sidebar_action_button" />
@@ -39,7 +39,7 @@
         <child>
           <object class="GtkToggleButton" id="selectorstyle_single_toggle">
             <property name="group">selectorstyle_polygon_toggle</property>
-            <property name="tooltip_text" translatable="yes">Select one by one</property>
+            <property name="tooltip_text" translatable="yes">Select One by One</property>
             <property name="icon_name">pen-selector-single-symbolic</property>
             <style>
               <class name="sidebar_action_button" />
@@ -49,7 +49,7 @@
         <child>
           <object class="GtkToggleButton" id="selectorstyle_intersectingpath_toggle">
             <property name="group">selectorstyle_polygon_toggle</property>
-            <property name="tooltip_text" translatable="yes">Select intersecting path</property>
+            <property name="tooltip_text" translatable="yes">Select Intersecting Path</property>
             <property name="icon_name">pen-selector-intersectingpath-symbolic</property>
             <style>
               <class name="sidebar_action_button" />
@@ -70,7 +70,7 @@
 
         <child>
           <object class="GtkToggleButton" id="resize_lock_aspectratio_togglebutton">
-            <property name="tooltip_text" translatable="yes">Lock aspectratio while resizing the selection</property>
+            <property name="tooltip_text" translatable="yes">Lock Aspectratio While Resizing the Selection</property>
             <property name="icon_name">selection-resize-lock-aspectratio-symbolic</property>
             <style>
               <class name="flat" />
@@ -80,7 +80,7 @@
         </child>
         <child>
           <object class="GtkButton" id="selection_select_all_button">
-            <property name="tooltip_text" translatable="yes">Select all strokes</property>
+            <property name="tooltip_text" translatable="yes">Select All Strokes</property>
             <property name="action-name">win.selection-select-all</property>
             <property name="icon_name">selection-select-all-symbolic</property>
             <style>
@@ -91,7 +91,7 @@
         </child>
         <child>
           <object class="GtkButton" id="selection_deselect_all_button">
-            <property name="tooltip_text" translatable="yes">Deselect all strokes</property>
+            <property name="tooltip_text" translatable="yes">Deselect All Strokes</property>
             <property name="action-name">win.selection-deselect-all</property>
             <property name="icon_name">selection-deselect-all-symbolic</property>
             <style>
@@ -102,7 +102,7 @@
         </child>
         <child>
           <object class="GtkButton" id="selection_duplicate_button">
-            <property name="tooltip_text" translatable="yes">Duplicate selection</property>
+            <property name="tooltip_text" translatable="yes">Duplicate Selection</property>
             <property name="action-name">win.selection-duplicate</property>
             <property name="icon_name">selection-duplicate-symbolic</property>
             <style>
@@ -113,7 +113,7 @@
         </child>
         <child>
           <object class="GtkButton" id="selection_delete_button">
-            <property name="tooltip_text" translatable="yes">Delete selection</property>
+            <property name="tooltip_text" translatable="yes">Delete Selection</property>
             <property name="action-name">win.selection-trash</property>
             <property name="icon_name">selection-trash-symbolic</property>
             <style>

--- a/rnote-ui/data/ui/penssidebar/shaperpage.ui
+++ b/rnote-ui/data/ui/penssidebar/shaperpage.ui
@@ -15,7 +15,7 @@
         <child>
           <object class="GtkMenuButton" id="shaperstyle_menubutton">
             <property name="direction">left</property>
-            <property name="tooltip_text" translatable="yes">Shaper style</property>
+            <property name="tooltip_text" translatable="yes">Shaper Style</property>
             <property name="popover">shaperstyle_popover</property>
             <property name="icon-name">pen-shaper-style-smooth-symbolic</property>
             <style>
@@ -28,7 +28,7 @@
           <object class="GtkMenuButton" id="shapeconfig_menubutton">
             <property name="icon-name">settings-symbolic</property>
             <property name="direction">left</property>
-            <property name="tooltip_text" translatable="yes">Shape configuration</property>
+            <property name="tooltip_text" translatable="yes">Shape Configuration</property>
             <property name="popover">shapeconfig_popover</property>
             <style>
               <class name="flat" />
@@ -58,7 +58,7 @@
         <child>
           <object class="GtkMenuButton" id="shapebuildertype_menubutton">
             <property name="direction">left</property>
-            <property name="tooltip_text" translatable="yes">Shape builders</property>
+            <property name="tooltip_text" translatable="yes">Shape Builders</property>
             <property name="popover">shapebuildertype_popover</property>
             <property name="icon-name">shapebuilder-line-symbolic</property>
             <style>
@@ -96,7 +96,7 @@
           <property name="spacing">12</property>
           <child>
             <object class="GtkLabel">
-              <property name="label" translatable="yes">Shaper styles</property>
+              <property name="label" translatable="yes">Shaper Styles</property>
               <property name="halign">center</property>
               <style>
                 <class name="title-3" />
@@ -151,7 +151,7 @@
           <property name="spacing">12</property>
           <child>
             <object class="GtkLabel">
-              <property name="label" translatable="yes">Shape configuration</property>
+              <property name="label" translatable="yes">Shape Configuration</property>
               <property name="halign">center</property>
               <style>
                 <class name="title-3" />
@@ -165,7 +165,7 @@
               <property name="width-request">300</property>
               <child>
                 <object class="AdwComboRow" id="roughstyle_fillstyle_row">
-                  <property name="title" translatable="yes">Fill style</property>
+                  <property name="title" translatable="yes">Fill Style</property>
                   <property name="subtitle" translatable="yes">Choose a fill style</property>
                   <property name="model">
                     <object class="GtkStringList">
@@ -184,7 +184,7 @@
               </child>
               <child>
                 <object class="AdwActionRow" id="roughstyle_hachure_angle_row">
-                  <property name="title" translatable="yes">Hachure angle</property>
+                  <property name="title" translatable="yes">Hachure Angle</property>
                   <property name="subtitle" translatable="yes">Set the angle of hachure fills</property>
                   <child type="suffix">
                     <object class="GtkAdjustment" id="roughstyle_hachure_angle_adj">
@@ -222,7 +222,7 @@
           <property name="spacing">12</property>
           <child>
             <object class="GtkLabel">
-              <property name="label" translatable="yes">Shape builders</property>
+              <property name="label" translatable="yes">Shape Builders</property>
               <property name="halign">center</property>
               <style>
                 <class name="title-3" />
@@ -300,7 +300,7 @@ when this switch is off/on</property>
               </child>
               <child>
                 <object class="AdwActionRow">
-                  <property name="title" translatable="yes">Golden ratio (1:1.618)</property>
+                  <property name="title" translatable="yes">Golden Ratio (1:1.618)</property>
                   <child type="suffix">
                     <object class="GtkSwitch" id="constraint_golden_switch">
                       <property name="valign">center</property>

--- a/rnote-ui/data/ui/penssidebar/toolspage.ui
+++ b/rnote-ui/data/ui/penssidebar/toolspage.ui
@@ -16,7 +16,7 @@
         <property name="spacing">6</property>
         <child>
           <object class="GtkToggleButton" id="toolstyle_verticalspace_toggle">
-            <property name="tooltip_text" translatable="yes">Insert vertical space</property>
+            <property name="tooltip_text" translatable="yes">Insert Vertical Space</property>
             <property name="icon-name">pen-tools-verticalspacetool-symbolic</property>
             <style>
               <class name="flat" />
@@ -26,7 +26,7 @@
         </child>
         <child>
           <object class="GtkToggleButton" id="toolstyle_offsetcamera_toggle">
-            <property name="tooltip_text" translatable="yes">Offset the camera by dragging</property>
+            <property name="tooltip_text" translatable="yes">Offset the Camera</property>
             <property name="icon-name">pen-tools-offsetcameratool-symbolic</property>
             <property name="group">toolstyle_verticalspace_toggle</property>
             <style>

--- a/rnote-ui/data/ui/penssidebar/typewriterpage.ui
+++ b/rnote-ui/data/ui/penssidebar/typewriterpage.ui
@@ -13,7 +13,7 @@
       <object class="GtkMenuButton" id="fontchooser_menubutton">
         <property name="direction">left</property>
         <property name="popover">fontchooser_popover</property>
-        <property name="tooltip_text" translatable="yes">Font chooser
+        <property name="tooltip_text" translatable="yes">Font Chooser
 (double-click, click on select
 or press Enter to select a new font)</property>
             <property name="icon-name">pen-typewriter-fontchooser-symbolic</property>
@@ -45,7 +45,7 @@ or press Enter to select a new font)</property>
       <object class="GtkMenuButton" id="emojichooser_menubutton">
         <property name="direction">left</property>
         <property name="popover">emojichooser</property>
-        <property name="tooltip_text" translatable="yes">Pick and insert an emoji</property>
+        <property name="tooltip_text" translatable="yes">Pick And Insert Emoji</property>
         <property name="icon-name">emojichooser-symbolic</property>
         <style>
           <class name="flat" />
@@ -70,7 +70,7 @@ or press Enter to select a new font)</property>
         <child>
           <object class="GtkButton" id="text_reset_button">
             <property name="icon-name">reset-state-symbolic</property>
-            <property name="tooltip_text" translatable="yes">Reset text attributes</property>
+            <property name="tooltip_text" translatable="yes">Reset Text Attributes</property>
             <style>
               <class name="flat" />
             </style>
@@ -128,21 +128,21 @@ or press Enter to select a new font)</property>
         <child>
           <object class="GtkToggleButton" id="text_align_start_togglebutton">
             <property name="icon-name">text-align-start-symbolic</property>
-            <property name="tooltip_text" translatable="yes">Align left</property>
+            <property name="tooltip_text" translatable="yes">Align Left</property>
             <property name="active">true</property>
           </object>
         </child>
         <child>
           <object class="GtkToggleButton" id="text_align_center_togglebutton">
             <property name="icon-name">text-align-center-symbolic</property>
-            <property name="tooltip_text" translatable="yes">Align center</property>
+            <property name="tooltip_text" translatable="yes">Align Center</property>
             <property name="group">text_align_start_togglebutton</property>
           </object>
         </child>
         <child>
           <object class="GtkToggleButton" id="text_align_end_togglebutton">
             <property name="icon-name">text-align-end-symbolic</property>
-            <property name="tooltip_text" translatable="yes">Align right</property>
+            <property name="tooltip_text" translatable="yes">Align Right</property>
             <property name="group">text_align_start_togglebutton</property>
           </object>
         </child>

--- a/rnote-ui/data/ui/settingspanel.ui
+++ b/rnote-ui/data/ui/settingspanel.ui
@@ -52,7 +52,7 @@
                     </child>
                     <child>
                       <object class="AdwActionRow" id="general_autosave_interval_secs_row">
-                        <property name="title" translatable="yes">Autosave interval (secs)</property>
+                        <property name="title" translatable="yes">Autosave Interval (secs)</property>
                         <property name="subtitle" translatable="yes">Set the autosave interval in seconds</property>
                         <child type="suffix">
                           <object class="GtkAdjustment" id="general_autosave_interval_secs_adj">
@@ -73,7 +73,7 @@
                     </child>
                     <child>
                       <object class="AdwActionRow" id="general_format_border_color_row">
-                        <property name="title" translatable="yes">Format border color</property>
+                        <property name="title" translatable="yes">Format Border Color</property>
                         <property name="subtitle" translatable="yes">Set the format border color</property>
                         <child type="suffix">
                           <object class="GtkBox">
@@ -91,7 +91,7 @@
                     </child>
                     <child>
                       <object class="AdwActionRow" id="general_show_scrollbars_row">
-                        <property name="title" translatable="yes">Show scrollbars</property>
+                        <property name="title" translatable="yes">Show Scrollbars</property>
                         <property name="subtitle" translatable="yes">Set whether the scrollbars on the canvas are shown</property>
                         <child type="suffix">
                           <object class="GtkSwitch" id="general_show_scrollbars_switch">
@@ -102,7 +102,7 @@
                     </child>
                     <child>
                       <object class="AdwActionRow" id="general_regular_cursor_picker_row">
-                        <property name="title" translatable="yes">Regular cursor</property>
+                        <property name="title" translatable="yes">Regular Cursor</property>
                         <property name="subtitle" translatable="yes">Set the regular cursor</property>
                         <child type="suffix">
                           <object class="GtkBox">
@@ -125,7 +125,7 @@
                     </child>
                     <child>
                       <object class="AdwActionRow" id="general_drawing_cursor_picker_row">
-                        <property name="title" translatable="yes">Drawing cursor</property>
+                        <property name="title" translatable="yes">Drawing Cursor</property>
                         <property name="subtitle" translatable="yes">Set the drawing cursor</property>
                         <child type="suffix">
                           <object class="GtkBox">
@@ -151,7 +151,7 @@
                 <!-- Format Group -->
                 <child>
                   <object class="AdwPreferencesGroup">
-                    <property name="title" translatable="yes">Page format</property>
+                    <property name="title" translatable="yes">Page Format</property>
                     <child>
                       <object class="AdwComboRow" id="format_predefined_formats_row">
                         <property name="title" translatable="yes">Format</property>
@@ -231,8 +231,8 @@
                     </child>
                     <child>
                       <object class="AdwActionRow" id="format_dpi_row">
-                        <property name="title" translatable="yes">DPI</property>
-                        <property name="subtitle" translatable="yes">Set the DPI (dots per inch). Defaults to 96</property>
+                        <property name="title" translatable="yes">Dpi</property>
+                        <property name="subtitle" translatable="yes">Set the Dpi (dots per inch). Defaults to 96</property>
                         <child type="suffix">
                           <object class="GtkAdjustment" id="format_dpi_adj">
                             <property name="step-increment">1</property>
@@ -277,7 +277,7 @@
                 <!-- Background Group -->
                 <child>
                   <object class="AdwPreferencesGroup">
-                    <property name="title" translatable="yes">Document background</property>
+                    <property name="title" translatable="yes">Document Background</property>
                     <child>
                       <object class="AdwActionRow" id="background_color_row">
                         <property name="title" translatable="yes">Color</property>
@@ -366,7 +366,7 @@
                     <property name="title" translatable="yes">Button Shortcuts</property>
                     <child>
                       <object class="RnPenShortcutRow" id="penshortcut_stylus_button_primary_row">
-                        <property name="title" translatable="yes">Stylus primary button action</property>
+                        <property name="title" translatable="yes">Stylus Primary Button Action</property>
                         <property name="subtitle" translatable="yes">Set the action for the primary stylus button</property>
                         <child type="prefix">
                           <object class="GtkImage">
@@ -378,7 +378,7 @@
                     </child>
                     <child>
                       <object class="RnPenShortcutRow" id="penshortcut_stylus_button_secondary_row">
-                        <property name="title" translatable="yes">Stylus secondary button action</property>
+                        <property name="title" translatable="yes">Stylus Secondary Button Action</property>
                         <property name="subtitle" translatable="yes">Set the action for the secondary stylus button</property>
                         <child type="prefix">
                           <object class="GtkImage">
@@ -390,7 +390,7 @@
                     </child>
                     <child>
                       <object class="RnPenShortcutRow" id="penshortcut_mouse_button_secondary_row">
-                        <property name="title" translatable="yes">Mouse secondary button action</property>
+                        <property name="title" translatable="yes">Mouse Secondary Button Action</property>
                         <property name="subtitle" translatable="yes">Set the action for the secondary mouse button</property>
                         <child type="prefix">
                           <object class="GtkImage">
@@ -402,7 +402,7 @@
                     </child>
                     <child>
                       <object class="RnPenShortcutRow" id="penshortcut_touch_two_finger_long_press_row">
-                        <property name="title" translatable="yes">Touch two-finger long-press action</property>
+                        <property name="title" translatable="yes">Touch Two-Finger Long-Press Action</property>
                         <property name="subtitle" translatable="yes">Set the action for the touch two-finger long-press gesture</property>
                         <child type="prefix">
                           <object class="GtkImage">

--- a/rnote-ui/data/ui/shortcuts.ui
+++ b/rnote-ui/data/ui/shortcuts.ui
@@ -11,37 +11,37 @@
             <property name="title" context="shortcut window" translatable="yes">General</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" context="shortcut window" translatable="yes">Show keyboard shortcuts</property>
+                <property name="title" context="shortcut window" translatable="yes">Show Keyboard Shortcuts</property>
                 <property name="accelerator">&lt;ctrl&gt;question</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" context="shortcut window" translatable="yes">Close the active tab</property>
+                <property name="title" context="shortcut window" translatable="yes">Close the Active Tab</property>
                 <property name="accelerator">&lt;ctrl&gt;w</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" context="shortcut window" translatable="yes">Quit the application</property>
+                <property name="title" context="shortcut window" translatable="yes">Quit the Application</property>
                 <property name="accelerator">&lt;ctrl&gt;q</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" context="shortcut window" translatable="yes">Open the canvas menu</property>
+                <property name="title" context="shortcut window" translatable="yes">Open the Canvas-Menu</property>
                 <property name="accelerator">F9</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" context="shortcut window" translatable="yes">Open the app menu</property>
+                <property name="title" context="shortcut window" translatable="yes">Open the App-Menu</property>
                 <property name="accelerator">F10</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" context="shortcut window" translatable="yes">Toggle fullscreen</property>
+                <property name="title" context="shortcut window" translatable="yes">Toggle Fullscreen</property>
                 <property name="accelerator">F11</property>
               </object>
             </child>
@@ -141,43 +141,43 @@
             <property name="title" context="shortcut window" translatable="yes">Document</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" context="shortcut window" translatable="yes">New document</property>
+                <property name="title" context="shortcut window" translatable="yes">New Document</property>
                 <property name="accelerator">&lt;ctrl&gt;n</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" context="shortcut window" translatable="yes">Open document</property>
+                <property name="title" context="shortcut window" translatable="yes">Open Document</property>
                 <property name="accelerator">&lt;ctrl&gt;o</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" context="shortcut window" translatable="yes">Save document</property>
+                <property name="title" context="shortcut window" translatable="yes">Save Document</property>
                 <property name="accelerator">&lt;ctrl&gt;s</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" context="shortcut window" translatable="yes">Save document as</property>
+                <property name="title" context="shortcut window" translatable="yes">Save Document As</property>
                 <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;s</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" context="shortcut window" translatable="yes">Clear document</property>
+                <property name="title" context="shortcut window" translatable="yes">Clear Document</property>
                 <property name="accelerator">&lt;ctrl&gt;l</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" context="shortcut window" translatable="yes">Print document</property>
+                <property name="title" context="shortcut window" translatable="yes">Print Document</property>
                 <property name="accelerator">&lt;ctrl&gt;p</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" context="shortcut window" translatable="yes">Import file</property>
+                <property name="title" context="shortcut window" translatable="yes">Import File</property>
                 <property name="accelerator">&lt;ctrl&gt;i</property>
               </object>
             </child>
@@ -186,25 +186,25 @@
                 <property name="title" context="shortcut window" translatable="yes">Drawing</property>
                 <child>
                   <object class="GtkShortcutsShortcut">
-                    <property name="title" context="shortcut window" translatable="yes">Copy to clipboard</property>
+                    <property name="title" context="shortcut window" translatable="yes">Copy to Clipboard</property>
                     <property name="accelerator">&lt;ctrl&gt;c</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkShortcutsShortcut">
-                    <property name="title" context="shortcut window" translatable="yes">Cut to clipboard</property>
+                    <property name="title" context="shortcut window" translatable="yes">Cut to Clipboard</property>
                     <property name="accelerator">&lt;ctrl&gt;x</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkShortcutsShortcut">
-                    <property name="title" context="shortcut window" translatable="yes">Paste clipboard</property>
+                    <property name="title" context="shortcut window" translatable="yes">Paste Clipboard</property>
                     <property name="accelerator">&lt;ctrl&gt;v</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkShortcutsShortcut">
-                    <property name="title" context="shortcut window" translatable="yes">Duplicate selection</property>
+                    <property name="title" context="shortcut window" translatable="yes">Duplicate Selection</property>
                     <property name="accelerator">&lt;ctrl&gt;d</property>
                   </object>
                 </child>

--- a/rnote-ui/data/ui/workspacebrowser.ui
+++ b/rnote-ui/data/ui/workspacebrowser.ui
@@ -40,7 +40,7 @@
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkButton" id="dir_controls_dir_up_button">
-                        <property name="tooltip_text" translatable="yes">Move directory up</property>
+                        <property name="tooltip_text" translatable="yes">Move Directory up</property>
                         <property name="halign">fill</property>
                         <property name="hexpand">true</property>
                         <child>
@@ -67,7 +67,7 @@
                             <property name="direction">down</property>
                             <property name="icon_name">dir-actions-symbolic</property>
                             <property name="popover">dir_controls_actions_popover</property>
-                            <property name="tooltip_text" translatable="yes">Workspace directory actions</property>
+                            <property name="tooltip_text" translatable="yes">Workspace Directory Actions</property>
                             <style>
                               <class name="flat" />
                             </style>
@@ -118,7 +118,7 @@
       <menu id="workspace_dir_actions_menu_model">
         <section>
           <item>
-            <attribute name="label" translatable="yes">Create new folder</attribute>
+            <attribute name="label" translatable="yes">Create new Folder</attribute>
             <attribute name="action">workspacebrowser.create-folder</attribute>
           </item>
         </section>

--- a/rnote-ui/data/ui/workspacesbar/workspacesbar.ui
+++ b/rnote-ui/data/ui/workspacesbar/workspacesbar.ui
@@ -51,7 +51,7 @@
         <child>
           <object class="GtkButton" id="move_selected_workspace_up_button">
             <property name="icon_name">up-symbolic</property>
-            <property name="tooltip_text" translatable="yes">Move selected workspace up</property>
+            <property name="tooltip_text" translatable="yes">Move Selected Workspace Up</property>
             <style>
               <class name="flat" />
             </style>
@@ -60,7 +60,7 @@
         <child>
           <object class="GtkButton" id="move_selected_workspace_down_button">
             <property name="icon_name">down-symbolic</property>
-            <property name="tooltip_text" translatable="yes">Move selected workspace down</property>
+            <property name="tooltip_text" translatable="yes">Move Selected Workspace Down</property>
             <style>
               <class name="flat" />
             </style>
@@ -69,7 +69,7 @@
         <child>
           <object class="GtkButton" id="add_workspace_button">
             <property name="icon_name">plus-symbolic</property>
-            <property name="tooltip_text" translatable="yes">Add workspace</property>
+            <property name="tooltip_text" translatable="yes">Add Workspace</property>
             <style>
               <class name="flat" />
             </style>
@@ -78,7 +78,7 @@
         <child>
           <object class="GtkButton" id="remove_selected_workspace_button">
             <property name="icon_name">trash-symbolic</property>
-            <property name="tooltip_text" translatable="yes">Remove selected workspace</property>
+            <property name="tooltip_text" translatable="yes">Remove Selected Workspace</property>
             <style>
               <class name="flat" />
               <class name="flat-destructive-action" />
@@ -88,7 +88,7 @@
         <child>
           <object class="GtkButton" id="edit_selected_workspace_button">
             <property name="icon-name">edit-symbolic</property>
-            <property name="tooltip_text" translatable="yes">Edit selected workspace</property>
+            <property name="tooltip_text" translatable="yes">Edit Selected Workspace</property>
             <style>
               <class name="flat" />
             </style>

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -674,7 +674,7 @@ impl RnAppWindow {
             if !canvas.engine().borrow().store.selection_keys_unordered().is_empty() {
                 dialogs::export::dialog_export_selection_w_prefs(&appwindow, &appwindow.active_tab().canvas());
             } else {
-                appwindow.overlays().dispatch_toast_error(&gettext("Export selection failed, nothing selected."));
+                appwindow.overlays().dispatch_toast_error(&gettext("Exporting selection failed, nothing selected."));
             }
         }));
 

--- a/rnote-ui/src/appwindow/mod.rs
+++ b/rnote-ui/src/appwindow/mod.rs
@@ -555,7 +555,7 @@ impl RnAppWindow {
                 crate::utils::FileType::Folder => {
                     log::error!("tried to open a folder as a file.");
                     appwindow.overlays()
-                        .dispatch_toast_error(&gettext("Error: Tried opening folder as file"));
+                        .dispatch_toast_error(&gettext("Failed to open file: Tried to open folder as file"));
                 }
                 crate::utils::FileType::Unsupported => {
                     log::error!("tried to open a unsupported file type.");

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -20,7 +20,7 @@ pub(crate) fn filechooser_save_doc_as(appwindow: &RnAppWindow, canvas: &RnCanvas
     filter.set_name(Some(&gettext(".rnote")));
 
     let filechooser: FileChooserNative = FileChooserNative::builder()
-        .title(&gettext("Save document as"))
+        .title(&gettext("Save Document As"))
         .modal(true)
         .transient_for(appwindow)
         .accept_label(&gettext("Save"))
@@ -192,7 +192,7 @@ pub(crate) fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &RnCanv
 
                             if let Err(e) = canvas.export_doc(&file, file_title, None).await {
                                 log::error!("exporting document failed with error `{e:?}`");
-                                appwindow.overlays().dispatch_toast_error(&gettext("Export document failed."));
+                                appwindow.overlays().dispatch_toast_error(&gettext("Exporting document failed."));
                             } else {
                                 appwindow.overlays().dispatch_toast_text(&gettext("Exported document successfully."));
                             }
@@ -200,7 +200,7 @@ pub(crate) fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &RnCanv
                             appwindow.overlays().finish_progressbar();
                         }));
                     } else {
-                        appwindow.overlays().dispatch_toast_error(&gettext("Export document failed, no file selected."));
+                        appwindow.overlays().dispatch_toast_error(&gettext("Exporting document failed, no file selected."));
                     }
                 }
                 _ => {}
@@ -220,7 +220,7 @@ fn create_filechooser_export_doc(
     doc_export_prefs: &DocExportPrefs,
 ) -> FileChooserNative {
     let filechooser: FileChooserNative = FileChooserNative::builder()
-        .title(&gettext("Export document"))
+        .title(&gettext("Export Document"))
         .modal(true)
         .transient_for(appwindow)
         .accept_label(&gettext("Select"))
@@ -465,7 +465,7 @@ pub(crate) fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, canvas: &
 
                             if let Err(e) = canvas.export_doc_pages(&dir, file_stem_name, None).await {
                                 log::error!("exporting document pages failed with error `{e:?}`");
-                                appwindow.overlays().dispatch_toast_error(&gettext("Export document pages failed."));
+                                appwindow.overlays().dispatch_toast_error(&gettext("Exporting document pages failed."));
                             } else {
                                 appwindow.overlays().dispatch_toast_text(&gettext("Exported document pages successfully."));
                             }
@@ -473,7 +473,7 @@ pub(crate) fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, canvas: &
                             appwindow.overlays().finish_progressbar();
                         }));
                     } else {
-                        appwindow.overlays().dispatch_toast_error(&gettext("Export document pages failed, no directory selected."));
+                        appwindow.overlays().dispatch_toast_error(&gettext("Exporting document pages failed, no directory selected."));
                     }
                 }
                 _ => {}
@@ -493,7 +493,7 @@ fn create_filechooser_export_doc_pages(
     doc_pages_export_prefs: &DocPagesExportPrefs,
 ) -> FileChooserNative {
     let filechooser: FileChooserNative = FileChooserNative::builder()
-        .title(&gettext("Export document pages"))
+        .title(&gettext("Export Document Pages"))
         .modal(true)
         .transient_for(appwindow)
         .accept_label(&gettext("Select"))
@@ -713,7 +713,7 @@ pub(crate) fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, canvas: &
 
                             if let Err(e) = canvas.export_selection(&file, None).await {
                                 log::error!("exporting selection failed with error `{e:?}`");
-                                appwindow.overlays().dispatch_toast_error(&gettext("Export selection failed."));
+                                appwindow.overlays().dispatch_toast_error(&gettext("Exporting selection failed."));
                             } else {
                                 appwindow.overlays().dispatch_toast_text(&gettext("Exported selection successfully."));
                             }
@@ -721,7 +721,7 @@ pub(crate) fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, canvas: &
                             appwindow.overlays().finish_progressbar();
                         }));
                     } else {
-                        appwindow.overlays().dispatch_toast_error(&gettext("Export selection failed, no file selected."));
+                        appwindow.overlays().dispatch_toast_error(&gettext("Exporting selection failed, no file selected."));
                     }
                 }
                 _ => {}
@@ -741,7 +741,7 @@ fn create_filechooser_export_selection(
     selection_export_prefs: &SelectionExportPrefs,
 ) -> FileChooserNative {
     let filechooser: FileChooserNative = FileChooserNative::builder()
-        .title(&gettext("Export selection"))
+        .title(&gettext("Export Selection"))
         .modal(true)
         .transient_for(appwindow)
         .accept_label(&gettext("Select"))
@@ -808,10 +808,10 @@ pub(crate) fn filechooser_export_engine_state(appwindow: &RnAppWindow, canvas: &
     let filter = FileFilter::new();
     filter.add_mime_type("application/json");
     filter.add_suffix("json");
-    filter.set_name(Some(&gettext("JSON")));
+    filter.set_name(Some(&gettext("Json")));
 
     let filechooser: FileChooserNative = FileChooserNative::builder()
-        .title(&gettext("Export engine state"))
+        .title(&gettext("Export Engine State"))
         .modal(true)
         .transient_for(appwindow)
         .accept_label(&gettext("Export"))
@@ -849,7 +849,7 @@ pub(crate) fn filechooser_export_engine_state(appwindow: &RnAppWindow, canvas: &
 
                             if let Err(e) = canvas.export_engine_state(&file).await {
                                 log::error!("exporting engine state failed with error `{e:?}`");
-                                appwindow.overlays().dispatch_toast_error(&gettext("Export engine state failed."));
+                                appwindow.overlays().dispatch_toast_error(&gettext("Exporting engine state failed."));
                             } else {
                                 appwindow.overlays().dispatch_toast_text(&gettext("Exported engine state successfully."));
                             }
@@ -872,10 +872,10 @@ pub(crate) fn filechooser_export_engine_config(appwindow: &RnAppWindow, canvas: 
     let filter = FileFilter::new();
     filter.add_mime_type("application/json");
     filter.add_suffix("json");
-    filter.set_name(Some(&gettext("JSON")));
+    filter.set_name(Some(&gettext("Json")));
 
     let filechooser: FileChooserNative = FileChooserNative::builder()
-        .title(&gettext("Export engine config"))
+        .title(&gettext("Export Engine Config"))
         .modal(true)
         .transient_for(appwindow)
         .accept_label(&gettext("Export"))
@@ -913,7 +913,7 @@ pub(crate) fn filechooser_export_engine_config(appwindow: &RnAppWindow, canvas: 
 
                             if let Err(e) = canvas.export_engine_config(&file).await {
                                 log::error!("exporting engine state failed with error `{e:?}`");
-                                appwindow.overlays().dispatch_toast_error(&gettext("Export engine config failed."));
+                                appwindow.overlays().dispatch_toast_error(&gettext("Exporting engine config failed."));
                             } else {
                                 appwindow.overlays().dispatch_toast_text(&gettext("Exported engine config successfully."));
                             }

--- a/rnote-ui/src/dialogs/import.rs
+++ b/rnote-ui/src/dialogs/import.rs
@@ -82,7 +82,7 @@ pub(crate) fn filechooser_open_doc(appwindow: &RnAppWindow) {
     filter.set_name(Some(&gettext(".rnote")));
 
     let filechooser: FileChooserNative = FileChooserNative::builder()
-        .title(&gettext("Open file"))
+        .title(&gettext("Open File"))
         .modal(true)
         .transient_for(appwindow)
         .accept_label(&gettext("Open"))
@@ -132,10 +132,10 @@ pub(crate) fn filechooser_import_file(appwindow: &RnAppWindow) {
     filter.add_suffix("png");
     filter.add_suffix("jpg");
     filter.add_suffix("jpeg");
-    filter.set_name(Some(&gettext("JPG, PDF, PNG, SVG, Xopp")));
+    filter.set_name(Some(&gettext("Jpg, Pdf, Png, Ssvg, Xopp")));
 
     let filechooser: FileChooserNative = FileChooserNative::builder()
-        .title(&gettext("Import file"))
+        .title(&gettext("Import File"))
         .modal(true)
         .transient_for(appwindow)
         .accept_label(&gettext("Import"))

--- a/rnote-ui/src/dialogs/import.rs
+++ b/rnote-ui/src/dialogs/import.rs
@@ -132,7 +132,7 @@ pub(crate) fn filechooser_import_file(appwindow: &RnAppWindow) {
     filter.add_suffix("png");
     filter.add_suffix("jpg");
     filter.add_suffix("jpeg");
-    filter.set_name(Some(&gettext("Jpg, Pdf, Png, Ssvg, Xopp")));
+    filter.set_name(Some(&gettext("Jpg, Pdf, Png, Svg, Xopp")));
 
     let filechooser: FileChooserNative = FileChooserNative::builder()
         .title(&gettext("Import File"))

--- a/rnote-ui/src/dialogs/mod.rs
+++ b/rnote-ui/src/dialogs/mod.rs
@@ -372,7 +372,7 @@ pub(crate) fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
     );
 
     let filechooser: FileChooserNative = FileChooserNative::builder()
-        .title(&gettext("Change workspace directory"))
+        .title(&gettext("Change Workspace Directory"))
         .modal(true)
         .transient_for(appwindow)
         .accept_label(&gettext("Select"))

--- a/rnote-ui/src/workspacebrowser/workspaceactions/createfolder.rs
+++ b/rnote-ui/src/workspacebrowser/workspaceactions/createfolder.rs
@@ -54,7 +54,7 @@ pub(crate) fn create_folder(workspacebrowser: &RnWorkspaceBrowser) -> gio::Simpl
 
 fn create_folder_name_entry() -> Entry {
     Entry::builder()
-        .placeholder_text(&gettext("Folder name"))
+        .placeholder_text(&gettext("Folder Name"))
         .build()
 }
 
@@ -62,7 +62,7 @@ fn create_dialog_title_label() -> Label {
     let label = Label::builder()
         .margin_bottom(12)
         .halign(Align::Center)
-        .label(&gettext("New folder"))
+        .label(&gettext("New Folder"))
         .width_chars(24)
         .ellipsize(pango::EllipsizeMode::End)
         .build();


### PR DESCRIPTION
this changes all titles to use header capitalization. Unfortunately this will invalidate almost all strings, so we should give translators as much time as possible to translate these changes by merging right after the next release.

Should be merged right after #485, and only after that the po template should be regenerated to present the string changes to the translators in one update.

Hopefully I didn't overlook any strings.
Also: fixed some string inconsistencies.

Before this PR is merged would be the ideal time to suggest other string improvements as well.

fixes #478 when merged