### PR TITLE
update to gtk v4.10 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "approx"
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.4"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -612,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.4"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1017,22 +1017,23 @@ dependencies = [
 
 [[package]]
 name = "directories"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74be3be809c18e089de43bdc504652bb2bc473fca8756131f8689db8cf079ba9"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1258,12 +1259,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.6.2",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -1311,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfec8f19f9b89b2901219cc62604810d2bfef15dc1182e95320f57e7cbbe041a"
+checksum = "237ff9f0813bbfc9de836016472e0c9ae7802f174a51594607e5f4ff334cb2f5"
 dependencies = [
  "fontconfig-parser",
  "log",
@@ -2144,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a2d0c1781729f69dbea30f968608cadfaeb6582e5ce903a167a5216b53cd0f"
+checksum = "d676038719d1c892f91e6e85121550143c75880b42f7feff6d413a078cf91fb3"
 dependencies = [
  "arrayvec",
 ]
@@ -2177,9 +2178,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libadwaita"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c4efd2020a4fcedbad2c4a97de97bf6045e5dc49d61d5a5d0cfd753db60700"
+checksum = "e82776542b73ac5691b2bddf3e2aaf0157d34f35193fb522de2fc258006c1785"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -2196,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "libadwaita-sys"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0727b85b4fe2b1bed5ac90df6343de15cbf8118bfb96d7c3cc1512681a4b34ac"
+checksum = "91be74a61f26efa6946c02dad76eb4cd3021addb0ff85dde445c1cd41d2eca2d"
 dependencies = [
  "gdk4-sys",
  "gio-sys",
@@ -2285,9 +2286,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "locale_config"
@@ -2367,10 +2368,11 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb99c395ae250e1bf9133673f03ca9f97b7e71b705436bf8f089453445d1e9fe"
+checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
 dependencies = [
+ "autocfg",
  "rawpointer",
 ]
 
@@ -2718,6 +2720,12 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "optional"
@@ -3079,9 +3087,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "png"
@@ -3699,9 +3707,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.14"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
@@ -3798,18 +3806,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4213,9 +4221,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.6"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
+checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 
 [[package]]
 name = "temp-dir"
@@ -4926,9 +4934,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]
@@ -4974,9 +4982,9 @@ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "zune-inflate"
-version = "0.2.53"
+version = "0.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440a08fd59c6442e4b846ea9b10386c38307eae728b216e1ab2c305d1c9daaf8"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
 dependencies = [
  "simd-adler32",
 ]

--- a/meson.build
+++ b/meson.build
@@ -68,8 +68,8 @@ cpp_compiler = meson.get_compiler('cpp')
 # However when building as flatpak libclang is not found, even though the llvm extension is installed. TODO: How to fix this?
 #cpp_compiler.find_library('clang')
 
-dependency('glib-2.0', version: '>= 2.66')
-dependency('gio-2.0', version: '>= 2.66')
+dependency('glib-2.0', version: '>= 2.72')
+dependency('gio-2.0', version: '>= 2.72')
 dependency('gtk4', version: '>= 4.10')
 dependency('libadwaita-1', version: '>= 1.3')
 dependency('poppler-glib', version: '>= 22.07')

--- a/meson.build
+++ b/meson.build
@@ -70,8 +70,8 @@ cpp_compiler = meson.get_compiler('cpp')
 
 dependency('glib-2.0', version: '>= 2.66')
 dependency('gio-2.0', version: '>= 2.66')
-dependency('gtk4', version: '>= 4.7')
-dependency('libadwaita-1', version: '>= 1.2')
+dependency('gtk4', version: '>= 4.10')
+dependency('libadwaita-1', version: '>= 1.3')
 dependency('poppler-glib', version: '>= 22.07')
 
 cargo = find_program('cargo', required: true)

--- a/rnote-engine/Cargo.toml
+++ b/rnote-engine/Cargo.toml
@@ -32,9 +32,9 @@ slotmap = { version = "1", features = ["serde"] }
 rstar = "0.10"
 nalgebra = { version = "0.32", features = ["serde-serialize"] }
 parry2d-f64 = { version = "0.13", features = ["serde-serialize"] }
-gtk4 = {version = "0.6", features = ["v4_8"]}
+gtk4 = {version = "0.6", features = ["v4_10"]}
 cairo-rs = {version = "0.17", features = ["png", "svg", "pdf"]}
-# newest poppler feature ("v21_12") is causing linking errors with mingw for some reason
+# newest poppler feature ("v21_12") is causing linking errors in mingw for some reason
 poppler-rs = {version = "0.21", features = ["v20_9"] }
 piet = "0.6"
 piet-cairo = "0.6"

--- a/rnote-ui/Cargo.toml
+++ b/rnote-ui/Cargo.toml
@@ -33,8 +33,8 @@ futures = "0.3"
 rayon = "1"
 nalgebra = { version = "0.32", features = ["serde-serialize"] }
 parry2d-f64 = { version = "0.13", features = ["serde-serialize"] }
-gtk4 = {version = "0.6", features = ["v4_8"]}
-adw = {version = "0.3", package="libadwaita", features = ["v1_2"]}
+gtk4 = {version = "0.6", features = ["v4_10"]}
+adw = {version = "0.4", package="libadwaita", features = ["v1_3"]}
 cairo-rs = {version = "0.17", features = ["png", "svg", "pdf"]}
 # newest poppler feature ("v21_12") is causing linking errors with mingw for some reason
 poppler-rs = {version = "0.21", features = ["v20_9"] }

--- a/rnote-ui/data/ui/colorpicker.ui
+++ b/rnote-ui/data/ui/colorpicker.ui
@@ -75,68 +75,12 @@
       </object>
     </child>
     <child>
-      <object class="GtkMenuButton" id="colorpicker_button">
-        <property name="direction">left</property>
+      <object class="GtkButton" id="colordialog_button">
         <property name="icon-name">preferences-color-symbolic</property>
-        <property name="hexpand">false</property>
-        <property name="vexpand">false</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
-        <property name="popover">colorpicker_popover</property>
         <style>
           <class name="flat" />
         </style>
       </object>
     </child>
-    <object class="GtkPopover" id="colorpicker_popover">
-      <property name="position">right</property>
-      <child>
-        <object class="GtkGrid">
-          <property name="row_spacing">12</property>
-          <property name="column_spacing">12</property>
-          <property name="margin_top">6</property>
-          <property name="margin_bottom">6</property>
-          <property name="margin_start">6</property>
-          <property name="margin_end">6</property>
-          <child>
-            <object class="GtkButton" id="colorchooser_editor_gobackbutton">
-              <property name="icon-name">left-symbolic</property>
-              <property name="hexpand">false</property>
-              <property name="halign">start</property>
-              <property name="vexpand">false</property>
-              <property name="visible">false</property>
-              <layout>
-                <property name="column">0</property>
-                <property name="row">0</property>
-              </layout>
-            </object>
-          </child>
-          <child>
-            <object class="GtkButton" id="colorchooser_editor_selectbutton">
-              <property name="label" translatable="yes">Select</property>
-              <property name="hexpand">false</property>
-              <property name="halign">end</property>
-              <property name="vexpand">false</property>
-              <style>
-                <class name="suggested-action" />
-              </style>
-              <layout>
-                <property name="column">1</property>
-                <property name="row">0</property>
-              </layout>
-            </object>
-          </child>
-          <child>
-            <object class="GtkColorChooserWidget" id="colorchooser">
-              <layout>
-                <property name="column">0</property>
-                <property name="row">1</property>
-                <property name="column-span">2</property>
-              </layout>
-            </object>
-          </child>
-        </object>
-      </child>
-    </object>
   </template>
 </interface>

--- a/rnote-ui/data/ui/dialogs/dialogs.ui
+++ b/rnote-ui/data/ui/dialogs/dialogs.ui
@@ -136,15 +136,17 @@ Do you want to save the current document?</property>
                   </object>
                 </child>
                 <child>
+                  <object class="GtkColorDialog" id="edit_selected_workspace_color_dialog"></object>
                   <object class="AdwActionRow">
                     <property name="title" translatable="yes">Color</property>
                     <property name="subtitle" translatable="yes">Change the workspace color</property>
                     <child type="suffix">
-                      <object class="GtkColorButton" id="edit_selected_workspace_color_button">
+                      <object class="GtkColorDialogButton" id="edit_selected_workspace_color_button">
                         <property name="hexpand">false</property>
                         <property name="hexpand">false</property>
                         <property name="valign">center</property>
                         <property name="halign">end</property>
+                        <property name="dialog">edit_selected_workspace_color_dialog</property>
                       </object>
                     </child>
                   </object>

--- a/rnote-ui/data/ui/overlays.ui
+++ b/rnote-ui/data/ui/overlays.ui
@@ -35,7 +35,7 @@
             <property name="homogeneous">true</property>
             <style>
               <class name="toolbar" />
-              <class name="overlay-toolbar" />
+              <class name="overlay_toolbar" />
             </style>
             <style>
             </style>
@@ -100,7 +100,7 @@
             <property name="margin-end">18</property>
             <property name="position">top</property>
             <style>
-              <class name="overlay-toolbar" />
+              <class name="overlay_toolbar" />
             </style>
           </object>
         </child>
@@ -115,7 +115,7 @@
             <property name="margin-start">18</property>
             <property name="margin-end">18</property>
             <style>
-              <class name="overlay-toolbar" />
+              <class name="overlay_toolbar" />
             </style>
             <child>
               <object class="GtkScrolledWindow" id="sidebar_scroller">

--- a/rnote-ui/data/ui/penssidebar/typewriterpage.ui
+++ b/rnote-ui/data/ui/penssidebar/typewriterpage.ui
@@ -10,13 +10,8 @@
     <property name="hexpand">false</property>
     <property name="vexpand">false</property>
     <child>
-      <object class="GtkMenuButton" id="fontchooser_menubutton">
-        <property name="direction">left</property>
-        <property name="popover">fontchooser_popover</property>
-        <property name="tooltip_text" translatable="yes">Font Chooser
-(double-click, click on select
-or press Enter to select a new font)</property>
-            <property name="icon-name">pen-typewriter-fontchooser-symbolic</property>
+      <object class="GtkButton" id="fontdialog_button">
+        <property name="icon-name">pen-typewriter-fontchooser-symbolic</property>
         <style>
           <class name="flat" />
           <class name="sidebar_action_button" />
@@ -155,56 +150,5 @@ or press Enter to select a new font)</property>
         </child>
       </object>
     </child>
-
-    <!-- fontchooser -->
-    <object class="GtkPopover" id="fontchooser_popover">
-      <property name="position">right</property>
-      <child>
-        <object class="GtkGrid">
-          <property name="row_spacing">12</property>
-          <property name="column_spacing">12</property>
-          <property name="margin_top">6</property>
-          <property name="margin_bottom">6</property>
-          <property name="margin_start">6</property>
-          <property name="margin_end">6</property>
-          <child>
-            <object class="GtkButton" id="fontchooser_cancelbutton">
-              <property name="label" translatable="yes">Cancel</property>
-              <property name="hexpand">false</property>
-              <property name="vexpand">false</property>
-              <property name="halign">start</property>
-              <layout>
-                <property name="column">0</property>
-                <property name="row">0</property>
-              </layout>
-            </object>
-          </child>
-          <child>
-            <object class="GtkButton" id="fontchooser_selectbutton">
-              <property name="label" translatable="yes">Select</property>
-              <property name="hexpand">false</property>
-              <property name="halign">end</property>
-              <property name="vexpand">false</property>
-              <style>
-                <class name="suggested-action" />
-              </style>
-              <layout>
-                <property name="column">1</property>
-                <property name="row">0</property>
-              </layout>
-            </object>
-          </child>
-          <child>
-            <object class="GtkFontChooserWidget" id="fontchooser">
-              <layout>
-                <property name="column">0</property>
-                <property name="row">1</property>
-                <property name="column-span">2</property>
-              </layout>
-            </object>
-          </child>
-        </object>
-      </child>
-    </object>
   </template>
 </interface>

--- a/rnote-ui/data/ui/settingspanel.ui
+++ b/rnote-ui/data/ui/settingspanel.ui
@@ -83,7 +83,10 @@
                             <property name="vexpand">false</property>
                             <property name="valign">center</property>
                             <child>
-                              <object class="GtkColorButton" id="general_format_border_color_choosebutton"></object>
+                              <object class="GtkColorDialog" id="general_format_border_color_dialog"></object>
+                              <object class="GtkColorDialogButton" id="general_format_border_color_button">
+                                <property name="dialog">general_format_border_color_dialog</property>
+                              </object>
                             </child>
                           </object>
                         </child>
@@ -290,7 +293,10 @@
                             <property name="vexpand">false</property>
                             <property name="valign">center</property>
                             <child>
-                              <object class="GtkColorButton" id="background_color_choosebutton"></object>
+                              <object class="GtkColorDialog" id="background_color_dialog"></object>
+                              <object class="GtkColorDialogButton" id="background_color_button">
+                                <property name="dialog">background_color_dialog</property>
+                              </object>
                             </child>
                           </object>
                         </child>
@@ -326,7 +332,10 @@
                             <property name="vexpand">false</property>
                             <property name="valign">center</property>
                             <child>
-                              <object class="GtkColorButton" id="background_pattern_color_choosebutton"></object>
+                              <object class="GtkColorDialog" id="background_pattern_color_dialog"></object>
+                              <object class="GtkColorDialogButton" id="background_pattern_color_button">
+                                <property name="dialog">background_pattern_color_dialog</property>
+                              </object>
                             </child>
                           </object>
                         </child>

--- a/rnote-ui/data/ui/shortcuts.ui
+++ b/rnote-ui/data/ui/shortcuts.ui
@@ -86,6 +86,11 @@
                 <property name="accelerator">&lt;ctrl&gt;6</property>
               </object>
             </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="title" translatable="yes">View</property>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Move View</property>

--- a/rnote-ui/data/ui/style.css
+++ b/rnote-ui/data/ui/style.css
@@ -233,14 +233,14 @@ from https://gitlab.com/posidon_software/paper/-/blob/main/src/css/style.css
     background: alpha(currentColor, 0.19);
 }
 
