### PR TITLE
improve typewriter keyboard navigation

### DIFF
--- a/rnote-compose/src/penevents.rs
+++ b/rnote-compose/src/penevents.rs
@@ -76,6 +76,10 @@ pub enum KeyboardKey {
     CtrlLeft,
     /// Ctrl right
     CtrlRight,
+    /// Home
+    Home,
+    /// End
+    End,
     /// Unsupported
     Unsupported,
 }

--- a/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/rnote-engine/src/pens/typewriter/penevents.rs
@@ -617,6 +617,7 @@ impl Typewriter {
                                             finished: false,
                                         };
                                     } else {
+                                        #[allow(clippy::collapsible_else_if)]
                                         if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
                                             textstroke.move_cursor_text_start(cursor);
                                         } else {
@@ -638,6 +639,7 @@ impl Typewriter {
                                             finished: false,
                                         };
                                     } else {
+                                        #[allow(clippy::collapsible_else_if)]
                                         if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
                                             textstroke.move_cursor_text_end(cursor);
                                         } else {

--- a/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/rnote-engine/src/pens/typewriter/penevents.rs
@@ -434,7 +434,7 @@ impl Typewriter {
                         let textstroke = TextStroke::new(String::from(keychar), *pos, text_style);
                         let mut cursor = GraphemeCursor::new(0, textstroke.text.len(), true);
 
-                        textstroke.move_cursor_forward(&mut cursor, false);
+                        textstroke.move_cursor_forward(&mut cursor);
                         let stroke_key = engine_view
                             .store
                             .insert_stroke(Stroke::TextStroke(textstroke), None);
@@ -495,11 +495,7 @@ impl Typewriter {
                                     if keychar == 'a'
                                         && modifier_keys.contains(&ModifierKey::KeyboardCtrl)
                                     {
-                                        *cursor = GraphemeCursor::new(
-                                            textstroke.text.len(),
-                                            textstroke.text.len(),
-                                            true,
-                                        );
+                                        cursor.set_cursor(textstroke.text.len());
                                         // Select entire text
                                         *modify_state = ModifyState::Selecting {
                                             selection_cursor: GraphemeCursor::new(
@@ -518,10 +514,11 @@ impl Typewriter {
                                     }
                                 }
                                 KeyboardKey::BackSpace => {
-                                    textstroke.remove_grapheme_before_cursor(
-                                        cursor,
-                                        modifier_keys.contains(&ModifierKey::KeyboardCtrl),
-                                    );
+                                    if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
+                                        textstroke.remove_word_before_cursor(cursor);
+                                    } else {
+                                        textstroke.remove_grapheme_before_cursor(cursor);
+                                    }
                                     update_stroke(engine_view.store);
                                 }
                                 KeyboardKey::HorizontalTab => {
@@ -533,48 +530,55 @@ impl Typewriter {
                                     update_stroke(engine_view.store);
                                 }
                                 KeyboardKey::Delete => {
-                                    textstroke.remove_grapheme_after_cursor(
-                                        cursor,
-                                        modifier_keys.contains(&ModifierKey::KeyboardCtrl),
-                                    );
+                                    if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
+                                        textstroke.remove_word_after_cursor(cursor);
+                                    } else {
+                                        textstroke.remove_grapheme_after_cursor(cursor);
+                                    }
                                     update_stroke(engine_view.store);
                                 }
                                 KeyboardKey::NavLeft => {
                                     if modifier_keys.contains(&ModifierKey::KeyboardShift) {
                                         let old_cursor = cursor.clone();
-                                        textstroke.move_cursor_back(
-                                            cursor,
-                                            modifier_keys.contains(&ModifierKey::KeyboardCtrl),
-                                        );
+                                        if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
+                                            textstroke.move_cursor_word_back(cursor);
+                                        } else {
+                                            textstroke.move_cursor_back(cursor);
+                                        }
 
                                         *modify_state = ModifyState::Selecting {
                                             selection_cursor: old_cursor,
                                             finished: false,
                                         }
                                     } else {
-                                        textstroke.move_cursor_back(
-                                            cursor,
-                                            modifier_keys.contains(&ModifierKey::KeyboardCtrl),
-                                        );
+                                        #[allow(clippy::collapsible_else_if)]
+                                        if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
+                                            textstroke.move_cursor_word_back(cursor);
+                                        } else {
+                                            textstroke.move_cursor_back(cursor);
+                                        }
                                     }
                                 }
                                 KeyboardKey::NavRight => {
                                     if modifier_keys.contains(&ModifierKey::KeyboardShift) {
                                         let old_cursor = cursor.clone();
-                                        textstroke.move_cursor_forward(
-                                            cursor,
-                                            modifier_keys.contains(&ModifierKey::KeyboardCtrl),
-                                        );
+                                        if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
+                                            textstroke.move_cursor_word_forward(cursor);
+                                        } else {
+                                            textstroke.move_cursor_forward(cursor);
+                                        }
 
                                         *modify_state = ModifyState::Selecting {
                                             selection_cursor: old_cursor,
                                             finished: false,
                                         };
                                     } else {
-                                        textstroke.move_cursor_forward(
-                                            cursor,
-                                            modifier_keys.contains(&ModifierKey::KeyboardCtrl),
-                                        );
+                                        #[allow(clippy::collapsible_else_if)]
+                                        if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
+                                            textstroke.move_cursor_word_forward(cursor);
+                                        } else {
+                                            textstroke.move_cursor_forward(cursor);
+                                        }
                                     }
                                 }
                                 KeyboardKey::NavUp => {
@@ -703,10 +707,11 @@ impl Typewriter {
                                 }
                                 KeyboardKey::NavLeft => {
                                     if modifier_keys.contains(&ModifierKey::KeyboardShift) {
-                                        textstroke.move_cursor_back(
-                                            cursor,
-                                            modifier_keys.contains(&ModifierKey::KeyboardCtrl),
-                                        );
+                                        if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
+                                            textstroke.move_cursor_word_back(cursor);
+                                        } else {
+                                            textstroke.move_cursor_back(cursor);
+                                        }
                                         false
                                     } else {
                                         cursor.set_cursor(
@@ -717,10 +722,11 @@ impl Typewriter {
                                 }
                                 KeyboardKey::NavRight => {
                                     if modifier_keys.contains(&ModifierKey::KeyboardShift) {
-                                        textstroke.move_cursor_forward(
-                                            cursor,
-                                            modifier_keys.contains(&ModifierKey::KeyboardCtrl),
-                                        );
+                                        if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
+                                            textstroke.move_cursor_word_forward(cursor);
+                                        } else {
+                                            textstroke.move_cursor_forward(cursor);
+                                        }
                                         false
                                     } else {
                                         cursor.set_cursor(

--- a/rnote-engine/src/strokes/textstroke.rs
+++ b/rnote-engine/src/strokes/textstroke.rs
@@ -693,42 +693,36 @@ impl TextStroke {
         let cur_pos = cursor.cur_cursor();
         let prev_pos = self.get_prev_word_start_index(cur_pos);
 
-        if cur_pos == prev_pos {
-            return;
+        if cur_pos != prev_pos {
+            self.text.replace_range(prev_pos..cur_pos, "");
+
+            // translate the text attributes
+            self.translate_attrs_after_cursor(
+                prev_pos,
+                prev_pos as i32 - cur_pos as i32 + "".len() as i32,
+            );
+
+            // New text length, new cursor
+            *cursor = GraphemeCursor::new(prev_pos, self.text.len(), true);
         }
-
-        cursor.set_cursor(prev_pos);
-
-        self.text.replace_range(prev_pos..cur_pos, "");
-
-        // translate the text attributes
-        self.translate_attrs_after_cursor(
-            prev_pos,
-            prev_pos as i32 - cur_pos as i32 + "".len() as i32,
-        );
-
-        // New text length, new cursor
-        *cursor = GraphemeCursor::new(cursor.cur_cursor(), self.text.len(), true);
     }
 
     pub fn remove_word_after_cursor(&mut self, cursor: &mut GraphemeCursor) {
         let cur_pos = cursor.cur_cursor();
         let next_pos = self.get_next_word_end_index(cur_pos);
 
-        if cur_pos == next_pos {
-            return;
+        if cur_pos != next_pos {
+            self.text.replace_range(cur_pos..next_pos, "");
+
+            // translate the text attributes
+            self.translate_attrs_after_cursor(
+                cur_pos,
+                -(next_pos as i32 - cur_pos as i32) + "".len() as i32,
+            );
+
+            // New text length, new cursor
+            *cursor = GraphemeCursor::new(cur_pos, self.text.len(), true);
         }
-
-        self.text.replace_range(cur_pos..next_pos, "");
-
-        // translate the text attributes
-        self.translate_attrs_after_cursor(
-            cur_pos,
-            -(next_pos as i32 - cur_pos as i32) + "".len() as i32,
-        );
-
-        // New text length, new cursor
-        *cursor = GraphemeCursor::new(cur_pos, self.text.len(), true);
     }
 
     pub fn replace_text_between_selection_cursors(

--- a/rnote-engine/src/strokes/textstroke.rs
+++ b/rnote-engine/src/strokes/textstroke.rs
@@ -908,13 +908,27 @@ impl TextStroke {
                 cursor,
             ),
         ) {
-            let mut offset = lines[hittest_position.line].end_offset;
+            let line_metric = &lines[hittest_position.line];
+            let mut offset = line_metric.end_offset;
 
-            if offset > 0 && self.text.chars().nth(offset - 1).unwrap() == '\n' {
+            // Move cursor in front of new line characters if they exist.
+            if offset > line_metric.start_offset
+                && self
+                    .text
+                    .chars()
+                    .nth(offset - 1)
+                    .map_or(false, |c| c == '\n')
+            {
                 offset -= 1;
             }
 
-            if offset > 0 && self.text.chars().nth(offset - 1).unwrap() == '\r' {
+            if offset > line_metric.start_offset
+                && self
+                    .text
+                    .chars()
+                    .nth(offset - 1)
+                    .map_or(false, |c| c == '\r')
+            {
                 offset -= 1;
             }
 

--- a/rnote-ui/src/canvas/input.rs
+++ b/rnote-ui/src/canvas/input.rs
@@ -432,6 +432,8 @@ pub(crate) fn retrieve_keyboard_key(gdk_key: gdk::Key) -> KeyboardKey {
             gdk::Key::Shift_R => KeyboardKey::ShiftRight,
             gdk::Key::Control_L => KeyboardKey::CtrlLeft,
             gdk::Key::Control_R => KeyboardKey::CtrlRight,
+            gdk::Key::Home => KeyboardKey::Home,
+            gdk::Key::End => KeyboardKey::End,
             _ => KeyboardKey::Unsupported,
         }
     }


### PR DESCRIPTION
- Closes #560.
- Implements all navigation keybindings mentioned in the issue and comment(s).
- Uses the same style that Chromium does, as described in my comment.
- ATM, quitting the selection using movement keys does not actually execute that movement. That behavior is improved:
  - move cursor to leftmost (rightmost) selected character on `NavLeft` (`NavRight`),
  - move cursor like when there's no selection on other key presses.
  
### Things for Discussion
- Word boundary/navigation style.
- If `move_cursor_text_start` and `move_cursor_line_start` (and the end variants) should be combined into one function like `move_cursor_forward` (and back), or if the latter should be split into two functions each. Or if it should stay as-is I guess.
- Is there any point in recreating the cursor instead of using `set_cursor()` when the text length does not change? `move_cursor_line_down` (and up) currently recreate it, but everything I've implemented in this PR does not. We should probably settle on a single way to do it, unless I'm missing something here.

EDIT: I could also implement the typical mouse navigation - i.e. double click to select whole word(s), triple click to select entire line(s) - but I don't know how to detect those yet. I'm assuming I could use `GestureClick`s, but everything related to it would have to be outside of the main `handle_pen_event_down` function then.