### PR TITLE
Pointer event controller

### DIFF
--- a/rnote-compose/src/builders/cubbezbuilder.rs
+++ b/rnote-compose/src/builders/cubbezbuilder.rs
@@ -80,7 +80,7 @@ impl ShapeBuilderBehaviour for CubBezBuilder {
             (CubBezBuilderState::Cp1 { start, .. }, PenEvent::Up { element, .. }) => {
                 self.state = CubBezBuilderState::Cp1Finished {
                     start: *start,
-                    cp1: element.pos,
+                    cp1: constraints.constrain(element.pos - *start) + *start,
                 };
             }
             (CubBezBuilderState::Cp1 { .. }, ..) => {}

--- a/rnote-compose/src/builders/fociellipsebuilder.rs
+++ b/rnote-compose/src/builders/fociellipsebuilder.rs
@@ -72,20 +72,28 @@ impl ShapeBuilderBehaviour for FociEllipseBuilder {
             }
             (FociEllipseBuilderState::StartFinished(_), _) => {}
             (FociEllipseBuilderState::Foci(foci), PenEvent::Down { element, .. }) => {
-                // we want to allow horizontal and vertical constraints while setting the second foci
                 constraints.ratios.insert(ConstraintRatio::Horizontal);
                 constraints.ratios.insert(ConstraintRatio::Vertical);
 
                 foci[1] = constraints.constrain(element.pos - foci[0]) + foci[0];
             }
             (FociEllipseBuilderState::Foci(foci), PenEvent::Up { element, .. }) => {
-                self.state = FociEllipseBuilderState::FociFinished([foci[0], element.pos]);
+                constraints.ratios.insert(ConstraintRatio::Horizontal);
+                constraints.ratios.insert(ConstraintRatio::Vertical);
+
+                self.state = FociEllipseBuilderState::FociFinished([
+                    foci[0],
+                    constraints.constrain(element.pos - foci[0]) + foci[0],
+                ]);
             }
             (FociEllipseBuilderState::Foci(_), _) => {}
             (FociEllipseBuilderState::FociFinished(foci), PenEvent::Down { element, .. }) => {
+                constraints.ratios.insert(ConstraintRatio::Horizontal);
+                constraints.ratios.insert(ConstraintRatio::Vertical);
+
                 self.state = FociEllipseBuilderState::FociAndPoint {
                     foci: *foci,
-                    point: element.pos,
+                    point: constraints.constrain(element.pos - foci[1]) + foci[1],
                 };
             }
             (FociEllipseBuilderState::FociFinished(_), _) => {}

--- a/rnote-compose/src/builders/fociellipsebuilder.rs
+++ b/rnote-compose/src/builders/fociellipsebuilder.rs
@@ -18,15 +18,12 @@ use crate::Constraints;
 #[derive(Debug, Clone)]
 /// The foci ellipse builder state
 pub enum FociEllipseBuilderState {
-    /// first
-    First(na::Vector2<f64>),
-    /// foci
+    Start(na::Vector2<f64>),
+    StartFinished(na::Vector2<f64>),
     Foci([na::Vector2<f64>; 2]),
-    /// foci and point
+    FociFinished([na::Vector2<f64>; 2]),
     FociAndPoint {
-        /// The foci
         foci: [na::Vector2<f64>; 2],
-        /// the point
         point: na::Vector2<f64>,
     },
 }
@@ -41,7 +38,7 @@ pub struct FociEllipseBuilder {
 impl ShapeBuilderCreator for FociEllipseBuilder {
     fn start(element: Element, _now: Instant) -> Self {
         Self {
-            state: FociEllipseBuilderState::First(element.pos),
+            state: FociEllipseBuilderState::Start(element.pos),
         }
     }
 }
@@ -56,13 +53,24 @@ impl ShapeBuilderBehaviour for FociEllipseBuilder {
         //log::debug!("state: {:?}, event: {:?}", &self.state, &event);
 
         match (&mut self.state, event) {
-            (FociEllipseBuilderState::First(first), PenEvent::Down { element, .. }) => {
+            (FociEllipseBuilderState::Start(first), PenEvent::Down { element, .. }) => {
                 *first = element.pos;
             }
-            (FociEllipseBuilderState::First(first), PenEvent::Up { element, .. }) => {
-                self.state = FociEllipseBuilderState::Foci([*first, element.pos])
+            (FociEllipseBuilderState::Start(_), PenEvent::Up { element, .. }) => {
+                self.state = FociEllipseBuilderState::StartFinished(element.pos);
             }
-            (FociEllipseBuilderState::First(_), _) => {}
+            (FociEllipseBuilderState::Start(_), _) => {}
+            (FociEllipseBuilderState::StartFinished(first), PenEvent::Down { element, .. }) => {
+                // we want to allow horizontal and vertical constraints while setting the second foci
+                constraints.ratios.insert(ConstraintRatio::Horizontal);
+                constraints.ratios.insert(ConstraintRatio::Vertical);
+
+                self.state = FociEllipseBuilderState::Foci([
+                    *first,
+                    constraints.constrain(element.pos - *first) + *first,
+                ]);
+            }
+            (FociEllipseBuilderState::StartFinished(_), _) => {}
             (FociEllipseBuilderState::Foci(foci), PenEvent::Down { element, .. }) => {
                 // we want to allow horizontal and vertical constraints while setting the second foci
                 constraints.ratios.insert(ConstraintRatio::Horizontal);
@@ -71,12 +79,16 @@ impl ShapeBuilderBehaviour for FociEllipseBuilder {
                 foci[1] = constraints.constrain(element.pos - foci[0]) + foci[0];
             }
             (FociEllipseBuilderState::Foci(foci), PenEvent::Up { element, .. }) => {
+                self.state = FociEllipseBuilderState::FociFinished([foci[0], element.pos]);
+            }
+            (FociEllipseBuilderState::Foci(_), _) => {}
+            (FociEllipseBuilderState::FociFinished(foci), PenEvent::Down { element, .. }) => {
                 self.state = FociEllipseBuilderState::FociAndPoint {
                     foci: *foci,
                     point: element.pos,
                 };
             }
-            (FociEllipseBuilderState::Foci(_), _) => {}
+            (FociEllipseBuilderState::FociFinished(_), _) => {}
             (
                 FociEllipseBuilderState::FociAndPoint { foci: _, point },
                 PenEvent::Down { element, .. },
@@ -98,14 +110,17 @@ impl ShapeBuilderBehaviour for FociEllipseBuilder {
         let stroke_width = style.stroke_width();
 
         match &self.state {
-            FociEllipseBuilderState::First(point) => Some(Aabb::from_half_extents(
-                na::Point2::from(*point),
+            FociEllipseBuilderState::Start(first)
+            | FociEllipseBuilderState::StartFinished(first) => Some(Aabb::from_half_extents(
+                na::Point2::from(*first),
                 na::Vector2::repeat(stroke_width.max(indicators::POS_INDICATOR_RADIUS) / zoom),
             )),
-            FociEllipseBuilderState::Foci(foci) => Some(
-                Aabb::new_positive(na::Point2::from(foci[0]), na::Point2::from(foci[1]))
-                    .loosened(stroke_width.max(indicators::POS_INDICATOR_RADIUS) / zoom),
-            ),
+            FociEllipseBuilderState::Foci(foci) | FociEllipseBuilderState::FociFinished(foci) => {
+                Some(
+                    Aabb::new_positive(na::Point2::from(foci[0]), na::Point2::from(foci[1]))
+                        .loosened(stroke_width.max(indicators::POS_INDICATOR_RADIUS) / zoom),
+                )
+            }
             FociEllipseBuilderState::FociAndPoint { foci, point } => {
                 let ellipse = Ellipse::from_foci_and_point(*foci, *point);
 
@@ -121,16 +136,16 @@ impl ShapeBuilderBehaviour for FociEllipseBuilder {
     fn draw_styled(&self, cx: &mut piet_cairo::CairoRenderContext, style: &Style, zoom: f64) {
         cx.save().unwrap();
         match &self.state {
-            FociEllipseBuilderState::First(point) => {
-                indicators::draw_pos_indicator(cx, PenState::Down, *point, zoom);
+            FociEllipseBuilderState::Start(first)
+            | FociEllipseBuilderState::StartFinished(first) => {
+                indicators::draw_pos_indicator(cx, PenState::Down, *first, zoom);
             }
-            FociEllipseBuilderState::Foci(foci) => {
+            FociEllipseBuilderState::Foci(foci) | FociEllipseBuilderState::FociFinished(foci) => {
                 indicators::draw_pos_indicator(cx, PenState::Up, foci[0], zoom);
                 indicators::draw_pos_indicator(cx, PenState::Down, foci[1], zoom);
             }
             FociEllipseBuilderState::FociAndPoint { foci, point } => {
                 let ellipse = Ellipse::from_foci_and_point(*foci, *point);
-
                 ellipse.draw_composed(cx, style);
 
                 indicators::draw_vec_indicator(cx, PenState::Down, foci[0], *point, zoom);

--- a/rnote-compose/src/penevents.rs
+++ b/rnote-compose/src/penevents.rs
@@ -10,29 +10,29 @@ pub enum PenEvent {
     Down {
         /// The element for the down event
         element: Element,
-        /// pressed shortcut keys pressed during the down event
-        shortcut_keys: Vec<ShortcutKey>,
+        /// pressed modifier keys pressed during the down event
+        modifier_keys: Vec<ModifierKey>,
     },
     /// A pen up event.
     Up {
         /// The element for the up event
         element: Element,
-        /// pressed shortcut keys pressed during the up event
-        shortcut_keys: Vec<ShortcutKey>,
+        /// pressed modifier keys pressed during the up event
+        modifier_keys: Vec<ModifierKey>,
     },
     /// A pen down event. Is repeatedly emitted while the pen is in proximity and moved
     Proximity {
         /// The element for the proximity event
         element: Element,
-        /// pressed shortcut keys during the proximity event
-        shortcut_keys: Vec<ShortcutKey>,
+        /// pressed modifier keys pressed during the proximity event
+        modifier_keys: Vec<ModifierKey>,
     },
     /// A keyboard key pressed event
     KeyPressed {
         /// the key
         keyboard_key: KeyboardKey,
-        /// pressed shortcut keys during the keyboard key event
-        shortcut_keys: Vec<ShortcutKey>,
+        /// pressed modifier keys pressed during the key event
+        modifier_keys: Vec<ModifierKey>,
     },
     /// Text input
     Text {
@@ -121,6 +121,12 @@ pub enum ShortcutKey {
     /// Touch two finger long press gesture
     #[serde(rename = "touch_two_finger_long_press")]
     TouchTwoFingerLongPress,
+}
+
+/// A modifier key
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename = "modifier_key")]
+pub enum ModifierKey {
     /// Shift
     #[serde(rename = "keyboard_shift")]
     KeyboardShift,

--- a/rnote-compose/src/penpath/element.rs
+++ b/rnote-compose/src/penpath/element.rs
@@ -1,5 +1,3 @@
-use std::collections::VecDeque;
-
 use p2d::bounding_volume::Aabb;
 use serde::{Deserialize, Serialize};
 
@@ -65,12 +63,5 @@ impl Element {
     /// Transforms the element position by the transform
     pub fn transform_by(&mut self, transform: na::Affine2<f64>) {
         self.pos = (transform * na::Point2::from(self.pos)).coords;
-    }
-
-    /// transform pen input data entries
-    pub fn transform_elements(els: &mut VecDeque<Self>, transform: na::Affine2<f64>) {
-        els.iter_mut().for_each(|element| {
-            element.transform_by(transform);
-        });
     }
 }

--- a/rnote-compose/src/style/indicators.rs
+++ b/rnote-compose/src/style/indicators.rs
@@ -116,16 +116,19 @@ pub fn draw_rectangular_node(
     zoom: f64,
 ) {
     static OUTLINE_COLOR: Lazy<piet::Color> = Lazy::new(|| color::GNOME_BLUES[4]);
-    static FILL_COLOR_STATE_DOWN: Lazy<piet::Color> =
-        Lazy::new(|| color::GNOME_BLUES[0].with_alpha(0.5));
+    static FILL_STATE_PROXIMITY: Lazy<piet::Color> =
+        Lazy::new(|| color::GNOME_BLUES[0].with_alpha(0.3));
+    static FILL_STATE_DOWN: Lazy<piet::Color> = Lazy::new(|| color::GNOME_BLUES[2].with_alpha(0.5));
 
     let rectangular_node = rectangular_node_shape(node_state, bounds, zoom);
 
     match node_state {
         PenState::Up => {}
-        PenState::Proximity => {}
+        PenState::Proximity => {
+            cx.fill(rectangular_node, &*FILL_STATE_PROXIMITY);
+        }
         PenState::Down => {
-            cx.fill(rectangular_node, &*FILL_COLOR_STATE_DOWN);
+            cx.fill(rectangular_node, &*FILL_STATE_DOWN);
         }
     }
 
@@ -163,7 +166,9 @@ pub fn draw_circular_node(
     zoom: f64,
 ) {
     static OUTLINE_COLOR: Lazy<piet::Color> = Lazy::new(|| color::GNOME_BLUES[4]);
-    static FILL_STATE_DOWN: Lazy<piet::Color> = Lazy::new(|| color::GNOME_BLUES[0].with_alpha(0.5));
+    static FILL_STATE_PROXIMITY: Lazy<piet::Color> =
+        Lazy::new(|| color::GNOME_BLUES[0].with_alpha(0.3));
+    static FILL_STATE_DOWN: Lazy<piet::Color> = Lazy::new(|| color::GNOME_BLUES[2].with_alpha(0.5));
 
     let circular_node = circular_node_shape(node_state, bounding_sphere, zoom);
 
@@ -175,7 +180,9 @@ pub fn draw_circular_node(
 
     match node_state {
         PenState::Up => {}
-        PenState::Proximity => {}
+        PenState::Proximity => {
+            cx.fill(circular_node, &*FILL_STATE_PROXIMITY);
+        }
         PenState::Down => {
             cx.fill(circular_node, &*FILL_STATE_DOWN);
         }
@@ -224,6 +231,8 @@ pub fn draw_triangular_down_node(
     zoom: f64,
 ) {
     static OUTLINE_COLOR: Lazy<piet::Color> = Lazy::new(|| color::GNOME_ORANGES[4]);
+    static FILL_STATE_PROXIMITY: Lazy<piet::Color> =
+        Lazy::new(|| color::GNOME_ORANGES[0].with_alpha(0.3));
     static FILL_STATE_DOWN: Lazy<piet::Color> =
         Lazy::new(|| color::GNOME_ORANGES[3].with_alpha(0.5));
 
@@ -237,7 +246,9 @@ pub fn draw_triangular_down_node(
 
     match node_state {
         PenState::Up => {}
-        PenState::Proximity => {}
+        PenState::Proximity => {
+            cx.fill(triangular_down_node, &*FILL_STATE_PROXIMITY);
+        }
         PenState::Down => {
             cx.fill(triangular_down_node, &*FILL_STATE_DOWN);
         }

--- a/rnote-engine/src/engine/mod.rs
+++ b/rnote-engine/src/engine/mod.rs
@@ -621,7 +621,7 @@ impl RnoteEngine {
     }
 
     /// Handle a pressed shortcut key
-    pub fn handle_pen_pressed_shortcut_key(
+    pub fn handle_pressed_shortcut_key(
         &mut self,
         shortcut_key: ShortcutKey,
         now: Instant,

--- a/rnote-engine/src/pens/brush.rs
+++ b/rnote-engine/src/pens/brush.rs
@@ -60,13 +60,7 @@ impl PenBehaviour for Brush {
         let mut widget_flags = WidgetFlags::default();
 
         let pen_progress = match (&mut self.state, event) {
-            (
-                BrushState::Idle,
-                PenEvent::Down {
-                    element,
-                    shortcut_keys: _,
-                },
-            ) => {
+            (BrushState::Idle, PenEvent::Down { element, .. }) => {
                 if !element
                     .filter_by_bounds(engine_view.doc.bounds().loosened(Self::INPUT_OVERSHOOT))
                 {

--- a/rnote-engine/src/pens/eraser.rs
+++ b/rnote-engine/src/pens/eraser.rs
@@ -52,13 +52,7 @@ impl PenBehaviour for Eraser {
         let mut widget_flags = WidgetFlags::default();
 
         let pen_progress = match (&mut self.state, event) {
-            (
-                EraserState::Up | EraserState::Proximity { .. },
-                PenEvent::Down {
-                    element,
-                    shortcut_keys: _,
-                },
-            ) => {
+            (EraserState::Up | EraserState::Proximity { .. }, PenEvent::Down { element, .. }) => {
                 widget_flags.merge(engine_view.store.record(Instant::now()));
 
                 match &engine_view.pens_config.eraser_config.style {

--- a/rnote-engine/src/pens/penholder.rs
+++ b/rnote-engine/src/pens/penholder.rs
@@ -180,13 +180,6 @@ impl PenHolder {
         now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> WidgetFlags {
-        let mut widget_flags = WidgetFlags::default();
-        widget_flags.redraw = true;
-
-        if let Some(pen_mode) = pen_mode {
-            widget_flags.merge(self.change_pen_mode(pen_mode, engine_view));
-        }
-
         /*
                log::debug!(
                    "handle_pen_event(), event: {:?}, pen_mode_state: {:?}",
@@ -194,27 +187,14 @@ impl PenHolder {
                    self.pen_mode_state,
                );
         */
+        let mut widget_flags = WidgetFlags::default();
+        widget_flags.redraw = true;
 
-        // First we handle certain pointer shortcut keys
-        // TODO: handle this better
-        match &event {
-            PenEvent::Down { shortcut_keys, .. }
-            | PenEvent::Up { shortcut_keys, .. }
-            | PenEvent::Proximity { shortcut_keys, .. } => {
-                if shortcut_keys.contains(&ShortcutKey::MouseSecondaryButton) {
-                    widget_flags.merge(self.handle_pressed_shortcut_key(
-                        ShortcutKey::MouseSecondaryButton,
-                        now,
-                        engine_view,
-                    ));
-                }
-            }
-            PenEvent::KeyPressed { .. } => {}
-            PenEvent::Text { .. } => {}
-            PenEvent::Cancel => {}
+        if let Some(pen_mode) = pen_mode {
+            widget_flags.merge(self.change_pen_mode(pen_mode, engine_view));
         }
 
-        // Handle the events with the current pen
+        // Handle the event with the current pen
         let (pen_progress, other_widget_flags) =
             self.current_pen.handle_event(event, now, engine_view);
 

--- a/rnote-engine/src/pens/selector/mod.rs
+++ b/rnote-engine/src/pens/selector/mod.rs
@@ -13,7 +13,7 @@ use once_cell::sync::Lazy;
 use p2d::query::PointQuery;
 use piet::RenderContext;
 use rnote_compose::helpers::{AabbHelpers, Vector2Helpers};
-use rnote_compose::penevents::{PenEvent, PenState, ShortcutKey};
+use rnote_compose::penevents::{ModifierKey, PenEvent, PenState};
 use rnote_compose::penpath::Element;
 use rnote_compose::shapes::ShapeBehaviour;
 use rnote_compose::style::indicators;
@@ -125,20 +125,20 @@ impl PenBehaviour for Selector {
         match event {
             PenEvent::Down {
                 element,
-                shortcut_keys,
-            } => self.handle_pen_event_down(element, shortcut_keys, now, engine_view),
+                modifier_keys,
+            } => self.handle_pen_event_down(element, modifier_keys, now, engine_view),
             PenEvent::Up {
                 element,
-                shortcut_keys,
-            } => self.handle_pen_event_up(element, shortcut_keys, now, engine_view),
+                modifier_keys,
+            } => self.handle_pen_event_up(element, modifier_keys, now, engine_view),
             PenEvent::Proximity {
                 element,
-                shortcut_keys,
-            } => self.handle_pen_event_proximity(element, shortcut_keys, now, engine_view),
+                modifier_keys,
+            } => self.handle_pen_event_proximity(element, modifier_keys, now, engine_view),
             PenEvent::KeyPressed {
                 keyboard_key,
-                shortcut_keys,
-            } => self.handle_pen_event_keypressed(keyboard_key, shortcut_keys, now, engine_view),
+                modifier_keys,
+            } => self.handle_pen_event_keypressed(keyboard_key, modifier_keys, now, engine_view),
             PenEvent::Text { text } => self.handle_pen_event_text(text, now, engine_view),
             PenEvent::Cancel => self.handle_pen_event_cancel(now, engine_view),
         }
@@ -700,11 +700,11 @@ impl Selector {
 
     fn select_all(
         &mut self,
-        shortcut_keys: Vec<ShortcutKey>,
+        modifier_keys: Vec<ModifierKey>,
         engine_view: &mut EngineViewMut,
         widget_flags: &mut WidgetFlags,
     ) -> PenProgress {
-        if shortcut_keys.contains(&ShortcutKey::KeyboardCtrl) {
+        if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
             // Select all keys
             let all_strokes = engine_view.store.keys_sorted_chrono();
 

--- a/rnote-engine/src/pens/selector/mod.rs
+++ b/rnote-engine/src/pens/selector/mod.rs
@@ -10,6 +10,7 @@ use crate::store::StrokeKey;
 use crate::{Camera, DrawOnDocBehaviour, WidgetFlags};
 use kurbo::Shape;
 use once_cell::sync::Lazy;
+use p2d::query::PointQuery;
 use piet::RenderContext;
 use rnote_compose::helpers::{AabbHelpers, Vector2Helpers};
 use rnote_compose::penevents::{PenEvent, PenState, ShortcutKey};
@@ -31,6 +32,7 @@ pub(super) enum ResizeCorner {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(super) enum ModifyState {
     Up,
+    Hover(na::Vector2<f64>),
     Translate {
         start_pos: na::Vector2<f64>,
         current_pos: na::Vector2<f64>,
@@ -466,51 +468,86 @@ impl Selector {
         piet_cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         let total_zoom = camera.total_zoom();
 
+        let rotate_node_sphere = Self::rotate_node_sphere(selection_bounds, camera);
         let rotate_node_state = match modify_state {
             ModifyState::Rotate { .. } => PenState::Down,
+            ModifyState::Hover(pos) => {
+                if rotate_node_sphere.contains_local_point(&na::Point2::from(*pos)) {
+                    PenState::Proximity
+                } else {
+                    PenState::Up
+                }
+            }
             _ => PenState::Up,
         };
-        let rotate_node_sphere = Self::rotate_node_sphere(selection_bounds, camera);
 
+        let resize_tl_node_bounds =
+            Self::resize_node_bounds(ResizeCorner::TopLeft, selection_bounds, camera);
         let resize_tl_node_state = match modify_state {
             ModifyState::Resize {
                 from_corner: ResizeCorner::TopLeft,
                 ..
             } => PenState::Down,
+            ModifyState::Hover(pos) => {
+                if resize_tl_node_bounds.contains_local_point(&na::Point2::from(*pos)) {
+                    PenState::Proximity
+                } else {
+                    PenState::Up
+                }
+            }
             _ => PenState::Up,
         };
-        let resize_tl_node_bounds =
-            Self::resize_node_bounds(ResizeCorner::TopLeft, selection_bounds, camera);
 
+        let resize_tr_node_bounds =
+            Self::resize_node_bounds(ResizeCorner::TopRight, selection_bounds, camera);
         let resize_tr_node_state = match modify_state {
             ModifyState::Resize {
                 from_corner: ResizeCorner::TopRight,
                 ..
             } => PenState::Down,
+            ModifyState::Hover(pos) => {
+                if resize_tr_node_bounds.contains_local_point(&na::Point2::from(*pos)) {
+                    PenState::Proximity
+                } else {
+                    PenState::Up
+                }
+            }
             _ => PenState::Up,
         };
-        let resize_tr_node_bounds =
-            Self::resize_node_bounds(ResizeCorner::TopRight, selection_bounds, camera);
 
+        let resize_bl_node_bounds =
+            Self::resize_node_bounds(ResizeCorner::BottomLeft, selection_bounds, camera);
         let resize_bl_node_state = match modify_state {
             ModifyState::Resize {
                 from_corner: ResizeCorner::BottomLeft,
                 ..
             } => PenState::Down,
+            ModifyState::Hover(pos) => {
+                if resize_bl_node_bounds.contains_local_point(&na::Point2::from(*pos)) {
+                    PenState::Proximity
+                } else {
+                    PenState::Up
+                }
+            }
             _ => PenState::Up,
         };
-        let resize_bl_node_bounds =
-            Self::resize_node_bounds(ResizeCorner::BottomLeft, selection_bounds, camera);
 
+        let resize_br_node_bounds =
+            Self::resize_node_bounds(ResizeCorner::BottomRight, selection_bounds, camera);
         let resize_br_node_state = match modify_state {
             ModifyState::Resize {
                 from_corner: ResizeCorner::BottomRight,
                 ..
             } => PenState::Down,
+            ModifyState::Hover(pos) => {
+                if resize_br_node_bounds.contains_local_point(&na::Point2::from(*pos)) {
+                    PenState::Proximity
+                } else {
+                    PenState::Up
+                }
+            }
             _ => PenState::Up,
         };
-        let resize_br_node_bounds =
-            Self::resize_node_bounds(ResizeCorner::BottomRight, selection_bounds, camera);
 
         // Selection rect
         let selection_rect = selection_bounds.to_kurbo_rect();

--- a/rnote-engine/src/pens/selector/penevents.rs
+++ b/rnote-engine/src/pens/selector/penevents.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use p2d::bounding_volume::Aabb;
 use p2d::query::PointQuery;
 use rnote_compose::helpers::{AabbHelpers, Vector2Helpers};
-use rnote_compose::penevents::{KeyboardKey, ShortcutKey};
+use rnote_compose::penevents::{KeyboardKey, ModifierKey};
 use rnote_compose::penpath::Element;
 
 use crate::engine::EngineViewMut;
@@ -17,7 +17,7 @@ impl Selector {
     pub(super) fn handle_pen_event_down(
         &mut self,
         element: Element,
-        shortcut_keys: Vec<ShortcutKey>,
+        modifier_keys: Vec<ModifierKey>,
         _now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
@@ -72,7 +72,7 @@ impl Selector {
                         let key_to_add = keys.last();
 
                         if (engine_view.pens_config.selector_config.style == SelectorStyle::Single
-                            || shortcut_keys.contains(&ShortcutKey::KeyboardShift))
+                            || modifier_keys.contains(&ModifierKey::KeyboardShift))
                             && key_to_add
                                 .and_then(|&key| engine_view.store.selected(key).map(|s| !s))
                                 .unwrap_or(false)
@@ -255,7 +255,7 @@ impl Selector {
                             .pens_config
                             .selector_config
                             .resize_lock_aspectratio
-                            || shortcut_keys.contains(&ShortcutKey::KeyboardCtrl)
+                            || modifier_keys.contains(&ModifierKey::KeyboardCtrl)
                         {
                             // Lock aspectratio
                             rnote_compose::helpers::scale_w_locked_aspectratio(
@@ -296,7 +296,7 @@ impl Selector {
     pub(super) fn handle_pen_event_up(
         &mut self,
         element: Element,
-        _shortcut_keys: Vec<ShortcutKey>,
+        _modifier_keys: Vec<ModifierKey>,
         _now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
@@ -452,7 +452,7 @@ impl Selector {
     pub(super) fn handle_pen_event_proximity(
         &mut self,
         element: Element,
-        _shortcut_keys: Vec<ShortcutKey>,
+        _modifier_keys: Vec<ModifierKey>,
         _now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
@@ -481,7 +481,7 @@ impl Selector {
     pub(super) fn handle_pen_event_keypressed(
         &mut self,
         keyboard_key: KeyboardKey,
-        shortcut_keys: Vec<ShortcutKey>,
+        modifier_keys: Vec<ModifierKey>,
         _now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
@@ -490,24 +490,24 @@ impl Selector {
         let progress = match &mut self.state {
             SelectorState::Idle => match keyboard_key {
                 KeyboardKey::Unicode('a') => {
-                    self.select_all(shortcut_keys, engine_view, &mut widget_flags)
+                    self.select_all(modifier_keys, engine_view, &mut widget_flags)
                 }
                 _ => PenProgress::InProgress,
             },
             SelectorState::Selecting { .. } => match keyboard_key {
                 KeyboardKey::Unicode('a') => {
-                    self.select_all(shortcut_keys, engine_view, &mut widget_flags)
+                    self.select_all(modifier_keys, engine_view, &mut widget_flags)
                 }
                 _ => PenProgress::InProgress,
             },
             SelectorState::ModifySelection { selection, .. } => {
                 match keyboard_key {
                     KeyboardKey::Unicode('a') => {
-                        self.select_all(shortcut_keys, engine_view, &mut widget_flags)
+                        self.select_all(modifier_keys, engine_view, &mut widget_flags)
                     }
                     KeyboardKey::Unicode('d') => {
                         //Duplicate selection
-                        if shortcut_keys.contains(&ShortcutKey::KeyboardCtrl) {
+                        if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
                             let duplicated = engine_view.store.duplicate_selection();
                             engine_view.store.update_geometry_for_strokes(&duplicated);
                             engine_view.store.regenerate_rendering_for_strokes_threaded(

--- a/rnote-engine/src/pens/shaper.rs
+++ b/rnote-engine/src/pens/shaper.rs
@@ -105,7 +105,7 @@ impl PenBehaviour for Shaper {
                         PenProgress::InProgress
                     }
                     ShapeBuilderProgress::EmitContinue(shapes) => {
-                        let mut drawstyle = engine_view
+                        let mut style = engine_view
                             .pens_config
                             .shaper_config
                             .gen_style_for_current_options();
@@ -113,15 +113,16 @@ impl PenBehaviour for Shaper {
                         if !shapes.is_empty() {
                             // Only record if new shapes actually were emitted
                             widget_flags.merge(engine_view.store.record(Instant::now()));
+                            widget_flags.store_modified = true;
                         }
 
                         for shape in shapes {
                             let key = engine_view.store.insert_stroke(
-                                Stroke::ShapeStroke(ShapeStroke::new(shape, drawstyle.clone())),
+                                Stroke::ShapeStroke(ShapeStroke::new(shape, style.clone())),
                                 None,
                             );
 
-                            drawstyle.advance_seed();
+                            style.advance_seed();
 
                             engine_view.store.regenerate_rendering_for_stroke(
                                 key,
@@ -131,12 +132,11 @@ impl PenBehaviour for Shaper {
                         }
 
                         widget_flags.redraw = true;
-                        widget_flags.store_modified = true;
 
                         PenProgress::InProgress
                     }
                     ShapeBuilderProgress::Finished(shapes) => {
-                        let mut drawstyle = engine_view
+                        let mut style = engine_view
                             .pens_config
                             .shaper_config
                             .gen_style_for_current_options();
@@ -144,24 +144,20 @@ impl PenBehaviour for Shaper {
                         if !shapes.is_empty() {
                             // Only record if new shapes actually were emitted
                             widget_flags.merge(engine_view.store.record(Instant::now()));
-                        }
-
-                        if !shapes.is_empty() {
                             engine_view
                                 .doc
                                 .resize_autoexpand(engine_view.store, engine_view.camera);
-
                             widget_flags.resize = true;
                             widget_flags.store_modified = true;
                         }
 
                         for shape in shapes {
                             let key = engine_view.store.insert_stroke(
-                                Stroke::ShapeStroke(ShapeStroke::new(shape, drawstyle.clone())),
+                                Stroke::ShapeStroke(ShapeStroke::new(shape, style.clone())),
                                 None,
                             );
 
-                            drawstyle.advance_seed();
+                            style.advance_seed();
 
                             engine_view.store.regenerate_rendering_for_stroke(
                                 key,

--- a/rnote-engine/src/pens/shaper.rs
+++ b/rnote-engine/src/pens/shaper.rs
@@ -16,7 +16,7 @@ use rnote_compose::builders::{
 };
 use rnote_compose::builders::{CubBezBuilder, QuadBezBuilder, ShapeBuilderType};
 use rnote_compose::builders::{ShapeBuilderCreator, ShapeBuilderProgress};
-use rnote_compose::penevents::{KeyboardKey, PenEvent, ShortcutKey};
+use rnote_compose::penevents::{KeyboardKey, ModifierKey, PenEvent};
 use rnote_compose::penpath::Element;
 
 #[derive(Debug)]
@@ -84,17 +84,17 @@ impl PenBehaviour for Shaper {
                 let mut constraints = engine_view.pens_config.shaper_config.constraints.clone();
                 constraints.enabled = match event {
                     PenEvent::Down {
-                        ref shortcut_keys, ..
+                        ref modifier_keys, ..
                     }
                     | PenEvent::Up {
-                        ref shortcut_keys, ..
+                        ref modifier_keys, ..
                     }
                     | PenEvent::Proximity {
-                        ref shortcut_keys, ..
+                        ref modifier_keys, ..
                     }
                     | PenEvent::KeyPressed {
-                        ref shortcut_keys, ..
-                    } => constraints.enabled ^ shortcut_keys.contains(&ShortcutKey::KeyboardCtrl),
+                        ref modifier_keys, ..
+                    } => constraints.enabled ^ modifier_keys.contains(&ModifierKey::KeyboardCtrl),
                     PenEvent::Text { .. } | PenEvent::Cancel => false,
                 };
 
@@ -177,10 +177,10 @@ impl PenBehaviour for Shaper {
                 // When esc is pressed, reset state
                 if let PenEvent::KeyPressed {
                     keyboard_key,
-                    shortcut_keys,
+                    modifier_keys,
                 } = event
                 {
-                    if keyboard_key == KeyboardKey::Escape && shortcut_keys.is_empty() {
+                    if keyboard_key == KeyboardKey::Escape && modifier_keys.is_empty() {
                         self.state = ShaperState::Idle;
                         widget_flags.redraw = true;
                         pen_progress = PenProgress::Finished;

--- a/rnote-engine/src/pens/tools.rs
+++ b/rnote-engine/src/pens/tools.rs
@@ -199,13 +199,7 @@ impl PenBehaviour for Tools {
         let mut widget_flags = WidgetFlags::default();
 
         let pen_progress = match (&mut self.state, event) {
-            (
-                ToolsState::Idle,
-                PenEvent::Down {
-                    element,
-                    shortcut_keys: _,
-                },
-            ) => {
+            (ToolsState::Idle, PenEvent::Down { element, .. }) => {
                 widget_flags.merge(engine_view.store.record(Instant::now()));
 
                 match engine_view.pens_config.tools_config.style {
@@ -234,13 +228,7 @@ impl PenBehaviour for Tools {
                 PenProgress::InProgress
             }
             (ToolsState::Idle, _) => PenProgress::Idle,
-            (
-                ToolsState::Active,
-                PenEvent::Down {
-                    element,
-                    shortcut_keys: _,
-                },
-            ) => {
+            (ToolsState::Active, PenEvent::Down { element, .. }) => {
                 let pen_progress = match engine_view.pens_config.tools_config.style {
                     ToolStyle::VerticalSpace => {
                         let y_offset = element.pos[1] - self.verticalspace_tool.current_pos_y;

--- a/rnote-engine/src/pens/typewriter/mod.rs
+++ b/rnote-engine/src/pens/typewriter/mod.rs
@@ -427,20 +427,20 @@ impl PenBehaviour for Typewriter {
         let (pen_progress, widget_flags) = match event {
             PenEvent::Down {
                 element,
-                shortcut_keys,
-            } => self.handle_pen_event_down(element, shortcut_keys, now, engine_view),
+                modifier_keys,
+            } => self.handle_pen_event_down(element, modifier_keys, now, engine_view),
             PenEvent::Up {
                 element,
-                shortcut_keys,
-            } => self.handle_pen_event_up(element, shortcut_keys, now, engine_view),
+                modifier_keys,
+            } => self.handle_pen_event_up(element, modifier_keys, now, engine_view),
             PenEvent::Proximity {
                 element,
-                shortcut_keys,
-            } => self.handle_pen_event_proximity(element, shortcut_keys, now, engine_view),
+                modifier_keys,
+            } => self.handle_pen_event_proximity(element, modifier_keys, now, engine_view),
             PenEvent::KeyPressed {
                 keyboard_key,
-                shortcut_keys,
-            } => self.handle_pen_event_keypressed(keyboard_key, shortcut_keys, now, engine_view),
+                modifier_keys,
+            } => self.handle_pen_event_keypressed(keyboard_key, modifier_keys, now, engine_view),
             PenEvent::Text { text } => self.handle_pen_event_text(text, now, engine_view),
             PenEvent::Cancel => self.handle_pen_event_cancel(now, engine_view),
         };

--- a/rnote-engine/src/pens/typewriter/mod.rs
+++ b/rnote-engine/src/pens/typewriter/mod.rs
@@ -23,40 +23,34 @@ use crate::strokes::{Stroke, TextStroke};
 use crate::{AudioPlayer, Camera, DrawOnDocBehaviour, WidgetFlags};
 
 #[derive(Debug, Clone)]
-pub enum TypewriterState {
-    Idle,
-    Start(na::Vector2<f64>),
-    Modifying {
-        stroke_key: StrokeKey,
-        cursor: GraphemeCursor,
-        pen_down: bool,
-    },
+pub(super) enum ModifyState {
+    Up,
+    Hover(na::Vector2<f64>),
     Selecting {
-        stroke_key: StrokeKey,
-        cursor: GraphemeCursor,
         selection_cursor: GraphemeCursor,
         /// If selecting is finished ( if true, will get reset on the next click )
         finished: bool,
     },
     Translating {
-        stroke_key: StrokeKey,
-        cursor: GraphemeCursor,
-        start_pos: na::Vector2<f64>,
         current_pos: na::Vector2<f64>,
     },
     AdjustTextWidth {
-        stroke_key: StrokeKey,
-        cursor: GraphemeCursor,
         start_text_width: f64,
         start_pos: na::Vector2<f64>,
         current_pos: na::Vector2<f64>,
     },
 }
 
-impl Default for TypewriterState {
-    fn default() -> Self {
-        Self::Idle
-    }
+#[derive(Debug, Clone)]
+pub(super) enum TypewriterState {
+    Idle,
+    Start(na::Vector2<f64>),
+    Modifying {
+        modify_state: ModifyState,
+        stroke_key: StrokeKey,
+        cursor: GraphemeCursor,
+        pen_down: bool,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -67,7 +61,7 @@ pub struct Typewriter {
 impl Default for Typewriter {
     fn default() -> Self {
         Self {
-            state: TypewriterState::default(),
+            state: TypewriterState::Idle,
         }
     }
 }
@@ -75,7 +69,6 @@ impl Default for Typewriter {
 impl DrawOnDocBehaviour for Typewriter {
     fn bounds_on_doc(&self, engine_view: &EngineView) -> Option<Aabb> {
         let total_zoom = engine_view.camera.total_zoom();
-
         let text_width = engine_view.pens_config.typewriter_config.text_width;
         let text_style = engine_view.pens_config.typewriter_config.text_style.clone();
 
@@ -85,15 +78,11 @@ impl DrawOnDocBehaviour for Typewriter {
                 na::Point2::from(*pos),
                 na::Point2::from(pos + na::vector![text_width, text_style.font_size]),
             )),
-            TypewriterState::Modifying { stroke_key, .. }
-            | TypewriterState::Selecting { stroke_key, .. }
-            | TypewriterState::Translating { stroke_key, .. }
-            | TypewriterState::AdjustTextWidth { stroke_key, .. } => {
+            TypewriterState::Modifying { stroke_key, .. } => {
                 if let Some(Stroke::TextStroke(textstroke)) =
                     engine_view.store.get_stroke_ref(*stroke_key)
                 {
                     let text_rect = Self::text_rect_bounds(text_width, textstroke);
-
                     let typewriter_bounds = text_rect.extend_by(
                         Self::TRANSLATE_NODE_SIZE.maxs(&Self::ADJUST_TEXT_WIDTH_NODE_SIZE)
                             / total_zoom,
@@ -116,14 +105,12 @@ impl DrawOnDocBehaviour for Typewriter {
 
         static OUTLINE_COLOR: Lazy<piet::Color> =
             Lazy::new(|| color::GNOME_BRIGHTS[4].with_alpha(0.941));
-
         let total_zoom = engine_view.camera.total_zoom();
-
         let outline_width = 1.5 / total_zoom;
         let outline_corner_radius = 1.0 / total_zoom;
-
         let text_width = engine_view.pens_config.typewriter_config.text_width;
         let text_style = engine_view.pens_config.typewriter_config.text_style.clone();
+        let typewriter_bounds = self.bounds_on_doc(engine_view);
 
         match &self.state {
             TypewriterState::Idle => {}
@@ -136,78 +123,28 @@ impl DrawOnDocBehaviour for Typewriter {
 
                     cx.stroke(rect, &*OUTLINE_COLOR, outline_width);
 
-                    let text = String::from("|");
-                    let text_len = text.len();
-
                     // Draw the cursor
+                    let cursor_text = String::from("|");
+                    let cursor_text_len = cursor_text.len();
                     text_style.draw_cursor(
                         cx,
-                        text,
-                        &GraphemeCursor::new(0, text_len, true),
+                        cursor_text,
+                        &GraphemeCursor::new(0, cursor_text_len, true),
                         &Transform::new_w_isometry(na::Isometry2::new(*pos, 0.0)),
                         engine_view.camera,
                     )?;
                 }
             }
             TypewriterState::Modifying {
-                stroke_key, cursor, ..
-            } => {
-                if let Some(Stroke::TextStroke(textstroke)) =
-                    engine_view.store.get_stroke_ref(*stroke_key)
-                {
-                    let text_rect = Self::text_rect_bounds(text_width, textstroke);
-
-                    let text_drawrect = text_rect
-                        .tightened(outline_width * 0.5)
-                        .to_kurbo_rect()
-                        .to_rounded_rect(outline_corner_radius);
-
-                    cx.stroke(text_drawrect, &*OUTLINE_COLOR, outline_width);
-
-                    // Draw the cursor
-                    textstroke.text_style.draw_cursor(
-                        cx,
-                        textstroke.text.clone(),
-                        cursor,
-                        &textstroke.transform,
-                        engine_view.camera,
-                    )?;
-
-                    // Draw the text width adjust node
-                    indicators::draw_triangular_down_node(
-                        cx,
-                        PenState::Up,
-                        Self::adjust_text_width_node_center(
-                            text_rect.mins.coords,
-                            text_width,
-                            engine_view.camera,
-                        ),
-                        Self::ADJUST_TEXT_WIDTH_NODE_SIZE / total_zoom,
-                        total_zoom,
-                    );
-
-                    if let Some(typewriter_bounds) = self.bounds_on_doc(engine_view) {
-                        // draw translate Node
-                        indicators::draw_rectangular_node(
-                            cx,
-                            PenState::Up,
-                            Self::translate_node_bounds(typewriter_bounds, engine_view.camera),
-                            total_zoom,
-                        );
-                    }
-                }
-            }
-            TypewriterState::Selecting {
+                modify_state,
                 stroke_key,
                 cursor,
-                selection_cursor,
                 ..
             } => {
                 if let Some(Stroke::TextStroke(textstroke)) =
                     engine_view.store.get_stroke_ref(*stroke_key)
                 {
                     let text_rect = Self::text_rect_bounds(text_width, textstroke);
-
                     let text_drawrect = text_rect
                         .tightened(outline_width * 0.5)
                         .to_kurbo_rect()
@@ -216,14 +153,19 @@ impl DrawOnDocBehaviour for Typewriter {
                     cx.stroke(text_drawrect, &*OUTLINE_COLOR, outline_width);
 
                     // Draw the text selection
-                    textstroke.text_style.draw_text_selection(
-                        cx,
-                        textstroke.text.clone(),
-                        cursor,
-                        selection_cursor,
-                        &textstroke.transform,
-                        engine_view.camera,
-                    );
+                    if let ModifyState::Selecting {
+                        selection_cursor, ..
+                    } = modify_state
+                    {
+                        textstroke.text_style.draw_text_selection(
+                            cx,
+                            textstroke.text.clone(),
+                            cursor,
+                            selection_cursor,
+                            &textstroke.transform,
+                            engine_view.camera,
+                        );
+                    }
 
                     // Draw the cursor
                     textstroke.text_style.draw_cursor(
@@ -235,9 +177,27 @@ impl DrawOnDocBehaviour for Typewriter {
                     )?;
 
                     // Draw the text width adjust node
+                    let adjust_text_width_node_bounds = Self::adjust_text_width_node_bounds(
+                        text_rect.mins.coords,
+                        text_width,
+                        engine_view.camera,
+                    );
+                    let adjust_text_width_node_state = match modify_state {
+                        ModifyState::AdjustTextWidth { .. } => PenState::Down,
+                        ModifyState::Hover(pos) => {
+                            if adjust_text_width_node_bounds
+                                .contains_local_point(&na::Point2::from(*pos))
+                            {
+                                PenState::Proximity
+                            } else {
+                                PenState::Up
+                            }
+                        }
+                        _ => PenState::Up,
+                    };
                     indicators::draw_triangular_down_node(
                         cx,
-                        PenState::Up,
+                        adjust_text_width_node_state,
                         Self::adjust_text_width_node_center(
                             text_rect.mins.coords,
                             text_width,
@@ -247,86 +207,27 @@ impl DrawOnDocBehaviour for Typewriter {
                         total_zoom,
                     );
 
-                    if let Some(typewriter_bounds) = self.bounds_on_doc(engine_view) {
-                        // draw translate Node
+                    // Draw the translate Node
+                    if let Some(typewriter_bounds) = typewriter_bounds {
+                        let translate_node_bounds =
+                            Self::translate_node_bounds(typewriter_bounds, engine_view.camera);
+                        let translate_node_state = match modify_state {
+                            ModifyState::Translating { .. } => PenState::Down,
+                            ModifyState::Hover(pos) => {
+                                if translate_node_bounds
+                                    .contains_local_point(&na::Point2::from(*pos))
+                                {
+                                    PenState::Proximity
+                                } else {
+                                    PenState::Up
+                                }
+                            }
+                            _ => PenState::Up,
+                        };
                         indicators::draw_rectangular_node(
                             cx,
-                            PenState::Up,
-                            Self::translate_node_bounds(typewriter_bounds, engine_view.camera),
-                            total_zoom,
-                        );
-                    }
-                }
-            }
-            TypewriterState::Translating { stroke_key, .. } => {
-                if let Some(Stroke::TextStroke(textstroke)) =
-                    engine_view.store.get_stroke_ref(*stroke_key)
-                {
-                    let text_rect = Self::text_rect_bounds(text_width, textstroke);
-
-                    let text_drawrect = text_rect
-                        .tightened(outline_width * 0.5)
-                        .to_kurbo_rect()
-                        .to_rounded_rect(outline_corner_radius);
-
-                    cx.stroke(text_drawrect, &*OUTLINE_COLOR, outline_width);
-
-                    // Draw the text width adjust node
-                    indicators::draw_triangular_down_node(
-                        cx,
-                        PenState::Up,
-                        Self::adjust_text_width_node_center(
-                            text_rect.mins.coords,
-                            text_width,
-                            engine_view.camera,
-                        ),
-                        Self::ADJUST_TEXT_WIDTH_NODE_SIZE / total_zoom,
-                        total_zoom,
-                    );
-
-                    // Translate Node
-                    if let Some(typewriter_bounds) = self.bounds_on_doc(engine_view) {
-                        indicators::draw_rectangular_node(
-                            cx,
-                            PenState::Down,
-                            Self::translate_node_bounds(typewriter_bounds, engine_view.camera),
-                            total_zoom,
-                        );
-                    }
-                }
-            }
-            TypewriterState::AdjustTextWidth { stroke_key, .. } => {
-                if let Some(Stroke::TextStroke(textstroke)) =
-                    engine_view.store.get_stroke_ref(*stroke_key)
-                {
-                    let text_rect = Self::text_rect_bounds(text_width, textstroke);
-
-                    let text_drawrect = text_rect
-                        .tightened(outline_width * 0.5)
-                        .to_kurbo_rect()
-                        .to_rounded_rect(outline_corner_radius);
-
-                    cx.stroke(text_drawrect, &*OUTLINE_COLOR, outline_width);
-
-                    // Draw the text width adjust node
-                    indicators::draw_triangular_down_node(
-                        cx,
-                        PenState::Down,
-                        Self::adjust_text_width_node_center(
-                            text_rect.mins.coords,
-                            text_width,
-                            engine_view.camera,
-                        ),
-                        Self::ADJUST_TEXT_WIDTH_NODE_SIZE / total_zoom,
-                        total_zoom,
-                    );
-
-                    // Translate Node
-                    if let Some(typewriter_bounds) = self.bounds_on_doc(engine_view) {
-                        indicators::draw_rectangular_node(
-                            cx,
-                            PenState::Up,
-                            Self::translate_node_bounds(typewriter_bounds, engine_view.camera),
+                            translate_node_state,
+                            translate_node_bounds,
                             total_zoom,
                         );
                     }
@@ -349,62 +250,61 @@ impl PenBehaviour for Typewriter {
 
         match &mut self.state {
             TypewriterState::Idle | TypewriterState::Start(_) => {}
-            TypewriterState::Selecting {
+            TypewriterState::Modifying {
+                modify_state,
                 stroke_key,
                 cursor,
-                selection_cursor,
                 ..
-            } => {
-                if let Some(Stroke::TextStroke(textstroke)) =
-                    engine_view.store.get_stroke_ref(*stroke_key)
-                {
-                    engine_view.pens_config.typewriter_config.text_style =
-                        textstroke.text_style.clone();
-                    engine_view
-                        .pens_config
-                        .typewriter_config
-                        .text_style
-                        .ranged_text_attributes
-                        .clear();
+            } => match modify_state {
+                ModifyState::Selecting {
+                    selection_cursor, ..
+                } => {
+                    if let Some(Stroke::TextStroke(textstroke)) =
+                        engine_view.store.get_stroke_ref(*stroke_key)
+                    {
+                        engine_view.pens_config.typewriter_config.text_style =
+                            textstroke.text_style.clone();
+                        engine_view
+                            .pens_config
+                            .typewriter_config
+                            .text_style
+                            .ranged_text_attributes
+                            .clear();
 
-                    if let Some(max_width) = textstroke.text_style.max_width {
-                        engine_view.pens_config.typewriter_config.text_width = max_width;
+                        if let Some(max_width) = textstroke.text_style.max_width {
+                            engine_view.pens_config.typewriter_config.text_width = max_width;
+                        }
+
+                        update_cursors_for_textstroke(textstroke, cursor, Some(selection_cursor));
+
+                        widget_flags.redraw = true;
+                        widget_flags.refresh_ui = true;
                     }
-
-                    update_cursors_for_textstroke(textstroke, cursor, Some(selection_cursor));
-
-                    widget_flags.redraw = true;
-                    widget_flags.refresh_ui = true;
                 }
-            }
-            TypewriterState::Modifying {
-                stroke_key, cursor, ..
-            }
-            | TypewriterState::Translating {
-                stroke_key, cursor, ..
-            }
-            | TypewriterState::AdjustTextWidth {
-                stroke_key, cursor, ..
-            } => {
-                if let Some(Stroke::TextStroke(textstroke)) =
-                    engine_view.store.get_stroke_ref(*stroke_key)
-                {
-                    engine_view.pens_config.typewriter_config.text_style =
-                        textstroke.text_style.clone();
-                    engine_view
-                        .pens_config
-                        .typewriter_config
-                        .text_style
-                        .ranged_text_attributes
-                        .clear();
+                ModifyState::Up
+                | ModifyState::Hover(_)
+                | ModifyState::Translating { .. }
+                | ModifyState::AdjustTextWidth { .. } => {
+                    if let Some(Stroke::TextStroke(textstroke)) =
+                        engine_view.store.get_stroke_ref(*stroke_key)
+                    {
+                        engine_view.pens_config.typewriter_config.text_style =
+                            textstroke.text_style.clone();
+                        engine_view
+                            .pens_config
+                            .typewriter_config
+                            .text_style
+                            .ranged_text_attributes
+                            .clear();
 
-                    if let Some(max_width) = textstroke.text_style.max_width {
-                        engine_view.pens_config.typewriter_config.text_width = max_width;
+                        if let Some(max_width) = textstroke.text_style.max_width {
+                            engine_view.pens_config.typewriter_config.text_width = max_width;
+                        }
+
+                        update_cursors_for_textstroke(textstroke, cursor, None);
                     }
-
-                    update_cursors_for_textstroke(textstroke, cursor, None);
                 }
-            }
+            },
         }
 
         widget_flags
@@ -455,39 +355,42 @@ impl PenBehaviour for Typewriter {
         let widget_flags = WidgetFlags::default();
 
         match &self.state {
-            TypewriterState::Idle
-            | TypewriterState::Start(_)
-            | TypewriterState::Modifying { .. }
-            | TypewriterState::Translating { .. }
-            | TypewriterState::AdjustTextWidth { .. } => Ok((None, widget_flags)),
-            TypewriterState::Selecting {
+            TypewriterState::Idle | TypewriterState::Start(_) => Ok((None, widget_flags)),
+            TypewriterState::Modifying {
+                modify_state,
                 stroke_key,
                 cursor,
-                selection_cursor,
                 ..
             } => {
-                if let Some(Stroke::TextStroke(textstroke)) =
-                    engine_view.store.get_stroke_ref(*stroke_key)
-                {
-                    let selection_range = crate::utils::positive_range(
-                        cursor.cur_cursor(),
-                        selection_cursor.cur_cursor(),
-                    );
+                match modify_state {
+                    ModifyState::Selecting {
+                        selection_cursor, ..
+                    } => {
+                        if let Some(Stroke::TextStroke(textstroke)) =
+                            engine_view.store.get_stroke_ref(*stroke_key)
+                        {
+                            let selection_range = crate::utils::positive_range(
+                                cursor.cur_cursor(),
+                                selection_cursor.cur_cursor(),
+                            );
 
-                    // Current selection as clipboard text
-                    let selection_text = textstroke
-                        .get_text_slice_for_range(selection_range)
-                        .to_string();
+                            // Current selection as clipboard text
+                            let selection_text = textstroke
+                                .get_text_slice_for_range(selection_range)
+                                .to_string();
 
-                    Ok((
-                        Some((
-                            selection_text.into_bytes(),
-                            String::from("text/plain;charset=utf-8"),
-                        )),
-                        widget_flags,
-                    ))
-                } else {
-                    Ok((None, widget_flags))
+                            Ok((
+                                Some((
+                                    selection_text.into_bytes(),
+                                    String::from("text/plain;charset=utf-8"),
+                                )),
+                                widget_flags,
+                            ))
+                        } else {
+                            Ok((None, widget_flags))
+                        }
+                    }
+                    _ => Ok((None, widget_flags)),
                 }
             }
         }
@@ -500,70 +403,73 @@ impl PenBehaviour for Typewriter {
         let mut widget_flags = WidgetFlags::default();
 
         match &mut self.state {
-            TypewriterState::Idle
-            | TypewriterState::Start(_)
-            | TypewriterState::Modifying { .. }
-            | TypewriterState::Translating { .. }
-            | TypewriterState::AdjustTextWidth { .. } => Ok((None, widget_flags)),
-            TypewriterState::Selecting {
+            TypewriterState::Idle | TypewriterState::Start(_) => Ok((None, widget_flags)),
+            TypewriterState::Modifying {
+                modify_state,
                 stroke_key,
                 cursor,
-                selection_cursor,
                 ..
             } => {
-                widget_flags.merge(engine_view.store.record(Instant::now()));
+                match modify_state {
+                    ModifyState::Selecting {
+                        selection_cursor, ..
+                    } => {
+                        widget_flags.merge(engine_view.store.record(Instant::now()));
 
-                if let Some(Stroke::TextStroke(textstroke)) =
-                    engine_view.store.get_stroke_mut(*stroke_key)
-                {
-                    let selection_range = crate::utils::positive_range(
-                        cursor.cur_cursor(),
-                        selection_cursor.cur_cursor(),
-                    );
+                        if let Some(Stroke::TextStroke(textstroke)) =
+                            engine_view.store.get_stroke_mut(*stroke_key)
+                        {
+                            let selection_range = crate::utils::positive_range(
+                                cursor.cur_cursor(),
+                                selection_cursor.cur_cursor(),
+                            );
 
-                    // Current selection as clipboard text
-                    let selection_text = textstroke
-                        .get_text_slice_for_range(selection_range)
-                        .to_string();
+                            // Current selection as clipboard text
+                            let selection_text = textstroke
+                                .get_text_slice_for_range(selection_range)
+                                .to_string();
 
-                    textstroke.replace_text_between_selection_cursors(
-                        cursor,
-                        selection_cursor,
-                        String::from("").as_str(),
-                    );
+                            textstroke.replace_text_between_selection_cursors(
+                                cursor,
+                                selection_cursor,
+                                String::from("").as_str(),
+                            );
 
-                    // Update stroke
-                    engine_view.store.update_geometry_for_stroke(*stroke_key);
-                    engine_view.store.regenerate_rendering_for_stroke(
-                        *stroke_key,
-                        engine_view.camera.viewport(),
-                        engine_view.camera.image_scale(),
-                    );
+                            // Update stroke
+                            engine_view.store.update_geometry_for_stroke(*stroke_key);
+                            engine_view.store.regenerate_rendering_for_stroke(
+                                *stroke_key,
+                                engine_view.camera.viewport(),
+                                engine_view.camera.image_scale(),
+                            );
+                            engine_view
+                                .doc
+                                .resize_autoexpand(engine_view.store, engine_view.camera);
 
-                    engine_view
-                        .doc
-                        .resize_autoexpand(engine_view.store, engine_view.camera);
+                            widget_flags.redraw = true;
+                            widget_flags.resize = true;
+                            widget_flags.store_modified = true;
 
-                    widget_flags.redraw = true;
-                    widget_flags.resize = true;
-                    widget_flags.store_modified = true;
+                            // Back to modifying state
+                            self.state = TypewriterState::Modifying {
+                                modify_state: ModifyState::Up,
+                                stroke_key: *stroke_key,
+                                cursor: cursor.clone(),
+                                pen_down: false,
+                            };
 
-                    // Back to modifying state
-                    self.state = TypewriterState::Modifying {
-                        stroke_key: *stroke_key,
-                        cursor: cursor.clone(),
-                        pen_down: false,
-                    };
-
-                    Ok((
-                        Some((
-                            selection_text.into_bytes(),
-                            String::from("text/plain;charset=utf-8"),
-                        )),
-                        widget_flags,
-                    ))
-                } else {
-                    Ok((None, widget_flags))
+                            Ok((
+                                Some((
+                                    selection_text.into_bytes(),
+                                    String::from("text/plain;charset=utf-8"),
+                                )),
+                                widget_flags,
+                            ))
+                        } else {
+                            Ok((None, widget_flags))
+                        }
+                    }
+                    _ => Ok((None, widget_flags)),
                 }
             }
         }
@@ -607,7 +513,6 @@ impl Typewriter {
     /// the bounds of the text rect enclosing the textstroke
     fn text_rect_bounds(text_width: f64, textstroke: &TextStroke) -> Aabb {
         let origin = textstroke.transform.translation_part();
-
         Aabb::new(
             na::Point2::from(origin),
             na::point![origin[0] + text_width, origin[1]],
@@ -618,7 +523,6 @@ impl Typewriter {
     /// the bounds of the translate node
     fn translate_node_bounds(typewriter_bounds: Aabb, camera: &Camera) -> Aabb {
         let total_zoom = camera.total_zoom();
-
         Aabb::from_half_extents(
             na::Point2::from(
                 typewriter_bounds.mins.coords + Self::TRANSLATE_NODE_SIZE * 0.5 / total_zoom,
@@ -634,7 +538,6 @@ impl Typewriter {
         camera: &Camera,
     ) -> na::Vector2<f64> {
         let total_zoom = camera.total_zoom();
-
         na::vector![
             text_rect_origin[0] + text_width,
             text_rect_origin[1] - Self::ADJUST_TEXT_WIDTH_NODE_SIZE[1] * 0.5 / total_zoom
@@ -649,7 +552,6 @@ impl Typewriter {
     ) -> Aabb {
         let total_zoom = camera.total_zoom();
         let center = Self::adjust_text_width_node_center(text_rect_origin, text_width, camera);
-
         Aabb::from_half_extents(
             na::Point2::from(center),
             Self::ADJUST_TEXT_WIDTH_NODE_SIZE * 0.5 / total_zoom,
@@ -658,10 +560,13 @@ impl Typewriter {
 
     /// Returns the range of the current selection, if available
     pub fn selection_range(&self) -> Option<(Range<usize>, StrokeKey)> {
-        if let TypewriterState::Selecting {
+        if let TypewriterState::Modifying {
+            modify_state:
+                ModifyState::Selecting {
+                    selection_cursor, ..
+                },
             stroke_key,
             cursor,
-            selection_cursor,
             ..
         } = &self.state
         {
@@ -686,31 +591,25 @@ impl Typewriter {
             engine_view.camera.viewport().mins.coords + Stroke::IMPORT_OFFSET_DEFAULT
         });
         let mut widget_flags = WidgetFlags::default();
-
         let text_width = engine_view.pens_config.typewriter_config.text_width;
         let mut text_style = engine_view.pens_config.typewriter_config.text_style.clone();
         let max_width_enabled = engine_view.pens_config.typewriter_config.max_width_enabled;
 
         match &mut self.state {
             TypewriterState::Idle => {
-                let text_len = text.len();
-
                 widget_flags.merge(engine_view.store.record(Instant::now()));
 
+                let text_len = text.len();
                 text_style.ranged_text_attributes.clear();
-
                 if max_width_enabled {
                     text_style.max_width = Some(text_width);
                 }
-
                 let textstroke = TextStroke::new(text, pos, text_style);
-
                 let cursor = GraphemeCursor::new(text_len, textstroke.text.len(), true);
 
                 let stroke_key = engine_view
                     .store
                     .insert_stroke(Stroke::TextStroke(textstroke), None);
-
                 engine_view.store.regenerate_rendering_for_stroke(
                     stroke_key,
                     engine_view.camera.viewport(),
@@ -718,6 +617,7 @@ impl Typewriter {
                 );
 
                 self.state = TypewriterState::Modifying {
+                    modify_state: ModifyState::Up,
                     stroke_key,
                     cursor,
                     pen_down: false,
@@ -728,23 +628,19 @@ impl Typewriter {
                 widget_flags.redraw = true;
             }
             TypewriterState::Start(pos) => {
-                let text_len = text.len();
-
                 widget_flags.merge(engine_view.store.record(Instant::now()));
 
+                let text_len = text.len();
                 text_style.ranged_text_attributes.clear();
-
                 if max_width_enabled {
                     text_style.max_width = Some(text_width);
                 }
-
                 let textstroke = TextStroke::new(text, *pos, text_style);
                 let cursor = GraphemeCursor::new(text_len, textstroke.text.len(), true);
 
                 let stroke_key = engine_view
                     .store
                     .insert_stroke(Stroke::TextStroke(textstroke), None);
-
                 engine_view.store.regenerate_rendering_for_stroke(
                     stroke_key,
                     engine_view.camera.viewport(),
@@ -752,6 +648,7 @@ impl Typewriter {
                 );
 
                 self.state = TypewriterState::Modifying {
+                    modify_state: ModifyState::Up,
                     stroke_key,
                     cursor,
                     pen_down: false,
@@ -762,70 +659,69 @@ impl Typewriter {
                 widget_flags.redraw = true;
             }
             TypewriterState::Modifying {
-                stroke_key, cursor, ..
-            } => {
-                widget_flags.merge(engine_view.store.record(Instant::now()));
-
-                if let Some(Stroke::TextStroke(textstroke)) =
-                    engine_view.store.get_stroke_mut(*stroke_key)
-                {
-                    textstroke.insert_text_after_cursor(text.as_str(), cursor);
-
-                    engine_view.store.update_geometry_for_stroke(*stroke_key);
-                    engine_view.store.regenerate_rendering_for_stroke(
-                        *stroke_key,
-                        engine_view.camera.viewport(),
-                        engine_view.camera.image_scale(),
-                    );
-
-                    engine_view
-                        .doc
-                        .resize_autoexpand(engine_view.store, engine_view.camera);
-
-                    widget_flags.store_modified = true;
-                    widget_flags.resize = true;
-                    widget_flags.redraw = true;
-                }
-            }
-            TypewriterState::Selecting {
+                modify_state,
                 stroke_key,
                 cursor,
-                selection_cursor,
                 ..
-            } => {
-                widget_flags.merge(engine_view.store.record(Instant::now()));
+            } => match modify_state {
+                ModifyState::Selecting {
+                    selection_cursor, ..
+                } => {
+                    widget_flags.merge(engine_view.store.record(Instant::now()));
 
-                if let Some(Stroke::TextStroke(textstroke)) =
-                    engine_view.store.get_stroke_mut(*stroke_key)
-                {
-                    textstroke.replace_text_between_selection_cursors(
-                        cursor,
-                        selection_cursor,
-                        text.as_str(),
-                    );
+                    if let Some(Stroke::TextStroke(textstroke)) =
+                        engine_view.store.get_stroke_mut(*stroke_key)
+                    {
+                        textstroke.replace_text_between_selection_cursors(
+                            cursor,
+                            selection_cursor,
+                            text.as_str(),
+                        );
+                        engine_view.store.update_geometry_for_stroke(*stroke_key);
+                        engine_view.store.regenerate_rendering_for_stroke(
+                            *stroke_key,
+                            engine_view.camera.viewport(),
+                            engine_view.camera.image_scale(),
+                        );
+                        engine_view
+                            .doc
+                            .resize_autoexpand(engine_view.store, engine_view.camera);
 
-                    engine_view.store.update_geometry_for_stroke(*stroke_key);
-                    engine_view.store.regenerate_rendering_for_stroke(
-                        *stroke_key,
-                        engine_view.camera.viewport(),
-                        engine_view.camera.image_scale(),
-                    );
-                    engine_view
-                        .doc
-                        .resize_autoexpand(engine_view.store, engine_view.camera);
+                        self.state = TypewriterState::Modifying {
+                            modify_state: ModifyState::Up,
+                            stroke_key: *stroke_key,
+                            cursor: cursor.clone(),
+                            pen_down: false,
+                        };
 
-                    self.state = TypewriterState::Modifying {
-                        stroke_key: *stroke_key,
-                        cursor: cursor.clone(),
-                        pen_down: false,
-                    };
-
-                    widget_flags.store_modified = true;
-                    widget_flags.resize = true;
-                    widget_flags.redraw = true;
+                        widget_flags.store_modified = true;
+                        widget_flags.resize = true;
+                        widget_flags.redraw = true;
+                    }
                 }
-            }
-            TypewriterState::Translating { .. } | TypewriterState::AdjustTextWidth { .. } => {}
+                _ => {
+                    widget_flags.merge(engine_view.store.record(Instant::now()));
+
+                    if let Some(Stroke::TextStroke(textstroke)) =
+                        engine_view.store.get_stroke_mut(*stroke_key)
+                    {
+                        textstroke.insert_text_after_cursor(text.as_str(), cursor);
+                        engine_view.store.update_geometry_for_stroke(*stroke_key);
+                        engine_view.store.regenerate_rendering_for_stroke(
+                            *stroke_key,
+                            engine_view.camera.viewport(),
+                            engine_view.camera.image_scale(),
+                        );
+                        engine_view
+                            .doc
+                            .resize_autoexpand(engine_view.store, engine_view.camera);
+
+                        widget_flags.store_modified = true;
+                        widget_flags.resize = true;
+                        widget_flags.redraw = true;
+                    }
+                }
+            },
         }
 
         widget_flags
@@ -842,18 +738,13 @@ impl Typewriter {
     {
         let mut widget_flags = WidgetFlags::default();
 
-        if let TypewriterState::Modifying { stroke_key, .. }
-        | TypewriterState::Selecting { stroke_key, .. }
-        | TypewriterState::Translating { stroke_key, .. }
-        | TypewriterState::AdjustTextWidth { stroke_key, .. } = &mut self.state
-        {
+        if let TypewriterState::Modifying { stroke_key, .. } = &mut self.state {
             widget_flags.merge(engine_view.store.record(Instant::now()));
 
             if let Some(Stroke::TextStroke(textstroke)) =
                 engine_view.store.get_stroke_mut(*stroke_key)
             {
                 modify_func(&mut textstroke.text_style);
-
                 engine_view.store.update_geometry_for_stroke(*stroke_key);
                 engine_view.store.regenerate_rendering_for_stroke(
                     *stroke_key,
@@ -882,7 +773,6 @@ impl Typewriter {
                 engine_view.store.get_stroke_mut(stroke_key)
             {
                 textstroke.remove_attrs_for_range(selection_range);
-
                 engine_view.store.update_geometry_for_stroke(stroke_key);
                 engine_view.store.regenerate_rendering_for_stroke(
                     stroke_key,
@@ -918,7 +808,6 @@ impl Typewriter {
                         attribute: text_attribute,
                         range: selection_range,
                     });
-
                 engine_view.store.update_geometry_for_stroke(stroke_key);
                 engine_view.store.regenerate_rendering_for_stroke(
                     stroke_key,

--- a/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/rnote-engine/src/pens/typewriter/penevents.rs
@@ -1,4 +1,4 @@
-use rnote_compose::penevents::{KeyboardKey, ShortcutKey};
+use rnote_compose::penevents::{KeyboardKey, ModifierKey};
 use rnote_compose::penpath::Element;
 use std::time::Instant;
 use unicode_segmentation::GraphemeCursor;
@@ -14,7 +14,7 @@ impl Typewriter {
     pub(super) fn handle_pen_event_down(
         &mut self,
         element: Element,
-        _shortcut_keys: Vec<ShortcutKey>,
+        _modifier_keys: Vec<ModifierKey>,
         _now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
@@ -273,7 +273,7 @@ impl Typewriter {
     pub(super) fn handle_pen_event_up(
         &mut self,
         _element: Element,
-        _shortcut_keys: Vec<ShortcutKey>,
+        _modifier_keys: Vec<ModifierKey>,
         _now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
@@ -358,7 +358,7 @@ impl Typewriter {
     pub(super) fn handle_pen_event_proximity(
         &mut self,
         _element: Element,
-        _shortcut_keys: Vec<ShortcutKey>,
+        _modifier_keys: Vec<ModifierKey>,
         _now: Instant,
         _engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
@@ -382,7 +382,7 @@ impl Typewriter {
     pub(super) fn handle_pen_event_keypressed(
         &mut self,
         keyboard_key: KeyboardKey,
-        shortcut_keys: Vec<ShortcutKey>,
+        modifier_keys: Vec<ModifierKey>,
         _now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
@@ -467,7 +467,7 @@ impl Typewriter {
                     // Handling keyboard input
                     let new_state = match keyboard_key {
                         KeyboardKey::Unicode(keychar) => {
-                            if keychar == 'a' && shortcut_keys.contains(&ShortcutKey::KeyboardCtrl)
+                            if keychar == 'a' && modifier_keys.contains(&ModifierKey::KeyboardCtrl)
                             {
                                 // Select entire text
 
@@ -515,7 +515,7 @@ impl Typewriter {
                             None
                         }
                         KeyboardKey::NavLeft => {
-                            if shortcut_keys.contains(&ShortcutKey::KeyboardShift) {
+                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
                                 let mut new_cursor = cursor.clone();
                                 textstroke.move_cursor_back(&mut new_cursor);
 
@@ -532,7 +532,7 @@ impl Typewriter {
                             }
                         }
                         KeyboardKey::NavRight => {
-                            if shortcut_keys.contains(&ShortcutKey::KeyboardShift) {
+                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
                                 let mut new_cursor = cursor.clone();
                                 textstroke.move_cursor_forward(&mut new_cursor);
 
@@ -549,7 +549,7 @@ impl Typewriter {
                             }
                         }
                         KeyboardKey::NavUp => {
-                            if shortcut_keys.contains(&ShortcutKey::KeyboardShift) {
+                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
                                 let mut new_cursor = cursor.clone();
                                 textstroke.move_cursor_line_up(&mut new_cursor);
 
@@ -566,7 +566,7 @@ impl Typewriter {
                             }
                         }
                         KeyboardKey::NavDown => {
-                            if shortcut_keys.contains(&ShortcutKey::KeyboardShift) {
+                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
                                 let mut new_cursor = cursor.clone();
                                 textstroke.move_cursor_line_down(&mut new_cursor);
 
@@ -627,7 +627,7 @@ impl Typewriter {
                     // Handle keyboard keys
                     let quit_selecting = match keyboard_key {
                         KeyboardKey::Unicode(keychar) => {
-                            if keychar == 'a' && shortcut_keys.contains(&ShortcutKey::KeyboardCtrl)
+                            if keychar == 'a' && modifier_keys.contains(&ModifierKey::KeyboardCtrl)
                             {
                                 textstroke.update_selection_entire_text(cursor, selection_cursor);
                                 *finished = true;
@@ -645,7 +645,7 @@ impl Typewriter {
                             }
                         }
                         KeyboardKey::NavLeft => {
-                            if shortcut_keys.contains(&ShortcutKey::KeyboardShift) {
+                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
                                 textstroke.move_cursor_back(cursor);
                                 false
                             } else {
@@ -653,7 +653,7 @@ impl Typewriter {
                             }
                         }
                         KeyboardKey::NavRight => {
-                            if shortcut_keys.contains(&ShortcutKey::KeyboardShift) {
+                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
                                 textstroke.move_cursor_forward(cursor);
                                 false
                             } else {
@@ -661,7 +661,7 @@ impl Typewriter {
                             }
                         }
                         KeyboardKey::NavUp => {
-                            if shortcut_keys.contains(&ShortcutKey::KeyboardShift) {
+                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
                                 textstroke.move_cursor_line_up(cursor);
                                 false
                             } else {
@@ -669,7 +669,7 @@ impl Typewriter {
                             }
                         }
                         KeyboardKey::NavDown => {
-                            if shortcut_keys.contains(&ShortcutKey::KeyboardShift) {
+                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
                                 textstroke.move_cursor_line_down(cursor);
                                 false
                             } else {

--- a/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/rnote-engine/src/pens/typewriter/penevents.rs
@@ -3,7 +3,7 @@ use rnote_compose::penpath::Element;
 use std::time::Instant;
 use unicode_segmentation::GraphemeCursor;
 
-use super::{Typewriter, TypewriterState};
+use super::{ModifyState, Typewriter, TypewriterState};
 use crate::engine::EngineViewMut;
 use crate::pens::penbehaviour::PenProgress;
 use crate::pens::PenBehaviour;
@@ -19,9 +19,7 @@ impl Typewriter {
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
         let mut widget_flags = WidgetFlags::default();
-
         let typewriter_bounds = self.bounds_on_doc(&engine_view.as_im());
-
         let text_width = engine_view.pens_config.typewriter_config.text_width;
 
         let pen_progress = match &mut self.state {
@@ -38,17 +36,19 @@ impl Typewriter {
                     if let Some(Stroke::TextStroke(textstroke)) =
                         engine_view.store.get_stroke_ref(stroke_key)
                     {
-                        let mut cursor = GraphemeCursor::new(0, textstroke.text.len(), true);
-
-                        // Updating the cursor for the clicked position
-                        if let Ok(new_cursor) = textstroke.get_cursor_for_global_coord(element.pos)
+                        let cursor = if let Ok(new_cursor) =
+                            // get the cursor for the current position
+                            textstroke.get_cursor_for_global_coord(element.pos)
                         {
-                            cursor = new_cursor;
-                        }
+                            new_cursor
+                        } else {
+                            GraphemeCursor::new(0, textstroke.text.len(), true)
+                        };
 
                         engine_view.store.update_chrono_to_last(stroke_key);
 
                         new_state = TypewriterState::Modifying {
+                            modify_state: ModifyState::Up,
                             stroke_key,
                             cursor,
                             pen_down: true,
@@ -71,199 +71,202 @@ impl Typewriter {
                 PenProgress::InProgress
             }
             TypewriterState::Modifying {
+                modify_state,
                 stroke_key,
                 cursor,
                 pen_down,
             } => {
-                let mut pen_progress = PenProgress::InProgress;
+                match modify_state {
+                    ModifyState::Up | ModifyState::Hover(_) => {
+                        let mut pen_progress = PenProgress::InProgress;
 
-                if let (Some(typewriter_bounds), Some(Stroke::TextStroke(textstroke))) = (
-                    typewriter_bounds,
-                    engine_view.store.get_stroke_ref(*stroke_key),
-                ) {
-                    if Self::translate_node_bounds(typewriter_bounds, engine_view.camera)
-                        .contains_local_point(&na::Point2::from(element.pos))
-                    {
-                        // switch to translating the text field
-                        widget_flags.merge(engine_view.store.record(Instant::now()));
-
-                        self.state = TypewriterState::Translating {
-                            stroke_key: *stroke_key,
-                            cursor: cursor.clone(),
-                            start_pos: element.pos,
-                            current_pos: element.pos,
-                        };
-                    } else if Self::adjust_text_width_node_bounds(
-                        Self::text_rect_bounds(text_width, textstroke).mins.coords,
-                        text_width,
-                        engine_view.camera,
-                    )
-                    .contains_local_point(&na::Point2::from(element.pos))
-                    {
-                        widget_flags.merge(engine_view.store.record(Instant::now()));
-
-                        // Clicking on the adjust text width node
-                        self.state = TypewriterState::AdjustTextWidth {
-                            stroke_key: *stroke_key,
-                            cursor: cursor.clone(),
-                            start_text_width: text_width,
-                            start_pos: element.pos,
-                            current_pos: element.pos,
-                        };
-                    // This is intentionally **not** the textstroke hitboxes
-                    } else if typewriter_bounds.contains_local_point(&na::Point2::from(element.pos))
-                    {
-                        if let Some(Stroke::TextStroke(textstroke)) =
-                            engine_view.store.get_stroke_ref(*stroke_key)
-                        {
-                            if let Ok(new_cursor) =
-                                textstroke.get_cursor_for_global_coord(element.pos)
+                        if let (Some(typewriter_bounds), Some(Stroke::TextStroke(textstroke))) = (
+                            typewriter_bounds,
+                            engine_view.store.get_stroke_ref(*stroke_key),
+                        ) {
+                            if Self::translate_node_bounds(typewriter_bounds, engine_view.camera)
+                                .contains_local_point(&na::Point2::from(element.pos))
                             {
-                                if new_cursor.cur_cursor() != cursor.cur_cursor() && *pen_down {
-                                    // switch to selecting
-                                    self.state = TypewriterState::Selecting {
-                                        stroke_key: *stroke_key,
-                                        cursor: cursor.clone(),
-                                        selection_cursor: cursor.clone(),
-                                        finished: false,
-                                    };
-                                } else {
-                                    *cursor = new_cursor;
-                                    *pen_down = true;
-                                }
-                            }
-                        }
-                    } else {
-                        // If we click outside, reset to idle
-                        self.state = TypewriterState::Idle;
+                                widget_flags.merge(engine_view.store.record(Instant::now()));
 
-                        pen_progress = PenProgress::Finished;
-                    }
-                }
+                                // switch to translating state
+                                self.state = TypewriterState::Modifying {
+                                    modify_state: ModifyState::Translating {
+                                        current_pos: element.pos,
+                                    },
+                                    stroke_key: *stroke_key,
+                                    cursor: cursor.clone(),
+                                    pen_down: true,
+                                };
+                            } else if Self::adjust_text_width_node_bounds(
+                                Self::text_rect_bounds(text_width, textstroke).mins.coords,
+                                text_width,
+                                engine_view.camera,
+                            )
+                            .contains_local_point(&na::Point2::from(element.pos))
+                            {
+                                widget_flags.merge(engine_view.store.record(Instant::now()));
 
-                widget_flags.redraw = true;
-
-                pen_progress
-            }
-            TypewriterState::Selecting {
-                stroke_key,
-                cursor,
-                finished,
-                ..
-            } => {
-                let mut pen_progress = PenProgress::InProgress;
-
-                if let Some(typewriter_bounds) = typewriter_bounds {
-                    // Clicking on the translate node
-                    if Self::translate_node_bounds(typewriter_bounds, engine_view.camera)
-                        .contains_local_point(&na::Point2::from(element.pos))
-                    {
-                        widget_flags.merge(engine_view.store.record(Instant::now()));
-
-                        self.state = TypewriterState::Translating {
-                            stroke_key: *stroke_key,
-                            cursor: cursor.clone(),
-                            start_pos: element.pos,
-                            current_pos: element.pos,
-                        };
-                    } else if typewriter_bounds.contains_local_point(&na::Point2::from(element.pos))
-                    {
-                        if let Some(Stroke::TextStroke(textstroke)) =
-                            engine_view.store.get_stroke_ref(*stroke_key)
-                        {
-                            // If selecting is finished, return to modifying with the current pen position as cursor
-                            if *finished {
-                                if let Ok(new_cursor) =
-                                    textstroke.get_cursor_for_global_coord(element.pos)
+                                // switch to adjust text width
+                                self.state = TypewriterState::Modifying {
+                                    modify_state: ModifyState::AdjustTextWidth {
+                                        start_text_width: text_width,
+                                        start_pos: element.pos,
+                                        current_pos: element.pos,
+                                    },
+                                    stroke_key: *stroke_key,
+                                    cursor: cursor.clone(),
+                                    pen_down: true,
+                                };
+                            // This is intentionally **not** the textstroke hitboxes
+                            } else if typewriter_bounds
+                                .contains_local_point(&na::Point2::from(element.pos))
+                            {
+                                if let Some(Stroke::TextStroke(textstroke)) =
+                                    engine_view.store.get_stroke_ref(*stroke_key)
                                 {
-                                    self.state = TypewriterState::Modifying {
-                                        stroke_key: *stroke_key,
-                                        cursor: new_cursor,
-                                        pen_down: false,
-                                    };
+                                    if let Ok(new_cursor) =
+                                        textstroke.get_cursor_for_global_coord(element.pos)
+                                    {
+                                        if new_cursor.cur_cursor() != cursor.cur_cursor()
+                                            && *pen_down
+                                        {
+                                            // switch to selecting state
+                                            self.state = TypewriterState::Modifying {
+                                                modify_state: ModifyState::Selecting {
+                                                    selection_cursor: cursor.clone(),
+                                                    finished: false,
+                                                },
+                                                stroke_key: *stroke_key,
+                                                cursor: cursor.clone(),
+                                                pen_down: true,
+                                            };
+                                        } else {
+                                            *cursor = new_cursor;
+                                            *pen_down = true;
+                                        }
+                                    }
                                 }
                             } else {
-                                // Updating the cursor for the clicked position
-                                if let Ok(new_cursor) =
-                                    textstroke.get_cursor_for_global_coord(element.pos)
-                                {
-                                    *cursor = new_cursor
-                                }
+                                // If we click outside, reset to idle
+                                self.state = TypewriterState::Idle;
+
+                                pen_progress = PenProgress::Finished;
                             }
                         }
-                    } else {
-                        // If we click outside, reset to idle
-                        self.state = TypewriterState::Idle;
 
-                        pen_progress = PenProgress::Finished;
+                        widget_flags.redraw = true;
+
+                        pen_progress
+                    }
+                    ModifyState::Selecting { finished, .. } => {
+                        let mut pen_progress = PenProgress::InProgress;
+
+                        if let Some(typewriter_bounds) = typewriter_bounds {
+                            // Clicking on the translate node
+                            if Self::translate_node_bounds(typewriter_bounds, engine_view.camera)
+                                .contains_local_point(&na::Point2::from(element.pos))
+                            {
+                                widget_flags.merge(engine_view.store.record(Instant::now()));
+
+                                self.state = TypewriterState::Modifying {
+                                    modify_state: ModifyState::Translating {
+                                        current_pos: element.pos,
+                                    },
+                                    stroke_key: *stroke_key,
+                                    cursor: cursor.clone(),
+                                    pen_down: true,
+                                };
+                            } else if typewriter_bounds
+                                .contains_local_point(&na::Point2::from(element.pos))
+                            {
+                                if let Some(Stroke::TextStroke(textstroke)) =
+                                    engine_view.store.get_stroke_ref(*stroke_key)
+                                {
+                                    // If selecting is finished, return to modifying with the current pen position as cursor
+                                    if *finished {
+                                        if let Ok(new_cursor) =
+                                            textstroke.get_cursor_for_global_coord(element.pos)
+                                        {
+                                            self.state = TypewriterState::Modifying {
+                                                modify_state: ModifyState::Up,
+                                                stroke_key: *stroke_key,
+                                                cursor: new_cursor,
+                                                pen_down: false,
+                                            };
+                                        }
+                                    } else {
+                                        // Updating the cursor for the clicked position
+                                        if let Ok(new_cursor) =
+                                            textstroke.get_cursor_for_global_coord(element.pos)
+                                        {
+                                            *cursor = new_cursor
+                                        }
+                                    }
+                                }
+                            } else {
+                                // If we click outside, reset to idle
+                                self.state = TypewriterState::Idle;
+
+                                pen_progress = PenProgress::Finished;
+                            }
+                        }
+
+                        widget_flags.redraw = true;
+
+                        pen_progress
+                    }
+                    ModifyState::Translating { current_pos, .. } => {
+                        let offset = element.pos - *current_pos;
+
+                        if offset.magnitude()
+                            > Self::TRANSLATE_MAGNITUDE_THRESHOLD / engine_view.camera.total_zoom()
+                        {
+                            engine_view.store.translate_strokes(&[*stroke_key], offset);
+                            engine_view
+                                .store
+                                .translate_strokes_images(&[*stroke_key], offset);
+                            engine_view.store.regenerate_rendering_for_stroke(
+                                *stroke_key,
+                                engine_view.camera.viewport(),
+                                engine_view.camera.image_scale(),
+                            );
+                            *current_pos = element.pos;
+
+                            widget_flags.redraw = true;
+                            widget_flags.store_modified = true;
+                        }
+
+                        PenProgress::InProgress
+                    }
+                    ModifyState::AdjustTextWidth {
+                        start_text_width,
+                        start_pos,
+                        current_pos,
+                    } => {
+                        if let Some(Stroke::TextStroke(textstroke)) =
+                            engine_view.store.get_stroke_mut(*stroke_key)
+                        {
+                            let abs_x_offset = element.pos[0] - start_pos[0];
+                            engine_view.pens_config.typewriter_config.text_width =
+                                (*start_text_width + abs_x_offset).max(2.0);
+                            if let Some(max_width) = &mut textstroke.text_style.max_width {
+                                *max_width = *start_text_width + abs_x_offset;
+                            }
+                        }
+                        engine_view.store.regenerate_rendering_for_stroke(
+                            *stroke_key,
+                            engine_view.camera.viewport(),
+                            engine_view.camera.image_scale(),
+                        );
+                        *current_pos = element.pos;
+
+                        widget_flags.redraw = true;
+                        widget_flags.store_modified = true;
+
+                        PenProgress::InProgress
                     }
                 }
-
-                widget_flags.redraw = true;
-
-                pen_progress
-            }
-            TypewriterState::Translating {
-                stroke_key,
-                current_pos,
-                ..
-            } => {
-                let offset = element.pos - *current_pos;
-
-                if offset.magnitude()
-                    > Self::TRANSLATE_MAGNITUDE_THRESHOLD / engine_view.camera.total_zoom()
-                {
-                    engine_view.store.translate_strokes(&[*stroke_key], offset);
-                    engine_view
-                        .store
-                        .translate_strokes_images(&[*stroke_key], offset);
-
-                    engine_view.store.regenerate_rendering_for_stroke(
-                        *stroke_key,
-                        engine_view.camera.viewport(),
-                        engine_view.camera.image_scale(),
-                    );
-
-                    *current_pos = element.pos;
-
-                    widget_flags.redraw = true;
-                    widget_flags.store_modified = true;
-                }
-
-                PenProgress::InProgress
-            }
-            TypewriterState::AdjustTextWidth {
-                stroke_key,
-                start_text_width,
-                start_pos,
-                current_pos,
-                ..
-            } => {
-                if let Some(Stroke::TextStroke(textstroke)) =
-                    engine_view.store.get_stroke_mut(*stroke_key)
-                {
-                    let abs_x_offset = element.pos[0] - start_pos[0];
-
-                    engine_view.pens_config.typewriter_config.text_width =
-                        (*start_text_width + abs_x_offset).max(2.0);
-
-                    if let Some(max_width) = &mut textstroke.text_style.max_width {
-                        *max_width = *start_text_width + abs_x_offset;
-                    }
-                }
-
-                engine_view.store.regenerate_rendering_for_stroke(
-                    *stroke_key,
-                    engine_view.camera.viewport(),
-                    engine_view.camera.image_scale(),
-                );
-
-                *current_pos = element.pos;
-
-                widget_flags.redraw = true;
-                widget_flags.store_modified = true;
-
-                PenProgress::InProgress
             }
         };
 
@@ -272,82 +275,93 @@ impl Typewriter {
 
     pub(super) fn handle_pen_event_up(
         &mut self,
-        _element: Element,
+        element: Element,
         _modifier_keys: Vec<ModifierKey>,
         _now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
         let mut widget_flags = WidgetFlags::default();
+        let typewriter_bounds = self.bounds_on_doc(&engine_view.as_im());
 
         let pen_progress = match &mut self.state {
             TypewriterState::Idle => PenProgress::Idle,
             TypewriterState::Start(_) => PenProgress::InProgress,
-            TypewriterState::Modifying { pen_down, .. } => {
+            TypewriterState::Modifying {
+                modify_state,
+                stroke_key,
+                cursor,
+                pen_down,
+                ..
+            } => {
                 *pen_down = false;
-                PenProgress::InProgress
-            }
-            TypewriterState::Selecting { finished, .. } => {
-                // finished when drag ended
-                *finished = true;
 
-                widget_flags.redraw = true;
+                match modify_state {
+                    ModifyState::Up | ModifyState::Hover(_) => {
+                        // hover state
+                        *modify_state = if typewriter_bounds
+                            .map(|b| b.contains_local_point(&na::Point2::from(element.pos)))
+                            .unwrap_or(false)
+                        {
+                            ModifyState::Hover(element.pos)
+                        } else {
+                            ModifyState::Up
+                        }
+                    }
+                    ModifyState::Selecting { finished, .. } => {
+                        // finished when drag ended
+                        *finished = true;
 
-                PenProgress::InProgress
-            }
-            TypewriterState::Translating {
-                stroke_key, cursor, ..
-            } => {
-                engine_view
-                    .store
-                    .update_geometry_for_strokes(&[*stroke_key]);
-                engine_view.store.regenerate_rendering_for_stroke(
-                    *stroke_key,
-                    engine_view.camera.viewport(),
-                    engine_view.camera.image_scale(),
-                );
+                        widget_flags.redraw = true;
+                    }
+                    ModifyState::Translating { .. } => {
+                        engine_view
+                            .store
+                            .update_geometry_for_strokes(&[*stroke_key]);
+                        engine_view.store.regenerate_rendering_for_stroke(
+                            *stroke_key,
+                            engine_view.camera.viewport(),
+                            engine_view.camera.image_scale(),
+                        );
+                        engine_view
+                            .doc
+                            .resize_autoexpand(engine_view.store, engine_view.camera);
 
-                self.state = TypewriterState::Modifying {
-                    stroke_key: *stroke_key,
-                    cursor: cursor.clone(),
-                    pen_down: false,
-                };
+                        self.state = TypewriterState::Modifying {
+                            modify_state: ModifyState::Up,
+                            stroke_key: *stroke_key,
+                            cursor: cursor.clone(),
+                            pen_down: false,
+                        };
 
-                engine_view
-                    .doc
-                    .resize_autoexpand(engine_view.store, engine_view.camera);
+                        widget_flags.redraw = true;
+                        widget_flags.resize = true;
+                        widget_flags.store_modified = true;
+                    }
+                    ModifyState::AdjustTextWidth { .. } => {
+                        engine_view
+                            .store
+                            .update_geometry_for_strokes(&[*stroke_key]);
+                        engine_view.store.regenerate_rendering_for_stroke(
+                            *stroke_key,
+                            engine_view.camera.viewport(),
+                            engine_view.camera.image_scale(),
+                        );
+                        engine_view
+                            .doc
+                            .resize_autoexpand(engine_view.store, engine_view.camera);
 
-                widget_flags.redraw = true;
-                widget_flags.resize = true;
-                widget_flags.store_modified = true;
+                        self.state = TypewriterState::Modifying {
+                            modify_state: ModifyState::Up,
+                            stroke_key: *stroke_key,
+                            cursor: cursor.clone(),
+                            pen_down: false,
+                        };
 
-                PenProgress::InProgress
-            }
-            TypewriterState::AdjustTextWidth {
-                stroke_key, cursor, ..
-            } => {
-                engine_view
-                    .store
-                    .update_geometry_for_strokes(&[*stroke_key]);
-                engine_view.store.regenerate_rendering_for_stroke(
-                    *stroke_key,
-                    engine_view.camera.viewport(),
-                    engine_view.camera.image_scale(),
-                );
-
-                self.state = TypewriterState::Modifying {
-                    stroke_key: *stroke_key,
-                    cursor: cursor.clone(),
-                    pen_down: false,
-                };
-
-                engine_view
-                    .doc
-                    .resize_autoexpand(engine_view.store, engine_view.camera);
-
-                widget_flags.redraw = true;
-                widget_flags.resize = true;
-                widget_flags.store_modified = true;
-
+                        widget_flags.redraw = true;
+                        widget_flags.resize = true;
+                        widget_flags.store_modified = true;
+                    }
+                }
                 PenProgress::InProgress
             }
         };
@@ -357,23 +371,33 @@ impl Typewriter {
 
     pub(super) fn handle_pen_event_proximity(
         &mut self,
-        _element: Element,
+        element: Element,
         _modifier_keys: Vec<ModifierKey>,
         _now: Instant,
-        _engine_view: &mut EngineViewMut,
+        engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
         let widget_flags = WidgetFlags::default();
+        let typewriter_bounds = self.bounds_on_doc(&engine_view.as_im());
 
         let pen_progress = match &mut self.state {
             TypewriterState::Idle => PenProgress::Idle,
             TypewriterState::Start(_) => PenProgress::InProgress,
-            TypewriterState::Modifying { pen_down, .. } => {
+            TypewriterState::Modifying {
+                modify_state,
+                pen_down,
+                ..
+            } => {
+                *modify_state = if typewriter_bounds
+                    .map(|b| b.contains_local_point(&na::Point2::from(element.pos)))
+                    .unwrap_or(false)
+                {
+                    ModifyState::Hover(element.pos)
+                } else {
+                    ModifyState::Up
+                };
                 *pen_down = false;
                 PenProgress::InProgress
             }
-            TypewriterState::Selecting { .. } => PenProgress::InProgress,
-            TypewriterState::Translating { .. } => PenProgress::InProgress,
-            TypewriterState::AdjustTextWidth { .. } => PenProgress::InProgress,
         };
 
         (pen_progress, widget_flags)
@@ -401,20 +425,16 @@ impl Typewriter {
                 match keyboard_key {
                     KeyboardKey::Unicode(keychar) => {
                         text_style.ranged_text_attributes.clear();
-
                         if max_width_enabled {
                             text_style.max_width = Some(text_width);
                         }
-
                         let textstroke = TextStroke::new(String::from(keychar), *pos, text_style);
-
                         let mut cursor = GraphemeCursor::new(0, textstroke.text.len(), true);
                         textstroke.move_cursor_forward(&mut cursor);
 
                         let stroke_key = engine_view
                             .store
                             .insert_stroke(Stroke::TextStroke(textstroke), None);
-
                         engine_view.store.regenerate_rendering_for_stroke(
                             stroke_key,
                             engine_view.camera.viewport(),
@@ -422,6 +442,7 @@ impl Typewriter {
                         );
 
                         self.state = TypewriterState::Modifying {
+                            modify_state: ModifyState::Up,
                             stroke_key,
                             cursor,
                             pen_down: false,
@@ -438,297 +459,269 @@ impl Typewriter {
                 PenProgress::InProgress
             }
             TypewriterState::Modifying {
+                modify_state,
                 stroke_key,
                 cursor,
                 pen_down,
             } => {
-                //log::debug!("key: {:?}", keyboard_key);
-                widget_flags.merge(engine_view.store.record(Instant::now()));
-                Self::start_audio(Some(keyboard_key), engine_view.audioplayer);
+                match modify_state {
+                    ModifyState::Up | ModifyState::Hover(_) => {
+                        //log::debug!("key: {:?}", keyboard_key);
+                        widget_flags.merge(engine_view.store.record(Instant::now()));
+                        Self::start_audio(Some(keyboard_key), engine_view.audioplayer);
 
-                if let Some(Stroke::TextStroke(ref mut textstroke)) =
-                    engine_view.store.get_stroke_mut(*stroke_key)
-                {
-                    let mut update_stroke = |store: &mut StrokeStore| {
-                        store.update_geometry_for_stroke(*stroke_key);
-                        store.regenerate_rendering_for_stroke(
-                            *stroke_key,
-                            engine_view.camera.viewport(),
-                            engine_view.camera.image_scale(),
-                        );
-
-                        engine_view.doc.resize_autoexpand(store, engine_view.camera);
-
-                        widget_flags.redraw = true;
-                        widget_flags.resize = true;
-                        widget_flags.store_modified = true;
-                    };
-
-                    // Handling keyboard input
-                    let new_state = match keyboard_key {
-                        KeyboardKey::Unicode(keychar) => {
-                            if keychar == 'a' && modifier_keys.contains(&ModifierKey::KeyboardCtrl)
-                            {
-                                // Select entire text
-
-                                Some(TypewriterState::Selecting {
-                                    stroke_key: *stroke_key,
-                                    cursor: GraphemeCursor::new(
-                                        textstroke.text.len(),
-                                        textstroke.text.len(),
-                                        true,
-                                    ),
-                                    selection_cursor: GraphemeCursor::new(
-                                        0,
-                                        textstroke.text.len(),
-                                        true,
-                                    ),
-                                    finished: true,
-                                })
-                            } else {
-                                textstroke
-                                    .insert_text_after_cursor(keychar.to_string().as_str(), cursor);
-                                update_stroke(engine_view.store);
-                                None
-                            }
-                        }
-                        KeyboardKey::BackSpace => {
-                            textstroke.remove_grapheme_before_cursor(cursor);
-                            update_stroke(engine_view.store);
-                            None
-                        }
-                        KeyboardKey::HorizontalTab => {
-                            textstroke.insert_text_after_cursor("\t", cursor);
-                            update_stroke(engine_view.store);
-                            None
-                        }
-                        KeyboardKey::CarriageReturn | KeyboardKey::Linefeed => {
-                            textstroke.insert_text_after_cursor("\n", cursor);
-                            update_stroke(engine_view.store);
-
-                            None
-                        }
-                        KeyboardKey::Delete => {
-                            textstroke.remove_grapheme_after_cursor(cursor);
-                            update_stroke(engine_view.store);
-
-                            None
-                        }
-                        KeyboardKey::NavLeft => {
-                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
-                                let mut new_cursor = cursor.clone();
-                                textstroke.move_cursor_back(&mut new_cursor);
-
-                                Some(TypewriterState::Selecting {
-                                    stroke_key: *stroke_key,
-                                    cursor: new_cursor,
-                                    selection_cursor: cursor.clone(),
-                                    finished: false,
-                                })
-                            } else {
-                                textstroke.move_cursor_back(cursor);
-
-                                None
-                            }
-                        }
-                        KeyboardKey::NavRight => {
-                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
-                                let mut new_cursor = cursor.clone();
-                                textstroke.move_cursor_forward(&mut new_cursor);
-
-                                Some(TypewriterState::Selecting {
-                                    stroke_key: *stroke_key,
-                                    cursor: new_cursor,
-                                    selection_cursor: cursor.clone(),
-                                    finished: false,
-                                })
-                            } else {
-                                textstroke.move_cursor_forward(cursor);
-
-                                None
-                            }
-                        }
-                        KeyboardKey::NavUp => {
-                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
-                                let mut new_cursor = cursor.clone();
-                                textstroke.move_cursor_line_up(&mut new_cursor);
-
-                                Some(TypewriterState::Selecting {
-                                    stroke_key: *stroke_key,
-                                    cursor: new_cursor,
-                                    selection_cursor: cursor.clone(),
-                                    finished: false,
-                                })
-                            } else {
-                                textstroke.move_cursor_line_up(cursor);
-
-                                None
-                            }
-                        }
-                        KeyboardKey::NavDown => {
-                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
-                                let mut new_cursor = cursor.clone();
-                                textstroke.move_cursor_line_down(&mut new_cursor);
-
-                                Some(TypewriterState::Selecting {
-                                    stroke_key: *stroke_key,
-                                    cursor: new_cursor,
-                                    selection_cursor: cursor.clone(),
-                                    finished: false,
-                                })
-                            } else {
-                                textstroke.move_cursor_line_down(cursor);
-
-                                None
-                            }
-                        }
-                        _ => None,
-                    };
-
-                    *pen_down = false;
-
-                    widget_flags.redraw = true;
-
-                    if let Some(new_state) = new_state {
-                        self.state = new_state;
-                    }
-                }
-
-                PenProgress::InProgress
-            }
-            TypewriterState::Selecting {
-                stroke_key,
-                cursor,
-                selection_cursor,
-                finished,
-            } => {
-                //log::debug!("key: {:?}", keyboard_key);
-                widget_flags.merge(engine_view.store.record(Instant::now()));
-                Self::start_audio(Some(keyboard_key), engine_view.audioplayer);
-
-                if let Some(Stroke::TextStroke(textstroke)) =
-                    engine_view.store.get_stroke_mut(*stroke_key)
-                {
-                    let mut update_stroke = |store: &mut StrokeStore| {
-                        store.update_geometry_for_stroke(*stroke_key);
-                        store.regenerate_rendering_for_stroke(
-                            *stroke_key,
-                            engine_view.camera.viewport(),
-                            engine_view.camera.image_scale(),
-                        );
-
-                        engine_view.doc.resize_autoexpand(store, engine_view.camera);
-
-                        widget_flags.redraw = true;
-                        widget_flags.resize = true;
-                        widget_flags.store_modified = true;
-                    };
-
-                    // Handle keyboard keys
-                    let quit_selecting = match keyboard_key {
-                        KeyboardKey::Unicode(keychar) => {
-                            if keychar == 'a' && modifier_keys.contains(&ModifierKey::KeyboardCtrl)
-                            {
-                                textstroke.update_selection_entire_text(cursor, selection_cursor);
-                                *finished = true;
-
-                                false
-                            } else {
-                                textstroke.replace_text_between_selection_cursors(
-                                    cursor,
-                                    selection_cursor,
-                                    String::from(keychar).as_str(),
+                        if let Some(Stroke::TextStroke(ref mut textstroke)) =
+                            engine_view.store.get_stroke_mut(*stroke_key)
+                        {
+                            let mut update_stroke = |store: &mut StrokeStore| {
+                                store.update_geometry_for_stroke(*stroke_key);
+                                store.regenerate_rendering_for_stroke(
+                                    *stroke_key,
+                                    engine_view.camera.viewport(),
+                                    engine_view.camera.image_scale(),
                                 );
+                                engine_view.doc.resize_autoexpand(store, engine_view.camera);
 
-                                update_stroke(engine_view.store);
-                                true
-                            }
-                        }
-                        KeyboardKey::NavLeft => {
-                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
-                                textstroke.move_cursor_back(cursor);
-                                false
-                            } else {
-                                true
-                            }
-                        }
-                        KeyboardKey::NavRight => {
-                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
-                                textstroke.move_cursor_forward(cursor);
-                                false
-                            } else {
-                                true
-                            }
-                        }
-                        KeyboardKey::NavUp => {
-                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
-                                textstroke.move_cursor_line_up(cursor);
-                                false
-                            } else {
-                                true
-                            }
-                        }
-                        KeyboardKey::NavDown => {
-                            if modifier_keys.contains(&ModifierKey::KeyboardShift) {
-                                textstroke.move_cursor_line_down(cursor);
-                                false
-                            } else {
-                                true
-                            }
-                        }
-                        KeyboardKey::CarriageReturn | KeyboardKey::Linefeed => {
-                            textstroke.replace_text_between_selection_cursors(
-                                cursor,
-                                selection_cursor,
-                                "\n",
-                            );
+                                widget_flags.redraw = true;
+                                widget_flags.resize = true;
+                                widget_flags.store_modified = true;
+                            };
 
-                            update_stroke(engine_view.store);
-                            true
-                        }
-                        KeyboardKey::BackSpace | KeyboardKey::Delete => {
-                            textstroke.replace_text_between_selection_cursors(
-                                cursor,
-                                selection_cursor,
-                                "",
-                            );
+                            // Handling keyboard input
+                            match keyboard_key {
+                                KeyboardKey::Unicode(keychar) => {
+                                    if keychar == 'a'
+                                        && modifier_keys.contains(&ModifierKey::KeyboardCtrl)
+                                    {
+                                        *cursor = GraphemeCursor::new(
+                                            textstroke.text.len(),
+                                            textstroke.text.len(),
+                                            true,
+                                        );
+                                        // Select entire text
+                                        *modify_state = ModifyState::Selecting {
+                                            selection_cursor: GraphemeCursor::new(
+                                                0,
+                                                textstroke.text.len(),
+                                                true,
+                                            ),
+                                            finished: true,
+                                        };
+                                    } else {
+                                        textstroke.insert_text_after_cursor(
+                                            keychar.to_string().as_str(),
+                                            cursor,
+                                        );
+                                        update_stroke(engine_view.store);
+                                    }
+                                }
+                                KeyboardKey::BackSpace => {
+                                    textstroke.remove_grapheme_before_cursor(cursor);
+                                    update_stroke(engine_view.store);
+                                }
+                                KeyboardKey::HorizontalTab => {
+                                    textstroke.insert_text_after_cursor("\t", cursor);
+                                    update_stroke(engine_view.store);
+                                }
+                                KeyboardKey::CarriageReturn | KeyboardKey::Linefeed => {
+                                    textstroke.insert_text_after_cursor("\n", cursor);
+                                    update_stroke(engine_view.store);
+                                }
+                                KeyboardKey::Delete => {
+                                    textstroke.remove_grapheme_after_cursor(cursor);
+                                    update_stroke(engine_view.store);
+                                }
+                                KeyboardKey::NavLeft => {
+                                    if modifier_keys.contains(&ModifierKey::KeyboardShift) {
+                                        let mut new_cursor = cursor.clone();
+                                        textstroke.move_cursor_back(&mut new_cursor);
+                                        *cursor = new_cursor;
+                                        *modify_state = ModifyState::Selecting {
+                                            selection_cursor: cursor.clone(),
+                                            finished: false,
+                                        }
+                                    } else {
+                                        textstroke.move_cursor_back(cursor);
+                                    }
+                                }
+                                KeyboardKey::NavRight => {
+                                    if modifier_keys.contains(&ModifierKey::KeyboardShift) {
+                                        let mut new_cursor = cursor.clone();
+                                        textstroke.move_cursor_forward(&mut new_cursor);
+                                        *cursor = new_cursor;
+                                        *modify_state = ModifyState::Selecting {
+                                            selection_cursor: cursor.clone(),
+                                            finished: false,
+                                        };
+                                    } else {
+                                        textstroke.move_cursor_forward(cursor);
+                                    }
+                                }
+                                KeyboardKey::NavUp => {
+                                    if modifier_keys.contains(&ModifierKey::KeyboardShift) {
+                                        let mut new_cursor = cursor.clone();
+                                        textstroke.move_cursor_line_up(&mut new_cursor);
+                                        *cursor = new_cursor;
+                                        *modify_state = ModifyState::Selecting {
+                                            selection_cursor: cursor.clone(),
+                                            finished: false,
+                                        };
+                                    } else {
+                                        textstroke.move_cursor_line_up(cursor);
+                                    }
+                                }
+                                KeyboardKey::NavDown => {
+                                    if modifier_keys.contains(&ModifierKey::KeyboardShift) {
+                                        let mut new_cursor = cursor.clone();
+                                        textstroke.move_cursor_line_down(&mut new_cursor);
+                                        *cursor = new_cursor;
+                                        *modify_state = ModifyState::Selecting {
+                                            selection_cursor: cursor.clone(),
+                                            finished: false,
+                                        };
+                                    } else {
+                                        textstroke.move_cursor_line_down(cursor);
+                                    }
+                                }
+                                _ => {}
+                            };
 
-                            update_stroke(engine_view.store);
-                            true
-                        }
-                        KeyboardKey::HorizontalTab => {
-                            textstroke.replace_text_between_selection_cursors(
-                                cursor,
-                                selection_cursor,
-                                "\t",
-                            );
+                            *pen_down = false;
 
-                            update_stroke(engine_view.store);
-                            true
+                            widget_flags.redraw = true;
                         }
-                        KeyboardKey::CtrlLeft
-                        | KeyboardKey::CtrlRight
-                        | KeyboardKey::ShiftLeft
-                        | KeyboardKey::ShiftRight => false,
-                        _ => true,
-                    };
 
-                    if quit_selecting {
-                        // Back to modifying
-                        self.state = TypewriterState::Modifying {
-                            stroke_key: *stroke_key,
-                            cursor: cursor.clone(),
-                            pen_down: false,
-                        };
+                        PenProgress::InProgress
                     }
+                    ModifyState::Selecting {
+                        selection_cursor,
+                        finished,
+                    } => {
+                        //log::debug!("key: {:?}", keyboard_key);
+                        widget_flags.merge(engine_view.store.record(Instant::now()));
+                        Self::start_audio(Some(keyboard_key), engine_view.audioplayer);
+
+                        if let Some(Stroke::TextStroke(textstroke)) =
+                            engine_view.store.get_stroke_mut(*stroke_key)
+                        {
+                            let mut update_stroke = |store: &mut StrokeStore| {
+                                store.update_geometry_for_stroke(*stroke_key);
+                                store.regenerate_rendering_for_stroke(
+                                    *stroke_key,
+                                    engine_view.camera.viewport(),
+                                    engine_view.camera.image_scale(),
+                                );
+                                engine_view.doc.resize_autoexpand(store, engine_view.camera);
+
+                                widget_flags.redraw = true;
+                                widget_flags.resize = true;
+                                widget_flags.store_modified = true;
+                            };
+
+                            // Handle keyboard keys
+                            let quit_selecting = match keyboard_key {
+                                KeyboardKey::Unicode(keychar) => {
+                                    if keychar == 'a'
+                                        && modifier_keys.contains(&ModifierKey::KeyboardCtrl)
+                                    {
+                                        textstroke
+                                            .update_selection_entire_text(cursor, selection_cursor);
+                                        *finished = true;
+                                        false
+                                    } else {
+                                        textstroke.replace_text_between_selection_cursors(
+                                            cursor,
+                                            selection_cursor,
+                                            String::from(keychar).as_str(),
+                                        );
+                                        update_stroke(engine_view.store);
+                                        true
+                                    }
+                                }
+                                KeyboardKey::NavLeft => {
+                                    if modifier_keys.contains(&ModifierKey::KeyboardShift) {
+                                        textstroke.move_cursor_back(cursor);
+                                        false
+                                    } else {
+                                        true
+                                    }
+                                }
+                                KeyboardKey::NavRight => {
+                                    if modifier_keys.contains(&ModifierKey::KeyboardShift) {
+                                        textstroke.move_cursor_forward(cursor);
+                                        false
+                                    } else {
+                                        true
+                                    }
+                                }
+                                KeyboardKey::NavUp => {
+                                    if modifier_keys.contains(&ModifierKey::KeyboardShift) {
+                                        textstroke.move_cursor_line_up(cursor);
+                                        false
+                                    } else {
+                                        true
+                                    }
+                                }
+                                KeyboardKey::NavDown => {
+                                    if modifier_keys.contains(&ModifierKey::KeyboardShift) {
+                                        textstroke.move_cursor_line_down(cursor);
+                                        false
+                                    } else {
+                                        true
+                                    }
+                                }
+                                KeyboardKey::CarriageReturn | KeyboardKey::Linefeed => {
+                                    textstroke.replace_text_between_selection_cursors(
+                                        cursor,
+                                        selection_cursor,
+                                        "\n",
+                                    );
+                                    update_stroke(engine_view.store);
+                                    true
+                                }
+                                KeyboardKey::BackSpace | KeyboardKey::Delete => {
+                                    textstroke.replace_text_between_selection_cursors(
+                                        cursor,
+                                        selection_cursor,
+                                        "",
+                                    );
+                                    update_stroke(engine_view.store);
+                                    true
+                                }
+                                KeyboardKey::HorizontalTab => {
+                                    textstroke.replace_text_between_selection_cursors(
+                                        cursor,
+                                        selection_cursor,
+                                        "\t",
+                                    );
+                                    update_stroke(engine_view.store);
+                                    true
+                                }
+                                KeyboardKey::CtrlLeft
+                                | KeyboardKey::CtrlRight
+                                | KeyboardKey::ShiftLeft
+                                | KeyboardKey::ShiftRight => false,
+                                _ => true,
+                            };
+
+                            if quit_selecting {
+                                // Back to modifying
+                                self.state = TypewriterState::Modifying {
+                                    modify_state: ModifyState::Up,
+                                    stroke_key: *stroke_key,
+                                    cursor: cursor.clone(),
+                                    pen_down: false,
+                                };
+                            }
+                        }
+
+                        widget_flags.redraw = true;
+
+                        PenProgress::InProgress
+                    }
+                    _ => PenProgress::InProgress,
                 }
-
-                widget_flags.redraw = true;
-
-                PenProgress::InProgress
             }
-            TypewriterState::Translating { .. } => PenProgress::InProgress,
-            TypewriterState::AdjustTextWidth { .. } => PenProgress::InProgress,
         };
 
         (pen_progress, widget_flags)
@@ -753,20 +746,16 @@ impl Typewriter {
                 Self::start_audio(None, engine_view.audioplayer);
 
                 text_style.ranged_text_attributes.clear();
-
                 if max_width_enabled {
                     text_style.max_width = Some(text_width);
                 }
                 let text_len = text.len();
-
                 let textstroke = TextStroke::new(text, *pos, text_style);
-
                 let cursor = GraphemeCursor::new(text_len, text_len, true);
 
                 let stroke_key = engine_view
                     .store
                     .insert_stroke(Stroke::TextStroke(textstroke), None);
-
                 engine_view.store.regenerate_rendering_for_stroke(
                     stroke_key,
                     engine_view.camera.viewport(),
@@ -774,6 +763,7 @@ impl Typewriter {
                 );
 
                 self.state = TypewriterState::Modifying {
+                    modify_state: ModifyState::Up,
                     stroke_key,
                     cursor,
                     pen_down: false,
@@ -786,83 +776,81 @@ impl Typewriter {
                 PenProgress::InProgress
             }
             TypewriterState::Modifying {
+                modify_state,
                 stroke_key,
                 cursor,
                 pen_down,
             } => {
-                // Only record between words
-                if text.contains(' ') {
-                    widget_flags.merge(engine_view.store.record(Instant::now()));
-                }
-                Self::start_audio(None, engine_view.audioplayer);
+                match modify_state {
+                    ModifyState::Up | ModifyState::Hover(_) => {
+                        // Only record between words
+                        if text.contains(' ') {
+                            widget_flags.merge(engine_view.store.record(Instant::now()));
+                        }
+                        Self::start_audio(None, engine_view.audioplayer);
 
-                if let Some(Stroke::TextStroke(ref mut textstroke)) =
-                    engine_view.store.get_stroke_mut(*stroke_key)
-                {
-                    textstroke.insert_text_after_cursor(&text, cursor);
+                        if let Some(Stroke::TextStroke(ref mut textstroke)) =
+                            engine_view.store.get_stroke_mut(*stroke_key)
+                        {
+                            textstroke.insert_text_after_cursor(&text, cursor);
+                            engine_view.store.update_geometry_for_stroke(*stroke_key);
+                            engine_view.store.regenerate_rendering_for_stroke(
+                                *stroke_key,
+                                engine_view.camera.viewport(),
+                                engine_view.camera.image_scale(),
+                            );
+                            engine_view
+                                .doc
+                                .resize_autoexpand(engine_view.store, engine_view.camera);
 
-                    engine_view.store.update_geometry_for_stroke(*stroke_key);
-                    engine_view.store.regenerate_rendering_for_stroke(
-                        *stroke_key,
-                        engine_view.camera.viewport(),
-                        engine_view.camera.image_scale(),
-                    );
+                            *pen_down = false;
 
-                    engine_view
-                        .doc
-                        .resize_autoexpand(engine_view.store, engine_view.camera);
+                            widget_flags.redraw = true;
+                            widget_flags.resize = true;
+                            widget_flags.store_modified = true;
+                        }
 
-                    widget_flags.redraw = true;
-                    widget_flags.resize = true;
-                    widget_flags.store_modified = true;
-
-                    *pen_down = false;
-                }
-
-                PenProgress::InProgress
-            }
-            TypewriterState::Selecting {
-                stroke_key,
-                cursor,
-                selection_cursor,
-                finished,
-            } => {
-                if text.contains(' ') {
-                    widget_flags.merge(engine_view.store.record(Instant::now()));
-                }
-                Self::start_audio(None, engine_view.audioplayer);
-
-                if let Some(Stroke::TextStroke(textstroke)) =
-                    engine_view.store.get_stroke_mut(*stroke_key)
-                {
-                    textstroke.replace_text_between_selection_cursors(
-                        cursor,
+                        PenProgress::InProgress
+                    }
+                    ModifyState::Selecting {
                         selection_cursor,
-                        text.as_str(),
-                    );
+                        finished,
+                    } => {
+                        if text.contains(' ') {
+                            widget_flags.merge(engine_view.store.record(Instant::now()));
+                        }
+                        Self::start_audio(None, engine_view.audioplayer);
 
-                    engine_view.store.update_geometry_for_stroke(*stroke_key);
-                    engine_view.store.regenerate_rendering_for_stroke(
-                        *stroke_key,
-                        engine_view.camera.viewport(),
-                        engine_view.camera.image_scale(),
-                    );
+                        if let Some(Stroke::TextStroke(textstroke)) =
+                            engine_view.store.get_stroke_mut(*stroke_key)
+                        {
+                            textstroke.replace_text_between_selection_cursors(
+                                cursor,
+                                selection_cursor,
+                                text.as_str(),
+                            );
+                            engine_view.store.update_geometry_for_stroke(*stroke_key);
+                            engine_view.store.regenerate_rendering_for_stroke(
+                                *stroke_key,
+                                engine_view.camera.viewport(),
+                                engine_view.camera.image_scale(),
+                            );
+                            engine_view
+                                .doc
+                                .resize_autoexpand(engine_view.store, engine_view.camera);
 
-                    engine_view
-                        .doc
-                        .resize_autoexpand(engine_view.store, engine_view.camera);
+                            *finished = true;
 
-                    widget_flags.redraw = true;
-                    widget_flags.resize = true;
-                    widget_flags.store_modified = true;
+                            widget_flags.redraw = true;
+                            widget_flags.resize = true;
+                            widget_flags.store_modified = true;
+                        }
 
-                    *finished = true
+                        PenProgress::InProgress
+                    }
+                    _ => PenProgress::InProgress,
                 }
-
-                PenProgress::InProgress
             }
-            TypewriterState::Translating { .. } => PenProgress::InProgress,
-            TypewriterState::AdjustTextWidth { .. } => PenProgress::InProgress,
         };
 
         (pen_progress, widget_flags)
@@ -877,39 +865,9 @@ impl Typewriter {
 
         let pen_progress = match &mut self.state {
             TypewriterState::Idle => PenProgress::Idle,
-            TypewriterState::Start(_) => {
+            _ => {
                 self.state = TypewriterState::Idle;
-
                 widget_flags.redraw = true;
-
-                PenProgress::Finished
-            }
-            TypewriterState::Modifying { .. } => {
-                self.state = TypewriterState::Idle;
-
-                widget_flags.redraw = true;
-
-                PenProgress::Finished
-            }
-            TypewriterState::Selecting { .. } => {
-                self.state = TypewriterState::Idle;
-
-                widget_flags.redraw = true;
-
-                PenProgress::Finished
-            }
-            TypewriterState::Translating { .. } => {
-                self.state = TypewriterState::Idle;
-
-                widget_flags.redraw = true;
-
-                PenProgress::Finished
-            }
-            TypewriterState::AdjustTextWidth { .. } => {
-                self.state = TypewriterState::Idle;
-
-                widget_flags.redraw = true;
-
                 PenProgress::Finished
             }
         };

--- a/rnote-engine/src/utils.rs
+++ b/rnote-engine/src/utils.rs
@@ -4,7 +4,7 @@ use geo::line_string;
 use gtk4::{gdk, gio, glib, graphene, gsk, pango, prelude::*};
 use p2d::bounding_volume::Aabb;
 use rnote_compose::Color;
-use rnote_compose::{penevents::KeyboardKey, Transform};
+use rnote_compose::Transform;
 use rnote_fileformats::xoppformat;
 
 pub trait GdkRGBAHelpers
@@ -188,32 +188,6 @@ pub fn p2d_aabb_to_geo_polygon(aabb: Aabb) -> geo::Polygon<f64> {
         (x: aabb.mins[0], y: aabb.mins[1]),
     ];
     geo::Polygon::new(line_string, vec![])
-}
-
-pub fn keyboard_key_from_gdk(gdk_key: gdk::Key) -> KeyboardKey {
-    //log::debug!("gdk: pressed key: {:?}", gdk_key);
-
-    if let Some(keychar) = gdk_key.to_unicode() {
-        KeyboardKey::Unicode(keychar).filter_convert_unicode_control_chars()
-    } else {
-        match gdk_key {
-            gdk::Key::BackSpace => KeyboardKey::BackSpace,
-            gdk::Key::Tab => KeyboardKey::HorizontalTab,
-            gdk::Key::Linefeed => KeyboardKey::Linefeed,
-            gdk::Key::Return => KeyboardKey::CarriageReturn,
-            gdk::Key::Escape => KeyboardKey::Escape,
-            gdk::Key::Delete => KeyboardKey::Delete,
-            gdk::Key::Down => KeyboardKey::NavDown,
-            gdk::Key::Up => KeyboardKey::NavUp,
-            gdk::Key::Left => KeyboardKey::NavLeft,
-            gdk::Key::Right => KeyboardKey::NavRight,
-            gdk::Key::Shift_L => KeyboardKey::ShiftLeft,
-            gdk::Key::Shift_R => KeyboardKey::ShiftRight,
-            gdk::Key::Control_L => KeyboardKey::CtrlLeft,
-            gdk::Key::Control_R => KeyboardKey::CtrlRight,
-            _ => KeyboardKey::Unsupported,
-        }
-    }
 }
 
 pub fn positive_range<I>(first: I, second: I) -> Range<I>

--- a/rnote-ui/src/canvas/input.rs
+++ b/rnote-ui/src/canvas/input.rs
@@ -50,8 +50,9 @@ pub(crate) fn handle_pointer_controller_event(
                     state = PenState::Proximity;
                 }
             } else {
-                // Only handle mouse left and right click
-                if modifiers.contains(gdk::ModifierType::BUTTON1_MASK)
+                // avoids handling middle mouse button
+                if modifiers.is_empty()
+                    | modifiers.contains(gdk::ModifierType::BUTTON1_MASK)
                     | modifiers.contains(gdk::ModifierType::BUTTON3_MASK)
                 {
                     handle_pen_event = true;

--- a/rnote-ui/src/canvas/input.rs
+++ b/rnote-ui/src/canvas/input.rs
@@ -19,9 +19,7 @@ pub(crate) fn handle_pointer_controller_event(
     let touch_drawing = canvas.touch_drawing();
     let event_type = event.event_type();
 
-    if event_type != gdk::EventType::MotionNotify {
-        super::input::debug_gdk_event(event);
-    }
+    super::input::debug_gdk_event(event);
 
     if reject_pointer_input(event, touch_drawing) {
         return (Inhibit(false), state);
@@ -48,10 +46,10 @@ pub(crate) fn handle_pointer_controller_event(
                     state = PenState::Proximity;
                 }
             } else {
-                // avoids handling middle mouse button
+                // only handle primary and secondary mouse buttons
                 if modifiers.is_empty()
-                    | modifiers.contains(gdk::ModifierType::BUTTON1_MASK)
-                    | modifiers.contains(gdk::ModifierType::BUTTON3_MASK)
+                    || modifiers.contains(gdk::ModifierType::BUTTON1_MASK)
+                    || modifiers.contains(gdk::ModifierType::BUTTON3_MASK)
                 {
                     handle_pen_event = true;
                     inhibit = true;

--- a/rnote-ui/src/canvas/input.rs
+++ b/rnote-ui/src/canvas/input.rs
@@ -318,7 +318,7 @@ pub(crate) fn retrieve_button_shortcut_key(
             if is_stylus {
                 Some(ShortcutKey::StylusPrimaryButton)
             } else {
-                Some(ShortcutKey::StylusSecondaryButton)
+                Some(ShortcutKey::MouseSecondaryButton)
             }
         }
         gdk::BUTTON_MIDDLE => {

--- a/rnote-ui/src/canvas/input.rs
+++ b/rnote-ui/src/canvas/input.rs
@@ -59,11 +59,11 @@ pub(crate) fn handle_pointer_controller_event(
         gdk::EventType::ButtonPress => {
             let button_event = event.downcast_ref::<gdk::ButtonEvent>().unwrap();
             let gdk_button = button_event.button();
-            log::debug!("ButtonPress - button: {gdk_button}, is_stylus: {is_stylus}");
+
+            //log::debug!("ButtonPress - button: {gdk_button}, is_stylus: {is_stylus}");
 
             if is_stylus {
                 // even though it is a button press, we handle it also as pen event so the engine gets the chance to switch pen mode, pen style, etc.
-                #[allow(clippy::collapsible_else_if)]
                 if gdk_button == gdk::BUTTON_PRIMARY
                     || gdk_button == gdk::BUTTON_SECONDARY
                     || gdk_button == gdk::BUTTON_MIDDLE
@@ -94,11 +94,17 @@ pub(crate) fn handle_pointer_controller_event(
         gdk::EventType::ButtonRelease => {
             let button_event = event.downcast_ref::<gdk::ButtonEvent>().unwrap();
             let gdk_button = button_event.button();
-            log::debug!("ButtonRelease - button: {gdk_button}, is_stylus: {is_stylus}");
+
+            //log::debug!("ButtonRelease - button: {gdk_button}, is_stylus: {is_stylus}");
 
             if is_stylus {
-                handle_pen_event = true;
-                inhibit = true;
+                if gdk_button == gdk::BUTTON_PRIMARY
+                    || gdk_button == gdk::BUTTON_SECONDARY
+                    || gdk_button == gdk::BUTTON_MIDDLE
+                {
+                    handle_pen_event = true;
+                    inhibit = true;
+                }
 
                 // again, this is the method to detect proximity on stylus
                 if gdk_button == gdk::BUTTON_PRIMARY {

--- a/rnote-ui/src/canvas/mod.rs
+++ b/rnote-ui/src/canvas/mod.rs
@@ -4,34 +4,29 @@ mod input;
 
 // Re-exports
 pub(crate) use canvaslayout::RnCanvasLayout;
-use gettextrs::gettext;
-use rnote_engine::pens::PenMode;
 
 // Imports
-use std::cell::{Cell, RefCell};
-use std::path::PathBuf;
-use std::rc::Rc;
-
-use crate::config;
-use rnote_engine::{RnoteEngine, WidgetFlags};
-
+use futures::StreamExt;
+use gettextrs::gettext;
 use gtk4::{
     gdk, gio, glib, glib::clone, graphene, prelude::*, subclass::prelude::*, AccessibleRole,
-    Adjustment, DropTarget, EventControllerKey, EventSequenceState, GestureDrag, GestureStylus,
-    IMMulticontext, Inhibit, PropagationPhase, Scrollable, ScrollablePolicy, Widget,
+    Adjustment, DropTarget, EventControllerKey, EventControllerLegacy, IMMulticontext, Inhibit,
+    PropagationPhase, Scrollable, ScrollablePolicy, Widget,
 };
-
-use crate::appwindow::RnAppWindow;
-use futures::StreamExt;
 use once_cell::sync::Lazy;
 use p2d::bounding_volume::Aabb;
 use rnote_compose::helpers::AabbHelpers;
-use rnote_compose::penpath::Element;
+use rnote_compose::penevents::PenState;
 use rnote_engine::utils::GrapheneRectHelpers;
 use rnote_engine::Document;
+use rnote_engine::{RnoteEngine, WidgetFlags};
+use std::cell::{Cell, RefCell};
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::time::Duration;
 
-use std::collections::VecDeque;
-use std::time::{self, Instant};
+use crate::appwindow::RnAppWindow;
+use crate::config;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, glib::Boxed)]
 #[boxed_type(name = "WidgetFlagsBoxed")]
@@ -70,9 +65,7 @@ mod imp {
         pub(crate) regular_cursor_icon_name: RefCell<String>,
         pub(crate) drawing_cursor: RefCell<gdk::Cursor>,
         pub(crate) drawing_cursor_icon_name: RefCell<String>,
-        pub(crate) stylus_drawing_gesture: GestureStylus,
-        pub(crate) mouse_drawing_gesture: GestureDrag,
-        pub(crate) touch_drawing_gesture: GestureDrag,
+        pub(crate) pointer_controller: EventControllerLegacy,
         pub(crate) key_controller: EventControllerKey,
         pub(crate) key_controller_im_context: IMMulticontext,
         pub(crate) drop_target: DropTarget,
@@ -93,24 +86,8 @@ mod imp {
 
     impl Default for RnCanvas {
         fn default() -> Self {
-            let stylus_drawing_gesture = GestureStylus::builder()
-                .name("stylus_drawing_gesture")
-                .propagation_phase(PropagationPhase::Target)
-                // Listen for any button
-                .button(0)
-                .build();
-
-            // mouse gesture handlers have a guard to not handle emulated pointer events ( e.g. coming from touch input )
-            // matching different input methods with gdk4::InputSource or gdk4::DeviceToolType did NOT WORK unfortunately, dont know why
-            let mouse_drawing_gesture = GestureDrag::builder()
-                .name("mouse_drawing_gesture")
-                .button(0)
-                .propagation_phase(PropagationPhase::Bubble)
-                .build();
-
-            let touch_drawing_gesture = GestureDrag::builder()
-                .name("touch_drawing_gesture")
-                .touch_only(true)
+            let pointer_controller = EventControllerLegacy::builder()
+                .name("pointer_controller")
                 .propagation_phase(PropagationPhase::Bubble)
                 .build();
 
@@ -129,10 +106,6 @@ mod imp {
 
             // The order here is important: first files, then text
             drop_target.set_types(&[gio::File::static_type(), glib::types::Type::STRING]);
-
-            // Gesture grouping
-            mouse_drawing_gesture.group_with(&stylus_drawing_gesture);
-            touch_drawing_gesture.group_with(&stylus_drawing_gesture);
 
             let regular_cursor_icon_name = String::from("cursor-dot-medium");
             let regular_cursor = gdk::Cursor::from_texture(
@@ -170,9 +143,7 @@ mod imp {
                 regular_cursor_icon_name: RefCell::new(regular_cursor_icon_name),
                 drawing_cursor: RefCell::new(drawing_cursor),
                 drawing_cursor_icon_name: RefCell::new(drawing_cursor_icon_name),
-                stylus_drawing_gesture,
-                mouse_drawing_gesture,
-                touch_drawing_gesture,
+                pointer_controller,
                 key_controller,
                 key_controller_im_context,
                 drop_target,
@@ -223,9 +194,7 @@ mod imp {
 
             inst.set_cursor(Some(&*self.regular_cursor.borrow()));
 
-            inst.add_controller(&self.stylus_drawing_gesture);
-            inst.add_controller(&self.mouse_drawing_gesture);
-            inst.add_controller(&self.touch_drawing_gesture);
+            inst.add_controller(&self.pointer_controller);
             inst.add_controller(&self.key_controller);
             inst.add_controller(&self.drop_target);
 
@@ -372,13 +341,6 @@ mod imp {
                     let touch_drawing: bool =
                         value.get().expect("The value needs to be of type `bool`");
                     self.touch_drawing.replace(touch_drawing);
-                    if touch_drawing {
-                        self.touch_drawing_gesture
-                            .set_propagation_phase(PropagationPhase::Bubble);
-                    } else {
-                        self.touch_drawing_gesture
-                            .set_propagation_phase(PropagationPhase::None);
-                    }
                 }
                 "regular-cursor" => {
                     let icon_name = value.get().unwrap();
@@ -484,258 +446,35 @@ mod imp {
         fn setup_input(&self) {
             let inst = self.instance();
 
-            // Stylus Drawing
-            self.stylus_drawing_gesture.connect_down(clone!(@weak inst as canvas => move |stylus_drawing_gesture,x,y| {
-            //log::debug!("stylus_drawing_gesture down");
-            //input::debug_stylus_gesture(stylus_drawing_gesture);
-
-            if input::filter_stylus_input(stylus_drawing_gesture) { return; }
-            stylus_drawing_gesture.set_state(EventSequenceState::Claimed);
-            canvas.grab_focus();
-
-            let mut data_entries = input::retrieve_stylus_elements(stylus_drawing_gesture, x, y);
-           Element::transform_elements(&mut data_entries, canvas.engine().borrow().camera.transform().inverse());
-
-            let shortcut_keys = input::retrieve_stylus_shortcut_keys(stylus_drawing_gesture);
-            let pen_mode = input::retrieve_stylus_pen_mode(stylus_drawing_gesture);
-
-            let mut widget_flags = WidgetFlags::default();
-            for element in data_entries {
-                widget_flags.merge(input::process_pen_down(&canvas, element, shortcut_keys.clone(), pen_mode, Instant::now(), ));
-            }
-
-            canvas.emit_handle_widget_flags(widget_flags);
-        }));
-
-            self.stylus_drawing_gesture.connect_motion(clone!(@weak inst as canvas => move |stylus_drawing_gesture, x, y| {
-            //log::debug!("stylus_drawing_gesture motion");
-            //input::debug_stylus_gesture(stylus_drawing_gesture);
-
-            if input::filter_stylus_input(stylus_drawing_gesture) { return; }
-
-            let mut data_entries: VecDeque<Element> = input::retrieve_stylus_elements(stylus_drawing_gesture, x, y);
-            Element::transform_elements(&mut data_entries, canvas.engine().borrow().camera.transform().inverse());
-
-            let shortcut_keys = input::retrieve_stylus_shortcut_keys(stylus_drawing_gesture);
-            let pen_mode = input::retrieve_stylus_pen_mode(stylus_drawing_gesture);
-
-            let mut widget_flags = WidgetFlags::default();
-            for element in data_entries {
-                widget_flags.merge(input::process_pen_down(&canvas, element, shortcut_keys.clone(), pen_mode, Instant::now()));
-            }
-            canvas.emit_handle_widget_flags(widget_flags);
-        }));
-
-            self.stylus_drawing_gesture.connect_up(clone!(@weak inst as canvas => move |stylus_drawing_gesture,x,y| {
-            //log::debug!("stylus_drawing_gesture up");
-            //input::debug_stylus_gesture(stylus_drawing_gesture);
-
-            if input::filter_stylus_input(stylus_drawing_gesture) { return; }
-
-            let mut data_entries = input::retrieve_stylus_elements(stylus_drawing_gesture, x, y);
-            Element::transform_elements(&mut data_entries, canvas.engine().borrow().camera.transform().inverse());
-
-            let shortcut_keys = input::retrieve_stylus_shortcut_keys(stylus_drawing_gesture);
-            let pen_mode = input::retrieve_stylus_pen_mode(stylus_drawing_gesture);
-
-            if let Some(last) = data_entries.pop_back() {
-                let mut widget_flags = WidgetFlags::default();
-                for element in data_entries {
-                    widget_flags.merge(input::process_pen_down(&canvas, element, shortcut_keys.clone(), pen_mode, Instant::now()));
-                }
-                widget_flags.merge(input::process_pen_up(&canvas, last, shortcut_keys, pen_mode, Instant::now()));
-                canvas.emit_handle_widget_flags(widget_flags);
-            }
-        }));
-
-            self.stylus_drawing_gesture.connect_proximity(clone!(@weak inst as canvas => move |stylus_drawing_gesture,x,y| {
-            //log::debug!("stylus_drawing_gesture proximity");
-            //input::debug_stylus_gesture(stylus_drawing_gesture);
-
-            if input::filter_stylus_input(stylus_drawing_gesture) { return; }
-
-            let mut data_entries = input::retrieve_stylus_elements(stylus_drawing_gesture, x, y);
-            Element::transform_elements(&mut data_entries, canvas.engine().borrow().camera.transform().inverse());
-
-            let shortcut_keys = input::retrieve_stylus_shortcut_keys(stylus_drawing_gesture);
-            let pen_mode = input::retrieve_stylus_pen_mode(stylus_drawing_gesture);
-
-            let mut widget_flags = WidgetFlags::default();
-            for element in data_entries {
-                widget_flags.merge(input::process_pen_proximity(&canvas, element, shortcut_keys.clone(), pen_mode, Instant::now()));
-            }
-            canvas.emit_handle_widget_flags(widget_flags);
-        }));
-
-            // Mouse drawing
-            self.mouse_drawing_gesture.connect_drag_begin(clone!(@weak inst as canvas => move |mouse_drawing_gesture, x, y| {
-            //log::debug!("mouse_drawing_gesture begin");
-            //input::debug_drag_gesture(mouse_drawing_gesture);
-
-            if input::filter_mouse_input(mouse_drawing_gesture) { return; }
-            mouse_drawing_gesture.set_state(EventSequenceState::Claimed);
-            canvas.grab_focus();
-
-            let mut data_entries = input::retrieve_pointer_elements(mouse_drawing_gesture, x, y);
-            Element::transform_elements(&mut data_entries, canvas.engine().borrow().camera.transform().inverse());
-
-            let shortcut_keys = input::retrieve_mouse_shortcut_keys(mouse_drawing_gesture);
-
-            let mut widget_flags = WidgetFlags::default();
-            for element in data_entries {
-                widget_flags.merge(input::process_pen_down(&canvas, element, shortcut_keys.clone(), Some(PenMode::Pen), Instant::now()));
-            }
-            canvas.emit_handle_widget_flags(widget_flags);
-        }));
-
-            self.mouse_drawing_gesture.connect_drag_update(clone!(@weak inst as canvas => move |mouse_drawing_gesture, x, y| {
-            //log::debug!("mouse_drawing_gesture motion");
-            //input::debug_drag_gesture(mouse_drawing_gesture);
-
-            if input::filter_mouse_input(mouse_drawing_gesture) { return; }
-
-            if let Some(start_point) = mouse_drawing_gesture.start_point() {
-                let mut data_entries = input::retrieve_pointer_elements(mouse_drawing_gesture, x, y);
-                Element::transform_elements(&mut data_entries, canvas.engine().borrow().camera.transform().inverse() * na::Translation2::new(start_point.0, start_point.1));
-
-                let shortcut_keys = input::retrieve_mouse_shortcut_keys(mouse_drawing_gesture);
-
-                let mut widget_flags = WidgetFlags::default();
-                for element in data_entries {
-                    widget_flags.merge(input::process_pen_down(&canvas, element, shortcut_keys.clone(), Some(PenMode::Pen), Instant::now()));
-                }
-                canvas.emit_handle_widget_flags(widget_flags);
-            }
-        }));
-
-            self.mouse_drawing_gesture.connect_drag_end(clone!(@weak inst as canvas => move |mouse_drawing_gesture, x, y| {
-            //log::debug!("mouse_drawing_gesture end");
-            //input::debug_drag_gesture(mouse_drawing_gesture);
-
-            if input::filter_mouse_input(mouse_drawing_gesture) { return; }
-
-            if let Some(start_point) = mouse_drawing_gesture.start_point() {
-                let mut data_entries = input::retrieve_pointer_elements(mouse_drawing_gesture, x, y);
-                Element::transform_elements(&mut data_entries, canvas.engine().borrow().camera.transform().inverse() * na::Translation2::new(start_point.0, start_point.1) );
-
-                let shortcut_keys = input::retrieve_mouse_shortcut_keys(mouse_drawing_gesture);
-
-                if let Some(last) = data_entries.pop_back() {
-                    let mut widget_flags = WidgetFlags::default();
-                    for element in data_entries {
-                        widget_flags.merge(input::process_pen_down(&canvas, element, shortcut_keys.clone(), Some(PenMode::Pen), Instant::now()));
-                    }
-                    widget_flags.merge(input::process_pen_up(&canvas, last, shortcut_keys, Some(PenMode::Pen), Instant::now()));
-                    canvas.emit_handle_widget_flags(widget_flags);
-                }
-            }
-        }));
-
-            // Touch drawing
-            self.touch_drawing_gesture.connect_drag_begin(clone!(@weak inst as canvas => move |touch_drawing_gesture, x, y| {
-            //log::debug!("touch_drawing_gesture begin");
-
-            if input::filter_touch_input(touch_drawing_gesture) { return; }
-            touch_drawing_gesture.set_state(EventSequenceState::Claimed);
-            canvas.grab_focus();
-
-            let mut data_entries = input::retrieve_pointer_elements(touch_drawing_gesture, x, y);
-            Element::transform_elements(&mut data_entries, canvas.engine().borrow().camera.transform().inverse());
-
-            let shortcut_keys = input::retrieve_touch_shortcut_keys(touch_drawing_gesture);
-
-            let mut widget_flags = WidgetFlags::default();
-            for element in data_entries {
-                widget_flags.merge(input::process_pen_down(&canvas, element, shortcut_keys.clone(), Some(PenMode::Pen), Instant::now()));
-            }
-            canvas.emit_handle_widget_flags(widget_flags);
-        }));
-
-            self.touch_drawing_gesture.connect_drag_update(clone!(@weak inst as canvas => move |touch_drawing_gesture, x, y| {
-            if let Some(start_point) = touch_drawing_gesture.start_point() {
-                //log::debug!("touch_drawing_gesture motion");
-
-                if input::filter_touch_input(touch_drawing_gesture) { return; }
-
-                let mut data_entries = input::retrieve_pointer_elements(touch_drawing_gesture, x, y);
-                Element::transform_elements(&mut data_entries, canvas.engine().borrow().camera.transform().inverse() * na::Translation2::new(start_point.0, start_point.1));
-
-                let shortcut_keys = input::retrieve_touch_shortcut_keys(touch_drawing_gesture);
-
-                let mut widget_flags = WidgetFlags::default();
-                for element in data_entries {
-                    widget_flags.merge(input::process_pen_down(&canvas, element, shortcut_keys.clone(), Some(PenMode::Pen), Instant::now()));
-                }
-                canvas.emit_handle_widget_flags(widget_flags);
-            }
-        }));
-
-            self.touch_drawing_gesture.connect_drag_end(clone!(@weak inst as canvas => move |touch_drawing_gesture, x, y| {
-            if let Some(start_point) = touch_drawing_gesture.start_point() {
-                //log::debug!("touch_drawing_gesture end");
-
-                if input::filter_touch_input(touch_drawing_gesture) { return; }
-
-                let mut data_entries = input::retrieve_pointer_elements(touch_drawing_gesture, x, y);
-                Element::transform_elements(&mut data_entries, canvas.engine().borrow().camera.transform().inverse() * na::Translation2::new(start_point.0, start_point.1));
-
-                let shortcut_keys = input::retrieve_touch_shortcut_keys(touch_drawing_gesture);
-
-                if let Some(last) = data_entries.pop_back() {
-                    let mut widget_flags = WidgetFlags::default();
-                    for element in data_entries {
-                        widget_flags.merge(input::process_pen_down(&canvas, element, shortcut_keys.clone(), Some(PenMode::Pen), Instant::now()));
-                    }
-                    widget_flags.merge(input::process_pen_up(&canvas, last, shortcut_keys, Some(PenMode::Pen), Instant::now()));
-                    canvas.emit_handle_widget_flags(widget_flags);
-                }
-            }
-        }));
-
-            // Key controller
-
-            self.key_controller.connect_key_pressed(clone!(@weak inst as canvas => @default-return Inhibit(false), move |_key_controller, key, _raw, modifier| {
-            //log::debug!("key pressed - key: {:?}, raw: {:?}, modifier: {:?}", key, raw, modifier);
-            canvas.grab_focus();
-
-            let keyboard_key = input::retrieve_keyboard_key(key);
-            let shortcut_keys = input::retrieve_modifier_shortcut_key(modifier);
-
-            //log::debug!("keyboard key: {:?}", keyboard_key);
-
-            let widget_flags = input::process_keyboard_key_pressed(&canvas, keyboard_key, shortcut_keys, Instant::now());
-            canvas.emit_handle_widget_flags(widget_flags);
-
-            Inhibit(true)
-        }));
+            // Pointer controller
+            let pen_state = Cell::new(PenState::Up);
+            self.pointer_controller.connect_event(clone!(@strong pen_state, @weak inst as canvas => @default-return Inhibit(false), move |_controller, event| {
+                let (inhibit, new_state) = super::input::handle_pointer_controller_event(&canvas, event, pen_state.get());
+                pen_state.set(new_state);
+                inhibit
+            }));
 
             // For unicode text the input is committed from the IM context, and won't trigger the key_pressed signal
-            self.key_controller_im_context.connect_commit(clone!(@weak inst as canvas => move |_cx, text| {
-            let widget_flags = input::process_keyboard_text(&canvas, text.to_string(), Instant::now());
-            canvas.emit_handle_widget_flags(widget_flags);
-        }));
+            self.key_controller_im_context.connect_commit(
+                clone!(@weak inst as canvas => move |_cx, text| {
+                    super::input::handle_imcontext_text_commit(&canvas, text);
+                }),
+            );
 
+            // Key controller
+            self.key_controller.connect_key_pressed(clone!(@weak inst as canvas => @default-return Inhibit(false), move |_key_controller, key, _raw, modifier| {
+                super::input::handle_key_controller_key_pressed(&canvas, key, modifier)
+            }));
             /*
-            self.imp().key_controller.connect_key_released(clone!(@weak inst as canvas => move |_key_controller, _key, _raw, _modifier| {
-                //log::debug!("key released - key: {:?}, raw: {:?}, modifier: {:?}", key, raw, modifier);
-            }));
+                       self.key_controller.connect_key_released(
+                           clone!(@weak inst as canvas => move |_key_controller, _key, _raw, _modifier| {
+                               //log::debug!("key released - key: {:?}, raw: {:?}, modifier: {:?}", key, raw, modifier);
+                           }),
+                       );
 
-            self.imp().key_controller.connect_modifiers(clone!(@weak inst as canvas, @weak appwindow => @default-return Inhibit(false), move |_key_controller, modifier| {
-                //log::debug!("key_controller modifier pressed: {:?}", modifier);
-
-                let shortcut_keys = input::retrieve_modifier_shortcut_key(modifier);
-                canvas.grab_focus();
-
-                let mut widget_flags = WidgetFlags::default();
-                for shortcut_key in shortcut_keys {
-                    log::debug!("shortcut key pressed: {:?}", shortcut_key);
-
-                    widget_flags.merge(input::process_shortcut_key_pressed(self, shortcut_key));
-                }
-                canvas.emit_handle_widget_flags(widget_flags);
-
-                Inhibit(true)
-            }));
+                       self.key_controller.connect_modifiers(clone!(@weak inst as canvas => @default-return Inhibit(false), move |_key_controller, modifier| {
+                           super::input::handle_key_controller_modifiers(&canvas, modifier)
+                       }));
             */
         }
     }
@@ -760,7 +499,7 @@ pub(crate) static OUTPUT_FILE_NEW_SUBTITLE: once_cell::sync::Lazy<String> =
 
 impl RnCanvas {
     // the zoom timeout time
-    pub(crate) const ZOOM_TIMEOUT_TIME: time::Duration = time::Duration::from_millis(300);
+    pub(crate) const ZOOM_TIMEOUT_TIME: Duration = Duration::from_millis(300);
     // Sets the canvas zoom scroll step in % for one unit of the event controller delta
     pub(crate) const ZOOM_STEP: f64 = 0.1;
 
@@ -906,10 +645,6 @@ impl RnCanvas {
                 .replace(signal_id);
         }
         self.imp().vadjustment.replace(adj);
-    }
-
-    pub(crate) fn stylus_drawing_gesture(&self) -> GestureStylus {
-        self.imp().stylus_drawing_gesture.clone()
     }
 
     pub(crate) fn set_text_preprocessing(&self, enable: bool) {

--- a/rnote-ui/src/canvas/mod.rs
+++ b/rnote-ui/src/canvas/mod.rs
@@ -471,10 +471,6 @@ mod imp {
                                //log::debug!("key released - key: {:?}, raw: {:?}, modifier: {:?}", key, raw, modifier);
                            }),
                        );
-
-                       self.key_controller.connect_modifiers(clone!(@weak inst as canvas => @default-return Inhibit(false), move |_key_controller, modifier| {
-                           super::input::handle_key_controller_modifiers(&canvas, modifier)
-                       }));
             */
         }
     }

--- a/rnote-ui/src/canvaswrapper.rs
+++ b/rnote-ui/src/canvaswrapper.rs
@@ -169,27 +169,6 @@ mod imp {
                     canvaswrapper.canvas_zoom_gesture_enable(!canvas.touch_drawing());
                 }),
             );
-
-            self.canvas.stylus_drawing_gesture().connect_down(
-                clone!(@weak inst as canvaswrapper => move |_,_,_| {
-                    // disable drag and zoom gestures entirely while drawing with stylus
-                    canvaswrapper.canvas_touch_drag_gesture_enable(false);
-                    canvaswrapper.canvas_zoom_gesture_enable(false);
-                    canvaswrapper.canvas_drag_empty_area_gesture_enable(false);
-                }),
-            );
-
-            self.canvas.stylus_drawing_gesture().connect_up(
-                clone!(@weak inst as canvaswrapper => move |_,_,_| {
-                    // enable drag and zoom gestures again
-                    canvaswrapper.canvas_touch_drag_gesture_enable(true);
-                    canvaswrapper.canvas_drag_empty_area_gesture_enable(true);
-
-                    if !canvaswrapper.canvas().touch_drawing() {
-                        canvaswrapper.canvas_zoom_gesture_enable(true);
-                    }
-                }),
-            );
         }
 
         fn dispose(&self) {
@@ -509,7 +488,7 @@ mod imp {
                     let widget_flags = canvaswrapper.canvas()
                         .engine()
                         .borrow_mut()
-                        .handle_pen_pressed_shortcut_key(ShortcutKey::TouchTwoFingerLongPress, Instant::now());
+                        .handle_pressed_shortcut_key(ShortcutKey::TouchTwoFingerLongPress, Instant::now());
 
                     canvaswrapper.canvas().emit_handle_widget_flags(widget_flags);
                 }));
@@ -626,30 +605,6 @@ impl RnCanvasWrapper {
     /// disconnects existing bindings / handlers to old tab pages.
     pub(crate) fn connect_to_tab_page(&self, page: &adw::TabPage) {
         self.canvas().connect_to_tab_page(page);
-    }
-
-    pub(crate) fn canvas_touch_drag_gesture_enable(&self, enable: bool) {
-        if enable {
-            self.imp()
-                .canvas_touch_drag_gesture
-                .set_propagation_phase(PropagationPhase::Bubble);
-        } else {
-            self.imp()
-                .canvas_touch_drag_gesture
-                .set_propagation_phase(PropagationPhase::None);
-        }
-    }
-
-    pub(crate) fn canvas_drag_empty_area_gesture_enable(&self, enable: bool) {
-        if enable {
-            self.imp()
-                .canvas_drag_empty_area_gesture
-                .set_propagation_phase(PropagationPhase::Bubble);
-        } else {
-            self.imp()
-                .canvas_drag_empty_area_gesture
-                .set_propagation_phase(PropagationPhase::None);
-        }
     }
 
     pub(crate) fn canvas_zoom_gesture_enable(&self, enable: bool) {


### PR DESCRIPTION
This PR refactors the pointer input part of canvas to a single controller which listens to all events received by the widget.

It enables two things: Cleans up the input handling in the engine, and enables hover states as `Up` events are now repeately emitted when moving the pointer without any button clicked. Some builders needed to be refactored a bit to adapt to this.

With it, the selector and typewriter state are refactored too, now displaying hover states on their nodes