-.overlay-toolbar {
+.overlay_toolbar {
     border-radius: 12px;
     background-color: @window_bg_color;
     border: 1px solid @borders;
     box-shadow: 0px 3px 6px @shade_color;
 }
 
-.overlay-toolbar.colorpicker {
+.overlay_toolbar.colorpicker {
     padding: 6px;
 }
 

--- a/rnote-ui/src/app/mod.rs
+++ b/rnote-ui/src/app/mod.rs
@@ -82,7 +82,7 @@ mod imp {
         fn new_appwindow_init_show(&self, input_file: Option<gio::File>) {
             let appwindow = RnAppWindow::new(self.obj().upcast_ref::<gtk4::Application>());
             appwindow.init();
-            appwindow.show();
+            appwindow.present();
 
             // Loading in input file in the first tab, if Some
             if let Some(input_file) = input_file {

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -234,15 +234,19 @@ impl RnAppWindow {
 
         // Export engine state
         action_debug_export_engine_state.connect_activate(
-            clone!(@weak self as appwindow => move |_action_debug_export_engine_state, _target| {
-                dialogs::export::filechooser_export_engine_state(&appwindow, &appwindow.active_tab().canvas());
+            clone!(@weak self as appwindow => move |_, _| {
+                glib::MainContext::default().spawn_local(clone!(@weak appwindow => async move {
+                    dialogs::export::filechooser_export_engine_state(&appwindow, &appwindow.active_tab().canvas()).await;
+                }));
             }),
         );
 
         // Export engine config
         action_debug_export_engine_config.connect_activate(
-            clone!(@weak self as appwindow => move |_action_debug_export_engine_config, _target| {
-                dialogs::export::filechooser_export_engine_config(&appwindow, &appwindow.active_tab().canvas());
+            clone!(@weak self as appwindow => move |_, _| {
+                glib::MainContext::default().spawn_local(clone!(@weak appwindow => async move {
+                    dialogs::export::filechooser_export_engine_config(&appwindow, &appwindow.active_tab().canvas()).await;
+                }));
             }),
         );
 
@@ -590,14 +594,16 @@ impl RnAppWindow {
                     // No success toast on saving without dialog, success is already indicated in the header title
                 } else {
                     // Open a dialog to choose a save location
-                    dialogs::export::filechooser_save_doc_as(&appwindow, &canvas);
+                    dialogs::export::dialog_save_doc_as(&appwindow, &canvas).await;
                 }
             }));
         }));
 
         // Save doc as
         action_save_doc_as.connect_activate(clone!(@weak self as appwindow => move |_, _| {
-            dialogs::export::filechooser_save_doc_as(&appwindow, &appwindow.active_tab().canvas());
+            glib::MainContext::default().spawn_local(clone!(@weak appwindow => async move {
+                dialogs::export::dialog_save_doc_as(&appwindow, &appwindow.active_tab().canvas()).await;
+            }));
         }));
 
         // Print doc
@@ -717,23 +723,29 @@ impl RnAppWindow {
 
         // Export document
         action_export_doc.connect_activate(clone!(@weak self as appwindow => move |_,_| {
-            dialogs::export::dialog_export_doc_w_prefs(&appwindow, &appwindow.active_tab().canvas());
+            glib::MainContext::default().spawn_local(clone!(@weak appwindow => async move {
+                dialogs::export::dialog_export_doc_w_prefs(&appwindow, &appwindow.active_tab().canvas()).await;
+            }));
         }));
 
         // Export document pages
         action_export_doc_pages.connect_activate(clone!(@weak self as appwindow => move |_,_| {
-            dialogs::export::dialog_export_doc_pages_w_prefs(&appwindow, &appwindow.active_tab().canvas());
+            glib::MainContext::default().spawn_local(clone!(@weak appwindow => async move {
+                dialogs::export::dialog_export_doc_pages_w_prefs(&appwindow, &appwindow.active_tab().canvas()).await;
+            }));
         }));
 
         // Export selection
         action_export_selection.connect_activate(clone!(@weak self as appwindow => move |_,_| {
-            let canvas = appwindow.active_tab().canvas();
+            glib::MainContext::default().spawn_local(clone!(@weak appwindow => async move {
+                let canvas = appwindow.active_tab().canvas();
 
-            if !canvas.engine().borrow().store.selection_keys_unordered().is_empty() {
-                dialogs::export::dialog_export_selection_w_prefs(&appwindow, &appwindow.active_tab().canvas());
-            } else {
-                appwindow.overlays().dispatch_toast_error(&gettext("Exporting selection failed, nothing selected"));
-            }
+                if !canvas.engine().borrow().store.selection_keys_unordered().is_empty() {
+                    dialogs::export::dialog_export_selection_w_prefs(&appwindow, &appwindow.active_tab().canvas()).await;
+                } else {
+                    appwindow.overlays().dispatch_toast_error(&gettext("Exporting selection failed, nothing selected"));
+                }
+            }));
         }));
 
         // Clipboard copy

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -1,6 +1,7 @@
 use gettextrs::gettext;
 use gtk4::{
-    gdk, gio, glib, glib::clone, prelude::*, PrintOperation, PrintOperationAction, Unit, Window,
+    gdk, gio, glib, glib::clone, prelude::*, PrintOperation, PrintOperationAction, Unit,
+    UriLauncher, Window,
 };
 use piet::RenderContext;
 use rnote_compose::helpers::Vector2Helpers;
@@ -169,7 +170,11 @@ impl RnAppWindow {
 
         // Donate
         action_donate.connect_activate(clone!(@weak self as appwindow => move |_, _| {
-            gtk4::show_uri(None::<&Window>, config::APP_DONATE_URL, 0);
+            UriLauncher::new(config::APP_DONATE_URL).launch(None::<&Window>, gio::Cancellable::NONE, |res| {
+                if let Err(e) = res {
+                    log::error!("launching donate URL failed, Err: {e:?}");
+                }
+            })
         }));
 
         // Keyboard shortcuts

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -572,7 +572,9 @@ impl RnAppWindow {
 
         // Open doc
         action_open_doc.connect_activate(clone!(@weak self as appwindow => move |_, _| {
-            dialogs::import::filechooser_open_doc(&appwindow);
+            glib::MainContext::default().spawn_local(clone!(@weak appwindow => async move {
+                dialogs::import::filedialog_open_doc(&appwindow).await;
+            }));
         }));
 
         // Save doc
@@ -718,7 +720,9 @@ impl RnAppWindow {
 
         // Import
         action_import_file.connect_activate(clone!(@weak self as appwindow => move |_,_| {
-            dialogs::import::filechooser_import_file(&appwindow);
+            glib::MainContext::default().spawn_local(clone!(@weak appwindow => async move {
+                dialogs::import::filedialog_import_file(&appwindow).await;
+            }));
         }));
 
         // Export document

--- a/rnote-ui/src/appwindow/imp.rs
+++ b/rnote-ui/src/appwindow/imp.rs
@@ -3,8 +3,8 @@ use gettextrs::gettext;
 use gtk4::PadActionType;
 use gtk4::{
     gdk, gio, glib, glib::clone, Align, ArrowType, Box, Button, CompositeTemplate, CornerType,
-    CssProvider, FileChooserNative, GestureDrag, Grid, Inhibit, PackType, PadController,
-    PositionType, PropagationPhase,
+    CssProvider, GestureDrag, Grid, Inhibit, PackType, PadController, PositionType,
+    PropagationPhase,
 };
 use once_cell::sync::Lazy;
 use std::{
@@ -21,7 +21,6 @@ use crate::{
 #[template(resource = "/com/github/flxzt/rnote/ui/appwindow.ui")]
 pub(crate) struct RnAppWindow {
     pub(crate) app_settings: gio::Settings,
-    pub(crate) filechoosernative: Rc<RefCell<Option<FileChooserNative>>>,
     pub(crate) drawing_pad_controller: RefCell<Option<PadController>>,
     pub(crate) autosave_source_id: RefCell<Option<glib::SourceId>>,
     pub(crate) periodic_configsave_source_id: RefCell<Option<glib::SourceId>>,
@@ -66,7 +65,6 @@ impl Default for RnAppWindow {
     fn default() -> Self {
         Self {
             app_settings: gio::Settings::new(config::APP_ID),
-            filechoosernative: Rc::new(RefCell::new(None)),
             drawing_pad_controller: RefCell::new(None),
             autosave_source_id: RefCell::new(None),
             periodic_configsave_source_id: RefCell::new(None),

--- a/rnote-ui/src/appwindow/mod.rs
+++ b/rnote-ui/src/appwindow/mod.rs
@@ -6,16 +6,14 @@ mod imp;
 use adw::{prelude::*, subclass::prelude::*};
 use gettextrs::gettext;
 use gtk4::gdk;
-use gtk4::{gio, glib, glib::clone, Application, Box, Button, FileChooserNative, IconTheme};
+use gtk4::{gio, glib, glib::clone, Application, Box, Button, IconTheme};
 use rnote_compose::Color;
 use rnote_engine::pens::pensconfig::brushconfig::BrushStyle;
 use rnote_engine::pens::pensconfig::shaperconfig::ShaperStyle;
 use rnote_engine::pens::PenStyle;
 use rnote_engine::utils::GdkRGBAHelpers;
 use rnote_engine::{engine::EngineTask, WidgetFlags};
-use std::cell::RefCell;
 use std::path::Path;
-use std::rc::Rc;
 
 use crate::{
     config, RnApp, RnCanvas, RnCanvasWrapper, RnOverlays, RnSettingsPanel, RnWorkspaceBrowser,
@@ -83,10 +81,6 @@ impl RnAppWindow {
 
     pub(crate) fn app_settings(&self) -> gio::Settings {
         self.imp().app_settings.clone()
-    }
-
-    pub(crate) fn filechoosernative(&self) -> Rc<RefCell<Option<FileChooserNative>>> {
-        self.imp().filechoosernative.clone()
     }
 
     pub(crate) fn overlays(&self) -> RnOverlays {

--- a/rnote-ui/src/appwindow/mod.rs
+++ b/rnote-ui/src/appwindow/mod.rs
@@ -139,6 +139,7 @@ impl RnAppWindow {
         imp.mainheader.get().init(self);
         imp.mainheader.get().canvasmenu().init(self);
         imp.mainheader.get().appmenu().init(self);
+        imp.overlays.get().colorpicker().init(self);
 
         // An initial tab. Must! come before setting up the settings binds and import
         self.add_initial_tab();

--- a/rnote-ui/src/canvaswrapper.rs
+++ b/rnote-ui/src/canvaswrapper.rs
@@ -514,16 +514,22 @@ mod imp {
                         // Only deny the sequence that is actually handled.
                         // Because this gesture is grouped with the zoom gesture, denying all
                         // sequences within the group ( by calling `set_state()` ) might result in a segfault in certain cases
-                        if event_sequence.is_some() {
-                            gesture.set_state(EventSequenceState::Denied);
+                        if let Some(es) = event_sequence {
+                            // setting event sequences states directly is deprecated,
+                            // by it is not clear how to refactor it while not regressing the fix 4c33594 for #595
+                            #[allow(deprecated)]
+                            gesture.set_sequence_state(es, EventSequenceState::Denied);
                         }
                     }),
                 );
 
                 self.touch_two_finger_long_press_gesture.connect_cancel(
                     clone!(@weak obj as canvaswrapper => move |gesture, event_sequence| {
-                        if event_sequence.is_some() {
-                            gesture.set_state(EventSequenceState::Denied);
+                        if let Some(es) = event_sequence {
+                            // setting event sequences states directly is deprecated,
+                            // by it is not clear how to refactor it while not regressing the fix 4c33594 for #595
+                            #[allow(deprecated)]
+                            gesture.set_sequence_state(es, EventSequenceState::Denied);
                         }
                     }),
                 );

--- a/rnote-ui/src/canvaswrapper.rs
+++ b/rnote-ui/src/canvaswrapper.rs
@@ -514,16 +514,16 @@ mod imp {
                         // Only deny the sequence that is actually handled.
                         // Because this gesture is grouped with the zoom gesture, denying all
                         // sequences within the group ( by calling `set_state()` ) might result in a segfault in certain cases
-                        if let Some(event_sequence) = event_sequence {
-                            gesture.set_sequence_state(event_sequence, EventSequenceState::Denied);
+                        if event_sequence.is_some() {
+                            gesture.set_state(EventSequenceState::Denied);
                         }
                     }),
                 );
 
                 self.touch_two_finger_long_press_gesture.connect_cancel(
                     clone!(@weak obj as canvaswrapper => move |gesture, event_sequence| {
-                        if let Some(event_sequence) = event_sequence {
-                            gesture.set_sequence_state(event_sequence, EventSequenceState::Denied);
+                        if event_sequence.is_some() {
+                            gesture.set_state(EventSequenceState::Denied);
                         }
                     }),
                 );

--- a/rnote-ui/src/canvaswrapper.rs
+++ b/rnote-ui/src/canvaswrapper.rs
@@ -516,7 +516,7 @@ mod imp {
                         // sequences within the group ( by calling `set_state()` ) might result in a segfault in certain cases
                         if let Some(es) = event_sequence {
                             // setting event sequences states directly is deprecated,
-                            // by it is not clear how to refactor it while not regressing the fix 4c33594 for #595
+                            // but it is not clear how to refactor it while not regressing the fix 4c33594 for #595
                             #[allow(deprecated)]
                             gesture.set_sequence_state(es, EventSequenceState::Denied);
                         }
@@ -527,7 +527,7 @@ mod imp {
                     clone!(@weak obj as canvaswrapper => move |gesture, event_sequence| {
                         if let Some(es) = event_sequence {
                             // setting event sequences states directly is deprecated,
-                            // by it is not clear how to refactor it while not regressing the fix 4c33594 for #595
+                            // but it is not clear how to refactor it while not regressing the fix 4c33594 for #595
                             #[allow(deprecated)]
                             gesture.set_sequence_state(es, EventSequenceState::Denied);
                         }

--- a/rnote-ui/src/colorpicker/colorpad.rs
+++ b/rnote-ui/src/colorpicker/colorpad.rs
@@ -12,7 +12,6 @@ mod imp {
 
     #[derive(Debug)]
     pub(crate) struct RnColorPad {
-        pub(crate) css: CssProvider,
         pub(crate) color: Cell<gdk::RGBA>,
     }
 
@@ -26,7 +25,6 @@ mod imp {
     impl Default for RnColorPad {
         fn default() -> Self {
             Self {
-                css: CssProvider::new(),
                 color: Cell::new(gdk::RGBA::from_compose_color(
                     super::RnColorPad::COLOR_DEFAULT,
                 )),
@@ -48,8 +46,6 @@ mod imp {
             obj.set_css_classes(&["colorpad"]);
 
             self.update_appearance(super::RnColorPad::COLOR_DEFAULT);
-            obj.style_context()
-                .add_provider(&self.css, gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION);
         }
 
         fn properties() -> &'static [glib::ParamSpec] {

--- a/rnote-ui/src/colorpicker/colorpad.rs
+++ b/rnote-ui/src/colorpicker/colorpad.rs
@@ -98,6 +98,10 @@ mod imp {
             );
             css.load_from_data(&custom_css);
 
+            // adding custom css is deprecated.
+            // TODO: We should refactor to drawing through snapshot().
+            // Doing this will also get rid of the css checkerboard glitches that appear on some devices and scaling levels.
+            #[allow(deprecated)]
             self.obj()
                 .style_context()
                 .add_provider(&css, gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION);

--- a/rnote-ui/src/colorpicker/colorsetter.rs
+++ b/rnote-ui/src/colorpicker/colorsetter.rs
@@ -120,6 +120,10 @@ mod imp {
             );
             css.load_from_data(&custom_css);
 
+            // adding custom css is deprecated.
+            // TODO: We should refactor to drawing through snapshot().
+            // Doing this will also get rid of the css checkerboard glitches that appear on some devices and scaling levels.
+            #[allow(deprecated)]
             self.obj()
                 .style_context()
                 .add_provider(&css, gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION);

--- a/rnote-ui/src/colorpicker/colorsetter.rs
+++ b/rnote-ui/src/colorpicker/colorsetter.rs
@@ -14,7 +14,6 @@ mod imp {
 
     #[derive(Debug)]
     pub(crate) struct RnColorSetter {
-        pub(crate) css: CssProvider,
         pub(crate) color: Cell<gdk::RGBA>,
         pub(crate) position: Cell<PositionType>,
     }
@@ -29,7 +28,6 @@ mod imp {
     impl Default for RnColorSetter {
         fn default() -> Self {
             Self {
-                css: CssProvider::new(),
                 color: Cell::new(gdk::RGBA::from_compose_color(
                     super::RnColorSetter::COLOR_DEFAULT,
                 )),
@@ -52,8 +50,6 @@ mod imp {
             obj.set_css_classes(&["colorsetter"]);
 
             self.update_appearance(super::RnColorSetter::COLOR_DEFAULT);
-            obj.style_context()
-                .add_provider(&self.css, gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION);
         }
 
         fn properties() -> &'static [glib::ParamSpec] {

--- a/rnote-ui/src/colorpicker/mod.rs
+++ b/rnote-ui/src/colorpicker/mod.rs
@@ -468,7 +468,7 @@ impl RnColorPicker {
         self.imp().colordialog_button.connect_clicked(
             clone!(@weak self as colorpicker, @weak appwindow => move |_| {
                 glib::MainContext::default().spawn_local(clone!(@weak colorpicker, @weak appwindow => async move {
-                    let dialog = ColorDialog::builder().modal(true).with_alpha(true).build();
+                    let dialog = ColorDialog::builder().modal(false).with_alpha(true).build();
 
                     let active_color = if colorpicker.stroke_color_pad_active() {
                         colorpicker.stroke_color()

--- a/rnote-ui/src/colorpicker/mod.rs
+++ b/rnote-ui/src/colorpicker/mod.rs
@@ -479,7 +479,7 @@ impl RnColorPicker {
                         },
                         // this reports as error if the dialog is dismissed by the user.
                         // The API is a bit odd, expected would be Result<Option<RGBA>>
-                        Err(e) => log::debug!("did not choose new color (Error or Dialog dismissed), {e:?}"),
+                        Err(e) => log::debug!("did not choose new color (Error or dialog dismissed by user), {e:?}"),
                     }
                 }));
             }),

--- a/rnote-ui/src/colorpicker/mod.rs
+++ b/rnote-ui/src/colorpicker/mod.rs
@@ -105,9 +105,6 @@ mod imp {
 
             self.setup_setters();
 
-            // we could theoretically update the colordialog color rgba preset when stroke-color and fill-color changes,
-            // but that would result in the active palette setter being changed. So we don't do that.
-
             self.stroke_color_pad
                 .bind_property("color", &*obj, "stroke-color")
                 .sync_create()

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -70,7 +70,9 @@ pub(crate) async fn dialog_save_doc_as(appwindow: &RnAppWindow, canvas: &RnCanva
             appwindow.overlays().finish_progressbar();
         }
         Err(e) => {
-            log::debug!("no file selected in save doc as dialog (Error or User dismissed), {e:?}")
+            log::debug!(
+                "no file selected in save doc as dialog (Error or dialog dismissed by user), {e:?}"
+            )
         }
     }
 }
@@ -128,7 +130,7 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
                         }
                     }
                     Err(e) => {
-                        log::debug!("{e:?}");
+                        log::debug!("did not export document (Error or dialog dismissed by user), {e:?}");
                         export_file_label.set_label(&gettext("- no file selected -"));
                         button_confirm.set_sensitive(false);
                         selected_file.replace(None);
@@ -348,7 +350,7 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
                         }
                     }
                     Err(e) => {
-                        log::debug!("{e:?}");
+                        log::debug!("did not export document pages (Error or dialog dismissed by user), {e:?}");
 
                         export_dir_label.set_label(&gettext("- no directory selected -"));
                         button_confirm.set_sensitive(false);
@@ -597,7 +599,7 @@ pub(crate) async fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, can
                         }
                     }
                     Err(e) => {
-                        log::debug!("{e:?}");
+                        log::debug!("did not export selection (Error or dialog dismissed by user), {e:?}");
                         export_file_label.set_label(&gettext("- no file selected -"));
                         button_confirm.set_sensitive(false);
                         selected_file.replace(None);
@@ -768,7 +770,7 @@ pub(crate) async fn filechooser_export_engine_state(appwindow: &RnAppWindow, can
             appwindow.overlays().finish_progressbar();
         }
         Err(e) => {
-            log::debug!("{e:?}");
+            log::debug!("did not export engine state (Error or dialog dismissed by user), {e:?}");
         }
     }
 }
@@ -814,7 +816,7 @@ pub(crate) async fn filechooser_export_engine_config(appwindow: &RnAppWindow, ca
             appwindow.overlays().finish_progressbar();
         }
         Err(e) => {
-            log::debug!("{e:?}");
+            log::debug!("did not export engine config (Error or dialog dismissed by user), {e:?}");
         }
     }
 }

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -457,10 +457,11 @@ fn create_filedialog_export_doc_pages(
 
     let initial_folder = if let Some(output_parent_dir) = output_file.and_then(|f| f.parent()) {
         Some(output_parent_dir)
-    } else if let Some(current_workspace_dir) = appwindow.workspacebrowser().dirlist_dir() {
-        Some(gio::File::for_path(current_workspace_dir))
     } else {
-        None
+        appwindow
+            .workspacebrowser()
+            .dirlist_dir()
+            .map(gio::File::for_path)
     };
     filedialog.set_initial_folder(initial_folder.as_ref());
 

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -1,3 +1,6 @@
+// gtk4::Dialog is deprecated, but the replacement adw::ToolbarView is not yet stable
+#![allow(deprecated)]
+
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -151,7 +151,7 @@ pub(crate) fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &RnCanv
             }
 
             filechooser.hide();
-            dialog.show();
+            dialog.present();
         }),
     );
 
@@ -209,7 +209,7 @@ pub(crate) fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &RnCanv
             dialog.close();
         }));
 
-    dialog.show();
+    dialog.present();
     // keeping the filechooser around because otherwise GTK won't keep it alive
     *appwindow.filechoosernative().borrow_mut() = Some(filechooser);
 }
@@ -389,7 +389,7 @@ pub(crate) fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, canvas: &
             }
 
             filechooser.hide();
-            dialog.show();
+            dialog.present();
         }),
     );
 
@@ -482,7 +482,7 @@ pub(crate) fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, canvas: &
             dialog.close();
         }));
 
-    dialog.show();
+    dialog.present();
     // keeping the filechooser around because otherwise GTK won't keep it alive
     *appwindow.filechoosernative().borrow_mut() = Some(filechooser);
 }
@@ -654,7 +654,7 @@ pub(crate) fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, canvas: &
             }
 
             filechooser.hide();
-            dialog.show();
+            dialog.present();
         }),
     );
 
@@ -730,7 +730,7 @@ pub(crate) fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, canvas: &
             dialog.close();
         }));
 
-    dialog.show();
+    dialog.present();
     // keeping the filechooser around because otherwise GTK won't keep it alive
     *appwindow.filechoosernative().borrow_mut() = Some(filechooser);
 }

--- a/rnote-ui/src/dialogs/import.rs
+++ b/rnote-ui/src/dialogs/import.rs
@@ -100,7 +100,7 @@ pub(crate) async fn filedialog_open_doc(appwindow: &RnAppWindow) {
             appwindow.open_file_w_dialogs(selected_file, None, true);
         }
         Err(e) => {
-            log::debug!("{e:?}");
+            log::debug!("did not open document (Error or dialog dismissed by user), {e:?}");
         }
     }
 }
@@ -136,7 +136,7 @@ pub(crate) async fn filedialog_import_file(appwindow: &RnAppWindow) {
             appwindow.open_file_w_dialogs(selected_file, None, true);
         }
         Err(e) => {
-            log::debug!("{e:?}");
+            log::debug!("did not import file (Error or dialog dismissed by user),{e:?}");
         }
     }
 }

