### PR TITLE
add dist archive CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo dnf upgrade --refresh -y
-          sudo dnf install -y gcc gcc-c++ clang python3 make cmake meson kernel-devel gtk4-devel libadwaita-devel poppler-glib-devel poppler-data alsa-lib-devel libappstream-glib desktop-file-utils
+          sudo dnf install -y gcc gcc-c++ clang python3 make cmake meson git kernel-devel gtk4-devel libadwaita-devel poppler-glib-devel poppler-data alsa-lib-devel libappstream-glib desktop-file-utils
       - name: Install toolchain
         id: toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
+  workflow_call:
 
 name: CI
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
     runs-on: ubuntu-22.04
     container: fedora:38
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           sudo dnf upgrade --refresh -y
@@ -26,6 +24,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Cache
         uses: actions/cache@v3
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   check:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-22.04
-    container: fedora:37
+    container: fedora:38
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -38,10 +38,9 @@ jobs:
             _mesonbuild/target/
           key: cargo-${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.workflow_sha }}
           restore-keys: cargo-${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}
-      - name: Configure
+      - name: Setup
         run: |
-          meson setup --prefix=/usr _mesonbuild
-          meson configure -Dprofile=devel -Dcli=true _mesonbuild
+          meson setup --prefix=/usr -Dprofile=devel -Dcli=true _mesonbuild
       - name: Run cargo fmt
         run: meson compile cargo-fmt-check -C _mesonbuild
       - name: Compile

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -19,12 +19,11 @@ jobs:
       - name: Install toolchain
         id: toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Configure
+      - name: Setup
         run: |
           meson setup --prefix=/usr _mesonbuild
-          meson configure _mesonbuild
       - name: Run meson dist
-        run: meson dist -C _mesonbuild
+        run: meson dist --no-tests -C _mesonbuild
       - name: Upload dist archive (Workflow Artifact)
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,6 +1,7 @@
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 name: Generate Dist Archive
 

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo dnf upgrade --refresh -y
-          sudo dnf install -y gcc gcc-c++ clang python3 make cmake meson git kernel-devel gtk4-devel libadwaita-devel poppler-glib-devel poppler-data alsa-lib-devel libappstream-glib desktop-file-utils
+          sudo dnf install -y gcc gcc-c++ clang python3 make cmake meson git gh kernel-devel gtk4-devel libadwaita-devel poppler-glib-devel poppler-data alsa-lib-devel libappstream-glib desktop-file-utils
       - name: Install toolchain
         id: toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -43,7 +43,6 @@ jobs:
           if-no-files-found: error
       - name: Upload dist archive (Release Asset)
         if: ${{ github.event_name == 'release' }}
-        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -6,9 +6,12 @@ on:
 name: Generate Dist Archive
 
 jobs:
-  check:
+  ci:
+    uses: ./.github/workflows/ci.yml
+  dist:
     runs-on: ubuntu-22.04
     container: fedora:38
+    needs: [ci]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -13,7 +13,6 @@ jobs:
     steps:
       - name: Register archive name
         id: register_archive_name
-        shell: bash
         run: echo "name=rnote-$(echo ${GITHUB_REF_NAME#v})" >> $GITHUB_OUTPUT
       - name: Install dependencies
         run: |

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo dnf upgrade --refresh -y
-          sudo dnf install -y gcc gcc-c++ clang python3 make cmake meson kernel-devel gtk4-devel libadwaita-devel poppler-glib-devel poppler-data alsa-lib-devel libappstream-glib desktop-file-utils
+          sudo dnf install -y gcc gcc-c++ clang python3 make cmake meson git kernel-devel gtk4-devel libadwaita-devel poppler-glib-devel poppler-data alsa-lib-devel libappstream-glib desktop-file-utils
       - name: Install toolchain
         id: toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -5,12 +5,11 @@ on:
 name: Generate Dist Archive
 
 jobs:
-  ci:
-    uses: ./.github/workflows/ci.yml
   dist:
     runs-on: ubuntu-22.04
     container: fedora:38
-    needs: [ci]
+    permissions:
+        contents: write # needed for uploading release artifact
     steps:
       - name: Register archive name
         id: register_archive_name

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -33,7 +33,7 @@ jobs:
         id: register_archive_file_names
         run: |
           echo "archive =$(basename _mesonbuild/meson-dist/rnote-*.tar.xz | tail -n1)" >> $GITHUB_OUTPUT
-          echo "sha=rnote-$(basename _mesonbuild/meson-dist/rnote-*.tar.xz.sha256sum | tail -n1)" >> $GITHUB_OUTPUT
+          echo "sha=$(basename _mesonbuild/meson-dist/rnote-*.tar.xz.sha256sum | tail -n1)" >> $GITHUB_OUTPUT
       - name: Upload dist archive (Workflow Artifact)
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -11,9 +11,6 @@ jobs:
     permissions:
       contents: write # needed for uploading release artifact
     steps:
-      - name: Register archive name
-        id: register_archive_name
-        run: echo "name=rnote-$(echo ${GITHUB_REF_NAME#v})" >> $GITHUB_OUTPUT
       - name: Install dependencies
         run: |
           sudo dnf upgrade --refresh -y
@@ -32,18 +29,23 @@ jobs:
           meson setup --prefix=/usr _mesonbuild
       - name: Run meson dist
         run: meson dist --no-tests -C _mesonbuild
+      - name: Register archive file names
+        id: register_archive_file_names
+        run: |
+          echo "archive =$(basename _mesonbuild/meson-dist/rnote-*.tar.xz | tail -n1)" >> $GITHUB_OUTPUT
+          echo "sha=rnote-$(basename _mesonbuild/meson-dist/rnote-*.tar.xz.sha256sum | tail -n1)" >> $GITHUB_OUTPUT
       - name: Upload dist archive (Workflow Artifact)
         uses: actions/upload-artifact@v3
         with:
           name: rnote-dist-archive-artifact
           path: |
-            _mesonbuild/meson-dist/${{ steps.register_archive_name.outputs.name }}.tar.xz
-            _mesonbuild/meson-dist/${{ steps.register_archive_name.outputs.name }}.tar.xz.sha256sum
+            _mesonbuild/meson-dist/${{ steps.register_archive_file_names.outputs.archive }}
+            _mesonbuild/meson-dist/${{ steps.register_archive_file_names.outputs.sha }}
           if-no-files-found: error
       - name: Upload dist archive (Release Asset)
         if: ${{ github.event_name == 'release' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ github.ref_name }} _mesonbuild/meson-dist/${{ steps.register_archive_name.outputs.name }}.tar.xz
-          gh release upload ${{ github.ref_name }} _mesonbuild/meson-dist/${{ steps.register_archive_name.outputs.name }}.tar.xz.sha256sum
+          gh release upload ${{ github.ref_name }} _mesonbuild/meson-dist/${{ steps.register_archive_file_names.outputs.archive }}
+          gh release upload ${{ github.ref_name }} _mesonbuild/meson-dist/${{ steps.register_archive_file_names.outputs.sha }}

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo dnf upgrade --refresh -y
-          sudo dnf install -y python3 meson
+          sudo dnf install -y gcc gcc-c++ clang python3 make cmake meson kernel-devel gtk4-devel libadwaita-devel poppler-glib-devel poppler-data alsa-lib-devel libappstream-glib desktop-file-utils
       - name: Install toolchain
         id: toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,7 +1,6 @@
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 name: Generate Dist Archive
 
@@ -13,8 +12,10 @@ jobs:
     container: fedora:38
     needs: [ci]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Register archive name
+        id: register_archive_name
+        shell: bash
+        run: echo "name=rnote-$(echo ${GITHUB_REF_NAME#v})" >> $GITHUB_OUTPUT
       - name: Install dependencies
         run: |
           sudo dnf upgrade --refresh -y
@@ -22,6 +23,12 @@ jobs:
       - name: Install toolchain
         id: toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Add workspace as git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Setup
         run: |
           meson setup --prefix=/usr _mesonbuild
@@ -32,8 +39,8 @@ jobs:
         with:
           name: rnote-dist-archive-artifact
           path: |
