### PR TITLE
add size limits for grid builder

### DIFF
--- a/rnote-compose/src/builders/gridbuilder.rs
+++ b/rnote-compose/src/builders/gridbuilder.rs
@@ -14,9 +14,6 @@ use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
 use super::ShapeBuilderBehaviour;
 use crate::Constraints;
 
-const GRIDBUILDER_FIRST_CELL_DIMENSIONS_MIN: f64 = 2.0;
-const GRIDBUILDER_CELL_GRID_DIMENSIONS_MAX: u32 = 500;
-
 #[derive(Debug, Clone, Copy)]
 enum GridBuilderState {
     FirstCell {
@@ -67,8 +64,8 @@ impl ShapeBuilderBehaviour for GridBuilder {
             (GridBuilderState::FirstCell { start, .. }, PenEvent::Up { element, .. }) => {
                 let cell_size = constraints.constrain(element.pos - *start);
 
-                if cell_size.x.abs() < GRIDBUILDER_FIRST_CELL_DIMENSIONS_MIN
-                    || cell_size.y.abs() < GRIDBUILDER_FIRST_CELL_DIMENSIONS_MIN
+                if cell_size.x.abs() < Self::FIRST_CELL_DIMENSIONS_MIN
+                    || cell_size.y.abs() < Self::FIRST_CELL_DIMENSIONS_MIN
                 {
                     return ShapeBuilderProgress::Finished(vec![]);
                 }
@@ -144,10 +141,10 @@ impl ShapeBuilderBehaviour for GridBuilder {
 
                 let cols = ((current - start)[0] / cell_size[0])
                     .floor()
-                    .min(GRIDBUILDER_CELL_GRID_DIMENSIONS_MAX as f64);
+                    .min(Self::CELL_GRID_DIMENSIONS_MAX as f64);
                 let rows = ((current - start)[1] / cell_size[1])
                     .floor()
-                    .min(GRIDBUILDER_CELL_GRID_DIMENSIONS_MAX as f64);
+                    .min(Self::CELL_GRID_DIMENSIONS_MAX as f64);
 
                 if cols > 0.0 && rows > 0.0 {
                     indicators::draw_pos_indicator(cx, PenState::Up, *start + cell_size, zoom);
@@ -166,6 +163,9 @@ impl ShapeBuilderBehaviour for GridBuilder {
 }
 
 impl GridBuilder {
+    const FIRST_CELL_DIMENSIONS_MIN: f64 = 2.0;
+    const CELL_GRID_DIMENSIONS_MAX: u32 = 100;
+
     fn state_as_lines(&self) -> Vec<Line> {
         match &self.state {
             GridBuilderState::FirstCell { start, current }
@@ -190,8 +190,8 @@ impl GridBuilder {
                     }
 
                     (
-                        (cols.floor() as u32).min(GRIDBUILDER_CELL_GRID_DIMENSIONS_MAX),
-                        (rows.floor() as u32).min(GRIDBUILDER_CELL_GRID_DIMENSIONS_MAX),
+                        (cols.floor() as u32).min(Self::CELL_GRID_DIMENSIONS_MAX),
+                        (rows.floor() as u32).min(Self::CELL_GRID_DIMENSIONS_MAX),
                     )
                 };
 


### PR DESCRIPTION
* Adds minimum dimensions for the first cell (2x2), which fixes #591.
* Adds maximum dimensions for the cell grid (500x500 cells).