--- a/rnote-ui/src/dialogs/import.rs
+++ b/rnote-ui/src/dialogs/import.rs
@@ -55,7 +55,7 @@ pub(crate) fn dialog_open_overwrite(
                             // No success toast on saving without dialog, success is already indicated in the header title
                         } else {
                             // Open a dialog to choose a save location
-                            super::export::filechooser_save_doc_as(&appwindow, &canvas);
+                            super::export::dialog_save_doc_as(&appwindow, &canvas).await;
                         }
 
                         // only open and overwrite document if saving was successful

--- a/rnote-ui/src/dialogs/import.rs
+++ b/rnote-ui/src/dialogs/import.rs
@@ -1,3 +1,6 @@
+// gtk4::Dialog is deprecated, but the replacement adw::ToolbarView is not yet stable
+#![allow(deprecated)]
+
 use adw::prelude::*;
 use gettextrs::gettext;
 use gtk4::{

--- a/rnote-ui/src/dialogs/import.rs
+++ b/rnote-ui/src/dialogs/import.rs
@@ -71,7 +71,7 @@ pub(crate) fn dialog_open_overwrite(
         }),
     );
 
-    dialog.show();
+    dialog.present();
 }
 
 /// Opens a new rnote save file in a new tab
@@ -352,7 +352,7 @@ pub(crate) fn dialog_import_pdf_w_prefs(
         }),
     );
 
