### PR TITLE
edit fill/stroke/text color of existing strokes 

### DIFF
--- a/rnote-compose/src/style/mod.rs
+++ b/rnote-compose/src/style/mod.rs
@@ -16,7 +16,7 @@ use anyhow::Context;
 pub use composer::Composer;
 
 use crate::shapes::{CubicBezier, Ellipse, Line, QuadraticBezier, Rectangle};
-use crate::{PenPath, Shape};
+use crate::{Color, PenPath, Shape};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,6 +66,24 @@ impl Style {
             Style::Rough(options) => options.advance_seed(),
             Style::Textured(options) => options.advance_seed(),
         }
+    }
+
+    /// Sets the stroke color of the style
+    pub fn set_stroke_color(&mut self, color: Color) {
+        match self {
+            Style::Smooth(options) => options.stroke_color = Some(color),
+            Style::Rough(options) => options.stroke_color = Some(color),
+            Style::Textured(options) => options.stroke_color = Some(color),
+        };
+    }
+
+    /// Sets the fill color of the style
+    pub fn set_fill_color(&mut self, color: Color) {
+        match self {
+            Style::Smooth(options) => options.fill_color = Some(color),
+            Style::Rough(options) => options.fill_color = Some(color),
+            Style::Textured(_) => {}
+        };
     }
 }
 

--- a/rnote-engine/src/pens/selector/mod.rs
+++ b/rnote-engine/src/pens/selector/mod.rs
@@ -724,6 +724,7 @@ impl Selector {
                 widget_flags.redraw = true;
                 widget_flags.resize = true;
                 widget_flags.store_modified = true;
+                widget_flags.deselect_color_setters = true;
             }
         }
         PenProgress::InProgress