-            _mesonbuild/meson-dist/rnote-$(echo ${GITHUB_REF_NAME#v}).tar.xz
-            _mesonbuild/meson-dist/rnote-$(echo ${GITHUB_REF_NAME#v}).tar.xz.sha256sum
+            _mesonbuild/meson-dist/${{ steps.register_archive_name.outputs.name }}.tar.xz
+            _mesonbuild/meson-dist/${{ steps.register_archive_name.outputs.name }}.tar.xz.sha256sum
           if-no-files-found: error
       - name: Upload dist archive (Release Asset)
         if: ${{ github.event_name == 'release' }}
@@ -41,5 +48,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ github.ref_name }} _mesonbuild/meson-dist/rnote-$(echo ${GITHUB_REF_NAME#v}).tar.xz
-          gh release upload ${{ github.ref_name }} _mesonbuild/meson-dist/rnote-$(echo ${GITHUB_REF_NAME#v}).tar.xz.sha256sum
+          gh release upload ${{ github.ref_name }} _mesonbuild/meson-dist/${{ steps.register_archive_name.outputs.name }}.tar.xz
+          gh release upload ${{ github.ref_name }} _mesonbuild/meson-dist/${{ steps.register_archive_name.outputs.name }}.tar.xz.sha256sum

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     container: fedora:38
     permissions:
-        contents: write # needed for uploading release artifact
+      contents: write # needed for uploading release artifact
     steps:
       - name: Register archive name
         id: register_archive_name

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,0 +1,43 @@
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: Generate Dist Archive
+
+jobs:
+  check:
+    runs-on: ubuntu-22.04
+    container: fedora:38
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo dnf upgrade --refresh -y
+          sudo dnf install -y python3 meson
+      - name: Install toolchain
+        id: toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Configure
+        run: |
+          meson setup --prefix=/usr _mesonbuild
+          meson configure _mesonbuild
+      - name: Run meson dist
+        run: meson dist -C _mesonbuild
+      - name: Upload dist archive (Workflow Artifact)
+        uses: actions/upload-artifact@v3
+        with:
+          name: rnote-dist-archive-artifact
+          path: |
+            _mesonbuild/meson-dist/rnote-$(echo ${GITHUB_REF_NAME#v}).tar.xz
+            _mesonbuild/meson-dist/rnote-$(echo ${GITHUB_REF_NAME#v}).tar.xz.sha256sum
+          if-no-files-found: error
+      - name: Upload dist archive (Release Asset)
+        if: ${{ github.event_name == 'release' }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.ref_name }} _mesonbuild/meson-dist/rnote-$(echo ${GITHUB_REF_NAME#v}).tar.xz
+          gh release upload ${{ github.ref_name }} _mesonbuild/meson-dist/rnote-$(echo ${GITHUB_REF_NAME#v}).tar.xz.sha256sum

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -6,6 +6,8 @@ on:
 name: Release Windows
 
 jobs:
+    ci:
+        uses: ./.github/workflows/ci.yml
     build:
         runs-on: windows-2022
         permissions:
@@ -13,6 +15,7 @@ jobs:
         defaults:
             run:
                 shell: msys2 {0}
+        needs: [ci]
         steps:
             - name: Checkout
               uses: actions/checkout@v3

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,59 +1,59 @@
 on:
-    release:
-        types: [published]
-    workflow_dispatch:
+  release:
+    types: [published]
+  workflow_dispatch:
 
 name: Release Windows
 
 jobs:
-    build:
-        runs-on: windows-2022
-        permissions:
-            contents: write # needed for uploading release artifact
-        defaults:
-            run:
-                shell: msys2 {0}
-        steps:
-            - name: Set installer name
-              id: set_installer_name
-              shell: bash
-              run: echo "name=rnote-win-installer-$(echo ${GITHUB_REF_NAME#v})-x86_64" >> $GITHUB_OUTPUT
-            - name: Setup MSYS2
-              uses: msys2/setup-msys2@v2
-              with:
-                  release: false
-                  update: true
-                  install: |
-                      git mingw-w64-x86_64-xz mingw-w64-x86_64-pkgconf mingw-w64-x86_64-gcc mingw-w64-x86_64-clang mingw-w64-x86_64-toolchain
-                      mingw-w64-x86_64-autotools mingw-w64-x86_64-make mingw-w64-x86_64-cmake mingw-w64-x86_64-meson mingw-w64-x86_64-diffutils
-                      mingw-w64-x86_64-desktop-file-utils mingw-w64-x86_64-appstream-glib mingw-w64-x86_64-gtk4 mingw-w64-x86_64-libadwaita
-                      mingw-w64-x86_64-poppler mingw-w64-x86_64-poppler-data
-            - name: Remove libpthread.dll.a
-              run: rm /mingw64/lib/libpthread.dll.a
-              continue-on-error: true
-            - name: Install toolchain
-              uses: dtolnay/rust-toolchain@stable
-              with:
-                  toolchain: stable-gnu
-            - name: Configure PATH
-              run: echo "export PATH=$PATH:/c/Users/$USER/.cargo/bin:/c/Program\ Files\ \(x86\)/Inno\ Setup\ 6" > ~/.bashrc
-            - name: Checkout
-              uses: actions/checkout@v3
-            - name: Setup
-              run: meson setup --prefix=C:/msys64/mingw64 -Dinstaller-name='${{ steps.set_installer_name.outputs.name }}' _mesonbuild
-            - name: Generate locale files
-              run: meson compile rnote-gmo -C _mesonbuild
-            - name: Build installer
-              run: meson compile build-installer -C _mesonbuild
-            - name: Upload installer (Workflow Artifact)
-              uses: actions/upload-artifact@v3
-              with:
-                  name: rnote-win-installer-artifact
-                  path: _mesonbuild/${{ steps.set_installer_name.outputs.name }}.exe
-                  if-no-files-found: error
-            - name: Upload installer (Release Asset)
-              if: ${{ github.event_name == 'release' }}
-              shell: powershell
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: gh release upload ${{ github.ref_name }} _mesonbuild/${{ steps.set_installer_name.outputs.name }}.exe
+  build:
+    runs-on: windows-2022
+    permissions:
+      contents: write # needed for uploading release artifact
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Set installer name
+        id: set_installer_name
+        shell: bash
+        run: echo "name=rnote-win-installer-$(echo ${GITHUB_REF_NAME#v})-x86_64" >> $GITHUB_OUTPUT
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          release: false
+          update: true
+          install: |
+            git mingw-w64-x86_64-xz mingw-w64-x86_64-pkgconf mingw-w64-x86_64-gcc mingw-w64-x86_64-clang mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-autotools mingw-w64-x86_64-make mingw-w64-x86_64-cmake mingw-w64-x86_64-meson mingw-w64-x86_64-diffutils
+            mingw-w64-x86_64-desktop-file-utils mingw-w64-x86_64-appstream-glib mingw-w64-x86_64-gtk4 mingw-w64-x86_64-libadwaita
+            mingw-w64-x86_64-poppler mingw-w64-x86_64-poppler-data
+      - name: Remove libpthread.dll.a
+        run: rm /mingw64/lib/libpthread.dll.a
+        continue-on-error: true
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable-gnu
+      - name: Configure PATH
+        run: echo "export PATH=$PATH:/c/Users/$USER/.cargo/bin:/c/Program\ Files\ \(x86\)/Inno\ Setup\ 6" > ~/.bashrc
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup
+        run: meson setup --prefix=C:/msys64/mingw64 -Dinstaller-name='${{ steps.set_installer_name.outputs.name }}' _mesonbuild
+      - name: Generate locale files
+        run: meson compile rnote-gmo -C _mesonbuild
+      - name: Build installer
+        run: meson compile build-installer -C _mesonbuild
+      - name: Upload installer (Workflow Artifact)
+        uses: actions/upload-artifact@v3
+        with:
+          name: rnote-win-installer-artifact
+          path: _mesonbuild/${{ steps.set_installer_name.outputs.name }}.exe
+          if-no-files-found: error
+      - name: Upload installer (Release Asset)
+        if: ${{ github.event_name == 'release' }}
+        shell: powershell
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ github.ref_name }} _mesonbuild/${{ steps.set_installer_name.outputs.name }}.exe

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -17,8 +17,6 @@ jobs:
                 shell: msys2 {0}
         needs: [ci]
         steps:
-            - name: Checkout
-              uses: actions/checkout@v3
             - name: Set installer name
               id: set_installer_name
               shell: bash
@@ -42,6 +40,8 @@ jobs:
                   toolchain: stable-gnu
             - name: Configure PATH
               run: echo "export PATH=$PATH:/c/Users/$USER/.cargo/bin:/c/Program\ Files\ \(x86\)/Inno\ Setup\ 6" > ~/.bashrc
+            - name: Checkout
+              uses: actions/checkout@v3
             - name: Setup
               run: meson setup --prefix=C:/msys64/mingw64 -Dinstaller-name='${{ steps.set_installer_name.outputs.name }}' _mesonbuild
             - name: Generate locale files

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -6,8 +6,6 @@ on:
 name: Release Windows
 
 jobs:
-    ci:
-        uses: ./.github/workflows/ci.yml
     build:
         runs-on: windows-2022
         permissions:
@@ -15,7 +13,6 @@ jobs:
         defaults:
             run:
                 shell: msys2 {0}
-        needs: [ci]
         steps:
             - name: Set installer name
               id: set_installer_name

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,7 +1,8 @@
 # Building
 
-First clone the repository and init its submodules
-```
+First install git, clone the repository and init its submodules
+```bash
+sudo dnf install git
 git clone https://github.com/flxzt/rnote
 cd rnote
 git submodule update --init --recursive
@@ -71,7 +72,7 @@ If a native build on the host is wanted, meson can be called directly.
 
 Install all needed dependencies and build tools, e.g. for fedora 37:
 ```bash
-sudo dnf install gcc gcc-c++ clang clang-devel python3 make cmake meson kernel-devel gtk4-devel libadwaita-devel poppler-glib-devel poppler-data alsa-lib-devel
+sudo dnf install gcc gcc-c++ clang clang-devel python3 make cmake meson git kernel-devel gtk4-devel libadwaita-devel poppler-glib-devel poppler-data alsa-lib-devel
 ```
 
 Also make sure `rustc` and `cargo` are installed ( see [https://www.rust-lang.org/](https://www.rust-lang.org/) ). Then run:


### PR DESCRIPTION
This adds a workflow that generates the dist archive (tarball) automatically on release.

`meson dist` is run with `--no-tests`, since we already have the CI for that. I am opening this as a draft because I want to add the CI is a "dependency" that needs to be completed successfully before this.

We should probably do the same for the `release-windows` workflow.