-    dialog.show();
+    dialog.present();
 }
 
 pub(crate) fn dialog_import_xopp_w_prefs(
@@ -411,5 +411,5 @@ pub(crate) fn dialog_import_xopp_w_prefs(
         }),
     );
 
-    dialog.show();
+    dialog.present();
 }

--- a/rnote-ui/src/dialogs/mod.rs
+++ b/rnote-ui/src/dialogs/mod.rs
@@ -3,10 +3,10 @@ pub(crate) mod import;
 
 use adw::prelude::*;
 use gettextrs::{gettext, pgettext};
-use gtk4::CheckButton;
 use gtk4::{
-    gio, glib, glib::clone, Builder, Button, ColorButton, Dialog, FileChooserAction,
-    FileChooserNative, Label, MenuButton, ResponseType, ShortcutsWindow, StringList,
+    gio, glib, glib::clone, Builder, Button, CheckButton, ColorDialogButton, Dialog,
+    FileChooserAction, FileChooserNative, Label, MenuButton, ResponseType, ShortcutsWindow,
+    StringList,
 };
 
 use crate::appwindow::RnAppWindow;
@@ -421,7 +421,7 @@ pub(crate) fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
     let name_entryrow: adw::EntryRow = builder
         .object("edit_selected_workspace_name_entryrow")
         .unwrap();