--- a/rnote-engine/src/pens/selector/penevents.rs
+++ b/rnote-engine/src/pens/selector/penevents.rs
@@ -326,6 +326,7 @@ impl Selector {
                             if !new_keys.is_empty() {
                                 engine_view.store.set_selected_keys(&new_keys, true);
                                 widget_flags.store_modified = true;
+                                widget_flags.deselect_color_setters = true;
                                 Some(new_keys)
                             } else {
                                 None
@@ -345,6 +346,7 @@ impl Selector {
                             if !new_keys.is_empty() {
                                 engine_view.store.set_selected_keys(&new_keys, true);
                                 widget_flags.store_modified = true;
+                                widget_flags.deselect_color_setters = true;
                                 Some(new_keys)
                             } else {
                                 None
@@ -365,6 +367,7 @@ impl Selector {
                             {
                                 engine_view.store.set_selected(new_key, true);
                                 widget_flags.store_modified = true;
+                                widget_flags.deselect_color_setters = true;
                                 Some(vec![new_key])
                             } else {
                                 None
@@ -387,6 +390,7 @@ impl Selector {
                                     .store
                                     .set_selected_keys(&intersecting_keys, true);
                                 widget_flags.store_modified = true;
+                                widget_flags.deselect_color_setters = true;
                                 Some(intersecting_keys)
                             } else {
                                 None

--- a/rnote-engine/src/store/stroke_comp.rs
+++ b/rnote-engine/src/store/stroke_comp.rs
@@ -10,9 +10,9 @@ use std::time::Instant;
 
 use super::render_comp::RenderCompState;
 use super::StrokeKey;
-use crate::engine::{EngineTaskSender, StrokeContent};
+use crate::engine::StrokeContent;
 use crate::strokes::Stroke;
-use crate::{render, Camera, StrokeStore, WidgetFlags};
+use crate::{render, StrokeStore, WidgetFlags};
 
 /// Systems that are related to the stroke components.
 impl StrokeStore {
@@ -234,13 +234,10 @@ impl StrokeStore {
         });
     }
 
-    pub fn change_stroke_colors(
-        &mut self,
-        keys: &[StrokeKey],
-        color: Color,
-        tasks_tx: EngineTaskSender,
-        camera: &Camera,
-    ) -> WidgetFlags {
+    /// Changes the stroke and text color of the given keys.
+    ///
+    /// Strokes then need to update their rendering
+    pub fn change_stroke_colors(&mut self, keys: &[StrokeKey], color: Color) -> WidgetFlags {
         let mut widget_flags = self.record(Instant::now());
 
         keys.iter().for_each(|&key| {
@@ -268,26 +265,16 @@ impl StrokeStore {
             }
         });
 
-        self.regenerate_rendering_in_viewport_threaded(
-            tasks_tx,
-            false,
-            camera.viewport(),
-            camera.image_scale(),
-        );
-
         widget_flags.redraw = true;
         widget_flags.store_modified = true;
 
         return widget_flags;
     }
 
-    pub fn change_fill_colors(
-        &mut self,
-        keys: &[StrokeKey],
-        color: Color,
-        tasks_tx: EngineTaskSender,
-        camera: &Camera,
-    ) -> WidgetFlags {
+    /// Changes the fill color of the given keys.
+    ///
+    /// Strokes then need to update their rendering
+    pub fn change_fill_colors(&mut self, keys: &[StrokeKey], color: Color) -> WidgetFlags {
         let mut widget_flags = self.record(Instant::now());
 
         keys.iter().for_each(|&key| {
@@ -310,13 +297,6 @@ impl StrokeStore {
                 }
             }
         });
-
-        self.regenerate_rendering_in_viewport_threaded(
-            tasks_tx,
-            false,
-            camera.viewport(),
-            camera.image_scale(),
-        );
 
         widget_flags.redraw = true;
         widget_flags.store_modified = true;

--- a/rnote-engine/src/store/stroke_comp.rs
+++ b/rnote-engine/src/store/stroke_comp.rs
@@ -268,7 +268,7 @@ impl StrokeStore {
         widget_flags.redraw = true;
         widget_flags.store_modified = true;
 
-        return widget_flags;
+        widget_flags
     }
 
     /// Changes the fill color of the given keys.
@@ -301,7 +301,7 @@ impl StrokeStore {
         widget_flags.redraw = true;
         widget_flags.store_modified = true;
 
-        return widget_flags;
+        widget_flags
     }
 
     /// Rotates the stroke rendering images

--- a/rnote-engine/src/widgetflags.rs
+++ b/rnote-engine/src/widgetflags.rs
@@ -12,6 +12,8 @@ pub struct WidgetFlags {
     pub store_modified: bool,
     /// update the current view offsets and size
     pub update_view: bool,
+    /// deselect the elements of the global color picker
+    pub deselect_color_setters: bool,
     /// Is Some when undo button visibility should be changed. Is None if should not be changed
     pub hide_undo: Option<bool>,
     /// Is Some when undo button visibility should be changed. Is None if should not be changed
@@ -29,6 +31,7 @@ impl Default for WidgetFlags {
             refresh_ui: false,
             store_modified: false,
             update_view: false,
+            deselect_color_setters: false,
             hide_undo: None,
             hide_redo: None,
             enable_text_preprocessing: None,
@@ -44,6 +47,7 @@ impl WidgetFlags {
         self.refresh_ui |= other.refresh_ui;
         self.store_modified |= other.store_modified;
         self.update_view |= other.update_view;
+        self.deselect_color_setters |= other.deselect_color_setters;
         if other.hide_undo.is_some() {
             self.hide_undo = other.hide_undo
         }

--- a/rnote-ui/src/appwindow/mod.rs
+++ b/rnote-ui/src/appwindow/mod.rs
@@ -224,6 +224,9 @@ impl RnAppWindow {
             // this updates the canvas adjustment values with the ones from the camera
             canvas.update_camera_offset(camera_offset);
         }
+        if widget_flags.deselect_color_setters {
+            self.overlays().colorpicker().deselect_setters();
+        }
         if let Some(hide_undo) = widget_flags.hide_undo {
             self.mainheader().undo_button().set_sensitive(!hide_undo);
         }

--- a/rnote-ui/src/overlays.rs
+++ b/rnote-ui/src/overlays.rs
@@ -262,7 +262,10 @@ impl RnOverlays {
                         }
                         PenStyle::Selector => {
                             let selection_keys = engine.store.selection_keys_unordered();
-                            let widget_flags = engine.store.change_stroke_colors(&selection_keys, stroke_color, engine.tasks_tx.clone(), &engine.camera);
+                            let widget_flags = engine.store.change_stroke_colors(&selection_keys, stroke_color);
+                            if let Err(e) = engine.update_rendering_current_viewport() {
+                                log::error!("failed to update rendering for current viewport while changing stroke color of selection, Err: {e:?}");
+                            }
                             appwindow.handle_widget_flags(widget_flags, &canvas);
                         }
                         PenStyle::Brush | PenStyle::Shaper | PenStyle::Eraser | PenStyle::Tools => {}
@@ -288,7 +291,10 @@ impl RnOverlays {
                 match stroke_style {
                     PenStyle::Selector => {
                         let selection_keys = engine.store.selection_keys_unordered();
-                        let widget_flags = engine.store.change_fill_colors(&selection_keys, fill_color, engine.tasks_tx.clone(), &engine.camera);
+                        let widget_flags = engine.store.change_fill_colors(&selection_keys, fill_color);
+                        if let Err(e) = engine.update_rendering_current_viewport() {
+                            log::error!("failed to update rendering for current viewport while changing fill color of selection, Err: {e:?}");
+                        }
                         appwindow.handle_widget_flags(widget_flags, &canvas);
                     }
                     PenStyle::Typewriter | PenStyle::Brush | PenStyle::Shaper | PenStyle::Eraser | PenStyle::Tools => {}

--- a/rnote-ui/src/overlays.rs
+++ b/rnote-ui/src/overlays.rs
@@ -2,10 +2,12 @@ use gtk4::{
     gio, glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate, Overlay,
     ProgressBar, ScrolledWindow, ToggleButton, Widget,
 };
+use rnote_compose::Style;
 use rnote_engine::engine::EngineViewMut;
 use rnote_engine::pens::{Pen, PenStyle};
 use rnote_engine::utils::GdkRGBAHelpers;
 use std::cell::RefCell;
+use std::time::Instant;
 
 use crate::canvaswrapper::RnCanvasWrapper;
 use crate::RnPensSideBar;
@@ -239,7 +241,7 @@ impl RnOverlays {
                     engine.pens_config.brush_config.solid_options.stroke_color = Some(stroke_color);
                     engine.pens_config.brush_config.textured_options.stroke_color = Some(stroke_color);
                     engine.pens_config.shaper_config.smooth_options.stroke_color = Some(stroke_color);
-                    engine.pens_config.shaper_config.rough_options.stroke_color= Some(stroke_color);
+                    engine.pens_config.shaper_config.rough_options.stroke_color = Some(stroke_color);
                     engine.pens_config.typewriter_config.text_style.color = stroke_color;
 
                     match stroke_style {
@@ -260,7 +262,34 @@ impl RnOverlays {
                                 appwindow.handle_widget_flags(widget_flags, &canvas);
                             }
                         }
-                        PenStyle::Brush | PenStyle::Shaper | PenStyle::Eraser | PenStyle::Selector | PenStyle::Tools => {}
+                        PenStyle::Selector => {
+                            let mut widget_flags = engine.record(Instant::now());
+                            let selection_keys = engine.store.selection_keys_unordered();
+
+                            engine.store.restyle_strokes(&selection_keys, |style| {
+                                match style {
+                                    Style::Rough(rough_style) => rough_style.stroke_color = Some(stroke_color),
+                                    Style::Smooth(smooth_style) => smooth_style.stroke_color = Some(stroke_color),
+                                    Style::Textured(textured_style) => textured_style.stroke_color = Some(stroke_color),
+                                }
+                            }, |text_style| {
+                                text_style.color = stroke_color;
+                            });
+
+                            engine.store.update_geometry_for_strokes(&selection_keys);
+                            engine.store.regenerate_rendering_in_viewport_threaded(
+                                engine.tasks_tx.clone(),
+                                false,
+                                engine.camera.viewport(),
+                                engine.camera.image_scale(),
+                            );
+
+                            widget_flags.redraw = true;
+                            widget_flags.store_modified = true;
+
+                            appwindow.handle_widget_flags(widget_flags, &canvas);
+                        }
+                        PenStyle::Brush | PenStyle::Shaper | PenStyle::Eraser | PenStyle::Tools => {}
                     }
                 }),
             );
@@ -270,14 +299,44 @@ impl RnOverlays {
             clone!(@weak appwindow => move |colorpicker, _paramspec| {
                 let fill_color = colorpicker.fill_color().into_compose_color();
                 let canvas = appwindow.active_tab().canvas();
+                let stroke_style = canvas.engine().borrow().penholder.current_pen_style_w_override();
                 let engine = canvas.engine();
                 let engine = &mut *engine.borrow_mut();
 
                 // We have a global colorpicker, so we apply it to all styles
                 engine.pens_config.brush_config.marker_options.fill_color = Some(fill_color);
-                engine.pens_config.brush_config.solid_options.fill_color= Some(fill_color);
+                engine.pens_config.brush_config.solid_options.fill_color = Some(fill_color);
                 engine.pens_config.shaper_config.smooth_options.fill_color = Some(fill_color);
-                engine.pens_config.shaper_config.rough_options.fill_color= Some(fill_color);
+                engine.pens_config.shaper_config.rough_options.fill_color = Some(fill_color);
+
+                match stroke_style {
+                    PenStyle::Selector => {
+                        let mut widget_flags = engine.record(Instant::now());
+                        let selection_keys = engine.store.selection_keys_unordered();
+
+                        engine.store.restyle_strokes(&selection_keys, |style| {
+                            match style {
+                                Style::Rough(rough_style) => rough_style.fill_color = Some(fill_color),
+                                Style::Smooth(smooth_style) => smooth_style.fill_color = Some(fill_color),
+                                Style::Textured(_) => {},
+                            }
+                        }, |_| {});
+
+                        engine.store.update_geometry_for_strokes(&selection_keys);
+                        engine.store.regenerate_rendering_in_viewport_threaded(
+                            engine.tasks_tx.clone(),
+                            false,
+                            engine.camera.viewport(),
+                            engine.camera.image_scale(),
+                        );
+
+                        widget_flags.redraw = true;
+                        widget_flags.store_modified = true;
+
+                        appwindow.handle_widget_flags(widget_flags, &canvas);
+                    }
+                    PenStyle::Typewriter | PenStyle::Brush | PenStyle::Shaper | PenStyle::Eraser | PenStyle::Tools => {}
+                }
             }),
         );
     }

--- a/rnote-ui/src/overlays.rs
+++ b/rnote-ui/src/overlays.rs
@@ -263,9 +263,7 @@ impl RnOverlays {
                         PenStyle::Selector => {
                             let selection_keys = engine.store.selection_keys_unordered();
                             let widget_flags = engine.store.change_stroke_colors(&selection_keys, stroke_color);
-                            if let Err(e) = engine.update_rendering_current_viewport() {
-                                log::error!("failed to update rendering for current viewport while changing stroke color of selection, Err: {e:?}");
-                            }
+                            engine.update_content_rendering_current_viewport();
                             appwindow.handle_widget_flags(widget_flags, &canvas);
                         }
                         PenStyle::Brush | PenStyle::Shaper | PenStyle::Eraser | PenStyle::Tools => {}
@@ -292,9 +290,7 @@ impl RnOverlays {
                     PenStyle::Selector => {
                         let selection_keys = engine.store.selection_keys_unordered();
                         let widget_flags = engine.store.change_fill_colors(&selection_keys, fill_color);
-                        if let Err(e) = engine.update_rendering_current_viewport() {
-                            log::error!("failed to update rendering for current viewport while changing fill color of selection, Err: {e:?}");
-                        }
+                        engine.update_content_rendering_current_viewport();
                         appwindow.handle_widget_flags(widget_flags, &canvas);
                     }
                     PenStyle::Typewriter | PenStyle::Brush | PenStyle::Shaper | PenStyle::Eraser | PenStyle::Tools => {}


### PR DESCRIPTION
* Partially implements #55. Editing other aspects of existing strokes is not possible without UI/workflow changes, because the selection disappears as soon as you select another tool (and color is currently the only global property).
* Might need some more abstraction/cleaner code, it's not very consistent with e.g. the transformation stuff. I'm not sure if style modifications should be split into a trait/function for each property, or stay flexible as-is (like `Typewriter#change_text_style_in_modifying_stroke()`).
* Because you can deselect colors, you have to click on a color twice in order to apply it if it's already selected.

I *hope* that the rendering/geometry updates are properly taken care of, I'm not very familiar with this part of Rnote. I haven't noticed any issues though.

@flxzt it would be great if you could take a look :P

[Bildschirmaufzeichnung vom 2023-03-15, 23-14-36.webm](https://user-images.githubusercontent.com/49598842/225458255-6a53fbb6-4805-4a74-b02f-fe2b38452421.webm)