### PR TITLE
Implement copy & paste between tabs and windows, fix svg import

### DIFF
--- a/rnote-compose/src/shapes/shapebehaviour.rs
+++ b/rnote-compose/src/shapes/shapebehaviour.rs
@@ -6,7 +6,17 @@ use crate::transform::TransformBehaviour;
 pub trait ShapeBehaviour: TransformBehaviour {
     /// The bounds of the shape
     fn bounds(&self) -> Aabb;
-
     /// The hitboxes of the shape
     fn hitboxes(&self) -> Vec<Aabb>;
+
+    /// The absolute position of the types upper-left corner
+    fn pos(&self) -> na::Vector2<f64> {
+        self.bounds().mins.coords
+    }
+
+    /// Set the absolute position of the types upper-left corner
+    fn set_pos(&mut self, pos: na::Vector2<f64>) {
+        self.translate(-self.pos());
+        self.translate(pos)
+    }
 }

--- a/rnote-engine/src/engine/import.rs
+++ b/rnote-engine/src/engine/import.rs
@@ -12,7 +12,7 @@ use crate::store::StrokeKey;
 use crate::strokes::{BitmapImage, Stroke, VectorImage};
 use crate::{RnoteEngine, WidgetFlags};
 
-use super::{EngineConfig, EngineViewMut, NativeClipboardContent};
+use super::{EngineConfig, EngineViewMut, StrokeContent};
 
 #[derive(
     Debug, Clone, Copy, Serialize, Deserialize, num_derive::FromPrimitive, num_derive::ToPrimitive,
@@ -343,9 +343,10 @@ impl RnoteEngine {
         Ok(widget_flags)
     }
 