-    let color_button: ColorButton = builder
+    let color_button: ColorDialogButton = builder
         .object("edit_selected_workspace_color_button")
         .unwrap();
     let dir_label: Label = builder.object("edit_selected_workspace_dir_label").unwrap();
@@ -488,7 +488,7 @@ pub(crate) fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
         }),
     );
 
-    color_button.connect_color_set(clone!(@weak preview_row => move |button| {
+    color_button.connect_rgba_notify(clone!(@weak preview_row => move |button| {
         let color = button.rgba();
         preview_row.entry().set_color(color);
     }));

--- a/rnote-ui/src/dialogs/mod.rs
+++ b/rnote-ui/src/dialogs/mod.rs
@@ -150,7 +150,7 @@ pub(crate) fn dialog_new_doc(appwindow: &RnAppWindow, canvas: &RnCanvas) {
                         }
                     } else {
                         // Open a dialog to choose a save location
-                        export::filechooser_save_doc_as(&appwindow, &canvas);
+                        export::dialog_save_doc_as(&appwindow, &canvas).await;
                     }
                 }));
             },

--- a/rnote-ui/src/dialogs/mod.rs
+++ b/rnote-ui/src/dialogs/mod.rs
@@ -512,7 +512,7 @@ pub(crate) async fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
                         }
                     }
                     Err(e) => {
-                        log::debug!("{e:?}");
+                        log::debug!("did not select new folder for workspacerow (Error or dialog dismissed by user), {e:?}");
                     }
                 }
                 dialog.present();

