### PR TITLE
inertial touch scrolling on canvas 

### DIFF
--- a/rnote-ui/data/app.gschema.xml.in
+++ b/rnote-ui/data/app.gschema.xml.in
@@ -129,6 +129,10 @@
       <default>false</default>
       <summary>Whether the canvas scrollbars are shown</summary>
     </key>
+    <key name="inertial-scrolling" type="b">
+      <default>true</default>
+      <summary>Whether touch scrolling on the canvas is inertial</summary>
+    </key>
     <key name="righthanded" type="b">
       <default>true</default>
       <summary>Whether the user is righthanded (or lefthanded)</summary>

--- a/rnote-ui/data/ui/canvaswrapper.ui
+++ b/rnote-ui/data/ui/canvaswrapper.ui
@@ -13,7 +13,6 @@
         <style>
           <class name="canvas_scroller" />
         </style>
-        <property name="kinetic_scrolling">false</property>
         <property name="propagate-natural-width">false</property>
         <property name="propagate-natural-height">false</property>
         <property name="halign">fill</property>

--- a/rnote-ui/data/ui/settingspanel.ui
+++ b/rnote-ui/data/ui/settingspanel.ui
@@ -85,7 +85,8 @@
                     <child>
                       <object class="AdwActionRow" id="general_inertial_scrolling_row">
                         <property name="title" translatable="yes">Inertial Touch Scrolling</property>
-                        <property name="subtitle" translatable="yes">Set whether touch scrolling on the canvas is inertial. Always disabled if touch drawing is enabled.</property>
+                        <property name="subtitle" translatable="yes">Set whether touch scrolling on the canvas is inertial.
+An application restart is required when this option gets disabled.</property>
                         <child type="suffix">
                           <object class="GtkSwitch" id="general_inertial_scrolling_switch">
                             <property name="valign">center</property>

--- a/rnote-ui/data/ui/settingspanel.ui
+++ b/rnote-ui/data/ui/settingspanel.ui
@@ -83,6 +83,17 @@
                       </object>
                     </child>
                     <child>
+                      <object class="AdwActionRow" id="general_inertial_scrolling_row">
+                        <property name="title" translatable="yes">Inertial Touch Scrolling</property>
+                        <property name="subtitle" translatable="yes">Set whether touch scrolling on the canvas is inertial</property>
+                        <child type="suffix">
+                          <object class="GtkSwitch" id="general_inertial_scrolling_switch">
+                            <property name="valign">center</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
                       <object class="AdwActionRow" id="general_regular_cursor_picker_row">
                         <property name="title" translatable="yes">Regular Cursor</property>
                         <property name="subtitle" translatable="yes">Set the regular cursor</property>

--- a/rnote-ui/data/ui/settingspanel.ui
+++ b/rnote-ui/data/ui/settingspanel.ui
@@ -85,7 +85,7 @@
                     <child>
                       <object class="AdwActionRow" id="general_inertial_scrolling_row">
                         <property name="title" translatable="yes">Inertial Touch Scrolling</property>
-                        <property name="subtitle" translatable="yes">Set whether touch scrolling on the canvas is inertial</property>
+                        <property name="subtitle" translatable="yes">Set whether touch scrolling on the canvas is inertial. Always disabled if touch drawing is enabled.</property>
                         <child type="suffix">
                           <object class="GtkSwitch" id="general_inertial_scrolling_switch">
                             <property name="valign">center</property>

--- a/rnote-ui/src/appwindow/appsettings.rs
+++ b/rnote-ui/src/appwindow/appsettings.rs
@@ -78,6 +78,14 @@ impl RnAppWindow {
             )
             .get_no_changes()
             .build();
+        self.bind_property(
+            "touch-drawing",
+            &self.settings_panel().general_inertial_scrolling_switch(),
+            "sensitive",
+        )
+        .invert_boolean()
+        .sync_create()
+        .build();
 
         // regular cursor
         self.app_settings()