-    pub fn paste_native_clipboard_content(
+    /// Inserts the stroke content. Data usually coming from the clipboard, drop source, etc.
+    pub fn insert_stroke_content(
         &mut self,
-        clipboard_content: NativeClipboardContent,
+        content: StrokeContent,
         pos: na::Vector2<f64>,
     ) -> WidgetFlags {
         let mut widget_flags = self.store.record(Instant::now());
@@ -354,7 +355,7 @@ impl RnoteEngine {
         self.store.set_selected_keys(&all_strokes, false);
         widget_flags.merge(self.change_pen_style(PenStyle::Selector));
 
-        let inserted_keys = self.store.paste_native_clipboard(clipboard_content, pos);
+        let inserted_keys = self.store.insert_stroke_content(content, pos);
         self.store.update_geometry_for_strokes(&inserted_keys);
         self.store.regenerate_rendering_for_strokes(
             &inserted_keys,

--- a/rnote-engine/src/engine/mod.rs
+++ b/rnote-engine/src/engine/mod.rs
@@ -815,22 +815,6 @@ impl RnoteEngine {
     pub fn cut_clipboard_content(
         &mut self,
     ) -> anyhow::Result<(Option<(Vec<u8>, String)>, WidgetFlags)> {
-        /*
-        // TODO: Until the current broken svg import is fixed, we don't want users being able to cut the selection without the possibility to insert it again.
-
-                let export_bytes = self.export_selection(Some(SelectionExportPrefs {
-                    with_background: true,
-                    export_format: SelectionExportFormat::Svg,
-                    ..Default::default()
-                }));
-
-                // First try exporting the selection as svg
-                if let Some(selection_bytes) = futures::executor::block_on(async { export_bytes.await? })? {
-                    return Ok(Some((selection_bytes, String::from("image/svg+xml"))));
-                }
-         */
-
-        // else fetch from pen
         self.penholder.cut_clipboard_content(&mut EngineViewMut {
             tasks_tx: self.tasks_tx(),
             pens_config: &mut self.pens_config,

--- a/rnote-engine/src/engine/mod.rs
+++ b/rnote-engine/src/engine/mod.rs
@@ -300,11 +300,11 @@ impl EngineSnapshot {
     }
 }
 
-pub const RNOTE_NATIVE_CLIPBOARD_MIME_TYPE: &str = "application/rnote-clipboard";
+pub const RNOTE_STROKE_CONTENT_MIME_TYPE: &str = "application/rnote-stroke-content";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default, rename = "native_clipboard_content")]
-pub struct NativeClipboardContent {
+#[serde(default, rename = "stroke_content")]
+pub struct StrokeContent {
     #[serde(rename = "strokes")]
     pub strokes: Vec<Arc<Stroke>>,
 }

--- a/rnote-engine/src/pens/selector/mod.rs
+++ b/rnote-engine/src/pens/selector/mod.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use super::penbehaviour::{PenBehaviour, PenProgress};
 use super::pensconfig::selectorconfig::SelectorStyle;
 use super::PenStyle;
-use crate::engine::{EngineView, EngineViewMut, RNOTE_NATIVE_CLIPBOARD_MIME_TYPE};
+use crate::engine::{EngineView, EngineViewMut, RNOTE_STROKE_CONTENT_MIME_TYPE};
 use crate::store::StrokeKey;
 use crate::{Camera, DrawOnDocBehaviour, WidgetFlags};
 use kurbo::Shape;
@@ -155,12 +155,12 @@ impl PenBehaviour for Selector {
         };
 
         if let Some(selected_keys) = selected_keys {
-            let clipboard_content = engine_view.store.fetch_native_clipboard(&selected_keys);
+            let clipboard_content = engine_view.store.fetch_stroke_content(&selected_keys);
 
             return Ok((
                 Some((
                     serde_json::to_string(&clipboard_content)?.into_bytes(),
-                    RNOTE_NATIVE_CLIPBOARD_MIME_TYPE.to_string(),
+                    RNOTE_STROKE_CONTENT_MIME_TYPE.to_string(),
                 )),
                 widget_flags,
             ));
@@ -182,7 +182,7 @@ impl PenBehaviour for Selector {
         };
 
         if let Some(selected_keys) = selected_keys {
-            let clipboard_content = engine_view.store.cut_into_native_clipboard(&selected_keys);
+            let clipboard_content = engine_view.store.cut_stroke_content(&selected_keys);
             widget_flags.store_modified = true;
             widget_flags.redraw = true;
 
@@ -191,7 +191,7 @@ impl PenBehaviour for Selector {
             return Ok((
                 Some((
                     serde_json::to_string(&clipboard_content)?.into_bytes(),
-                    RNOTE_NATIVE_CLIPBOARD_MIME_TYPE.to_string(),
+                    RNOTE_STROKE_CONTENT_MIME_TYPE.to_string(),
                 )),
                 widget_flags,
             ));

--- a/rnote-engine/src/pens/selector/mod.rs
+++ b/rnote-engine/src/pens/selector/mod.rs
@@ -159,7 +159,7 @@ impl PenBehaviour for Selector {
 
             return Ok((
                 Some((
-                    serde_json::to_vec(&clipboard_content)?,
+                    serde_json::to_string(&clipboard_content)?.into_bytes(),
                     RNOTE_NATIVE_CLIPBOARD_MIME_TYPE.to_string(),
                 )),
                 widget_flags,
@@ -190,7 +190,7 @@ impl PenBehaviour for Selector {
 
             return Ok((
                 Some((
-                    serde_json::to_vec(&clipboard_content)?,
+                    serde_json::to_string(&clipboard_content)?.into_bytes(),
                     RNOTE_NATIVE_CLIPBOARD_MIME_TYPE.to_string(),
                 )),
                 widget_flags,

--- a/rnote-engine/src/pens/selector/mod.rs
+++ b/rnote-engine/src/pens/selector/mod.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use super::penbehaviour::{PenBehaviour, PenProgress};
 use super::pensconfig::selectorconfig::SelectorStyle;
 use super::PenStyle;
-use crate::engine::{EngineView, EngineViewMut};
+use crate::engine::{EngineView, EngineViewMut, RNOTE_NATIVE_CLIPBOARD_MIME_TYPE};
 use crate::store::StrokeKey;
 use crate::{Camera, DrawOnDocBehaviour, WidgetFlags};
 use kurbo::Shape;
@@ -140,6 +140,64 @@ impl PenBehaviour for Selector {
             PenEvent::Text { text } => self.handle_pen_event_text(text, now, engine_view),
             PenEvent::Cancel => self.handle_pen_event_cancel(now, engine_view),
         }
+    }
+
+    fn fetch_clipboard_content(
+        &self,
+        engine_view: &EngineView,
+    ) -> anyhow::Result<(Option<(Vec<u8>, String)>, WidgetFlags)> {
+        let widget_flags = WidgetFlags::default();
+
+        let selected_keys = if let SelectorState::ModifySelection { selection, .. } = &self.state {
+            Some(selection.clone())
+        } else {
+            None
+        };
+
+        if let Some(selected_keys) = selected_keys {
+            let clipboard_content = engine_view.store.fetch_native_clipboard(&selected_keys);
+
+            return Ok((
+                Some((
+                    serde_json::to_vec(&clipboard_content)?,
+                    RNOTE_NATIVE_CLIPBOARD_MIME_TYPE.to_string(),
+                )),
+                widget_flags,
+            ));
+        }
+
+        Ok((None, widget_flags))
+    }
+
+    fn cut_clipboard_content(
+        &mut self,
+        engine_view: &mut EngineViewMut,
+    ) -> anyhow::Result<(Option<(Vec<u8>, String)>, WidgetFlags)> {
+        let mut widget_flags = engine_view.store.record(Instant::now());
+
+        let selected_keys = if let SelectorState::ModifySelection { selection, .. } = &self.state {
+            Some(selection.clone())
+        } else {
+            None
+        };
+
+        if let Some(selected_keys) = selected_keys {
+            let clipboard_content = engine_view.store.cut_into_native_clipboard(&selected_keys);
+            widget_flags.store_modified = true;
+            widget_flags.redraw = true;
+
+            self.state = SelectorState::Idle;
+
+            return Ok((
+                Some((
+                    serde_json::to_vec(&clipboard_content)?,
+                    RNOTE_NATIVE_CLIPBOARD_MIME_TYPE.to_string(),
+                )),
+                widget_flags,
+            ));
+        }
+
+        Ok((None, widget_flags))
     }
 }
 

--- a/rnote-engine/src/pens/selector/penevents.rs
+++ b/rnote-engine/src/pens/selector/penevents.rs
@@ -488,7 +488,14 @@ impl Selector {
                     KeyboardKey::Unicode('d') => {
                         //Duplicate selection
                         if shortcut_keys.contains(&ShortcutKey::KeyboardCtrl) {
-                            engine_view.store.duplicate_selection();
+                            let duplicated = engine_view.store.duplicate_selection();
+                            engine_view.store.update_geometry_for_strokes(&duplicated);
+                            engine_view.store.regenerate_rendering_for_strokes_threaded(
+                                engine_view.tasks_tx.clone(),
+                                &duplicated,
+                                engine_view.camera.viewport(),
+                                engine_view.camera.image_scale(),
+                            );
                         }
                         PenProgress::Finished
                     }

--- a/rnote-engine/src/store/render_comp.rs
+++ b/rnote-engine/src/store/render_comp.rs
@@ -218,6 +218,23 @@ impl StrokeStore {
         }
     }
 
+    pub fn regenerate_rendering_for_strokes_threaded(
+        &mut self,
+        tasks_tx: EngineTaskSender,
+        keys: &[StrokeKey],
+        viewport: Aabb,
+        image_scale: f64,
+    ) {
+        for &key in keys {
+            self.regenerate_rendering_for_stroke_threaded(
+                tasks_tx.clone(),
+                key,
+                viewport,
+                image_scale,
+            );
+        }
+    }
+
     /// Regenerates the rendering of all keys for the given viewport that need rerendering
     pub fn regenerate_rendering_in_viewport_threaded(
         &mut self,

--- a/rnote-engine/src/store/selection_comp.rs
+++ b/rnote-engine/src/store/selection_comp.rs
@@ -1,3 +1,5 @@
+use crate::strokes::Stroke;
+
 use super::{StrokeKey, StrokeStore};
 
 use p2d::bounding_volume::Aabb;
@@ -18,8 +20,6 @@ impl Default for SelectionComponent {
 }
 
 impl SelectionComponent {
-    const SELECTION_DUPLICATION_OFFSET: na::Vector2<f64> = na::vector![20.0, 20.0];
-
     pub fn new(selected: bool) -> Self {
         Self { selected }
     }
@@ -120,10 +120,7 @@ impl StrokeStore {
             .collect::<Vec<StrokeKey>>();
 
         // Offsetting the new selected stroke to make the duplication apparent
-        self.translate_strokes(
-            &new_selected,
-            SelectionComponent::SELECTION_DUPLICATION_OFFSET,
-        );
+        self.translate_strokes(&new_selected, Stroke::IMPORT_OFFSET_DEFAULT);
 
         new_selected
     }

--- a/rnote-engine/src/store/stroke_comp.rs
+++ b/rnote-engine/src/store/stroke_comp.rs
@@ -611,12 +611,22 @@ impl StrokeStore {
         clipboard_content: NativeClipboardContent,
         pos: na::Vector2<f64>,
     ) -> Vec<StrokeKey> {
+        if clipboard_content.strokes.is_empty() {
+            return vec![];
+        }
+        let clipboard_bounds = clipboard_content
+            .strokes
+            .iter()
+            .fold(Aabb::new_invalid(), |acc, s| acc.merged(&s.bounds()));
+
         clipboard_content
             .strokes
             .into_iter()
             .map(|s| {
+                let offset = s.bounds().mins.coords - clipboard_bounds.mins.coords;
                 let key = self.insert_stroke((*s).clone(), None);
                 self.set_stroke_pos(key, pos);
+                self.translate_strokes(&[key], offset);
                 self.set_selected(key, true);
                 key
             })

--- a/rnote-engine/src/store/stroke_comp.rs
+++ b/rnote-engine/src/store/stroke_comp.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use super::render_comp::RenderCompState;
 use super::StrokeKey;
-use crate::engine::NativeClipboardContent;
+use crate::engine::StrokeContent;
 use crate::strokes::Stroke;
 use crate::{render, StrokeStore};
 
@@ -579,17 +579,17 @@ impl StrokeStore {
             .collect::<Vec<StrokeKey>>()
     }
 
-    pub fn fetch_native_clipboard(&self, keys: &[StrokeKey]) -> NativeClipboardContent {
+    pub fn fetch_stroke_content(&self, keys: &[StrokeKey]) -> StrokeContent {
         let strokes = keys
             .iter()
             .filter_map(|k| self.stroke_components.get(*k).map(Arc::clone))
             .collect();
 
-        NativeClipboardContent { strokes }
+        StrokeContent { strokes }
     }
 
     /// Cuts the strokes for the given keys (meaning: marking them as trashed) and returns them as clipboard content
-    pub fn cut_into_native_clipboard(&mut self, keys: &[StrokeKey]) -> NativeClipboardContent {
+    pub fn cut_stroke_content(&mut self, keys: &[StrokeKey]) -> StrokeContent {
         let strokes = keys
             .iter()
             .filter_map(|k| {
@@ -599,16 +599,16 @@ impl StrokeStore {
             })
             .collect();
 
-        NativeClipboardContent { strokes }
+        StrokeContent { strokes }
     }
 
     /// Pastes the clipboard content as a selection
     ///
     /// returns the keys for the inserted strokes.
     /// The inserted strokes then need to update their geometry and rendering.
-    pub fn paste_native_clipboard(
+    pub fn insert_stroke_content(
         &mut self,
-        clipboard_content: NativeClipboardContent,
+        clipboard_content: StrokeContent,
         pos: na::Vector2<f64>,
     ) -> Vec<StrokeKey> {
         if clipboard_content.strokes.is_empty() {

--- a/rnote-engine/src/store/stroke_comp.rs
+++ b/rnote-engine/src/store/stroke_comp.rs
@@ -588,7 +588,7 @@ impl StrokeStore {
         StrokeContent { strokes }
     }
 
-    /// Cuts the strokes for the given keys (meaning: marking them as trashed) and returns them as clipboard content
+    /// Cuts the strokes for the given keys (meaning: marking them as trashed) and returns them as stroke content
     pub fn cut_stroke_content(&mut self, keys: &[StrokeKey]) -> StrokeContent {
         let strokes = keys
             .iter()

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -15,6 +15,8 @@ use gtk4::{PrintStatus, Window};
 use std::path::PathBuf;
 use std::time::Instant;
 
+const CLIPBOARD_INPUT_STREAM_BUFSIZE: usize = 4096;
+
 impl RnAppWindow {
     /// Boolean actions have no target, and a boolean state. They have a default implementation for the activate signal, which requests the state to be inverted, and the default implementation for change_state, which sets the state to the request.
     /// We generally want to connect to the change_state signal. (but then have to set the state with action.set_state() )
@@ -779,7 +781,7 @@ impl RnAppWindow {
                         Ok((input_stream, _)) => {
                             let mut acc = Vec::new();
                             loop {
-                                match input_stream.read_future(vec![0; 4096], glib::PRIORITY_DEFAULT).await {
+                                match input_stream.read_future(vec![0; CLIPBOARD_INPUT_STREAM_BUFSIZE], glib::PRIORITY_DEFAULT).await {
                                     Ok((mut bytes, n)) => {
                                         if n == 0 {
                                             break;
@@ -818,7 +820,7 @@ impl RnAppWindow {
                         Ok((input_stream, _)) => {
                             let mut acc = Vec::new();
                             loop {
-                                match input_stream.read_future(vec![0; 4096], glib::PRIORITY_DEFAULT).await {
+                                match input_stream.read_future(vec![0; CLIPBOARD_INPUT_STREAM_BUFSIZE], glib::PRIORITY_DEFAULT).await {
                                     Ok((mut bytes, n)) => {
                                         if n == 0 {
                                             break;

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -812,7 +812,6 @@ impl RnAppWindow {
                         }
                     };
                 }));
-            // TODO: Fix the broken svg import
             } else if content_formats.contain_mime_type("image/svg+xml") {
                 glib::MainContext::default().spawn_local(clone!(@weak appwindow => async move {
                     log::debug!("recognized clipboard content: svg image");

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -5,7 +5,7 @@ use crate::{dialogs, RnCanvas};
 use piet::RenderContext;
 use rnote_compose::helpers::Vector2Helpers;
 use rnote_engine::document::Layout;
-use rnote_engine::engine::RNOTE_NATIVE_CLIPBOARD_MIME_TYPE;
+use rnote_engine::engine::RNOTE_STROKE_CONTENT_MIME_TYPE;
 use rnote_engine::pens::PenStyle;
 use rnote_engine::{render, Camera, DrawBehaviour, RnoteEngine};
 
@@ -774,10 +774,10 @@ impl RnAppWindow {
                         }
                     }
                 }));
-            } else if content_formats.contain_mime_type(RNOTE_NATIVE_CLIPBOARD_MIME_TYPE) {
+            } else if content_formats.contain_mime_type(RNOTE_STROKE_CONTENT_MIME_TYPE) {
                 glib::MainContext::default().spawn_local(clone!(@weak canvas, @weak appwindow => async move {
-                    log::debug!("recognized clipboard content format: {RNOTE_NATIVE_CLIPBOARD_MIME_TYPE}");
-                    match appwindow.clipboard().read_future(&[RNOTE_NATIVE_CLIPBOARD_MIME_TYPE], glib::PRIORITY_DEFAULT).await {
+                    log::debug!("recognized clipboard content format: {RNOTE_STROKE_CONTENT_MIME_TYPE}");
+                    match appwindow.clipboard().read_future(&[RNOTE_STROKE_CONTENT_MIME_TYPE], glib::PRIORITY_DEFAULT).await {
                         Ok((input_stream, _)) => {
                             let mut acc = Vec::new();
                             loop {
@@ -799,7 +799,7 @@ impl RnAppWindow {
                             if !acc.is_empty() {
                                 match crate::utils::str_from_u8_nul_utf8(&acc) {
                                     Ok(json_string) => {
-                                        if let Err(e) = canvas.paste_native_clipboard(json_string.to_string()).await {
+                                        if let Err(e) = canvas.insert_stroke_content(json_string.to_string()).await {
                                             log::error!("failed to paste clipboard, Err: {e:?}");
                                         }
                                     }
@@ -808,7 +808,7 @@ impl RnAppWindow {
                             }
                         }
                         Err(e) => {
-                            log::error!("failed to paste clipboard as {RNOTE_NATIVE_CLIPBOARD_MIME_TYPE}, read_future() failed with Err: {e:?}");
+                            log::error!("failed to paste clipboard as {RNOTE_STROKE_CONTENT_MIME_TYPE}, read_future() failed with Err: {e:?}");
                         }
                     };
                 }));

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -795,8 +795,13 @@ impl RnAppWindow {
                             }
 
                             if !acc.is_empty() {
-                                if let Err(e) = canvas.paste_native_clipboard(acc).await {
-                                    log::error!("failed to paste clipboard, Err: {e:?}");
+                                match crate::utils::str_from_u8_nul_utf8(&acc) {
+                                    Ok(json_string) => {
+                                        if let Err(e) = canvas.paste_native_clipboard(json_string.to_string()).await {
+                                            log::error!("failed to paste clipboard, Err: {e:?}");
+                                        }
+                                    }
+                                    Err(e) => log::error!("failed to read &str from clipboard data, Err: {e:?}"),
                                 }
                             }
                         }
@@ -829,15 +834,13 @@ impl RnAppWindow {
                             }
 
                             if !acc.is_empty() {
-                                match String::from_utf8(acc) {
+                                match crate::utils::str_from_u8_nul_utf8(&acc) {
                                     Ok(text) => {
                                         if let Err(e) = canvas.load_in_vectorimage_bytes(text.as_bytes().to_vec(), None).await {
                                             log::error!("failed to paste clipboard as vector image, load_in_vectorimage_bytes() returned Err: {e:?}");
                                         };
                                     }
-                                    Err(e) => {
-                                        log::error!("failed to paste clipboard, Err: {e:?}");
-                                    }
+                                    Err(e) => log::error!("failed to read &str from clipboard data, Err: {e:?}"),
                                 }
                             }
                         }

--- a/rnote-ui/src/canvas/imexport.rs
+++ b/rnote-ui/src/canvas/imexport.rs
@@ -175,15 +175,13 @@ impl RnCanvas {
         Ok(())
     }
 
-    pub(crate) async fn paste_native_clipboard(&self, bytes: Vec<u8>) -> anyhow::Result<()> {
+    pub(crate) async fn paste_native_clipboard(&self, json_string: String) -> anyhow::Result<()> {
         let (oneshot_sender, oneshot_receiver) =
             oneshot::channel::<anyhow::Result<NativeClipboardContent>>();
 
         rayon::spawn(move || {
             let result = || -> Result<NativeClipboardContent, anyhow::Error> {
-                let text = String::from_utf8(bytes)?;
-                //log::debug!("\"\n{text}\n\"");
-                Ok(serde_json::from_str(&text)?)
+                Ok(serde_json::from_str(&json_string)?)
             };
             if let Err(_data) = oneshot_sender.send(result()) {
                 log::error!("sending result to receiver in paste_native_clipboard() failed. Receiver already dropped.");

--- a/rnote-ui/src/canvas/imexport.rs
+++ b/rnote-ui/src/canvas/imexport.rs
@@ -188,11 +188,14 @@ impl RnCanvas {
             }
         });
         let content = oneshot_receiver.await??;
+        let pos = (self.engine().borrow().camera.transform().inverse()
+            * na::Point2::from(Stroke::IMPORT_OFFSET_DEFAULT))
+        .coords;
 
         let widget_flags = self
             .engine()
             .borrow_mut()
-            .paste_native_clipboard_content(content);
+            .paste_native_clipboard_content(content, pos);
 
         self.emit_handle_widget_flags(widget_flags);
         Ok(())

--- a/rnote-ui/src/utils.rs
+++ b/rnote-ui/src/utils.rs
@@ -153,3 +153,11 @@ pub(crate) async fn create_replace_file_future(
 
     Ok(())
 }
+
+pub(crate) fn str_from_u8_nul_utf8(utf8_src: &[u8]) -> Result<&str, std::str::Utf8Error> {
+    let nul_range_end = utf8_src
+        .iter()
+        .position(|&c| c == b'\0')
+        .unwrap_or(utf8_src.len()); // default to length if no `\0` present
+    std::str::from_utf8(&utf8_src[0..nul_range_end])
+}


### PR DESCRIPTION
This implements copy & pasting with the rnote-native json based format. For this a new mime-type `application/rnote-stroke-content` is introduced.

While implementing this I was able to fix the Svg clipboard import as well, copy & pasting from e.g. Inkscape now works as expected.

fixes #383 when merged.