--- a/rnote-ui/src/dialogs/mod.rs
+++ b/rnote-ui/src/dialogs/mod.rs
@@ -1,3 +1,6 @@
+// gtk4::Dialog is deprecated, but the replacement adw::ToolbarView is not yet stable
+#![allow(deprecated)]
+
 pub(crate) mod export;
 pub(crate) mod import;
 

--- a/rnote-ui/src/dialogs/mod.rs
+++ b/rnote-ui/src/dialogs/mod.rs
@@ -50,31 +50,25 @@ pub(crate) fn dialog_about(appwindow: &RnAppWindow) {
         aboutdialog.add_css_class("devel");
     }
 
-    aboutdialog.show();
+    aboutdialog.present();
 }
 
 pub(crate) fn dialog_keyboard_shortcuts(appwindow: &RnAppWindow) {
     let builder =
         Builder::from_resource((String::from(config::APP_IDPATH) + "ui/shortcuts.ui").as_str());
-    let dialog_shortcuts: ShortcutsWindow = builder.object("shortcuts_window").unwrap();
-
-    if config::PROFILE == "devel" {
-        dialog_shortcuts.add_css_class("devel");
-    }
-
-    dialog_shortcuts.set_transient_for(Some(appwindow));
-    dialog_shortcuts.show();
+    let dialog: ShortcutsWindow = builder.object("shortcuts_window").unwrap();
+    dialog.set_transient_for(Some(appwindow));
+    dialog.present();
 }
 
 pub(crate) fn dialog_clear_doc(appwindow: &RnAppWindow, canvas: &RnCanvas) {
     let builder = Builder::from_resource(
         (String::from(config::APP_IDPATH) + "ui/dialogs/dialogs.ui").as_str(),
     );
-    let dialog_clear_doc: adw::MessageDialog = builder.object("dialog_clear_doc").unwrap();
+    let dialog: adw::MessageDialog = builder.object("dialog_clear_doc").unwrap();
+    dialog.set_transient_for(Some(appwindow));
 
-    dialog_clear_doc.set_transient_for(Some(appwindow));
-
-    dialog_clear_doc.connect_response(
+    dialog.connect_response(
         None,
         clone!(@weak canvas, @weak appwindow => move |_dialog_clear_doc, response| {
             match response {
@@ -100,7 +94,7 @@ pub(crate) fn dialog_clear_doc(appwindow: &RnAppWindow, canvas: &RnCanvas) {
         }),
     );
 
-    dialog_clear_doc.show();
+    dialog.present();
 }
 
 pub(crate) fn dialog_new_doc(appwindow: &RnAppWindow, canvas: &RnCanvas) {
@@ -167,7 +161,7 @@ pub(crate) fn dialog_new_doc(appwindow: &RnAppWindow, canvas: &RnCanvas) {
         }),
     );
 
-    dialog_new_doc.show();
+    dialog_new_doc.present();
 }
 
 /// Only to be called from the tabview close-page handler
@@ -274,7 +268,7 @@ pub(crate) fn dialog_close_tab(appwindow: &RnAppWindow, tab_page: &adw::TabPage)
         }),
     );
 
-    dialog.show();
+    dialog.present();
 }
 
 pub(crate) async fn dialog_close_window(appwindow: &RnAppWindow) {
@@ -413,7 +407,7 @@ pub(crate) async fn dialog_close_window(appwindow: &RnAppWindow) {
         }),
     );
 
-    dialog.show();
+    dialog.present();
 }
 
 pub(crate) fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
@@ -524,7 +518,7 @@ pub(crate) fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
         }
 
         filechooser.hide();
-        dialog.show();
+        dialog.present();
     }));
 
     dialog.connect_response(
@@ -551,7 +545,7 @@ pub(crate) fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
         }),
     );
 
-    dialog.show();
+    dialog.present();
     *appwindow.filechoosernative().borrow_mut() = Some(filechooser);
 }
 