--- a/rnote-ui/src/appwindow/appsettings.rs
+++ b/rnote-ui/src/appwindow/appsettings.rs
@@ -69,6 +69,16 @@ impl RnAppWindow {
             .get_no_changes()
             .build();
 
+        // inertial scrolling
+        self.app_settings()
+            .bind(
+                "inertial-scrolling",
+                &self.settings_panel().general_inertial_scrolling_switch(),
+                "active",
+            )
+            .get_no_changes()
+            .build();
+
         // regular cursor
         self.app_settings()
             .bind(

--- a/rnote-ui/src/appwindow/appsettings.rs
+++ b/rnote-ui/src/appwindow/appsettings.rs
@@ -78,14 +78,6 @@ impl RnAppWindow {
             )
             .get_no_changes()
             .build();
-        self.bind_property(
-            "touch-drawing",
-            &self.settings_panel().general_inertial_scrolling_switch(),
-            "sensitive",
-        )
-        .invert_boolean()
-        .sync_create()
-        .build();
 
         // regular cursor
         self.app_settings()

--- a/rnote-ui/src/canvas/mod.rs
+++ b/rnote-ui/src/canvas/mod.rs
@@ -858,7 +858,7 @@ impl RnCanvas {
 
                             canvas.set_output_file(other_file.cloned());
 
-                            appwindow.overlays().dispatch_toast_text(&gettext("Opened file was renamed on disk"), 5);
+                            appwindow.overlays().dispatch_toast_text(&gettext("Opened file was renamed on disk"), crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT);
                         }
                     },
                     gio::FileMonitorEvent::Deleted | gio::FileMonitorEvent::MovedOut => {
@@ -871,7 +871,7 @@ impl RnCanvas {
                         canvas.set_unsaved_changes(true);
                         canvas.set_output_file(None);
 
-                        appwindow.overlays().dispatch_toast_text(&gettext("Opened file was moved or deleted on disk"), 5);
+                        appwindow.overlays().dispatch_toast_text(&gettext("Opened file was moved or deleted on disk"), crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT);
                     },
                     _ => {},
                 }

--- a/rnote-ui/src/canvas/mod.rs
+++ b/rnote-ui/src/canvas/mod.rs
@@ -858,7 +858,7 @@ impl RnCanvas {
 
                             canvas.set_output_file(other_file.cloned());
 
-                            appwindow.overlays().dispatch_toast_text(&gettext("Opened file was renamed on disk"))
+                            appwindow.overlays().dispatch_toast_text(&gettext("Opened file was renamed on disk"), 5);
                         }
                     },
                     gio::FileMonitorEvent::Deleted | gio::FileMonitorEvent::MovedOut => {
@@ -871,7 +871,7 @@ impl RnCanvas {
                         canvas.set_unsaved_changes(true);
                         canvas.set_output_file(None);
 
-                        appwindow.overlays().dispatch_toast_text(&gettext("Opened file was moved or deleted on disk"));
+                        appwindow.overlays().dispatch_toast_text(&gettext("Opened file was moved or deleted on disk"), 5);
                     },
                     _ => {},
                 }

