### PR TITLE
Add feature: Remove page of fixed size document

### DIFF
--- a/rnote-ui/data/icons/scalable/actions/remove-page-symbolic.svg
+++ b/rnote-ui/data/icons/scalable/actions/remove-page-symbolic.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   fill="#bebebe"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="remove-page-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview5"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="29.5"
+     inkscape:cx="8.9322034"
+     inkscape:cy="6.6101695"
+     inkscape:window-width="1281"
+     inkscape:window-height="785"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <defs
+     id="defs8" />
+  <path
+     d="M 3,1 C 2.4477153,1 2,1.4477153 2,2 v 13 c 0,0.552285 0.4477153,1 1,1 h 10 c 0.552285,0 1,-0.447715 1,-1 v -5 c 0,-1.3333328 -2,-1.3333328 -2,0 v 4 H 4 V 3 H 6 C 7.3333328,3 7.3333328,1 6,1 Z m 4,3.02 v 1.99 c 6.018947,-0.00359 1.2704198,0 6,0 V 4.02 c -6.0090101,0.04333 -1.248855,0 -6,0 z"
+     id="path2"
+     style="fill:#333333;fill-opacity:1"
+     sodipodi:nodetypes="sssssssscccsssccccc" />
+</svg>

--- a/rnote-ui/data/resources.gresource.xml.in
+++ b/rnote-ui/data/resources.gresource.xml.in
@@ -81,6 +81,7 @@
         <file compressed="true">icons/scalable/actions/cursor-teardrop-ne-large.svg</file>
         <file compressed="true">icons/scalable/actions/workspacebrowser-symbolic.svg</file>
         <file compressed="true">icons/scalable/actions/add-page-symbolic.svg</file>
+        <file compressed="true">icons/scalable/actions/remove-page-symbolic.svg</file>
         <file compressed="true">icons/scalable/actions/resize-to-fit-strokes-symbolic.svg</file>
         <file compressed="true">icons/scalable/actions/return-origin-page-symbolic.svg</file>
         <file compressed="true">icons/scalable/actions/zoom-fit-width-symbolic.svg</file>

--- a/rnote-ui/data/ui/mainheader.ui
+++ b/rnote-ui/data/ui/mainheader.ui
@@ -90,6 +90,13 @@
                     </child>
                     <child>
                       <object class="GtkButton">
+                        <property name="icon_name">remove-page-symbolic</property>
+                        <property name="tooltip_text" translatable="yes">Remove Page</property>
+                        <property name="action-name">win.remove-page-from-doc</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton">
                         <property name="icon_name">resize-to-fit-strokes-symbolic</property>
                         <property name="tooltip_text" translatable="yes">Resize Document to Fit Strokes</property>
                         <property name="action-name">win.resize-to-fit-strokes</property>

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -92,6 +92,8 @@ impl RnAppWindow {
         self.add_action(&action_zoom_to_value);
         let action_add_page_to_doc = gio::SimpleAction::new("add-page-to-doc", None);
         self.add_action(&action_add_page_to_doc);
+        let action_remove_page_from_doc = gio::SimpleAction::new("remove-page-from-doc", None);
+        self.add_action(&action_remove_page_from_doc);
         let action_resize_to_fit_strokes = gio::SimpleAction::new("resize-to-fit-strokes", None);
         self.add_action(&action_resize_to_fit_strokes);
         let action_return_origin_page = gio::SimpleAction::new("return-origin-page", None);
@@ -528,6 +530,22 @@ impl RnAppWindow {
                 canvas.engine().borrow_mut().document.height = new_doc_height;
 
                 canvas.update_engine_rendering();
+            }),
+        );
+        
+        // Remove page from doc in fixed size mode
+        action_remove_page_from_doc.connect_activate(
+            clone!(@weak self as appwindow => move |_action_remove_page_from_doc, _target| {
+                let canvas = appwindow.active_tab().canvas();
+
+                let format_height = canvas.engine().borrow().document.format.height;
+                let doc_height = canvas.engine().borrow().document.height;
+                let new_doc_height = doc_height - format_height;
+                if doc_height != format_height {
+                    canvas.engine().borrow_mut().document.height = new_doc_height;
+
+                    canvas.update_engine_rendering();
+                }
             }),
         );
 


### PR DESCRIPTION
Closes https://github.com/flxzt/rnote/issues/463
This pull request adds a button next to the add page button in the headerbar which removes a page. At the moment there are two issues:

1. This only reduces the document height by one page but doesn't remove the content.  @flxzt Is there a way to remove the content of a specific page or from a specific height to another height?
2. On some document types (e.g. A3 landscape) the page can be removed even if only one exists and the height of the document can go into the negative area which makes documents appear above the two red x.