--- a/rnote-ui/src/penssidebar/typewriterpage.rs
+++ b/rnote-ui/src/penssidebar/typewriterpage.rs
@@ -119,7 +119,7 @@ impl RnTypewriterPage {
 
         imp.fontdialog_button.connect_clicked(clone!(@weak self as typewriterpage, @weak appwindow => move |_| {
             glib::MainContext::default().spawn_local(clone!(@weak typewriterpage, @weak appwindow => async move {
-                let dialog = FontDialog::builder().modal(true).build();
+                let dialog = FontDialog::builder().modal(false).build();
                 let canvas = appwindow.active_tab().canvas();
                 let prev_picked_font_family = typewriterpage.imp().prev_picked_font_family.borrow().clone();
 

--- a/rnote-ui/src/penssidebar/typewriterpage.rs
+++ b/rnote-ui/src/penssidebar/typewriterpage.rs
@@ -147,7 +147,7 @@ impl RnTypewriterPage {
                             appwindow.handle_widget_flags(widget_flags, &canvas);
                         }
                     }
-                    Err(e) => log::debug!("did not choose new font family (Error or Dialog dismissed), {e:?}"),
+                    Err(e) => log::debug!("did not choose new font family (Error or dialog dismissed by user), {e:?}"),
                 }
             }));
         }));

--- a/rnote-ui/src/penssidebar/typewriterpage.rs
+++ b/rnote-ui/src/penssidebar/typewriterpage.rs
@@ -1,12 +1,12 @@
-use gtk4::pango;
 use gtk4::{
-    glib, glib::clone, prelude::*, subclass::prelude::*, Button, CompositeTemplate, EmojiChooser,
-    FontChooserLevel, FontChooserWidget, MenuButton, Popover, SpinButton, ToggleButton,
+    glib, glib::clone, pango, prelude::*, subclass::prelude::*, Button, CompositeTemplate,
+    EmojiChooser, FontDialog, SpinButton, ToggleButton,
 };
 use rnote_engine::engine::EngineViewMut;
 use rnote_engine::pens::Pen;
 use rnote_engine::strokes::textstroke::TextStyle;
 use rnote_engine::strokes::textstroke::{FontStyle, TextAlignment, TextAttribute};
+use std::cell::RefCell;
 
 use crate::{RnAppWindow, RnCanvasWrapper};
 