--- a/rnote-ui/src/canvaswrapper.rs
+++ b/rnote-ui/src/canvaswrapper.rs
@@ -20,10 +20,12 @@ mod imp {
     pub(crate) struct RnCanvasWrapper {
         pub(crate) show_scrollbars: Cell<bool>,
         pub(crate) block_pinch_zoom: Cell<bool>,
+        pub(crate) inertial_scrolling: Cell<bool>,
         pub(crate) pointer_pos: Cell<Option<na::Vector2<f64>>>,
 
         pub(crate) appwindow_block_pinch_zoom_bind: RefCell<Option<glib::Binding>>,
         pub(crate) appwindow_show_scrollbars_bind: RefCell<Option<glib::Binding>>,
+        pub(crate) appwindow_inertial_scrolling_bind: RefCell<Option<glib::Binding>>,
         pub(crate) appwindow_righthanded_bind: RefCell<Option<glib::Binding>>,
         pub(crate) canvas_touch_drawing_handler: RefCell<Option<glib::SignalHandlerId>>,
 
@@ -104,10 +106,12 @@ mod imp {
             Self {
                 show_scrollbars: Cell::new(false),
                 block_pinch_zoom: Cell::new(false),
+                inertial_scrolling: Cell::new(true),
                 pointer_pos: Cell::new(None),
 
                 appwindow_block_pinch_zoom_bind: RefCell::new(None),
                 appwindow_show_scrollbars_bind: RefCell::new(None),
+                appwindow_inertial_scrolling_bind: RefCell::new(None),
                 appwindow_righthanded_bind: RefCell::new(None),
                 canvas_touch_drawing_handler: RefCell::new(None),
 
@@ -173,8 +177,10 @@ mod imp {
             let canvas_touch_drawing_handler = self.canvas.connect_notify_local(
                 Some("touch-drawing"),
                 clone!(@weak obj as canvaswrapper => move |_canvas, _pspec| {
-                    // Disable the zoom gesture when touch drawing is enabled
+                    // Enable the touch drag gesture, disable the zoom gesture and kinetic scrolling when touch drawing is enabled
                     canvaswrapper.imp().canvas_zoom_gesture_update();
+                    canvaswrapper.scroller().set_kinetic_scrolling(!canvas.touch_drawing() && canvaswrapper.inertial_scrolling());
+                    canvaswrapper.canvas_touch_drag_gesture_enable(canvas.touch_drawing());
                 }),
             );
 
@@ -207,6 +213,9 @@ mod imp {
                     glib::ParamSpecBoolean::builder("block-pinch-zoom")
                         .default_value(false)
                         .build(),
+                    glib::ParamSpecBoolean::builder("inertial-scrolling")
+                        .default_value(true)
+                        .build(),
                 ]
             });
             PROPERTIES.as_ref()
@@ -216,6 +225,7 @@ mod imp {
             match pspec.name() {
                 "show-scrollbars" => self.show_scrollbars.get().to_value(),
                 "block-pinch-zoom" => self.block_pinch_zoom.get().to_value(),
+                "inertial-scrolling" => self.inertial_scrolling.get().to_value(),
                 _ => unimplemented!(),
             }
         }
@@ -238,7 +248,16 @@ mod imp {
                     self.block_pinch_zoom.replace(block_pinch_zoom);
                     self.canvas_zoom_gesture_update();
                 }
+                "inertial-scrolling" => {
+                    let inertial_scrolling = value
+                        .get::<bool>()
+                        .expect("The value needs to be of type `bool`");
 
+                    self.inertial_scrolling.replace(inertial_scrolling);
+
+                    self.scroller
+                        .set_kinetic_scrolling(!self.canvas.touch_drawing() && inertial_scrolling);
+                }
                 _ => unimplemented!(),
             }
         }
@@ -607,6 +626,16 @@ impl RnCanvasWrapper {
         self.set_property("block-pinch-zoom", block_pinch_zoom);
     }
 
+    #[allow(unused)]
+    pub(crate) fn inertial_scrolling(&self) -> bool {
+        self.property::<bool>("inertial-scrolling")
+    }
+
+    #[allow(unused)]
+    pub(crate) fn set_intertial_scrolling(&self, inertial_scrolling: bool) {
+        self.set_property("inertial-scrolling", inertial_scrolling.to_value());
+    }
+
     pub(crate) fn scroller(&self) -> ScrolledWindow {
         self.imp().scroller.get()
     }
@@ -633,6 +662,13 @@ impl RnCanvasWrapper {
             .settings_panel()
             .general_show_scrollbars_switch()
             .bind_property("state", self, "show-scrollbars")
+            .sync_create()
+            .build();
+
+        let appwindow_inertial_scrolling_bind = appwindow
+            .settings_panel()
+            .general_inertial_scrolling_switch()
+            .bind_property("state", self, "inertial-scrolling")
             .sync_create()
             .build();
 
@@ -665,6 +701,14 @@ impl RnCanvasWrapper {
         }
 
         if let Some(old) = imp
+            .appwindow_inertial_scrolling_bind
+            .borrow_mut()
+            .replace(appwindow_inertial_scrolling_bind)
+        {
+            old.unbind();
+        }
+
+        if let Some(old) = imp
             .appwindow_righthanded_bind
             .borrow_mut()
             .replace(appwindow_righthanded_bind)
@@ -690,6 +734,10 @@ impl RnCanvasWrapper {
             old.unbind();
         }
 
+        if let Some(old) = imp.appwindow_inertial_scrolling_bind.borrow_mut().take() {
+            old.unbind();
+        }
+
         if let Some(old) = imp.appwindow_righthanded_bind.borrow_mut().take() {
             old.unbind();
         }
@@ -702,5 +750,17 @@ impl RnCanvasWrapper {
     /// The same method of the canvas child is chained up in here.
     pub(crate) fn connect_to_tab_page(&self, page: &adw::TabPage) {
         self.canvas().connect_to_tab_page(page);
+    }
+
+    pub(crate) fn canvas_touch_drag_gesture_enable(&self, enable: bool) {
+        if enable {
+            self.imp()
+                .canvas_touch_drag_gesture
+                .set_propagation_phase(PropagationPhase::Bubble);
+        } else {
+            self.imp()
+                .canvas_touch_drag_gesture
+                .set_propagation_phase(PropagationPhase::None);
+        }
     }
 }

--- a/rnote-ui/src/canvaswrapper.rs
+++ b/rnote-ui/src/canvaswrapper.rs
@@ -177,14 +177,9 @@ mod imp {
             let canvas_touch_drawing_handler = self.canvas.connect_notify_local(
                 Some("touch-drawing"),
                 clone!(@weak obj as canvaswrapper => move |canvas, _pspec| {
-                    // Enable the touch drag gesture, disable the zoom gesture and kinetic scrolling when touch drawing is enabled.
-
+                    // Disable the zoom gesture and kinetic scrolling when touch drawing is enabled.
                     canvaswrapper.scroller().set_kinetic_scrolling(!canvas.touch_drawing() && canvaswrapper.inertial_scrolling());
                     canvaswrapper.imp().canvas_zoom_gesture_update();
-
-                    // touch drawing enabled -> kinetic-scrolling disabled (regardless of setting) & touch drag gesture enabled
-                    // touch drawing disabled -> touch drag gesture disabled (only needed for touch drawing)
-                    canvaswrapper.canvas_touch_drag_gesture_enable(canvas.touch_drawing());
                 }),
             );
 
@@ -754,17 +749,5 @@ impl RnCanvasWrapper {
     /// The same method of the canvas child is chained up in here.
     pub(crate) fn connect_to_tab_page(&self, page: &adw::TabPage) {
         self.canvas().connect_to_tab_page(page);
-    }
-
-    pub(crate) fn canvas_touch_drag_gesture_enable(&self, enable: bool) {
-        if enable {
-            self.imp()
-                .canvas_touch_drag_gesture
-                .set_propagation_phase(PropagationPhase::Bubble);
-        } else {
-            self.imp()
-                .canvas_touch_drag_gesture
-                .set_propagation_phase(PropagationPhase::None);
-        }
     }
 }

--- a/rnote-ui/src/canvaswrapper.rs
+++ b/rnote-ui/src/canvaswrapper.rs
@@ -176,10 +176,14 @@ mod imp {
 
             let canvas_touch_drawing_handler = self.canvas.connect_notify_local(
                 Some("touch-drawing"),
-                clone!(@weak obj as canvaswrapper => move |_canvas, _pspec| {
-                    // Enable the touch drag gesture, disable the zoom gesture and kinetic scrolling when touch drawing is enabled
-                    canvaswrapper.imp().canvas_zoom_gesture_update();
+                clone!(@weak obj as canvaswrapper => move |canvas, _pspec| {
+                    // Enable the touch drag gesture, disable the zoom gesture and kinetic scrolling when touch drawing is enabled.
+
                     canvaswrapper.scroller().set_kinetic_scrolling(!canvas.touch_drawing() && canvaswrapper.inertial_scrolling());
+                    canvaswrapper.imp().canvas_zoom_gesture_update();
+
+                    // touch drawing enabled -> kinetic-scrolling disabled (regardless of setting) & touch drag gesture enabled
+                    // touch drawing disabled -> touch drag gesture disabled (only needed for touch drawing)
                     canvaswrapper.canvas_touch_drag_gesture_enable(canvas.touch_drawing());
                 }),
             );
@@ -632,7 +636,7 @@ impl RnCanvasWrapper {
     }
 
     #[allow(unused)]
-    pub(crate) fn set_intertial_scrolling(&self, inertial_scrolling: bool) {
+    pub(crate) fn set_inertial_scrolling(&self, inertial_scrolling: bool) {
         self.set_property("inertial-scrolling", inertial_scrolling.to_value());
     }
 

--- a/rnote-ui/src/canvaswrapper.rs
+++ b/rnote-ui/src/canvaswrapper.rs
@@ -277,9 +277,6 @@ mod imp {
             self.scroller.set_kinetic_scrolling(
                 !self.canvas.touch_drawing() && self.inertial_scrolling.get(),
             );
-
-            // Workaround for https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/5863.
-            self.scroller.queue_allocate();
         }
 
         fn setup_input(&self) {

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -53,7 +53,7 @@ pub(crate) async fn dialog_save_doc_as(appwindow: &RnAppWindow, canvas: &RnCanva
                 Ok(true) => {
                     appwindow
                         .overlays()
-                        .dispatch_toast_text(&gettext("Saved document successfully"));
+                        .dispatch_toast_text(&gettext("Saved document successfully"), 5);
                 }
                 Ok(false) => {
                     // Saving was already in progress
@@ -195,7 +195,7 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
                                 log::error!("exporting document failed, Error: `{e:?}`");
                                 appwindow.overlays().dispatch_toast_error(&gettext("Exporting document failed"));
                             } else {
-                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document successfully"));
+                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document successfully"), 5);
                             }
 
                             appwindow.overlays().finish_progressbar();
@@ -451,7 +451,7 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
                                 log::error!("exporting document pages failed, Error: `{e:?}`");
                                 appwindow.overlays().dispatch_toast_error(&gettext("Exporting document pages failed"));
                             } else {
-                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document pages successfully"));
+                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document pages successfully"), 5);
                             }
 
                             appwindow.overlays().finish_progressbar();
@@ -679,7 +679,7 @@ pub(crate) async fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, can
                 } else {
                     appwindow
                         .overlays()
-                        .dispatch_toast_text(&gettext("Exported selection successfully"));
+                        .dispatch_toast_text(&gettext("Exported selection successfully"), 5);
                 }
 
                 appwindow.overlays().finish_progressbar();
@@ -775,7 +775,7 @@ pub(crate) async fn filechooser_export_engine_state(appwindow: &RnAppWindow, can
             } else {
                 appwindow
                     .overlays()
-                    .dispatch_toast_text(&gettext("Exported engine state successfully"));
+                    .dispatch_toast_text(&gettext("Exported engine state successfully"), 5);
             }
 
             appwindow.overlays().finish_progressbar();
@@ -821,7 +821,7 @@ pub(crate) async fn filechooser_export_engine_config(appwindow: &RnAppWindow, ca
             } else {
                 appwindow
                     .overlays()
-                    .dispatch_toast_text(&gettext("Exported engine config successfully"));
+                    .dispatch_toast_text(&gettext("Exported engine config successfully"), 5);
             }
 
             appwindow.overlays().finish_progressbar();

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -51,9 +51,10 @@ pub(crate) async fn dialog_save_doc_as(appwindow: &RnAppWindow, canvas: &RnCanva
 
             match canvas.save_document_to_file(&selected_file).await {
                 Ok(true) => {
-                    appwindow
-                        .overlays()
-                        .dispatch_toast_text(&gettext("Saved document successfully"), 5);
+                    appwindow.overlays().dispatch_toast_text(
+                        &gettext("Saved document successfully"),
+                        crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT,
+                    );
                 }
                 Ok(false) => {
                     // Saving was already in progress
@@ -195,7 +196,7 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
                                 log::error!("exporting document failed, Error: `{e:?}`");
                                 appwindow.overlays().dispatch_toast_error(&gettext("Exporting document failed"));
                             } else {
-                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document successfully"), 5);
+                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document successfully"), crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT);
                             }
 
                             appwindow.overlays().finish_progressbar();
@@ -451,7 +452,7 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
                                 log::error!("exporting document pages failed, Error: `{e:?}`");
                                 appwindow.overlays().dispatch_toast_error(&gettext("Exporting document pages failed"));
                             } else {
-                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document pages successfully"), 5);
+                                appwindow.overlays().dispatch_toast_text(&gettext("Exported document pages successfully"), crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT);
                             }
 
                             appwindow.overlays().finish_progressbar();
@@ -677,9 +678,10 @@ pub(crate) async fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, can
                         .overlays()
                         .dispatch_toast_error(&gettext("Exporting selection failed"));
                 } else {
-                    appwindow
-                        .overlays()
-                        .dispatch_toast_text(&gettext("Exported selection successfully"), 5);
+                    appwindow.overlays().dispatch_toast_text(
+                        &gettext("Exported selection successfully"),
+                        crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT,
+                    );
                 }
 
                 appwindow.overlays().finish_progressbar();
@@ -773,9 +775,10 @@ pub(crate) async fn filechooser_export_engine_state(appwindow: &RnAppWindow, can
                     .overlays()
                     .dispatch_toast_error(&gettext("Exporting engine state failed"));
             } else {
-                appwindow
-                    .overlays()
-                    .dispatch_toast_text(&gettext("Exported engine state successfully"), 5);
+                appwindow.overlays().dispatch_toast_text(
+                    &gettext("Exported engine state successfully"),
+                    crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT,
+                );
             }
 
             appwindow.overlays().finish_progressbar();
@@ -819,9 +822,10 @@ pub(crate) async fn filechooser_export_engine_config(appwindow: &RnAppWindow, ca
                     .overlays()
                     .dispatch_toast_error(&gettext("Exporting engine config failed"));
             } else {
-                appwindow
-                    .overlays()
-                    .dispatch_toast_text(&gettext("Exported engine config successfully"), 5);
+                appwindow.overlays().dispatch_toast_text(
+                    &gettext("Exported engine config successfully"),
+                    crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT,
+                );
             }
 
             appwindow.overlays().finish_progressbar();

--- a/rnote-ui/src/main.rs
+++ b/rnote-ui/src/main.rs
@@ -18,7 +18,7 @@ pub(crate) mod globals;
 pub(crate) mod groupediconpicker;
 mod iconpicker;
 mod mainheader;
-mod overlays;
+pub(crate) mod overlays;
 pub(crate) mod penssidebar;
 mod settingspanel;
 pub(crate) mod strokewidthpicker;

--- a/rnote-ui/src/overlays.rs
+++ b/rnote-ui/src/overlays.rs
@@ -100,6 +100,9 @@ mod imp {
     }
 }
 
+/// The default timeout for regular text toasts.
+pub(crate) const TEXT_TOAST_TIMEOUT_DEFAULT: u32 = 5;
+
 glib::wrapper! {
     pub(crate) struct RnOverlays(ObjectSubclass<imp::RnOverlays>)
     @extends Widget;

--- a/rnote-ui/src/overlays.rs
+++ b/rnote-ui/src/overlays.rs
@@ -473,17 +473,15 @@ impl RnOverlays {
         button_callback: F,
         timeout: u32,
     ) -> adw::Toast {
-        let text_notify_toast = adw::Toast::builder()
+        let toast = adw::Toast::builder()
             .title(text)
             .priority(adw::ToastPriority::High)
             .button_label(button_label)
             .timeout(timeout)
             .build();
-
-        text_notify_toast.connect_button_clicked(button_callback);
-        self.toast_overlay().add_toast(text_notify_toast.clone());
-
-        text_notify_toast
+        toast.connect_button_clicked(button_callback);
+        self.toast_overlay().add_toast(toast.clone());
+        toast
     }
 
     /// Ensures that only one toast per `singleton_toast` is queued at the same time by dismissing the previous toast.
@@ -501,31 +499,40 @@ impl RnOverlays {
         if let Some(previous_toast) = singleton_toast {
             previous_toast.dismiss();
         }
-
-        let text_notify_toast =
-            self.dispatch_toast_w_button(text, button_label, button_callback, timeout);
-        *singleton_toast = Some(text_notify_toast);
+        *singleton_toast =
+            Some(self.dispatch_toast_w_button(text, button_label, button_callback, timeout));
     }
 
-    pub(crate) fn dispatch_toast_text(&self, text: &str) {
-        let text_notify_toast = adw::Toast::builder()
+    pub(crate) fn dispatch_toast_text(&self, text: &str, timeout: u32) -> adw::Toast {
+        let toast = adw::Toast::builder()
             .title(text)
             .priority(adw::ToastPriority::High)
-            .timeout(5)
+            .timeout(timeout)
             .build();
-
-        self.toast_overlay().add_toast(text_notify_toast);
+        self.toast_overlay().add_toast(toast.clone());
+        toast
     }
 
-    pub(crate) fn dispatch_toast_error(&self, error: &String) {
-        let text_notify_toast = adw::Toast::builder()
-            .title(error.as_str())
+    pub(crate) fn dispatch_toast_text_singleton(
+        &self,
+        text: &str,
+        timeout: u32,
+        singleton_toast: &mut Option<adw::Toast>,
+    ) {
+        if let Some(previous_toast) = singleton_toast {
+            previous_toast.dismiss();
+        }
+        *singleton_toast = Some(self.dispatch_toast_text(text, timeout));
+    }
+
+    pub(crate) fn dispatch_toast_error(&self, error: &str) -> adw::Toast {
+        let toast = adw::Toast::builder()
+            .title(error)
             .priority(adw::ToastPriority::High)
             .timeout(0)
             .build();
-
+        self.toast_overlay().add_toast(toast.clone());
         log::error!("{error}");
-
-        self.toast_overlay().add_toast(text_notify_toast);
+        toast
     }
 }

--- a/rnote-ui/src/settingspanel/mod.rs
+++ b/rnote-ui/src/settingspanel/mod.rs
@@ -8,7 +8,7 @@ pub(crate) use penshortcutrow::RnPenShortcutRow;
 // Imports
 use crate::{RnAppWindow, RnCanvasWrapper, RnIconPicker, RnUnitEntry};
 use adw::prelude::*;
-use gettextrs::pgettext;
+use gettextrs::{gettext, pgettext};
 use gtk4::{
     gdk, glib, glib::clone, subclass::prelude::*, Adjustment, Button, ColorDialogButton,
     CompositeTemplate, MenuButton, ScrolledWindow, SpinButton, StringList, Switch, ToggleButton,

--- a/rnote-ui/src/settingspanel/mod.rs
+++ b/rnote-ui/src/settingspanel/mod.rs
@@ -28,6 +28,7 @@ mod imp {
     #[template(resource = "/com/github/flxzt/rnote/ui/settingspanel.ui")]
     pub(crate) struct RnSettingsPanel {
         pub(crate) temporary_format: RefCell<Format>,
+        pub(crate) app_restart_toast_singleton: RefCell<Option<adw::Toast>>,
 
         #[template_child]
         pub(crate) settings_scroller: TemplateChild<ScrolledWindow>,
@@ -559,6 +560,18 @@ impl RnSettingsPanel {
             )
             .sync_create()
             .build();
+
+        imp.general_inertial_scrolling_switch.connect_active_notify(
+            clone!(@weak self as settingspanel, @weak appwindow => move |switch| {
+                if !switch.is_active() {
+                    appwindow.overlays().dispatch_toast_text_singleton(
+                        &gettext("The app needs to be restarted."),
+                        0,
+                        &mut settingspanel.imp().app_restart_toast_singleton.borrow_mut()
+                    );
+                }
+            }),
+        );
     }
 
     fn setup_format(&self, appwindow: &RnAppWindow) {

--- a/rnote-ui/src/settingspanel/mod.rs
+++ b/rnote-ui/src/settingspanel/mod.rs
@@ -565,7 +565,7 @@ impl RnSettingsPanel {
             clone!(@weak self as settingspanel, @weak appwindow => move |switch| {
                 if !switch.is_active() {
                     appwindow.overlays().dispatch_toast_text_singleton(
-                        &gettext("The application needs to be restarted."),
+                        &gettext("Application restart is required"),
                         0,
                         &mut settingspanel.imp().app_restart_toast_singleton.borrow_mut()
                     );

--- a/rnote-ui/src/settingspanel/mod.rs
+++ b/rnote-ui/src/settingspanel/mod.rs
@@ -40,6 +40,8 @@ mod imp {
         #[template_child]
         pub(crate) general_show_scrollbars_switch: TemplateChild<Switch>,
         #[template_child]
+        pub(crate) general_inertial_scrolling_switch: TemplateChild<Switch>,
+        #[template_child]
         pub(crate) general_regular_cursor_picker: TemplateChild<RnIconPicker>,
         #[template_child]
         pub(crate) general_regular_cursor_picker_menubutton: TemplateChild<MenuButton>,
@@ -361,6 +363,10 @@ impl RnSettingsPanel {
 
     pub(crate) fn general_show_scrollbars_switch(&self) -> Switch {
         self.imp().general_show_scrollbars_switch.clone()
+    }
+
+    pub(crate) fn general_inertial_scrolling_switch(&self) -> Switch {
+        self.imp().general_inertial_scrolling_switch.clone()
     }
 
     pub(crate) fn refresh_ui(&self, active_tab: &RnCanvasWrapper) {

--- a/rnote-ui/src/settingspanel/mod.rs
+++ b/rnote-ui/src/settingspanel/mod.rs
@@ -565,7 +565,7 @@ impl RnSettingsPanel {
             clone!(@weak self as settingspanel, @weak appwindow => move |switch| {
                 if !switch.is_active() {
                     appwindow.overlays().dispatch_toast_text_singleton(
-                        &gettext("The app needs to be restarted."),
+                        &gettext("The application needs to be restarted."),
                         0,
                         &mut settingspanel.imp().app_restart_toast_singleton.borrow_mut()
                     );


### PR DESCRIPTION
This PR adds an option for "inertial touch scrolling" which is enabled by default and gets unsensitive if touch drawing is enabled. Enabling touch drawing overrides & disables inertial scrolling and enables the touch drag gesture (in general, the behavior should be identical to the one described [in this comment](https://github.com/flxzt/rnote/issues/291#issuecomment-1476619529)).

* Closes #291.
* Inertial scrolling seems to be much more commonly used than kinetic scrolling.

![grafik](https://user-images.githubusercontent.com/49598842/226467371-e5cd82a6-8d60-4a3a-9004-187bc9e37527.png)
