### PR TITLE
Multi-brush input support

### DIFF
--- a/rnote-engine/src/engine/mod.rs
+++ b/rnote-engine/src/engine/mod.rs
@@ -27,7 +27,7 @@ use rnote_compose::helpers::AabbHelpers;
 use rnote_compose::penevents::{PenEvent, ShortcutKey};
 
 use futures::channel::{mpsc, oneshot};
-use gtk4::gsk;
+use gtk4::{gsk, gdk::Device};
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use rnote_compose::shapes::ShapeBehaviour;
 use rnote_fileformats::{rnoteformat, xoppformat, FileFormatLoader};
@@ -629,11 +629,13 @@ impl RnoteEngine {
     pub fn handle_pen_event(
         &mut self,
         event: PenEvent,
+        device: Option<Device>,
         pen_mode: Option<PenMode>,
         now: Instant,
     ) -> WidgetFlags {
         self.penholder.handle_pen_event(
             event,
+            device,
             pen_mode,
             now,
             &mut EngineViewMut {

--- a/rnote-engine/src/pens/eraser.rs
+++ b/rnote-engine/src/pens/eraser.rs
@@ -5,6 +5,7 @@ use super::pensconfig::eraserconfig::EraserStyle;
 use super::PenStyle;
 use crate::engine::{EngineView, EngineViewMut};
 use crate::{DrawOnDocBehaviour, WidgetFlags};
+use gtk4::gdk::Device;
 use once_cell::sync::Lazy;
 use piet::RenderContext;
 use rnote_compose::color;
@@ -46,6 +47,7 @@ impl PenBehaviour for Eraser {
     fn handle_event(
         &mut self,
         event: PenEvent,
+        _device: Option<Device>,
         _now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {

--- a/rnote-engine/src/pens/mod.rs
+++ b/rnote-engine/src/pens/mod.rs
@@ -24,7 +24,7 @@ pub use tools::Tools;
 pub use typewriter::Typewriter;
 
 // Imports
-use gtk4::glib;
+use gtk4::{glib, gdk::Device};
 use piet_cairo::CairoRenderContext;
 use rnote_compose::penevents::PenEvent;
 use serde::{Deserialize, Serialize};
@@ -76,16 +76,17 @@ impl PenBehaviour for Pen {
     fn handle_event(
         &mut self,
         event: PenEvent,
+        device: Option<Device>,
         now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
         match self {
-            Pen::Brush(brush) => brush.handle_event(event, now, engine_view),
-            Pen::Shaper(shaper) => shaper.handle_event(event, now, engine_view),
-            Pen::Typewriter(typewriter) => typewriter.handle_event(event, now, engine_view),
-            Pen::Eraser(eraser) => eraser.handle_event(event, now, engine_view),
-            Pen::Selector(selector) => selector.handle_event(event, now, engine_view),
-            Pen::Tools(tools) => tools.handle_event(event, now, engine_view),
+            Pen::Brush(brush) => brush.handle_event(event, device, now, engine_view),
+            Pen::Shaper(shaper) => shaper.handle_event(event, device, now, engine_view),
+            Pen::Typewriter(typewriter) => typewriter.handle_event(event, device, now, engine_view),
+            Pen::Eraser(eraser) => eraser.handle_event(event, device, now, engine_view),
+            Pen::Selector(selector) => selector.handle_event(event, device, now, engine_view),
+            Pen::Tools(tools) => tools.handle_event(event, device, now, engine_view),
         }
     }
 

--- a/rnote-engine/src/pens/penbehaviour.rs
+++ b/rnote-engine/src/pens/penbehaviour.rs
@@ -1,4 +1,5 @@
 use std::time::Instant;
+use gtk4::gdk::Device;
 
 use rnote_compose::penevents::PenEvent;
 
@@ -19,6 +20,7 @@ pub trait PenBehaviour: DrawOnDocBehaviour {
     fn handle_event(
         &mut self,
         event: PenEvent,
+        device: Option<Device>,
         now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags);

--- a/rnote-engine/src/pens/penholder.rs
+++ b/rnote-engine/src/pens/penholder.rs
@@ -1,3 +1,4 @@
+use gtk4::gdk::Device;
 use p2d::bounding_volume::Aabb;
 use piet::RenderContext;
 use rnote_compose::penevents::{PenEvent, ShortcutKey};
@@ -202,7 +203,7 @@ impl PenHolder {
         // first cancel the current pen
         let (_, mut widget_flags) =
             self.current_pen
-                .handle_event(PenEvent::Cancel, Instant::now(), engine_view);
+                .handle_event(PenEvent::Cancel, None, Instant::now(), engine_view);
 
         // then reinstall a new instance
         let new_pen = new_pen(self.current_pen_style_w_override());
@@ -218,6 +219,7 @@ impl PenHolder {
     pub fn handle_pen_event(
         &mut self,
         event: PenEvent,
+        device: Option<Device>,
         pen_mode: Option<PenMode>,
         now: Instant,
         engine_view: &mut EngineViewMut,
@@ -236,7 +238,7 @@ impl PenHolder {
 
         // Handle the event with the current pen
         let (pen_progress, other_widget_flags) =
-            self.current_pen.handle_event(event, now, engine_view);
+            self.current_pen.handle_event(event, device, now, engine_view);
         widget_flags.merge(other_widget_flags);
 
         widget_flags.merge(self.handle_pen_progress(pen_progress, engine_view));

--- a/rnote-engine/src/pens/selector/mod.rs
+++ b/rnote-engine/src/pens/selector/mod.rs
@@ -8,6 +8,7 @@ use super::PenStyle;
 use crate::engine::{EngineView, EngineViewMut, RNOTE_STROKE_CONTENT_MIME_TYPE};
 use crate::store::StrokeKey;
 use crate::{Camera, DrawOnDocBehaviour, WidgetFlags};
+use gtk4::gdk::Device;
 use kurbo::Shape;
 use once_cell::sync::Lazy;
 use p2d::query::PointQuery;
@@ -117,6 +118,7 @@ impl PenBehaviour for Selector {
     fn handle_event(
         &mut self,
         event: PenEvent,
+        _device: Option<Device>,
         now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
@@ -126,14 +128,17 @@ impl PenBehaviour for Selector {
             PenEvent::Down {
                 element,
                 modifier_keys,
+                ..
             } => self.handle_pen_event_down(element, modifier_keys, now, engine_view),
             PenEvent::Up {
                 element,
                 modifier_keys,
+                ..
             } => self.handle_pen_event_up(element, modifier_keys, now, engine_view),
             PenEvent::Proximity {
                 element,
                 modifier_keys,
+                ..
             } => self.handle_pen_event_proximity(element, modifier_keys, now, engine_view),
             PenEvent::KeyPressed {
                 keyboard_key,

--- a/rnote-engine/src/pens/shaper.rs
+++ b/rnote-engine/src/pens/shaper.rs
@@ -7,6 +7,7 @@ use crate::strokes::ShapeStroke;
 use crate::strokes::Stroke;
 use crate::{DrawOnDocBehaviour, WidgetFlags};
 
+use gtk4::gdk::Device;
 use p2d::bounding_volume::Aabb;
 use piet::RenderContext;
 use rnote_compose::builders::{ArrowBuilder, GridBuilder};
@@ -52,6 +53,7 @@ impl PenBehaviour for Shaper {
     fn handle_event(
         &mut self,
         event: PenEvent,
+        _device: Option<Device>,
         now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {

--- a/rnote-engine/src/pens/tools.rs
+++ b/rnote-engine/src/pens/tools.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use crate::engine::{EngineView, EngineViewMut};
 use crate::store::StrokeKey;
 use crate::{DrawOnDocBehaviour, WidgetFlags};
+use gtk4::gdk::Device;
 use once_cell::sync::Lazy;
 use piet::RenderContext;
 use rnote_compose::color;
@@ -193,6 +194,7 @@ impl PenBehaviour for Tools {
     fn handle_event(
         &mut self,
         event: PenEvent,
+        _device: Option<Device>,
         _now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {

--- a/rnote-engine/src/pens/typewriter/mod.rs
+++ b/rnote-engine/src/pens/typewriter/mod.rs
@@ -1,6 +1,7 @@
 mod penevents;
 
 // Imports
+use gtk4::gdk::Device;
 use once_cell::sync::Lazy;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use piet::RenderContext;
@@ -313,6 +314,7 @@ impl PenBehaviour for Typewriter {
     fn handle_event(
         &mut self,
         event: PenEvent,
+        _device: Option<Device>,
         now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
@@ -328,14 +330,17 @@ impl PenBehaviour for Typewriter {
             PenEvent::Down {
                 element,
                 modifier_keys,
+                ..
             } => self.handle_pen_event_down(element, modifier_keys, now, engine_view),
             PenEvent::Up {
                 element,
                 modifier_keys,
+                ..
             } => self.handle_pen_event_up(element, modifier_keys, now, engine_view),
             PenEvent::Proximity {
                 element,
                 modifier_keys,
+                ..
             } => self.handle_pen_event_proximity(element, modifier_keys, now, engine_view),
             PenEvent::KeyPressed {
                 keyboard_key,

--- a/rnote-ui/src/canvas/input.rs
+++ b/rnote-ui/src/canvas/input.rs
@@ -163,8 +163,14 @@ pub(crate) fn handle_pointer_controller_event(
         let modifier_keys = retrieve_modifier_keys(event.modifier_state());
         let pen_mode = retrieve_pen_mode(event);
 
+        let elements_len = elements.len();
         for (element, event_time) in elements {
-            //log::debug!("handle event, state: {state:?}, event_time_d: {:?}, modifier_keys: {modifier_keys:?}, pen_mode: {pen_mode:?}", now.duration_since(event_time));
+            log::debug!(
+                "({:.1}, {:.1}) handle event, state: {state:?}, event_time_d: {:?}, modifier_keys: {modifier_keys:?}, pen_mode: {pen_mode:?}, length: {elements_len:?}",
+                element.pos.x,
+                element.pos.y,
+                now.duration_since(event_time)
+            );
 
             match state {
                 PenState::Up => {

--- a/rnote-ui/src/canvas/input.rs
+++ b/rnote-ui/src/canvas/input.rs
@@ -16,6 +16,21 @@ pub(crate) fn handle_pointer_controller_event(
     event: &gdk::Event,
     mut state: PenState,
 ) -> (Inhibit, PenState) {
+    /*if let Some(device) = event.device() {
+        log::debug!("[evnt] {:?} {:?} {:?} {device:?}", device.product_id(), device.vendor_id(), device.name());
+        log::debug!("{:?}", device.as_ptr());
+    }
+    if let Some(seat) = event.seat() {
+        log::debug!("[seat] {seat:?}");
+        log::debug!("[disp] {:?}", seat.display());
+        let devices = seat.devices(gdk::SeatCapabilities::ALL_POINTING);
+        for dev in devices {
+            log::debug!("[dvce] {:?} {:?} {:?} {dev:?}", dev.product_id(), dev.vendor_id(), dev.name());
+        }
+        if let Some(pointer) = seat.pointer() {
+            log::debug!("[pntr] {:?} {:?} {:?} {pointer:?}", pointer.product_id(), pointer.vendor_id(), pointer.name());
+        }
+    }*/
     //std::thread::sleep(std::time::Duration::from_millis(100));
     let touch_drawing = canvas.touch_drawing();
     let event_type = event.event_type();
@@ -165,12 +180,14 @@ pub(crate) fn handle_pointer_controller_event(
 
         let elements_len = elements.len();
         for (element, event_time) in elements {
-            log::debug!(
-                "({:.1}, {:.1}) handle event, state: {state:?}, event_time_d: {:?}, modifier_keys: {modifier_keys:?}, pen_mode: {pen_mode:?}, length: {elements_len:?}",
-                element.pos.x,
-                element.pos.y,
-                now.duration_since(event_time)
-            );
+            if pen_mode.is_none() {
+                log::debug!(
+                    "({:.1}, {:.1}) handle event, state: {state:?}, event_time_d: {:?}, modifier_keys: {modifier_keys:?}, pen_mode: {pen_mode:?}, length: {elements_len:?}",
+                    element.pos.x,
+                    element.pos.y,
+                    now.duration_since(event_time)
+                );
+            }
 
             match state {
                 PenState::Up => {
@@ -181,6 +198,7 @@ pub(crate) fn handle_pointer_controller_event(
                             element,
                             modifier_keys: modifier_keys.clone(),
                         },
+                        event.device(),
                         pen_mode,
                         event_time,
                     ));
@@ -193,6 +211,7 @@ pub(crate) fn handle_pointer_controller_event(
                             element,
                             modifier_keys: modifier_keys.clone(),
                         },
+                        event.device(),
                         pen_mode,
                         event_time,
                     ));
@@ -206,6 +225,7 @@ pub(crate) fn handle_pointer_controller_event(
                             element,
                             modifier_keys: modifier_keys.clone(),
                         },
+                        event.device(),
                         pen_mode,
                         event_time,
                     ));
@@ -238,6 +258,7 @@ pub(crate) fn handle_key_controller_key_pressed(
             modifier_keys,
         },
         None,
+        None,
         now,
     );
     canvas.emit_handle_widget_flags(widget_flags);
@@ -251,6 +272,7 @@ pub(crate) fn handle_imcontext_text_commit(canvas: &RnCanvas, text: &str) {
         PenEvent::Text {
             text: text.to_string(),
         },
+        None,
         None,
         now,
     );


### PR DESCRIPTION
(Draft while I attempt to implement this to see how feasible it is)
Fixes #665 , fixes #534 .

This PR implements support for brush input with multiple devices at once (each making its own stroke (path)).

This is primarily aimed as fix for issues related to pointer devices sending events even when not used, resulting in the brush jumping across the canvas (see #665 and #534). It could also make the behaviour more expected in #624 if different input devices are being used (ie. thouch + something else (like a mouse)).

**Implementation notes**
- Pointer events come with a logical device with no unique identifiers apart from the name, but they do implement `eq` and it seems to do the job well enough from my testing.

**Tasks**
- [X] Allow a brush to have multiple states - one per device.
- [ ] Fix erasing.
  - This is a result of the pen being reinstalled as soon as any of the devices finish their stroke. Possible options are:
    1. Return `PenProgress::Finished` only when all devices are finished.
    2. Use separate pens (requires much more work.
- [ ] Potentially unintended Down events (my device for example will sometimes send down events from the touchpad even though only the pen is pressed down, resulting in a small dot).