@@ -16,16 +16,10 @@ mod imp {
     #[derive(Default, Debug, CompositeTemplate)]
     #[template(resource = "/com/github/flxzt/rnote/ui/penssidebar/typewriterpage.ui")]
     pub(crate) struct RnTypewriterPage {
+        pub(super) prev_picked_font_family: RefCell<Option<pango::FontFamily>>,
+
         #[template_child]
-        pub(crate) fontchooser_menubutton: TemplateChild<MenuButton>,
-        #[template_child]
-        pub(crate) fontchooser_popover: TemplateChild<Popover>,
-        #[template_child]
-        pub(crate) fontchooser: TemplateChild<FontChooserWidget>,
-        #[template_child]
-        pub(crate) fontchooser_cancelbutton: TemplateChild<Button>,
-        #[template_child]
-        pub(crate) fontchooser_selectbutton: TemplateChild<Button>,
+        pub(crate) fontdialog_button: TemplateChild<Button>,
         #[template_child]
         pub(crate) font_size_spinbutton: TemplateChild<SpinButton>,
         #[template_child]
@@ -68,9 +62,6 @@ mod imp {
     impl ObjectImpl for RnTypewriterPage {
         fn constructed(&self) {
             self.parent_constructed();
-
-            // Sets the level of the font chooser (we want FAMILY, as we have separate widgets for weight, style, etc.)
-            self.fontchooser.set_level(FontChooserLevel::FAMILY);
         }
 
         fn dispose(&self) {
@@ -123,68 +114,42 @@ impl RnTypewriterPage {
         }
     }
 
-    #[allow(unused)]
-    pub(crate) fn text_style(&self) -> TextStyle {
-        let mut text_style = TextStyle::default();
-        if let Some(font_desc) = self.imp().fontchooser.font_desc() {
-            text_style.load_pango_font_desc(font_desc);
-        }
-        text_style.font_size = self.imp().font_size_spinbutton.value();
-
-        text_style
-    }
-
     pub(crate) fn init(&self, appwindow: &RnAppWindow) {
         let imp = self.imp();
 
-        let fontchooser = imp.fontchooser.get();
-        let fontchooser_popover = imp.fontchooser_popover.get();
-
-        // Font chooser
-        imp.fontchooser_cancelbutton.connect_clicked(
-            clone!(@weak fontchooser, @weak fontchooser_popover => move |_fontchooser_cancelbutton| {
-                fontchooser_popover.popdown();
-            }),
-        );
-
-        imp.fontchooser_selectbutton.connect_clicked(
-            clone!(@weak fontchooser, @weak fontchooser_popover => move |_fontchooser_selectbutton| {
-                if let Some(font) = fontchooser.font() {
-                    fontchooser.emit_by_name::<()>("font-activated", &[&font.to_value()]);
-                }
-
-                fontchooser_popover.popdown();
-            }),
-        );
-
-        // Listening to connect_font_notify would always activate at app startup. font_activated only emits when the user interactively selects a font (with double click or Enter)
-        // or we activate the signal manually elsewhere in the code
-        imp.fontchooser.connect_font_activated(clone!(@weak fontchooser_popover, @weak appwindow => move |fontchooser, _font| {
-            if let Some(font_family) = fontchooser.font_family().map(|font_family| font_family.name().to_string()) {
+        imp.fontdialog_button.connect_clicked(clone!(@weak self as typewriterpage, @weak appwindow => move |_| {
+            glib::MainContext::default().spawn_local(clone!(@weak typewriterpage, @weak appwindow => async move {
+                let dialog = FontDialog::builder().modal(true).build();
                 let canvas = appwindow.active_tab().canvas();
-                let engine = canvas.engine();
-                let engine = &mut *engine.borrow_mut();
+                let prev_picked_font_family = typewriterpage.imp().prev_picked_font_family.borrow().clone();
 
-                engine.pens_config.typewriter_config.text_style.font_family = font_family.clone();
+                match dialog.choose_family_future(Some(&appwindow), prev_picked_font_family.as_ref()).await {
+                    Ok(new_font_family) => {
+                        let engine = canvas.engine();
+                        let engine = &mut *engine.borrow_mut();
+                        let new_font_family_name = new_font_family.name();
 
-                if let Pen::Typewriter(typewriter) = engine.penholder.current_pen_mut() {
-                    let widget_flags = typewriter.change_text_style_in_modifying_stroke(
-                        |text_style| {
-                            text_style.font_family = font_family;
-                        },
-                        &mut EngineViewMut {
-                            tasks_tx: engine.tasks_tx.clone(),
-                            pens_config: &mut engine.pens_config,
-                            doc: &mut engine.document,
-                            store: &mut engine.store,
-                            camera: &mut engine.camera,
-                            audioplayer: &mut engine.audioplayer
-                    });
-                    appwindow.handle_widget_flags(widget_flags, &canvas);
+                        typewriterpage.imp().prev_picked_font_family.borrow_mut().replace(new_font_family);
+
+                        if let Pen::Typewriter(typewriter) = engine.penholder.current_pen_mut() {
+                            let widget_flags = typewriter.change_text_style_in_modifying_stroke(
+                                |text_style| {
+                                    text_style.font_family = new_font_family_name.into();
+                                },
+                                &mut EngineViewMut {
+                                    tasks_tx: engine.tasks_tx.clone(),
+                                    pens_config: &mut engine.pens_config,
+                                    doc: &mut engine.document,
+                                    store: &mut engine.store,
+                                    camera: &mut engine.camera,
+                                    audioplayer: &mut engine.audioplayer
+                            });
+                            appwindow.handle_widget_flags(widget_flags, &canvas);
+                        }
+                    }
+                    Err(e) => log::debug!("did not choose new font family (Error or Dialog dismissed), {e:?}"),
                 }
-
-                fontchooser_popover.popdown();
-            }
+            }));
         }));
 
         // Font size
@@ -220,24 +185,6 @@ impl RnTypewriterPage {
                 }
             }),
         );
-
-        // Update the font chooser font size, to display the preview text in the correct size
-        imp.font_size_spinbutton
-            .bind_property("value", &fontchooser, "font-desc")
-            .transform_to(|binding, val: f64| {
-                let fontchooser = binding
-                    .target()
-                    .unwrap()
-                    .downcast::<FontChooserWidget>()
-                    .unwrap();
-                let mut font_desc = fontchooser.font_desc()?;
-
-                font_desc.set_size((val * f64::from(pango::SCALE)).round() as i32);
-
-                Some(font_desc.to_value())
-            })
-            .sync_create()
-            .build();
 
         // Emojis
         imp.emojichooser.connect_emoji_picked(
@@ -499,8 +446,6 @@ impl RnTypewriterPage {
             .typewriter_config
             .clone();
 
-        imp.fontchooser
-            .set_font_desc(&typewriter_config.text_style.extract_pango_font_desc());
         imp.font_size_spinbutton
             .set_value(typewriter_config.text_style.font_size);
 

--- a/rnote-ui/src/strokewidthpicker/strokewidthpreview.rs
+++ b/rnote-ui/src/strokewidthpicker/strokewidthpreview.rs
@@ -107,7 +107,8 @@ mod imp {
             let center = (size.0 * 0.5, size.1 * 0.5);
             let stroke_width = self.stroke_width.get();
 
-            // this will only be removed in Gtk5. Until a new color API is available, it's okay to use it.
+            // accessing colors through the style context is deprecated,
+            // but until a new color API is available I don't see how it can be refactored.
             #[allow(deprecated)]
             let window_fg_color = obj
                 .style_context()

--- a/rnote-ui/src/strokewidthpicker/strokewidthpreview.rs
+++ b/rnote-ui/src/strokewidthpicker/strokewidthpreview.rs
@@ -107,6 +107,8 @@ mod imp {
             let center = (size.0 * 0.5, size.1 * 0.5);
             let stroke_width = self.stroke_width.get();
 
+            // this will only be removed in Gtk5. Until a new color API is available, it's okay to use it.
+            #[allow(deprecated)]
             let window_fg_color = obj
                 .style_context()
                 .lookup_color("window_fg_color")

--- a/rnote-ui/src/strokewidthpicker/strokewidthpreview.rs
+++ b/rnote-ui/src/strokewidthpicker/strokewidthpreview.rs
@@ -108,7 +108,7 @@ mod imp {
             let stroke_width = self.stroke_width.get();
 
             // accessing colors through the style context is deprecated,
-            // but until a new color API is available I don't see how it can be refactored.
+            // but this needs new color API to fetch theme colors.
             #[allow(deprecated)]
             let window_fg_color = obj
                 .style_context()

--- a/rnote-ui/src/workspacebrowser/filerow/actions/rename.rs
+++ b/rnote-ui/src/workspacebrowser/filerow/actions/rename.rs
@@ -5,7 +5,7 @@ use gtk4::{
     glib::clone,
     pango,
     prelude::FileExt,
-    traits::{BoxExt, ButtonExt, EditableExt, PopoverExt, StyleContextExt, WidgetExt},
+    traits::{BoxExt, ButtonExt, EditableExt, PopoverExt, WidgetExt},
     Align, Button, Entry, Label, Popover,
 };
 
@@ -59,8 +59,7 @@ fn create_label() -> Label {
         .width_chars(24)
         .ellipsize(pango::EllipsizeMode::End)
         .build();
-    label.style_context().add_class("title-4");
-
+    label.add_css_class("title-4");
     label
 }
 

--- a/rnote-ui/src/workspacebrowser/widgethelper.rs
+++ b/rnote-ui/src/workspacebrowser/widgethelper.rs
@@ -2,7 +2,7 @@ use gettextrs::gettext;
 use gtk4::{
     glib,
     glib::clone,
-    traits::{ButtonExt, GridExt, PopoverExt, StyleContextExt, WidgetExt},
+    traits::{ButtonExt, GridExt, PopoverExt, WidgetExt},
     Align, Button, Entry, Grid, Label, Popover, PositionType,
 };
 
@@ -37,7 +37,7 @@ pub(crate) fn create_entry_dialog(entry: &Entry, label: &Label) -> (ApplyButton,
         .halign(Align::End)
         .label(gettext("Apply"))
         .build();
-    apply_button.style_context().add_class("suggested-action");
+    apply_button.add_css_class("suggested-action");
 
     grid.attach(label, 0, 0, 2, 1);
     grid.attach(entry, 0, 1, 2, 1);

--- a/rnote-ui/src/workspacebrowser/workspaceactions/createfolder.rs
+++ b/rnote-ui/src/workspacebrowser/workspaceactions/createfolder.rs
@@ -6,7 +6,7 @@ use gtk4::{
     glib::clone,
     pango,
     prelude::*,
-    traits::{BoxExt, ButtonExt, EditableExt, PopoverExt, StyleContextExt, WidgetExt},
+    traits::{BoxExt, ButtonExt, EditableExt, PopoverExt, WidgetExt},
     Align, Button, Entry, Label, Popover,
 };
 
@@ -66,8 +66,7 @@ fn create_dialog_title_label() -> Label {
         .width_chars(24)
         .ellipsize(pango::EllipsizeMode::End)
         .build();
-    label.style_context().add_class("title-4");
-
+    label.add_css_class("title-4");
     label
 }
 

--- a/rnote-ui/src/workspacebrowser/workspacesbar/mod.rs
+++ b/rnote-ui/src/workspacebrowser/workspacesbar/mod.rs
@@ -395,11 +395,13 @@ impl RnWorkspacesBar {
         // Add workspace
         action_add_workspace.connect_activate(
             clone!(@weak self as workspacesbar, @weak appwindow => move |_, _| {
+                glib::MainContext::default().spawn_local(clone!(@weak workspacesbar, @weak appwindow => async move {
                     let entry = workspacesbar.selected_workspacelistentry().unwrap_or_default();
                     workspacesbar.push_workspace(entry);
 
                     // Popup the edit dialog after creation
-                    dialogs::dialog_edit_selected_workspace(&appwindow);
+                    dialogs::dialog_edit_selected_workspace(&appwindow).await;
+                }));
             }),
         );
 
@@ -412,7 +414,9 @@ impl RnWorkspacesBar {
 
         // Edit selected workspace
         action_edit_selected_workspace.connect_activate(clone!(@weak appwindow => move |_, _| {
-            dialogs::dialog_edit_selected_workspace(&appwindow);
+            glib::MainContext::default().spawn_local(clone!(@weak appwindow => async move {
+                dialogs::dialog_edit_selected_workspace(&appwindow).await;
+            }));
         }));
     }
 }

--- a/rnote-ui/src/workspacebrowser/workspacesbar/workspacerow.rs
+++ b/rnote-ui/src/workspacebrowser/workspacesbar/workspacerow.rs
@@ -166,6 +166,9 @@ mod imp {
 
             css.load_from_data(&custom_css);
 
+            // adding custom css is deprecated.
+            // TODO: We should refactor to drawing through snapshot().
+            #[allow(deprecated)]
             self.obj()
                 .style_context()
                 .add_provider(&css, gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION);


### PR DESCRIPTION
This updates to the gtk4 v4.10 API. Notably:

- use the new dialogs with their async API - FontDialog, ColorDialog, FileDialog instead of the widgets / choosers.
- fix some trivial deprecations - for example use `present()` instead of `show()`, or `add_css_class()` instead of `style_context().add_class()`.
- there are some deprecations where there is no replacement available: `gtk4::Dialog` should be replaced by `adw::Window` and `adw::ToolbarView`, but that is not yet stable. Because of that, this is `#![allowed()]` for now.
- other deprecations will need more refactoring in the code - adding custom css should be replaced by custom drawing through snapshot(). To do that, we would also need a new color API to fetch theme colors. So these deprecations are allowed for now as well.