### PR TITLE
spring clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@
 
 > Sketch and take handwritten notes.  
 
-Rnote is an open-source vector-based drawing app for sketching, handwritten notes and to annotate documents and pictures. Targeted at students, teachers and those who own a drawing tablet, it provides features like PDF and picture import and export, an infinite canvas and an adaptive UI for big and small screens.
+Rnote is an open-source vector-based drawing app for sketching, handwritten notes and to annotate documents and pictures.
+It is targeted at students, teachers and those who own a drawing tablet and provides features like Pdf and picture import and export,
+an infinite canvas and an adaptive UI for big and small screens.
 
 Written in Rust and GTK4.
 
@@ -33,8 +35,8 @@ Written in Rust and GTK4.
 - Reconfigurable stylus button shortcuts
 - An integrated workspace browser for quick access to related files
 - Drag & Drop, clipboard support
-- PDF, Bitmap and SVG image import
-- Document, document pages and selection export to many formats including SVG, PDF, Xopp
+- Pdf, Bitmap and Svg image import
+- Document, document pages and selection export to many formats including Svg, Pdf, Xopp
 - Save and load the documents in the native `.rnote` file format
 - Tabs to work on multiple documents at the same time
 - Autosave, printing

--- a/build-aux/inno_build.py
+++ b/build-aux/inno_build.py
@@ -55,7 +55,7 @@ for loader in glob.glob(f"{msys_path}/mingw64/lib/gdk-pixbuf-2.0/2.10.0/loaders/
         f"Collecting pixbuf-loader ({loader}) DLLs failed"
     )
 
-# Collect necessary GSchema XML's and compile them into a `gschema.compiled`
+# Collect necessary GSchema Xml's and compile them into a `gschema.compiled`
 print("Collecting and compiling GSchemas...", file=sys.stderr)
 gschemas_dir = os.path.join(build_root, "gschemas")
 

--- a/meson.build
+++ b/meson.build
@@ -196,6 +196,17 @@ run_target(
     env: cargo_env,
 )
 
+# app cargo doc
+run_target(
+    'app-cargo-doc',
+    command: [
+        cargo,
+        'doc',
+        app_cargo_options,
+    ],
+    env: cargo_env,
+)
+
 # app cargo build
 app_cargo_build = custom_target(
     'app-cargo-build',
@@ -269,6 +280,17 @@ if build_cli == true
         command: [
             cargo,
             'clippy',
+            cli_cargo_options,
+        ],
+        env: cargo_env,
+    )
+
+    # cli cargo doc
+    run_target(
+        'cli-cargo-doc',
+        command: [
+            cargo,
+            'doc',
             cli_cargo_options,
         ],
         env: cargo_env,

--- a/rnote-compose/src/builders/arrowbuilder.rs
+++ b/rnote-compose/src/builders/arrowbuilder.rs
@@ -1,25 +1,23 @@
-use std::time::Instant;
-
-use p2d::bounding_volume::{Aabb, BoundingVolume};
-use piet::RenderContext;
-
+// Imports
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
+use super::ShapeBuilderBehaviour;
+use crate::constraints::ConstraintRatio;
 use crate::penevents::{PenEvent, PenState};
 use crate::penpath::Element;
 use crate::shapes::Arrow;
 use crate::style::{indicators, Composer};
-use crate::{Shape, Style};
-
-use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
-use super::ShapeBuilderBehaviour;
-use crate::constraints::ConstraintRatio;
 use crate::Constraints;
+use crate::{Shape, Style};
+use p2d::bounding_volume::{Aabb, BoundingVolume};
+use piet::RenderContext;
+use std::time::Instant;
 
-/// arrow builder
+/// Arrow builder.
 #[derive(Debug, Clone)]
 pub struct ArrowBuilder {
-    /// the start position
+    /// Start position.
     start: na::Vector2<f64>,
-    /// the position of the tip
+    /// Position of the tip.
     tip: na::Vector2<f64>,
 }
 

--- a/rnote-compose/src/builders/coordsystem2dbuilder.rs
+++ b/rnote-compose/src/builders/coordsystem2dbuilder.rs
@@ -1,17 +1,15 @@
-use std::time::Instant;
-
-use p2d::bounding_volume::{Aabb, BoundingVolume};
-use piet::RenderContext;
-
+// Imports
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
+use super::ShapeBuilderBehaviour;
 use crate::penevents::{PenEvent, PenState};
 use crate::penpath::Element;
 use crate::shapes::Line;
 use crate::style::{indicators, Composer};
-use crate::{Shape, Style};
-
-use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
-use super::ShapeBuilderBehaviour;
 use crate::Constraints;
+use crate::{Shape, Style};
+use p2d::bounding_volume::{Aabb, BoundingVolume};
+use piet::RenderContext;
+use std::time::Instant;
 
 /// 2D coordinate system builder
 #[derive(Debug, Clone)]
@@ -80,7 +78,7 @@ impl ShapeBuilderBehaviour for CoordSystem2DBuilder {
 }
 
 impl CoordSystem2DBuilder {
-    /// The current state represented by four lines
+    /// The current state as four individual lines.
     pub fn state_as_lines(&self) -> Vec<Line> {
         let center = na::vector!(self.tip_y.x, self.tip_x.y);
 

--- a/rnote-compose/src/builders/coordsystem3dbuilder.rs
+++ b/rnote-compose/src/builders/coordsystem3dbuilder.rs
@@ -1,24 +1,22 @@
-use std::time::Instant;
-
-use p2d::bounding_volume::{Aabb, BoundingVolume};
-use piet::RenderContext;
-
+// Imports
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
+use super::ShapeBuilderBehaviour;
 use crate::penevents::{PenEvent, PenState};
 use crate::penpath::Element;
 use crate::shapes::Line;
 use crate::style::{indicators, Composer};
-use crate::{Shape, Style};
-
-use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
-use super::ShapeBuilderBehaviour;
 use crate::Constraints;
+use crate::{Shape, Style};
+use p2d::bounding_volume::{Aabb, BoundingVolume};
+use piet::RenderContext;
+use std::time::Instant;
 
-/// 3D coordinate system builder
+/// 3D coordinate system builder.
 #[derive(Debug, Clone)]
 pub struct CoordSystem3DBuilder {
-    /// the tip of the z axis
+    /// Tip of the z axis.
     tip_z: na::Vector2<f64>,
-    /// the tip of the y axis
+    /// Tip of the y axis.
     tip_y: na::Vector2<f64>,
 }
 
@@ -80,7 +78,7 @@ impl ShapeBuilderBehaviour for CoordSystem3DBuilder {
 }
 
 impl CoordSystem3DBuilder {
-    /// The current state represented by six lines
+    /// The current state as six individual lines.
     pub fn state_as_lines(&self) -> Vec<Line> {
         let center = na::vector!(self.tip_z.x, self.tip_y.y);
         let tip_x_offset =

--- a/rnote-compose/src/builders/cubbezbuilder.rs
+++ b/rnote-compose/src/builders/cubbezbuilder.rs
@@ -64,8 +64,6 @@ impl ShapeBuilderBehaviour for CubBezBuilder {
         _now: Instant,
         mut constraints: Constraints,
     ) -> ShapeBuilderProgress {
-        //log::debug!("state: {:?}, event: {:?}", &self.state, &event);
-
         // we always want to allow horizontal and vertical constraints while building a cubbez
         constraints.ratios.insert(ConstraintRatio::Horizontal);
         constraints.ratios.insert(ConstraintRatio::Vertical);

--- a/rnote-compose/src/builders/cubbezbuilder.rs
+++ b/rnote-compose/src/builders/cubbezbuilder.rs
@@ -1,18 +1,16 @@
-use std::time::Instant;
-
-use p2d::bounding_volume::{Aabb, BoundingVolume};
-
+// Impoorts
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
+use super::ShapeBuilderBehaviour;
+use crate::constraints::ConstraintRatio;
 use crate::helpers::AabbHelpers;
 use crate::penevents::{PenEvent, PenState};
 use crate::penpath::Element;
 use crate::shapes::CubicBezier;
 use crate::style::{indicators, Composer};
-use crate::{Shape, Style};
-
-use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
-use super::ShapeBuilderBehaviour;
-use crate::constraints::ConstraintRatio;
 use crate::Constraints;
+use crate::{Shape, Style};
+use p2d::bounding_volume::{Aabb, BoundingVolume};
+use std::time::Instant;
 
 #[derive(Debug, Clone)]
 enum CubBezBuilderState {
@@ -43,9 +41,8 @@ enum CubBezBuilderState {
 }
 
 #[derive(Debug, Clone)]
-/// cubic bezier builder
+/// Cubic bezier builder.
 pub struct CubBezBuilder {
-    /// the state
     state: CubBezBuilderState,
 }
 

--- a/rnote-compose/src/builders/ellipsebuilder.rs
+++ b/rnote-compose/src/builders/ellipsebuilder.rs
@@ -1,24 +1,22 @@
-use std::time::Instant;
-
-use p2d::bounding_volume::{Aabb, BoundingVolume};
-use piet::RenderContext;
-
+// Imports
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
+use super::ShapeBuilderBehaviour;
 use crate::penevents::{PenEvent, PenState};
 use crate::penpath::Element;
 use crate::shapes::Ellipse;
 use crate::style::{indicators, Composer};
-use crate::{Shape, Style, Transform};
-
-use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
-use super::ShapeBuilderBehaviour;
 use crate::Constraints;
+use crate::{Shape, Style, Transform};
+use p2d::bounding_volume::{Aabb, BoundingVolume};
+use piet::RenderContext;
+use std::time::Instant;
 
-/// ellipse builder
+/// Ellipse builder.
 #[derive(Debug, Clone)]
 pub struct EllipseBuilder {
-    /// the start position
+    /// Start position.
     start: na::Vector2<f64>,
-    /// the current position
+    /// Current position.
     current: na::Vector2<f64>,
 }
 
@@ -73,7 +71,7 @@ impl ShapeBuilderBehaviour for EllipseBuilder {
 }
 
 impl EllipseBuilder {
-    /// The current state as ellipse
+    /// The current state as an ellipse.
     pub fn state_as_ellipse(&self) -> Ellipse {
         let transform = Transform::new_w_isometry(na::Isometry2::new(self.start, 0.0));
         let radii = (self.current - self.start).abs();

--- a/rnote-compose/src/builders/fociellipsebuilder.rs
+++ b/rnote-compose/src/builders/fociellipsebuilder.rs
@@ -1,22 +1,20 @@
-use std::time::Instant;
-
-use p2d::bounding_volume::{Aabb, BoundingVolume};
-use piet::RenderContext;
-
+// Imports
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
+use super::ShapeBuilderBehaviour;
+use crate::constraints::ConstraintRatio;
 use crate::helpers::AabbHelpers;
 use crate::penevents::{PenEvent, PenState};
 use crate::penpath::Element;
 use crate::shapes::Ellipse;
 use crate::style::{indicators, Composer};
-use crate::{Shape, Style};
-
-use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
-use super::ShapeBuilderBehaviour;
-use crate::constraints::ConstraintRatio;
 use crate::Constraints;
+use crate::{Shape, Style};
+use p2d::bounding_volume::{Aabb, BoundingVolume};
+use piet::RenderContext;
+use std::time::Instant;
 
 #[derive(Debug, Clone)]
-/// The foci ellipse builder state
+/// Foci ellipse builder state.
 pub enum FociEllipseBuilderState {
     Start(na::Vector2<f64>),
     StartFinished(na::Vector2<f64>),
@@ -29,9 +27,8 @@ pub enum FociEllipseBuilderState {
 }
 
 #[derive(Debug, Clone)]
-/// building ellipse with foci and point
+/// Ellipse builder with foci and point.
 pub struct FociEllipseBuilder {
-    /// the state
     state: FociEllipseBuilderState,
 }
 

--- a/rnote-compose/src/builders/fociellipsebuilder.rs
+++ b/rnote-compose/src/builders/fociellipsebuilder.rs
@@ -47,8 +47,6 @@ impl ShapeBuilderBehaviour for FociEllipseBuilder {
         _now: Instant,
         mut constraints: Constraints,
     ) -> ShapeBuilderProgress {
-        //log::debug!("state: {:?}, event: {:?}", &self.state, &event);
-
         match (&mut self.state, event) {
             (FociEllipseBuilderState::Start(first), PenEvent::Down { element, .. }) => {
                 *first = element.pos;

--- a/rnote-compose/src/builders/gridbuilder.rs
+++ b/rnote-compose/src/builders/gridbuilder.rs
@@ -1,18 +1,16 @@
-use std::time::Instant;
-
-use p2d::bounding_volume::{Aabb, BoundingVolume};
-use piet::RenderContext;
-
+// Imports
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
+use super::ShapeBuilderBehaviour;
 use crate::helpers::AabbHelpers;
 use crate::penevents::{PenEvent, PenState};
 use crate::penpath::Element;
 use crate::shapes::{Line, Rectangle};
 use crate::style::{indicators, Composer};
-use crate::{Shape, Style};
-
-use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
-use super::ShapeBuilderBehaviour;
 use crate::Constraints;
+use crate::{Shape, Style};
+use p2d::bounding_volume::{Aabb, BoundingVolume};
+use piet::RenderContext;
+use std::time::Instant;
 
 #[derive(Debug, Clone, Copy)]
 enum GridBuilderState {

--- a/rnote-compose/src/builders/gridbuilder.rs
+++ b/rnote-compose/src/builders/gridbuilder.rs
@@ -53,8 +53,6 @@ impl ShapeBuilderBehaviour for GridBuilder {
         _now: Instant,
         constraints: Constraints,
     ) -> ShapeBuilderProgress {
-        //log::debug!("state: {:?}, event: {:?}", &self.state, &event);
-
         match (&mut self.state, event) {
             (GridBuilderState::FirstCell { start, current }, PenEvent::Down { element, .. }) => {
                 *current = constraints.constrain(element.pos - *start) + *start;

--- a/rnote-compose/src/builders/linebuilder.rs
+++ b/rnote-compose/src/builders/linebuilder.rs
@@ -1,25 +1,23 @@
-use std::time::Instant;
-
-use p2d::bounding_volume::{Aabb, BoundingVolume};
-use piet::RenderContext;
-
+// Imports
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
+use super::ShapeBuilderBehaviour;
+use crate::constraints::ConstraintRatio;
 use crate::penevents::{PenEvent, PenState};
 use crate::penpath::Element;
 use crate::shapes::Line;
 use crate::style::{indicators, Composer};
-use crate::{Shape, Style};
-
-use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
-use super::ShapeBuilderBehaviour;
-use crate::constraints::ConstraintRatio;
 use crate::Constraints;
+use crate::{Shape, Style};
+use p2d::bounding_volume::{Aabb, BoundingVolume};
+use piet::RenderContext;
+use std::time::Instant;
 
-/// line builder
+/// Line builder.
 #[derive(Debug, Clone)]
 pub struct LineBuilder {
-    /// the start position
+    /// Start position.
     start: na::Vector2<f64>,
-    /// the current position
+    /// Current position.
     current: na::Vector2<f64>,
 }
 
@@ -76,7 +74,7 @@ impl ShapeBuilderBehaviour for LineBuilder {
 }
 
 impl LineBuilder {
-    /// The current state as line
+    /// The current state as a line.
     pub fn state_as_line(&self) -> Line {
         Line {
             start: self.start,

--- a/rnote-compose/src/builders/mod.rs
+++ b/rnote-compose/src/builders/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 mod arrowbuilder;
 mod coordsystem2dbuilder;
 mod coordsystem3dbuilder;

--- a/rnote-compose/src/builders/penpathbuilderbehaviour.rs
+++ b/rnote-compose/src/builders/penpathbuilderbehaviour.rs
@@ -1,33 +1,35 @@
-use std::time::Instant;
-
-use p2d::bounding_volume::Aabb;
-
+// Imports
 use crate::penevents::PenEvent;
 use crate::penpath::{Element, Segment};
 use crate::Constraints;
 use crate::Style;
+use p2d::bounding_volume::Aabb;
+use std::time::Instant;
 
 #[derive(Debug, Clone)]
-/// the builder progress
+/// Builder progress.
 pub enum PenPathBuilderProgress {
-    /// in progress
+    /// In progress.
     InProgress,
-    /// emits new path segments, but continue
+    /// Emit new path segments, but continue.
     EmitContinue(Vec<Segment>),
-    /// done building
+    /// Done building.
     Finished(Vec<Segment>),
 }
 
-/// Creates a pen path builder
+/// Creator of a pen path builder.
 pub trait PenPathBuilderCreator {
-    /// Start the builder
+    /// Start the builder.
     fn start(element: Element, now: Instant) -> Self;
 }
 
 /// Types that are pen path builders.
-/// They receive pen events, and return path segments. They usually are drawn while building the shape, and are state machines.
+///
+/// They receive pen events, and return path segments.
+/// They usually are drawn while building the shape and are finite state machines.
 pub trait PenPathBuilderBehaviour: std::fmt::Debug {
-    /// handles a pen event.
+    /// Handle a pen event.
+    ///
     /// Returns the builder progress.
     fn handle_event(
         &mut self,
@@ -36,9 +38,9 @@ pub trait PenPathBuilderBehaviour: std::fmt::Debug {
         constraints: Constraints,
     ) -> PenPathBuilderProgress;
 
-    /// the bounds
+    /// Bounds.
     fn bounds(&self, style: &Style, zoom: f64) -> Option<Aabb>;
 
-    /// draw with a style
+    /// Draw with a style.
     fn draw_styled(&self, cx: &mut piet_cairo::CairoRenderContext, style: &Style, zoom: f64);
 }

--- a/rnote-compose/src/builders/penpathcurvedbuilder.rs
+++ b/rnote-compose/src/builders/penpathcurvedbuilder.rs
@@ -1,17 +1,15 @@
-use std::time::Instant;
-
-use p2d::bounding_volume::{Aabb, BoundingVolume};
-use piet::RenderContext;
-
+// Imports
+use super::penpathbuilderbehaviour::PenPathBuilderCreator;
+use super::{PenPathBuilderBehaviour, PenPathBuilderProgress};
 use crate::penevents::PenEvent;
 use crate::penpath::{Element, Segment};
 use crate::shapes::CubicBezier;
 use crate::style::Composer;
-use crate::{PenPath, Style};
-
-use super::penpathbuilderbehaviour::PenPathBuilderCreator;
-use super::{PenPathBuilderBehaviour, PenPathBuilderProgress};
 use crate::Constraints;
+use crate::{PenPath, Style};
+use p2d::bounding_volume::{Aabb, BoundingVolume};
+use piet::RenderContext;
+use std::time::Instant;
 
 #[derive(Debug, Clone)]
 pub(crate) enum PenPathCurvedBuilderState {
@@ -20,12 +18,12 @@ pub(crate) enum PenPathCurvedBuilderState {
 }
 
 #[derive(Debug, Clone)]
-/// The pen path builder
+/// Pen path curved builder.
 pub struct PenPathCurvedBuilder {
     state: PenPathCurvedBuilderState,
-    /// Buffered elements, which are filled up by new pen events and used to build path segments
+    /// Buffered elements, which are filled up by new pen events and used to build path segments.
     buffer: Vec<Element>,
-    /// the index of the current first unprocessed buffer element
+    /// the index of the current first unprocessed buffer element.
     i: usize,
 }
 
@@ -119,7 +117,8 @@ impl PenPathBuilderBehaviour for PenPathCurvedBuilder {
             PenPathCurvedBuilderState::Start => {
                 PenPath::try_from_elements(self.buffer[self.i..].iter().copied())
             }
-            // Skipping the first buffer element as that is the not drained by the segment builder and is the prev element in the "During" state
+            // Skipping the first buffer element as that is the not drained by the segment builder
+            // and is the prev element in the "During" state
             PenPathCurvedBuilderState::During => {
                 PenPath::try_from_elements(self.buffer[self.i..].iter().skip(1).copied())
             }

--- a/rnote-compose/src/builders/penpathcurvedbuilder.rs
+++ b/rnote-compose/src/builders/penpathcurvedbuilder.rs
@@ -44,13 +44,6 @@ impl PenPathBuilderBehaviour for PenPathCurvedBuilder {
         _now: Instant,
         _constraints: Constraints,
     ) -> PenPathBuilderProgress {
-        /*         log::debug!(
-            "event: {:?}; buffer.len(): {}, state: {:?}",
-            event,
-            self.buffer.len(),
-            self.state
-        ); */
-
         match (&mut self.state, event) {
             (PenPathCurvedBuilderState::Start, PenEvent::Down { element, .. }) => {
                 self.buffer.push(element);

--- a/rnote-compose/src/builders/penpathmodeledbuilder.rs
+++ b/rnote-compose/src/builders/penpathmodeledbuilder.rs
@@ -64,13 +64,6 @@ impl PenPathBuilderBehaviour for PenPathModeledBuilder {
         now: Instant,
         _constraints: Constraints,
     ) -> PenPathBuilderProgress {
-        /*         log::debug!(
-            "event: {:?}; buffer.len(): {}, state: {:?}",
-            event,
-            self.buffer.len(),
-            self.state
-        ); */
-
         match event {
             PenEvent::Down { element, .. } => {
                 // kDown is already fed into the modeler when the builder was instantiated (with start())
@@ -116,17 +109,6 @@ impl PenPathBuilderBehaviour for PenPathModeledBuilder {
                 .chain(self.prediction_buffer.iter())
                 .copied(),
         );
-
-        /*
-                // Change prediction stroke color for debugging
-                let mut style = style.clone();
-                match style {
-                    Style::Smooth(ref mut smooth_options) => {
-                        smooth_options.stroke_color = Some(crate::Color::RED)
-                    }
-                    _ => {}
-                }
-        */
 
         if let Some(pen_path) = pen_path {
             pen_path.draw_composed(cx, style);

--- a/rnote-compose/src/builders/penpathmodeledbuilder.rs
+++ b/rnote-compose/src/builders/penpathmodeledbuilder.rs
@@ -1,3 +1,10 @@
+// Imports
+use super::{PenPathBuilderBehaviour, PenPathBuilderCreator, PenPathBuilderProgress};
+use crate::penevents::PenEvent;
+use crate::penpath::{Element, Segment};
+use crate::style::Composer;
+use crate::Constraints;
+use crate::{PenPath, Style};
 use ink_stroke_modeler_rs::{
     ModelerInput, ModelerInputEventType, PredictionParams, StrokeModeler, StrokeModelerParams,
 };
@@ -6,20 +13,12 @@ use p2d::bounding_volume::Aabb;
 use piet::RenderContext;
 use std::time::{Duration, Instant};
 
-use crate::penevents::PenEvent;
-use crate::penpath::{Element, Segment};
-use crate::style::Composer;
-use crate::{PenPath, Style};
-
-use super::{PenPathBuilderBehaviour, PenPathBuilderCreator, PenPathBuilderProgress};
-use crate::Constraints;
-
-/// The pen path builder
+/// Pen path modeled builder.
 pub struct PenPathModeledBuilder {
-    /// Buffered elements, which are filled up by new pen events and used to build path segments
+    /// Buffered elements, which are filled up by new pen events and used to build path segments.
     buffer: Vec<Element>,
     prediction_start: Element,
-    /// Holding the current prediction. Is recalculated after the modeler is updated with a new element
+    /// Holding the current prediction. Is recalculated after the modeler is updated with a new element.
     prediction_buffer: Vec<Element>,
     start_time: Instant,
     last_element: Element,

--- a/rnote-compose/src/builders/penpathsimplebuilder.rs
+++ b/rnote-compose/src/builders/penpathsimplebuilder.rs
@@ -34,13 +34,6 @@ impl PenPathBuilderBehaviour for PenPathSimpleBuilder {
         _now: Instant,
         _constraints: Constraints,
     ) -> PenPathBuilderProgress {
-        /*         log::debug!(
-            "event: {:?}; buffer.len(): {}, state: {:?}",
-            event,
-            self.buffer.len(),
-            self.state
-        ); */
-
         match event {
             PenEvent::Down { element, .. } => {
                 self.buffer.push_back(element);

--- a/rnote-compose/src/builders/penpathsimplebuilder.rs
+++ b/rnote-compose/src/builders/penpathsimplebuilder.rs
@@ -1,22 +1,21 @@
+// Imports
+use super::penpathbuilderbehaviour::{
+    PenPathBuilderBehaviour, PenPathBuilderCreator, PenPathBuilderProgress,
+};
+use crate::penevents::PenEvent;
+use crate::penpath::{Element, Segment};
+use crate::style::Composer;
+use crate::Constraints;
+use crate::{PenPath, Style};
 use p2d::bounding_volume::Aabb;
 use piet::RenderContext;
 use std::collections::VecDeque;
 use std::time::Instant;
 
-use crate::penevents::PenEvent;
-use crate::penpath::{Element, Segment};
-use crate::style::Composer;
-use crate::{PenPath, Style};
-
-use super::penpathbuilderbehaviour::{
-    PenPathBuilderBehaviour, PenPathBuilderCreator, PenPathBuilderProgress,
-};
-use crate::Constraints;
-
 #[derive(Debug, Clone)]
-/// The simple pen path builder
+/// Pen path simple builder
 pub struct PenPathSimpleBuilder {
-    /// Buffered elements, which are filled up by new pen events and used to try to build path segments
+    /// Buffered elements, which are filled up by new pen events and used to try to build path segments.
     buffer: VecDeque<Element>,
 }
 

--- a/rnote-compose/src/builders/quadbezbuilder.rs
+++ b/rnote-compose/src/builders/quadbezbuilder.rs
@@ -1,21 +1,18 @@
-use std::time::Instant;
-
-use p2d::bounding_volume::{Aabb, BoundingVolume};
-
+// Imports
+use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
+use super::ShapeBuilderBehaviour;
+use crate::constraints::ConstraintRatio;
 use crate::helpers::AabbHelpers;
 use crate::penevents::{PenEvent, PenState};
 use crate::penpath::Element;
 use crate::shapes::QuadraticBezier;
 use crate::style::{indicators, Composer};
-use crate::{Shape, Style};
-
-use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
-use super::ShapeBuilderBehaviour;
-use crate::constraints::ConstraintRatio;
 use crate::Constraints;
+use crate::{Shape, Style};
+use p2d::bounding_volume::{Aabb, BoundingVolume};
+use std::time::Instant;
 
 #[derive(Debug, Clone)]
-/// The quadbez builder state
 enum QuadBezBuilderState {
     Cp {
         start: na::Vector2<f64>,
@@ -32,8 +29,8 @@ enum QuadBezBuilderState {
     },
 }
 
+/// Quadratic bezier builder.
 #[derive(Debug, Clone)]
-/// quadratic bezier builder
 pub struct QuadBezBuilder {
     state: QuadBezBuilderState,
 }

--- a/rnote-compose/src/builders/quadbezbuilder.rs
+++ b/rnote-compose/src/builders/quadbezbuilder.rs
@@ -53,8 +53,6 @@ impl ShapeBuilderBehaviour for QuadBezBuilder {
         _now: Instant,
         mut constraints: Constraints,
     ) -> ShapeBuilderProgress {
-        //log::debug!("state: {:?}, event: {:?}", &self.state, &event);
-
         // we always want to allow horizontal and vertical constraints while building a quadbez
         constraints.ratios.insert(ConstraintRatio::Horizontal);
         constraints.ratios.insert(ConstraintRatio::Vertical);

--- a/rnote-compose/src/builders/quadrantcoordsystem2dbuilder.rs
+++ b/rnote-compose/src/builders/quadrantcoordsystem2dbuilder.rs
@@ -11,12 +11,12 @@ use crate::style::{indicators, Composer};
 use crate::Constraints;
 use crate::{Shape, Style};
 
-/// 2D single quadrant coordinate system builder
+/// 2D single quadrant coordinate system builder.
 #[derive(Debug, Clone)]
 pub struct QuadrantCoordSystem2DBuilder {
-    /// the tip of the y axis
+    /// Tip of the y axis.
     tip_y: na::Vector2<f64>,
-    /// the tip of the x axis
+    /// Tip of the x axis.
     tip_x: na::Vector2<f64>,
 }
 
@@ -78,7 +78,7 @@ impl ShapeBuilderBehaviour for QuadrantCoordSystem2DBuilder {
 }
 
 impl QuadrantCoordSystem2DBuilder {
-    /// The current state represented by two lines
+    /// The current state as two individual lines.
     pub fn state_as_lines(&self) -> Vec<Line> {
         let center = na::vector!(self.tip_y.x, self.tip_x.y);
 

--- a/rnote-compose/src/builders/rectanglebuilder.rs
+++ b/rnote-compose/src/builders/rectanglebuilder.rs
@@ -1,8 +1,4 @@
-use p2d::bounding_volume::{Aabb, BoundingVolume};
-use p2d::shape::Cuboid;
-use piet::RenderContext;
-use std::time::Instant;
-
+// Imports
 use super::shapebuilderbehaviour::{ShapeBuilderCreator, ShapeBuilderProgress};
 use super::ShapeBuilderBehaviour;
 use crate::penevents::{PenEvent, PenState};
@@ -11,13 +7,17 @@ use crate::shapes::Rectangle;
 use crate::style::{indicators, Composer};
 use crate::Constraints;
 use crate::{Shape, Style, Transform};
+use p2d::bounding_volume::{Aabb, BoundingVolume};
+use p2d::shape::Cuboid;
+use piet::RenderContext;
+use std::time::Instant;
 
-/// rectangle builder
+/// Rectangle builder.
 #[derive(Debug, Clone)]
 pub struct RectangleBuilder {
-    /// the start position
+    /// Start position.
     start: na::Vector2<f64>,
-    /// the current position
+    /// Current position.
     current: na::Vector2<f64>,
 }
 
@@ -72,7 +72,7 @@ impl ShapeBuilderBehaviour for RectangleBuilder {
 }
 
 impl RectangleBuilder {
-    /// The current state as rectangle
+    /// The current state as a rectangle.
     pub fn state_as_rect(&self) -> Rectangle {
         let center = (self.start + self.current) * 0.5;
         let transform = Transform::new_w_isometry(na::Isometry2::new(center, 0.0));

--- a/rnote-compose/src/builders/shapebuilderbehaviour.rs
+++ b/rnote-compose/src/builders/shapebuilderbehaviour.rs
@@ -1,32 +1,38 @@
-use p2d::bounding_volume::Aabb;
-use std::time::Instant;
-
+// Imports
 use crate::penevents::PenEvent;
 use crate::penpath::Element;
 use crate::Constraints;
 use crate::{Shape, Style};
+use p2d::bounding_volume::Aabb;
+use std::time::Instant;
 
 #[derive(Debug, Clone)]
-/// the builder progress
+/// Builder progress.
 pub enum ShapeBuilderProgress {
-    /// in progress
+    /// In progress.
     InProgress,
-    /// emits shapes, but continue
+    /// Emit shapes, but continue.
     EmitContinue(Vec<Shape>),
-    /// done building
+    /// Done building.
     Finished(Vec<Shape>),
 }
 
-/// Creates a shape builder (separate trait because we use the ShapeBuilderBehaviour as trait object, so we can't have a method returning Self there.)
+/// Creator for a shape builder.
+///
+/// This needs to be a separate trait because ShapeBuilderBehaviour is used as trait object,
+/// so we can't have a method on it returning `Self`.
 pub trait ShapeBuilderCreator {
-    /// Start the builder
+    /// Start the builder.
     fn start(element: Element, now: Instant) -> Self;
 }
 
 /// Types that are shape builders.
-/// They receive pen events, and return built shapes. They usually are drawn while building the shape, and are state machines.
+///
+/// They receive pen events, and return built shapes.
+/// They are usually drawn while building the shape, and are finite state machines.
 pub trait ShapeBuilderBehaviour: std::fmt::Debug {
-    /// handles a pen event.
+    /// Handle a pen event.
+    ///
     /// Returns the builder progress.
     fn handle_event(
         &mut self,
@@ -35,9 +41,9 @@ pub trait ShapeBuilderBehaviour: std::fmt::Debug {
         constraints: Constraints,
     ) -> ShapeBuilderProgress;
 
-    /// the bounds
+    /// Bounds.
     fn bounds(&self, style: &Style, zoom: f64) -> Option<Aabb>;
 
-    /// draw with a style
+    /// Draw with a style.
     fn draw_styled(&self, cx: &mut piet_cairo::CairoRenderContext, style: &Style, zoom: f64);
 }

--- a/rnote-compose/src/color.rs
+++ b/rnote-compose/src/color.rs
@@ -1,22 +1,23 @@
+// Imports
 use serde::{Deserialize, Serialize};
 
-/// The threshold of the luminance of a color, deciding if a light or dark fg color is used. Between 0.0 and 1.0
+/// The threshold of the luminance of a color, deciding if a light or dark fg color is used. Between 0.0 and 1.0.
 pub const FG_LUMINANCE_THRESHOLD: f64 = 0.7;
 
 /// A rgba color
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[serde(default, rename = "color")]
 pub struct Color {
-    /// red, ranging [0.0, 1.0]
+    /// Red, ranging [0.0, 1.0].
     #[serde(rename = "r", with = "crate::serialize::f64_dp3")]
     pub r: f64,
-    /// green, ranging [0.0, 1.0]
+    /// Green, ranging [0.0, 1.0].
     #[serde(rename = "g", with = "crate::serialize::f64_dp3")]
     pub g: f64,
-    /// blue, ranging [0.0, 1.0]
+    /// Blue, ranging [0.0, 1.0].
     #[serde(rename = "b", with = "crate::serialize::f64_dp3")]
     pub b: f64,
-    /// alpha, ranging [0.0, 1.0]
+    /// Alpha, ranging [0.0, 1.0].
     #[serde(rename = "a", with = "crate::serialize::f64_dp3")]
     pub a: f64,
 }
@@ -28,7 +29,7 @@ impl Default for Color {
 }
 
 impl Color {
-    /// Transparent color with rgb set to 0.0
+    /// Transparent color with r,g,b set to 0.0.
     pub const TRANSPARENT: Self = Self {
         r: 0.0,
         g: 0.0,
@@ -36,7 +37,7 @@ impl Color {
         a: 0.0,
     };
 
-    /// Black color
+    /// Black color.
     pub const BLACK: Self = Self {
         r: 0.0,
         g: 0.0,
@@ -44,7 +45,7 @@ impl Color {
         a: 1.0,
     };
 
-    /// White color
+    /// White color.
     pub const WHITE: Self = Self {
         r: 1.0,
         g: 1.0,
@@ -52,7 +53,7 @@ impl Color {
         a: 1.0,
     };
 
-    /// Red color
+    /// Red color.
     pub const RED: Self = Self {
         r: 1.0,
         g: 0.0,
@@ -60,7 +61,7 @@ impl Color {
         a: 1.0,
     };
 
-    /// Green color
+    /// Green color.
     pub const GREEN: Self = Self {
         r: 0.0,
         g: 1.0,
@@ -68,7 +69,7 @@ impl Color {
         a: 1.0,
     };
 
-    /// Blue color
+    /// Blue color.
     pub const BLUE: Self = Self {
         r: 0.0,
         g: 0.0,
@@ -76,7 +77,7 @@ impl Color {
         a: 1.0,
     };
 
-    /// A new color from rgba values
+    /// A new color from rgba values.
     pub fn new(r: f64, g: f64, b: f64, a: f64) -> Self {
         Self {
             r: r.clamp(0.0, 1.0),
@@ -86,13 +87,15 @@ impl Color {
         }
     }
 
-    /// The luma value, in range [0.0 - 1.0]
+    /// The luma value, ranging [0.0 - 1.0].
+    ///
     /// see: <https://en.wikipedia.org/wiki/Luma_(video)>
     pub fn luma(&self) -> f64 {
         0.2126 * self.r + 0.7152 * self.g + 0.0722 * self.b
     }
 
-    /// converts to a css color attribute in the style: `rgb(xxx,xxx,xxx,xxx)`. The values are 8 bit integers, ranging [0, 255]
+    /// converts to a css color attribute in the style: `rgb(xxx,xxx,xxx,xxx)`.
+    /// The values are 8 bit integers, ranging [0, 255].
     pub fn to_css_color_attr(self) -> String {
         format!(
             "rgba({:03},{:03},{:03},{:.3})",
@@ -176,7 +179,7 @@ impl From<Color> for roughr::Srgba {
     }
 }
 
-/// Gnome palette blues
+/// Gnome palette blues.
 pub const GNOME_BLUES: [piet::Color; 5] = [
     piet::Color::rgb8(0x99, 0xc1, 0xf1),
     piet::Color::rgb8(0x62, 0xa0, 0xea),
@@ -185,7 +188,7 @@ pub const GNOME_BLUES: [piet::Color; 5] = [
     piet::Color::rgb8(0x1a, 0x5f, 0xb4),
 ];
 
-/// Gnome palette greens
+/// Gnome palette greens.
 pub const GNOME_GREENS: [piet::Color; 5] = [
     piet::Color::rgb8(0x8f, 0xf0, 0xa4),
     piet::Color::rgb8(0x57, 0xe3, 0x89),
@@ -194,7 +197,7 @@ pub const GNOME_GREENS: [piet::Color; 5] = [
     piet::Color::rgb8(0x26, 0xa2, 0x69),
 ];
 
-/// Gnome palette yellows
+/// Gnome palette yellows.
 pub const GNOME_YELLOWS: [piet::Color; 5] = [
     piet::Color::rgb8(0xf9, 0xf0, 0x6b),
     piet::Color::rgb8(0xf8, 0xe4, 0x5c),
@@ -203,7 +206,7 @@ pub const GNOME_YELLOWS: [piet::Color; 5] = [
     piet::Color::rgb8(0xe5, 0xa5, 0x0a),
 ];
 
-/// Gnome palette oranges
+/// Gnome palette oranges.
 pub const GNOME_ORANGES: [piet::Color; 5] = [
     piet::Color::rgb8(0xff, 0xbe, 0x6f),
     piet::Color::rgb8(0xff, 0xa3, 0x48),
@@ -212,7 +215,7 @@ pub const GNOME_ORANGES: [piet::Color; 5] = [
     piet::Color::rgb8(0xc6, 0x46, 0x00),
 ];
 
-/// Gnome palette reds
+/// Gnome palette reds.
 pub const GNOME_REDS: [piet::Color; 5] = [
     piet::Color::rgb8(0xf6, 0x61, 0x51),
     piet::Color::rgb8(0xed, 0x33, 0x3b),
@@ -221,7 +224,7 @@ pub const GNOME_REDS: [piet::Color; 5] = [
     piet::Color::rgb8(0xa5, 0x1d, 0x2d),
 ];
 
-/// Gnome palette purples
+/// Gnome palette purples.
 pub const GNOME_PURPLES: [piet::Color; 5] = [
     piet::Color::rgb8(0xdc, 0x8a, 0xdd),
     piet::Color::rgb8(0xc0, 0x61, 0xcb),
@@ -230,7 +233,7 @@ pub const GNOME_PURPLES: [piet::Color; 5] = [
     piet::Color::rgb8(0x61, 0x35, 0x83),
 ];
 
-/// Gnome palette browns
+/// Gnome palette browns.
 pub const GNOME_BROWNS: [piet::Color; 5] = [
     piet::Color::rgb8(0xcd, 0xab, 0x8f),
     piet::Color::rgb8(0xb5, 0x83, 0x5a),
@@ -239,7 +242,7 @@ pub const GNOME_BROWNS: [piet::Color; 5] = [
     piet::Color::rgb8(0x63, 0x45, 0x2c),
 ];
 
-/// Gnome palette brights
+/// Gnome palette brights.
 pub const GNOME_BRIGHTS: [piet::Color; 5] = [
     piet::Color::rgb8(0xff, 0xff, 0xff),
     piet::Color::rgb8(0xf6, 0xf5, 0xf4),
@@ -248,7 +251,7 @@ pub const GNOME_BRIGHTS: [piet::Color; 5] = [
     piet::Color::rgb8(0x9a, 0x99, 0x96),
 ];
 
-/// Gnome palette darks
+/// Gnome palette darks.
 pub const GNOME_DARKS: [piet::Color; 5] = [
     piet::Color::rgb8(0x77, 0x76, 0x7b),
     piet::Color::rgb8(0x5e, 0x5c, 0x64),

--- a/rnote-compose/src/constraints.rs
+++ b/rnote-compose/src/constraints.rs
@@ -1,7 +1,8 @@
+// Imports
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-/// constraints
+/// Constraints.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default, rename = "constraints")]
 pub struct Constraints {
@@ -14,7 +15,7 @@ pub struct Constraints {
 }
 
 impl Constraints {
-    /// constrain the coordinates of a vector by the current stored constraint ratios
+    /// Constrain the coordinates of a vector by the current stored constraint ratios
     pub fn constrain(&self, pos: na::Vector2<f64>) -> na::Vector2<f64> {
         if !self.enabled {
             return pos;
@@ -34,32 +35,32 @@ impl Constraints {
     }
 }
 
-/// the constraint ratio
+/// A constraint ratio.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename = "constraint_ratio")]
 pub enum ConstraintRatio {
     #[serde(rename = "horizontal")]
-    /// Horizontal axis
+    /// Horizontal axis.
     Horizontal,
     #[serde(rename = "vertical")]
-    /// Vertical axis
+    /// Vertical axis.
     Vertical,
     #[serde(rename = "one_to_one")]
-    /// 1:1 (enables drawing circles, squares, etc.)
+    /// 1:1 (enables drawing circles, squares, etc.).
     OneToOne,
     #[serde(rename = "three_to_two")]
-    /// 3:2
+    /// 3:2.
     ThreeToTwo,
     #[serde(rename = "golden")]
-    /// Golden ratio
+    /// Golden ratio.
     Golden,
 }
 
 impl ConstraintRatio {
-    /// the golden ratio
+    /// Golden ratio.
     pub const GOLDEN_RATIO: f64 = 1.618;
 
-    /// Constrain the coordinates of a vector by the constraint ratio
+    /// Constrain the coordinates of a vector by the constraint ratio.
     pub fn constrain(&self, pos: na::Vector2<f64>) -> na::Vector2<f64> {
         let dx = pos[0];
         let dy = pos[1];

--- a/rnote-compose/src/helpers.rs
+++ b/rnote-compose/src/helpers.rs
@@ -1,3 +1,4 @@
+// Imports
 use p2d::bounding_volume::Aabb;
 
 /// Helpers that extend the Vector2 type

--- a/rnote-compose/src/lib.rs
+++ b/rnote-compose/src/lib.rs
@@ -4,6 +4,7 @@
 
 //! the rnote-compose crate provides rnote with building blocks for creating, styling, composing, drawing, transforming shapes and paths.
 
+// Modules
 /// module for shape builders
 pub mod builders;
 /// colors
@@ -35,5 +36,6 @@ pub use shapes::Shape;
 pub use style::Style;
 pub use transform::Transform;
 
+// Renames
 extern crate nalgebra as na;
 extern crate parry2d_f64 as p2d;

--- a/rnote-compose/src/penevents.rs
+++ b/rnote-compose/src/penevents.rs
@@ -1,91 +1,99 @@
+// Imports
 use crate::penpath::Element;
 use serde::{Deserialize, Serialize};
 
-/// Represents a Pen Event. Note that there is no "motion" event, because we want the events to be entirely stateless.
-/// Motion event already encode state as they would only be valid if they are preceded by down events.
-/// As a result, multiple down events are emitted if the pen is pressed down and drawing. This should be handled accordingly by the state machines which receives the events.
+/// A Pen Event.
+///
+/// Note that there is no "motion" event, because we want the events to be entirely stateless.
+/// Motion event already encode state as they would only be valid if they are preceded by a down event.
+/// As a result, multiple down events are emitted while the pen is pressed down and being moved.
+/// This should be handled accordingly by the state machines which receive the events.
 #[derive(Debug, Clone)]
 pub enum PenEvent {
-    /// A pen down event. Is repeatedly emitted while the pen is pressed and moved
+    /// A pen down event. Is repeatedly emitted while the pen is pressed down and moved.
     Down {
-        /// The element for the down event
+        /// The element for the down event.
         element: Element,
-        /// pressed modifier keys pressed during the down event
+        /// Modifier keys pressed during the event.
         modifier_keys: Vec<ModifierKey>,
     },
     /// A pen up event.
     Up {
-        /// The element for the up event
+        /// The element for the up event.
         element: Element,
-        /// pressed modifier keys pressed during the up event
+        /// Modifier keys pressed during the event.
         modifier_keys: Vec<ModifierKey>,
     },
-    /// A pen down event. Is repeatedly emitted while the pen is in proximity and moved
+    /// A pen down event. Is repeatedly emitted while the pen is in proximity and moved.
     Proximity {
-        /// The element for the proximity event
+        /// The element for the proximity event.
         element: Element,
-        /// pressed modifier keys pressed during the proximity event
+        /// Modifier keys pressed during the event.
         modifier_keys: Vec<ModifierKey>,
     },
-    /// A keyboard key pressed event
+    /// A keyboard key pressed event.
     KeyPressed {
         /// the key
         keyboard_key: KeyboardKey,
-        /// pressed modifier keys pressed during the key event
+        /// Modifier keys pressed during the event.
         modifier_keys: Vec<ModifierKey>,
     },
-    /// Text input
+    /// Text input event.
     Text {
-        /// The committed text
+        /// The committed text.
         text: String,
     },
-    /// event when the pen vanishes unexpected. should reset all pending actions and state
+    /// Cancel event when the pen vanishes unexpected.
+    ///
+    /// Should finish all current actions and reset all state.
     Cancel,
 }
 
-/// A key on the keyboard
+/// A key on the keyboard.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum KeyboardKey {
-    /// a unicode character. Expects that control characters are already converted and filtered out with the method `filter_convert_unicode_control_chars`
+    /// A Unicode character.
+    ///
+    /// Expects that control characters are already converted and filtered out with the method [KeyboardKey::filter_convert_unicode_control_chars].
     Unicode(char),
-    /// backspace
+    /// Backspace.
     BackSpace,
-    /// Tab
+    /// Tab.
     HorizontalTab,
-    /// Line feed
+    /// Line feed.
     Linefeed,
-    /// Carriage return
+    /// Carriage return.
     CarriageReturn,
-    /// Escape
+    /// Escape.
     Escape,
-    /// delete
+    /// Delete.
     Delete,
-    /// Arrow up
+    /// Arrow up.
     NavUp,
-    /// Arrow down
+    /// Arrow down.
     NavDown,
-    /// Arrow left
+    /// Arrow left.
     NavLeft,
-    /// Arrow right
+    /// Arrow right.
     NavRight,
-    /// Shift left
+    /// Shift left.
     ShiftLeft,
-    /// Shift right
+    /// Shift right.
     ShiftRight,
-    /// Ctrl left
+    /// Ctrl left.
     CtrlLeft,
-    /// Ctrl right
+    /// Ctrl right.
     CtrlRight,
-    /// Home
+    /// Home.
     Home,
-    /// End
+    /// End.
     End,
-    /// Unsupported
+    /// Unsupported Key.
     Unsupported,
 }
 
 impl KeyboardKey {
-    /// Filters and converts unicode control characters to a fitting variant, or `Unsupported`
+    /// Filter and convert unicode control characters to a fitting variant, or if unsupported [KeyboardKey::Unsupported].
     pub fn filter_convert_unicode_control_chars(self) -> Self {
         match self {
             key @ Self::Unicode(keychar) => {
@@ -111,56 +119,56 @@ impl KeyboardKey {
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename = "shortcut_key")]
-/// A input shortcut key
+/// A Shortcut key.
 pub enum ShortcutKey {
-    /// the primary button of the stylus
+    /// Primary button of the stylus.
     #[serde(rename = "stylus_primary_button")]
     StylusPrimaryButton,
-    /// the secondary button of the stylus
+    /// Secondary button of the stylus.
     #[serde(rename = "stylus_secondary_button")]
     StylusSecondaryButton,
-    /// the secondary mouse button, usually right click
+    /// Secondary mouse button.
     #[serde(rename = "mouse_secondary_button")]
     MouseSecondaryButton,
-    /// Touch two finger long press gesture
+    /// Touch two finger long press gesture.
     #[serde(rename = "touch_two_finger_long_press")]
     TouchTwoFingerLongPress,
-    /// Button 0 on a drawing pad
+    /// Button 0 on a drawing pad.
     #[serde(rename = "drawing_pad_button_0")]
     DrawingPadButton0,
-    /// Button 1 on a drawing pad
+    /// Button 1 on a drawing pad.
     #[serde(rename = "drawing_pad_button_1")]
     DrawingPadButton1,
-    /// Button 2 on a drawing pad
+    /// Button 2 on a drawing pad.
     #[serde(rename = "drawing_pad_button_2")]
     DrawingPadButton2,
-    /// Button 3 on a drawing pad
+    /// Button 3 on a drawing pad.
     #[serde(rename = "drawing_pad_button_3")]
     DrawingPadButton3,
 }
 
-/// A modifier key
+/// A modifier key.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename = "modifier_key")]
 pub enum ModifierKey {
-    /// Shift
+    /// Shift.
     #[serde(rename = "keyboard_shift")]
     KeyboardShift,
-    /// Ctrl
+    /// Ctrl.
     #[serde(rename = "keyboard_ctrl")]
     KeyboardCtrl,
-    /// Alt
+    /// Alt.
     #[serde(rename = "keyboard_alt")]
     KeyboardAlt,
 }
 
-/// The current pen state. Used wherever the we have internal state
+/// The current pen state. Used wherever there is internal state.
 #[derive(Debug, Clone, Copy)]
 pub enum PenState {
-    /// Up
+    /// Up.
     Up,
-    /// Proximity
+    /// Proximity.
     Proximity,
-    /// Down
+    /// Down.
     Down,
 }

--- a/rnote-compose/src/penpath/element.rs
+++ b/rnote-compose/src/penpath/element.rs
@@ -1,17 +1,17 @@
+// Imports
+use crate::transform::TransformBehaviour;
 use p2d::bounding_volume::Aabb;
 use serde::{Deserialize, Serialize};
 
-use crate::transform::TransformBehaviour;
-
-/// A pen input element
+/// A pen input element.
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default, rename = "element")]
 pub struct Element {
     #[serde(rename = "pos", with = "crate::serialize::na_vector2_f64_dp3")]
-    /// The position of the element
+    /// The position of the element.
     pub pos: na::Vector2<f64>,
     #[serde(rename = "pressure", with = "crate::serialize::f64_dp3")]
-    /// The pen pressure. The valid range is [0.0, 1.0]
+    /// The pen pressure. The valid range is [0.0, 1.0].
     pub pressure: f64,
 }
 
@@ -39,10 +39,10 @@ impl TransformBehaviour for Element {
 }
 
 impl Element {
-    /// The default fallback pen pressure, when it could not be retrieved from the input
+    /// The default fallback pen pressure, when it could not be retrieved from the input.
     pub const PRESSURE_DEFAULT: f64 = 0.5;
 
-    /// A new element from a position and pressure
+    /// A new element from a position and pressure.
     pub fn new(pos: na::Vector2<f64>, pressure: f64) -> Self {
         Self {
             pos,
@@ -50,17 +50,19 @@ impl Element {
         }
     }
 
-    /// Sets the pressure, clamped to the range [0.0 - 1.0]
+    /// Sets the pressure, clamped to the range [0.0 - 1.0].
     pub fn set_pressure_clamped(&mut self, pressure: f64) {
         self.pressure = pressure.clamp(0.0, 1.0);
     }
 
-    /// indicates if a element is out of valid bounds and should be filtered out. Returns true if element pos is not inside the bounds
+    /// Indicates if a element is out of valid bounds and should be filtered out.
+    ///
+    /// Returns true if element pos is not inside the bounds.
     pub fn filter_by_bounds(&self, filter_bounds: Aabb) -> bool {
         !filter_bounds.contains_local_point(&na::Point2::from(self.pos))
     }
 
-    /// Transforms the element position by the transform
+    /// Transforms the element position by the given transform.
     pub fn transform_by(&mut self, transform: na::Affine2<f64>) {
         self.pos = (transform * na::Point2::from(self.pos)).coords;
     }

--- a/rnote-compose/src/penpath/mod.rs
+++ b/rnote-compose/src/penpath/mod.rs
@@ -1,17 +1,18 @@
+// Modules
 mod element;
 mod segment;
 
-// Re exports
+// Re-exports
 pub use element::Element;
-use kurbo::Shape;
 pub use segment::Segment;
 
-use p2d::bounding_volume::{Aabb, BoundingVolume};
-use serde::{Deserialize, Serialize};
-
+// Imports
 use crate::helpers::KurboHelpers;
 use crate::shapes::{CubicBezier, Line, QuadraticBezier, ShapeBehaviour};
 use crate::transform::TransformBehaviour;
+use kurbo::Shape;
+use p2d::bounding_volume::{Aabb, BoundingVolume};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename = "pen_path")]

--- a/rnote-compose/src/penpath/segment.rs
+++ b/rnote-compose/src/penpath/segment.rs
@@ -1,40 +1,40 @@
-use serde::{Deserialize, Serialize};
-
+// Imports
 use super::Element;
 use crate::transform::TransformBehaviour;
+use serde::{Deserialize, Serialize};
 
-/// A single segment (usually of a path)
+/// A single segment, usually of a pen path.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename = "segment")]
 pub enum Segment {
     #[serde(rename = "lineto", alias = "line")]
-    /// A line to segment
+    /// A line-to segment.
     LineTo {
         #[serde(rename = "end")]
-        /// The line end
+        /// The line end.
         end: Element,
     },
     #[serde(rename = "quadbezto", alias = "quadbez")]
-    /// A quadratic bezier to segment
+    /// A quadratic-bezier-to segment.
     QuadBezTo {
         #[serde(rename = "cp", with = "crate::serialize::na_vector2_f64_dp3")]
-        /// The quadratic curve control point
+        /// The quadratic curve control point.
         cp: na::Vector2<f64>,
         #[serde(rename = "end")]
-        /// The quadratic curve end
+        /// The quadratic curve end.
         end: Element,
     },
     #[serde(rename = "cubbezto", alias = "cubbez")]
-    /// A cubic bezier to segment.
+    /// A cubic-bezier-to segment.
     CubBezTo {
         #[serde(rename = "cp1", with = "crate::serialize::na_vector2_f64_dp3")]
-        /// The cubic curve first control point
+        /// The cubic curve first control point.
         cp1: na::Vector2<f64>,
         #[serde(rename = "cp2", with = "crate::serialize::na_vector2_f64_dp3")]
-        /// The cubic curve second control point
+        /// The cubic curve second control point.
         cp2: na::Vector2<f64>,
         #[serde(rename = "end")]
-        /// The cubic curve end
+        /// The cubic curve end.
         end: Element,
     },
 }
@@ -96,7 +96,9 @@ impl TransformBehaviour for Segment {
 }
 
 impl Segment {
-    /// All segments have an end
+    /// The end element of a segment.
+    ///
+    /// All segment variants have an end.
     pub fn end(&self) -> Element {
         match self {
             Segment::LineTo { end, .. } => *end,

--- a/rnote-compose/src/serialize.rs
+++ b/rnote-compose/src/serialize.rs
@@ -1,28 +1,28 @@
-// TODO: a macro would be perfect here to reduce the code repetition
+// TODO: a macro would be perfect here to reduce code repetition
 
-/// (De)Serialize a f64 rounded to 3 decimal places
+/// (De)Serialize a [f64] rounded to 3 decimal places
 pub mod f64_dp3 {
     use serde::{Deserialize, Serialize};
     use serde::{Deserializer, Serializer};
 
-    /// Serialize a f64 rounded to 3 decimal places
+    /// Serialize a [f64] rounded to 3 decimal places
     pub fn serialize<S: Serializer>(v: &f64, s: S) -> Result<S::Ok, S::Error> {
         const D: f64 = (10_u32.pow(3)) as f64;
         ((v * D).round() / D).serialize(s)
     }
 
-    /// Deserialize a f64
+    /// Deserialize a [f64]
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<f64, D::Error> {
         f64::deserialize(d)
     }
 }
 
-/// (De)Serialize a na::Vector2<f64> rounded to 3 decimal places
+/// (De)Serialize a [`na::Vector2<f64>`] rounded to 3 decimal places
 pub mod na_vector2_f64_dp3 {
     use serde::{Deserialize, Serialize};
     use serde::{Deserializer, Serializer};
 
-    /// Serialize a na::Vector2<f64> rounded to 3 decimal places
+    /// Serialize a [`na::Vector2<f64>`] rounded to 3 decimal places
     pub fn serialize<S: Serializer>(v: &na::Vector2<f64>, s: S) -> Result<S::Ok, S::Error> {
         const D: f64 = (10_u32.pow(3)) as f64;
         let mut a = v * D;
@@ -30,18 +30,18 @@ pub mod na_vector2_f64_dp3 {
         (a / D).serialize(s)
     }
 
-    /// Deserialize a na::Vector2<f64>
+    /// Deserialize a [`na::Vector2<f64>`]
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<na::Vector2<f64>, D::Error> {
         na::Vector2::<f64>::deserialize(d)
     }
 }
 
-/// (De)Serialize a na::Affine2<f64> rounded to 3 decimal places
+/// (De)Serialize a [`na::Affine2<f64>`] rounded to 3 decimal places
 pub mod na_affine2_f64_dp3 {
     use serde::{Deserialize, Serialize};
     use serde::{Deserializer, Serializer};
 
-    /// Serialize a na::Vector2<f64> rounded to 3 decimal places
+    /// Serialize a [`na::Vector2<f64>`] rounded to 3 decimal places
     pub fn serialize<S: Serializer>(v: &na::Affine2<f64>, s: S) -> Result<S::Ok, S::Error> {
         const D: f64 = (10_u32.pow(3)) as f64;
         let mut a = v.into_inner() * D;
@@ -53,18 +53,18 @@ pub mod na_affine2_f64_dp3 {
         na::Affine2::<f64>::from_matrix_unchecked(a / D).serialize(s)
     }
 
-    /// Deserialize a na::Vector2<f64>
+    /// Deserialize a [`na::Vector2<f64>`]
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<na::Affine2<f64>, D::Error> {
         na::Affine2::<f64>::deserialize(d)
     }
 }
 
-/// (De)Serialize a p2d::shape::Cuboid rounded to 3 decimal places
+/// (De)Serialize a [p2d::shape::Cuboid] rounded to 3 decimal places
 pub mod p2d_cuboid_dp3 {
     use serde::{Deserialize, Serialize};
     use serde::{Deserializer, Serializer};
 
-    /// Serialize a p2d::shape::Cuboid rounded to 3 decimal places
+    /// Serialize a [p2d::shape::Cuboid] rounded to 3 decimal places
     pub fn serialize<S: Serializer>(v: &p2d::shape::Cuboid, s: S) -> Result<S::Ok, S::Error> {
         const D: f64 = (10_u32.pow(3)) as f64;
         let mut a = v.half_extents * D;
@@ -72,24 +72,24 @@ pub mod p2d_cuboid_dp3 {
         p2d::shape::Cuboid::new(a / D).serialize(s)
     }
 
-    /// Deserialize a p2d::shape::Cuboid
+    /// Deserialize a [p2d::shape::Cuboid]
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<p2d::shape::Cuboid, D::Error> {
         p2d::shape::Cuboid::deserialize(d)
     }
 }
 
-/// (De)Serialize a Vec<u8> with base64 encoding
+/// (De)Serialize a [`Vec<u8>`] with base64 encoding
 pub mod vecu8_base64 {
     use base64::Engine;
     use serde::{Deserialize, Serialize};
     use serde::{Deserializer, Serializer};
 
-    /// Serialize a Vec<u8> as base64 encoded
+    /// Serialize a [`Vec<u8>`] as base64 encoded
     pub fn serialize<S: Serializer>(v: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
         String::serialize(&base64::engine::general_purpose::STANDARD.encode(v), s)
     }
 
-    /// Deserialize base64 encoded Vec<u8>
+    /// Deserialize base64 encoded [`Vec<u8>`]
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
         base64::engine::general_purpose::STANDARD
             .decode(String::deserialize(d)?.as_bytes())

--- a/rnote-compose/src/shapes/arrow.rs
+++ b/rnote-compose/src/shapes/arrow.rs
@@ -1,17 +1,17 @@
+// Imports
+use super::Line;
+use crate::helpers::Vector2Helpers;
+use crate::shapes::ShapeBehaviour;
+use crate::transform::TransformBehaviour;
 use kurbo::PathEl;
 use na::Rotation2;
 use p2d::bounding_volume::Aabb;
 use serde::{Deserialize, Serialize};
 
-use crate::helpers::Vector2Helpers;
-use crate::shapes::ShapeBehaviour;
-use crate::transform::TransformBehaviour;
-
-use super::Line;
-
-/// All doc-comments of this file and [`ArrowBuilder`] rely on the following
+/// All doc-comments of this file and [ArrowBuilder][crate::builders] rely on the following
 /// graphic:
-/// ```
+///
+/// ```text
 ///         tip
 ///         /|\
 ///        / | \
@@ -22,14 +22,16 @@ use super::Line;
 ///          |
 ///         start
 /// ```
+///
 /// Where `lline`, `tip`, `start` and `rline` represent a vector of the arrow.
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default, rename = "arrow")]
 pub struct Arrow {
-    /// The start of the arrow
+    /// Start of the arrow.
     pub start: na::Vector2<f64>,
 
-    /// The tip of the arow
+    /// Tip of the arow.
     pub tip: na::Vector2<f64>,
 }
 
@@ -88,7 +90,7 @@ impl Arrow {
         Self { start, tip }
     }
 
-    /// Splits the stem of the arrow into the given number of lines.
+    /// Split the stem of the arrow into the given number of lines.
     pub fn split(&self, n_splits: i32) -> Vec<Line> {
         (0..n_splits)
             .map(|i| {
@@ -107,7 +109,7 @@ impl Arrow {
             .collect::<Vec<Line>>()
     }
 
-    /// convert the arrow to kurbo-elements.
+    /// Convert to kurbo shapes.
     pub fn to_kurbo(&self, stroke_width: Option<f64>) -> ArrowKurbo {
         let main = kurbo::Line::new(self.start.to_kurbo_point(), self.tip.to_kurbo_point());
         let tip_triangle = {
@@ -128,7 +130,8 @@ impl Arrow {
         }
     }
 
-    /// Computes and returns `lline`.
+    /// Compute the `lline` of the arrow tip.
+    ///
     /// Optionally add the stroke width to adjust the length of the line.
     pub fn compute_lline(&self, stroke_width: Option<f64>) -> na::Vector2<f64> {
         let vec_a =
@@ -138,7 +141,8 @@ impl Arrow {
         rotation_matrix * vec_a + self.tip
     }
 
-    /// Computes and returns `rline`.
+    /// Compute the `rline` of the arrow tip.
+    ///
     /// Optionally add the stroke width to adjust the length of the line.
     pub fn compute_rline(&self, stroke_width: Option<f64>) -> na::Vector2<f64> {
         let vec_b =
@@ -148,7 +152,7 @@ impl Arrow {
         rotation_matrix * vec_b + self.tip
     }
 
-    /// Computes the bounds of the arrow in respect to the given stroke width.
+    /// Compute the bounds of the arrow in respect to the given stroke width.
     pub fn internal_compute_bounds(&self, stroke_width: Option<f64>) -> Aabb {
         let points: Vec<na::Point2<f64>> = {
             let lline = self.compute_lline(stroke_width);
@@ -163,8 +167,7 @@ impl Arrow {
         Aabb::from_points(&points)
     }
 
-    /// Computes and returns the normalized direction vector from `start` to
-    /// `tip`.
+    /// Compute the normalized direction vector from `start` to `tip`.
     fn compute_stem_direction_vector(&self) -> na::Vector2<f64> {
         let direction_vector = self.tip - self.start;
 
@@ -175,8 +178,9 @@ impl Arrow {
         }
     }
 
-    /// Computes and returns the length of the tip lines with the given stroke
-    /// width.
+    /// Compute the length of the tip lines.
+    ///
+    /// Optionally add the stroke width to adjust the length of the line.
     fn compute_tip_lines_length(stroke_width: Option<f64>) -> f64 {
         let factor = stroke_width.unwrap_or(0.0);
         Self::TIP_LINES_DEFAULT_LENGTH * (1.0 + 0.18 * factor)
@@ -186,9 +190,8 @@ impl Arrow {
 /// A helper struct which holds the kurbo-elements of the arrow.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ArrowKurbo {
-    /// This holds the line from `start` -> `tip`.
+    /// The line from `start` -> `tip`.
     pub stem: kurbo::Line,
-
-    /// This holds the line from `lline` -> `tip` -> `rline`.
+    /// The line from `lline` -> `tip` -> `rline`.
     pub tip_triangle: kurbo::BezPath,
 }

--- a/rnote-compose/src/shapes/cubbez.rs
+++ b/rnote-compose/src/shapes/cubbez.rs
@@ -1,29 +1,28 @@
+// Imports
+use super::line::Line;
+use super::quadbez::QuadraticBezier;
+use crate::helpers::{KurboHelpers, Vector2Helpers};
+use crate::shapes::ShapeBehaviour;
+use crate::transform::TransformBehaviour;
 use kurbo::Shape;
 use p2d::bounding_volume::Aabb;
 use serde::{Deserialize, Serialize};
 
-use crate::helpers::{KurboHelpers, Vector2Helpers};
-use crate::shapes::ShapeBehaviour;
-use crate::transform::TransformBehaviour;
-
-use super::line::Line;
-use super::quadbez::QuadraticBezier;
-
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 #[serde(default, rename = "cubic_bezier")]
-/// A cubic bezier curve
+/// A cubic bezier curve.
 pub struct CubicBezier {
     #[serde(rename = "start", with = "crate::serialize::na_vector2_f64_dp3")]
-    /// the cubic curve start
+    /// Start coordinate.
     pub start: na::Vector2<f64>,
     #[serde(rename = "cp1", with = "crate::serialize::na_vector2_f64_dp3")]
-    /// the cubic curve first control point
+    /// First control point coordinate.
     pub cp1: na::Vector2<f64>,
     #[serde(rename = "cp2", with = "crate::serialize::na_vector2_f64_dp3")]
-    /// the cubic curve second control point
+    /// Second control point coordinate.
     pub cp2: na::Vector2<f64>,
     #[serde(rename = "end", with = "crate::serialize::na_vector2_f64_dp3")]
-    /// the cubic curve end
+    /// End coordinate.
     pub end: na::Vector2<f64>,
 }
 
@@ -69,8 +68,10 @@ impl ShapeBehaviour for CubicBezier {
 }
 
 impl CubicBezier {
-    /// tries to create a new cubic curve with the catmull-rom spline algorithm. Subsequent curves ( meaning, advancing the elements by one) have a smooth transition between them.
-    /// See 'Conversion between Cubic Bezier Curves and Catmull-Rom Splines'
+    /// Attempts to create a new cubic curve with the catmull-rom spline algorithm.
+    /// Subsequent curves ( meaning, advancing the elements by one) have a smooth transition between them.
+    ///
+    /// See 'Conversion between Cubic Bezier Curves and Catmull-Rom Splines'.
     pub fn new_w_catmull_rom(
         first: na::Vector2<f64>,
         second: na::Vector2<f64>,
@@ -101,7 +102,7 @@ impl CubicBezier {
         Some(cubbez)
     }
 
-    /// Split a cubic bezier into two at t where t > 0.0, < 1.0
+    /// Split a cubic bezier into two at t where t in [0.0 - 1.0].
     pub fn split(&self, t: f64) -> (CubicBezier, CubicBezier) {
         let a0 = self.start;
         let a1 = self.cp1;
@@ -131,7 +132,7 @@ impl CubicBezier {
         )
     }
 
-    /// Approximating a cubic bezier with a quadratic bezier
+    /// Approximate a cubic with a quadratic bezier curve.
     pub fn approx_with_quadbez(&self) -> QuadraticBezier {
         let start = self.start;
         let cp = self.cp1.lerp(&self.cp2, 0.5);
@@ -140,7 +141,7 @@ impl CubicBezier {
         QuadraticBezier { start, cp, end }
     }
 
-    /// Approximating a cubic bezier with lines, given the number of splits
+    /// Approximate a cubic bezier with lines, given the number of splits.
     pub fn approx_with_lines(&self, n_splits: i32) -> Vec<Line> {
         let mut lines = Vec::new();
 
@@ -157,7 +158,7 @@ impl CubicBezier {
         lines
     }
 
-    /// to kurbo
+    /// Convert to kurbo shape.
     pub fn to_kurbo(&self) -> kurbo::CubicBez {
         kurbo::CubicBez::new(
             self.start.to_kurbo_point(),
@@ -168,7 +169,7 @@ impl CubicBezier {
     }
 }
 
-/// Calculates a point on a cubic curve given t ranging [0.0, 1.0]
+/// Calculate a point on a cubic curve given t ranging [0.0, 1.0].
 pub fn cubbez_calc(
     p0: na::Vector2<f64>,
     p1: na::Vector2<f64>,

--- a/rnote-compose/src/shapes/ellipse.rs
+++ b/rnote-compose/src/shapes/ellipse.rs
@@ -1,22 +1,21 @@
-use kurbo::Shape;
-use p2d::bounding_volume::Aabb;
-use serde::{Deserialize, Serialize};
-
+// Imports
+use super::Line;
 use crate::helpers::{Affine2Helpers, Vector2Helpers};
 use crate::shapes::ShapeBehaviour;
 use crate::transform::TransformBehaviour;
 use crate::Transform;
-
-use super::Line;
+use kurbo::Shape;
+use p2d::bounding_volume::Aabb;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename = "ellipse")]
-/// A Ellipse
+/// An Ellipse.
 pub struct Ellipse {
-    /// The radii of the ellipse
+    /// The radii of the ellipse.
     #[serde(rename = "radii", with = "crate::serialize::na_vector2_f64_dp3")]
     pub radii: na::Vector2<f64>,
-    /// The transform of the  center of the ellipse
+    /// The transform of the center of the ellipse.
     #[serde(rename = "transform")]
     pub transform: Transform,
 }
@@ -88,7 +87,7 @@ impl Ellipse {
         Self { radii, transform }
     }
 
-    /// Approximate with lines
+    /// Approximate with lines.
     pub fn approx_with_lines(&self) -> Vec<Line> {
         let mut lines = Vec::new();
         let mut prev = kurbo::Point::new(0.0, 0.0);
@@ -108,7 +107,7 @@ impl Ellipse {
         lines
     }
 
-    /// to kurbo
+    /// Convert to kurbo shape.
     pub fn to_kurbo(&self) -> kurbo::Ellipse {
         self.transform.affine.to_kurbo()
             * kurbo::Ellipse::new(kurbo::Point::ZERO, self.radii.to_kurbo_vec(), 0.0)

--- a/rnote-compose/src/shapes/line.rs
+++ b/rnote-compose/src/shapes/line.rs
@@ -1,21 +1,21 @@
-use p2d::bounding_volume::Aabb;
-use serde::{Deserialize, Serialize};
-
+// Imports
 use crate::helpers::{AabbHelpers, Vector2Helpers};
 use crate::shapes::Rectangle;
 use crate::shapes::ShapeBehaviour;
 use crate::transform::TransformBehaviour;
 use crate::Transform;
+use p2d::bounding_volume::Aabb;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 #[serde(default, rename = "line")]
-/// A line
+/// A line.
 pub struct Line {
     #[serde(rename = "start", with = "crate::serialize::na_vector2_f64_dp3")]
-    /// The line start
+    /// Start coordinate.
     pub start: na::Vector2<f64>,
     #[serde(rename = "end", with = "crate::serialize::na_vector2_f64_dp3")]
-    /// The line end
+    /// End coordinate.
     pub end: na::Vector2<f64>,
 }
 
@@ -55,7 +55,7 @@ impl ShapeBehaviour for Line {
 }
 
 impl Line {
-    /// creates a rect in the direction of the line, with a constant given width
+    /// Create a rectangle rotated in the direction of the line, with the given width.
     pub fn line_w_width_to_rect(&self, width: f64) -> Rectangle {
         let vec = self.end - self.start;
         let magn = vec.magnitude();
@@ -67,7 +67,7 @@ impl Line {
         }
     }
 
-    /// Splits itself given the no splits
+    /// Split itself given the number of splits.
     pub fn split(&self, n_splits: i32) -> Vec<Self> {
         (0..n_splits)
             .map(|i| {
@@ -86,7 +86,7 @@ impl Line {
             .collect::<Vec<Self>>()
     }
 
-    /// to kurbo
+    /// Convert to kurbo shape.
     pub fn to_kurbo(&self) -> kurbo::Line {
         kurbo::Line::new(self.start.to_kurbo_point(), self.end.to_kurbo_point())
     }

--- a/rnote-compose/src/shapes/mod.rs
+++ b/rnote-compose/src/shapes/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 mod arrow;
 /// cubic bezier curves
 pub mod cubbez;
@@ -19,9 +20,8 @@ pub use rectangle::Rectangle;
 pub use shape::Shape;
 pub use shapebehaviour::ShapeBehaviour;
 
-/// Calculates the number hitbox elems for the given length ( e.g. length of a line, curve, etc.)
+/// Calculate the number hitbox elems for the given length ( e.g. length of a line, curve, etc.).
 fn hitbox_elems_for_shape_len(len: f64) -> i32 {
-    // Maximum hitbox diagonal length
     const MAX_HITBOX_DIAGONAL: f64 = 15.0;
 
     ((len / MAX_HITBOX_DIAGONAL).ceil() as i32).max(1)

--- a/rnote-compose/src/shapes/quadbez.rs
+++ b/rnote-compose/src/shapes/quadbez.rs
@@ -1,26 +1,25 @@
+// Imports
+use super::line::Line;
+use super::CubicBezier;
+use crate::helpers::{KurboHelpers, Vector2Helpers};
+use crate::shapes::ShapeBehaviour;
+use crate::transform::TransformBehaviour;
 use kurbo::Shape;
 use p2d::bounding_volume::Aabb;
 use serde::{Deserialize, Serialize};
 
-use crate::helpers::{KurboHelpers, Vector2Helpers};
-use crate::shapes::ShapeBehaviour;
-use crate::transform::TransformBehaviour;
-
-use super::line::Line;
-use super::CubicBezier;
-
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 #[serde(default, rename = "quadratic_bezier")]
-/// A quadratic bezier curve
+/// A quadratic bezier curve.
 pub struct QuadraticBezier {
     #[serde(rename = "start", with = "crate::serialize::na_vector2_f64_dp3")]
-    /// The curve start
+    /// Start coordinates.
     pub start: na::Vector2<f64>,
     #[serde(rename = "cp", with = "crate::serialize::na_vector2_f64_dp3")]
-    /// The curve control point
+    /// Control point coordinates.
     pub cp: na::Vector2<f64>,
     #[serde(rename = "end", with = "crate::serialize::na_vector2_f64_dp3")]
-    /// The curve end
+    /// End coordinates.
     pub end: na::Vector2<f64>,
 }
 
@@ -63,7 +62,7 @@ impl ShapeBehaviour for QuadraticBezier {
 }
 
 impl QuadraticBezier {
-    /// Split a quadratic bezier curve into two quadratics, at interpolation value z: between 0.0 and 1.0
+    /// Split itself into two quadratic bezier curves, at interpolation value z ranging [0.0 - 1.0].
     pub fn split(&self, z: f64) -> (QuadraticBezier, QuadraticBezier) {
         let p0 = self.start;
         let p1 = self.cp;
@@ -84,7 +83,7 @@ impl QuadraticBezier {
         (first_split, second_split)
     }
 
-    /// convert to a cubic bezier ( raising the order is without losses)
+    /// Convert to a cubic bezier (raising the order of a bezier curve is without losses).
     pub fn to_cubic_bezier(&self) -> CubicBezier {
         CubicBezier {
             start: self.start,
@@ -94,7 +93,7 @@ impl QuadraticBezier {
         }
     }
 
-    /// Approximating a quadratic bezier with lines, given the number of splits distributed evenly based on the t value.
+    /// Approximate with lines, given the number of splits.
     pub fn approx_with_lines(&self, n_splits: i32) -> Vec<Line> {
         let mut lines = Vec::new();
 
@@ -111,7 +110,7 @@ impl QuadraticBezier {
         lines
     }
 
-    /// to kurbo
+    /// Convert to kurbo shape.
     pub fn to_kurbo(&self) -> kurbo::QuadBez {
         kurbo::QuadBez::new(
             self.start.to_kurbo_point(),

--- a/rnote-compose/src/shapes/rectangle.rs
+++ b/rnote-compose/src/shapes/rectangle.rs
@@ -1,22 +1,21 @@
-use p2d::bounding_volume::Aabb;
-use serde::{Deserialize, Serialize};
-
+// Imports
+use super::Line;
 use crate::helpers::{AabbHelpers, Vector2Helpers};
 use crate::shapes::ShapeBehaviour;
 use crate::transform::TransformBehaviour;
 use crate::Transform;
-
-use super::Line;
+use p2d::bounding_volume::Aabb;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(default, rename = "rectangle")]
-/// A rectangle
+/// A rectangle.
 pub struct Rectangle {
     #[serde(rename = "cuboid", with = "crate::serialize::p2d_cuboid_dp3")]
     /// The cuboid, specifies the extents.
     pub cuboid: p2d::shape::Cuboid,
     #[serde(rename = "transform")]
-    /// The transform of the center of the cuboid
+    /// The transform of the center of the cuboid.
     pub transform: Transform,
 }
 
@@ -66,7 +65,7 @@ impl TransformBehaviour for Rectangle {
 }
 
 impl Rectangle {
-    /// From center and half extents
+    /// Construct from center and half extents
     pub fn from_half_extents(center: na::Vector2<f64>, half_extents: na::Vector2<f64>) -> Self {
         let cuboid = p2d::shape::Cuboid::new(half_extents);
         let transform = Transform::new_w_isometry(na::Isometry2::new(center, 0.0));
@@ -74,7 +73,7 @@ impl Rectangle {
         Self { cuboid, transform }
     }
 
-    /// From corners (across from each other)
+    /// Construct from corners across from each other.
     pub fn from_corners(first: na::Vector2<f64>, second: na::Vector2<f64>) -> Self {
         let half_extents = (second - first).abs() * 0.5;
         let center = first + (second - first) * 0.5;
@@ -85,7 +84,7 @@ impl Rectangle {
         Self { cuboid, transform }
     }
 
-    /// New from bounds
+    /// Construct from bounds.
     pub fn from_p2d_aabb(mut bounds: Aabb) -> Self {
         bounds.ensure_positive();
         let cuboid = p2d::shape::Cuboid::new(bounds.half_extents());
@@ -94,7 +93,7 @@ impl Rectangle {
         Self { cuboid, transform }
     }
 
-    /// The outline lines of the rect
+    /// The outlines of the rect.
     pub fn outline_lines(&self) -> [Line; 4] {
         let upper_left = self.transform.transform_point(na::point![
             -self.cuboid.half_extents[0],
@@ -133,7 +132,7 @@ impl Rectangle {
         ]
     }
 
-    /// to kurbo
+    /// Convert to kurbo shape.
     pub fn to_kurbo(&self) -> kurbo::BezPath {
         let tl = self.transform.affine
             * na::point![-self.cuboid.half_extents[0], -self.cuboid.half_extents[1]];

--- a/rnote-compose/src/shapes/shape.rs
+++ b/rnote-compose/src/shapes/shape.rs
@@ -1,31 +1,30 @@
+// Imports
+use super::{Arrow, CubicBezier, Ellipse, Line, QuadraticBezier, Rectangle, ShapeBehaviour};
+use crate::transform::TransformBehaviour;
 use p2d::bounding_volume::Aabb;
 use serde::{Deserialize, Serialize};
 
-use super::{Arrow, CubicBezier, Ellipse, Line, QuadraticBezier, Rectangle, ShapeBehaviour};
-use crate::transform::TransformBehaviour;
-
-// Container type to store shapes
+/// Shape, storing shape variants.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename = "shape")]
-/// A Shape type, holding the actual shape inside it
 pub enum Shape {
     #[serde(rename = "line")]
-    /// A line shape
+    /// A line shape.
     Line(Line),
     #[serde(rename = "arrow")]
-    /// An arrow shape
+    /// An arrow shape.
     Arrow(Arrow),
     #[serde(rename = "rect")]
-    /// A rectangle shape
+    /// A rectangle shape.
     Rectangle(Rectangle),
     #[serde(rename = "ellipse")]
-    /// An ellipse shape
+    /// An ellipse shape.
     Ellipse(Ellipse),
     #[serde(rename = "quadbez")]
-    /// A quadratic bezier curve shape
+    /// A quadratic bezier curve shape.
     QuadraticBezier(QuadraticBezier),
     #[serde(rename = "cubbez")]
-    /// A cubic bezier curve shape
+    /// A cubic bezier curve shape.
     CubicBezier(CubicBezier),
 }
 

--- a/rnote-compose/src/shapes/shapebehaviour.rs
+++ b/rnote-compose/src/shapes/shapebehaviour.rs
@@ -1,18 +1,18 @@
+// Imports
+use crate::transform::TransformBehaviour;
 use p2d::bounding_volume::Aabb;
 
-use crate::transform::TransformBehaviour;
-
-/// types that behave as a shape
+/// Types that behave as a shape.
 pub trait ShapeBehaviour: TransformBehaviour {
-    /// The bounds of the shape
+    /// The bounds of the shape.
     fn bounds(&self) -> Aabb;
-    /// The hitboxes of the shape
+    /// The hitboxes of the shape.
     fn hitboxes(&self) -> Vec<Aabb>;
-    /// The absolute position of the types upper-left corner
+    /// The absolute position of the types upper-left corner.
     fn pos(&self) -> na::Vector2<f64> {
         self.bounds().mins.coords
     }
-    /// Set the absolute position of the types upper-left corner
+    /// Set the absolute position of the types upper-left corner.
     fn set_pos(&mut self, pos: na::Vector2<f64>) {
         self.translate(-self.pos());
         self.translate(pos)

--- a/rnote-compose/src/style/composer.rs
+++ b/rnote-compose/src/style/composer.rs
@@ -1,13 +1,14 @@
+// Imports
 use p2d::bounding_volume::Aabb;
 
-/// Specifies that the implementing type can be composed and drawn with a style
+/// Trait for types can be composed and drawn with a style.
 pub trait Composer<O>
 where
     O: std::fmt::Debug + Clone,
 {
-    /// the bounds of the composed shape.
+    /// Bounds of the composed shape.
     fn composed_bounds(&self, options: &O) -> Aabb;
 
-    /// composes and draws the shape onto the context, applying the style options to it.
+    /// Composes and draws the type onto the context, applying the style options to it.
     fn draw_composed(&self, cx: &mut impl piet::RenderContext, options: &O);
 }

--- a/rnote-compose/src/style/indicators.rs
+++ b/rnote-compose/src/style/indicators.rs
@@ -1,21 +1,21 @@
 //! Helpers for drawing indicators, edit nodes, guides, etc.
 
+// Imports
+use crate::color;
+use crate::helpers::{AabbHelpers, Vector2Helpers};
+use crate::penevents::PenState;
 use once_cell::sync::Lazy;
 use p2d::bounding_volume::{Aabb, BoundingSphere, BoundingVolume};
 use piet::RenderContext;
 
-use crate::color;
-use crate::helpers::{AabbHelpers, Vector2Helpers};
-use crate::penevents::PenState;
+// Pos indicator
 
-/// ## Pos indicator
-
-/// the radius
+/// Position indicator radius.
 pub const POS_INDICATOR_RADIUS: f64 = 3.0;
-/// the outline width
+/// Position indicator outline width.
 pub const POS_INDICATOR_OUTLINE_WIDTH: f64 = 1.5;
 
-/// the pos indicator shape
+/// Position indicator shape.
 pub fn pos_indicator_shape(
     _node_state: PenState,
     pos: na::Vector2<f64>,
@@ -27,7 +27,7 @@ pub fn pos_indicator_shape(
     )
 }
 
-/// Draw a position indicator
+/// Draw a position indicator.
 pub fn draw_pos_indicator(
     cx: &mut impl RenderContext,
     node_state: PenState,
@@ -53,12 +53,12 @@ pub fn draw_pos_indicator(
     );
 }
 
-/// ## Vec indicator
+// Vec indicator
 
-/// the line width
+/// Vector indicator line width.
 pub const VEC_INDICATOR_LINE_WIDTH: f64 = 1.5;
 
-/// vec indicator shape
+/// Vector indicator shape.
 pub fn vec_indicator_shape(
     _node_state: PenState,
     start: na::Vector2<f64>,
@@ -68,7 +68,7 @@ pub fn vec_indicator_shape(
     kurbo::Line::new(start.to_kurbo_point(), end.to_kurbo_point())
 }
 
-/// Draw a vec indicator
+/// Draw a vector indicator.
 pub fn draw_vec_indicator(
     cx: &mut impl RenderContext,
     node_state: PenState,
@@ -87,12 +87,12 @@ pub fn draw_vec_indicator(
     cx.stroke(vec_indicator, &line_color, VEC_INDICATOR_LINE_WIDTH / zoom);
 }
 
-/// ## Rectangular node
+// Rectangular node
 
-/// the outline width
+/// Rectangular node outline width.
 pub const RECTANGULAR_NODE_OUTLINE_WIDTH: f64 = 1.5;
 
-/// Return the rectangular node shape
+/// Rectangular node shape.
 pub fn rectangular_node_shape(
     _node_state: PenState,
     bounds: Aabb,
@@ -108,7 +108,7 @@ pub fn rectangular_node_shape(
     )
 }
 
-/// Draw a rectangular node
+/// Draw a rectangular node.
 pub fn draw_rectangular_node(
     cx: &mut impl RenderContext,
     node_state: PenState,
@@ -139,12 +139,12 @@ pub fn draw_rectangular_node(
     );
 }
 
-/// ## Circular Node
+/// Circular Node
 
-/// the outline width
+/// Circular node outline width.
 pub const CIRCULAR_NODE_OUTLINE_WIDTH: f64 = 1.5;
 
-/// circular node shape
+/// circular node shape.
 pub fn circular_node_shape(
     _node_state: PenState,
     mut bounding_sphere: BoundingSphere,
@@ -158,7 +158,7 @@ pub fn circular_node_shape(
     )
 }
 
-/// Draw a circular node
+/// Draw a circular node.
 pub fn draw_circular_node(
     cx: &mut impl RenderContext,
     node_state: PenState,
@@ -189,12 +189,12 @@ pub fn draw_circular_node(
     }
 }
 
-/// ## Triangular down node
+// Triangular down node
 
-/// the outline width
+/// Triangular node outline width.
 pub const TRIANGULAR_DOWN_NODE_OUTLINE_WIDTH: f64 = 1.5;
 
-/// circular node shape
+/// Triangular node shape.
 pub fn triangular_down_node_shape(
     _node_state: PenState,
     center: na::Vector2<f64>,
@@ -222,8 +222,8 @@ pub fn triangular_down_node_shape(
     )
 }
 
-/// Draw a triangular down node
-pub fn draw_triangular_down_node(
+/// Draw a triangular node.
+pub fn draw_triangular_node(
     cx: &mut impl RenderContext,
     node_state: PenState,
     center: na::Vector2<f64>,

--- a/rnote-compose/src/style/mod.rs
+++ b/rnote-compose/src/style/mod.rs
@@ -1,3 +1,5 @@
+// Modules
+/// Composer
 mod composer;
 /// Draw helpers
 pub mod indicators;
@@ -8,19 +10,20 @@ pub mod smooth;
 /// The textured module for textured styles
 pub mod textured;
 
-// Re exports
+// Re-exports
 use self::rough::RoughOptions;
 use self::smooth::SmoothOptions;
 use self::textured::TexturedOptions;
-use anyhow::Context;
-pub use composer::Composer;
 
+// Imports
 use crate::shapes::{Arrow, CubicBezier, Ellipse, Line, QuadraticBezier, Rectangle};
 use crate::{Color, PenPath, Shape};
+use anyhow::Context;
+pub use composer::Composer;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// A style choice holding the style options inside its variants
+/// A style choice holding the style options inside its variants.
 #[serde(rename = "style")]
 pub enum Style {
     /// A smooth style
@@ -41,7 +44,7 @@ impl Default for Style {
 }
 
 impl Style {
-    /// returns the stroke width. available on all styles
+    /// The stroke width. Available on all styles.
     pub fn stroke_width(&self) -> f64 {
         match self {
             Style::Smooth(options) => options.stroke_width,
@@ -50,7 +53,7 @@ impl Style {
         }
     }
 
-    /// The margins for bounds in which the shape fits
+    /// The margins for bounds which contain the shape.
     pub fn bounds_margin(&self) -> f64 {
         match self {
             Style::Smooth(options) => options.stroke_width,
@@ -59,7 +62,7 @@ impl Style {
         }
     }
 
-    /// Advances the seed for styles that have one
+    /// Advances the seed for styles that have one.
     pub fn advance_seed(&mut self) {
         match self {
             Style::Smooth(_) => {}
@@ -68,7 +71,7 @@ impl Style {
         }
     }
 
-    /// Sets the stroke color of the style
+    /// Set the stroke color of the style.
     pub fn set_stroke_color(&mut self, color: Color) {
         match self {
             Style::Smooth(options) => options.stroke_color = Some(color),
@@ -77,7 +80,7 @@ impl Style {
         };
     }
 
-    /// Sets the fill color of the style
+    /// Set the fill color of the style.
     pub fn set_fill_color(&mut self, color: Color) {
         match self {
             Style::Smooth(options) => options.fill_color = Some(color),
@@ -237,28 +240,28 @@ impl Composer<Style> for Shape {
     }
 }
 
-/// The pressure curve used by some styles
+/// The pressure curve used by some styles.
 #[derive(
     Debug, Clone, Copy, Serialize, Deserialize, num_derive::FromPrimitive, num_derive::ToPrimitive,
 )]
 #[serde(rename = "pressure_curve")]
 pub enum PressureCurve {
-    /// Constant
+    /// Constant.
     #[serde(rename = "const")]
     Const = 0,
-    /// linear
+    /// Linear.
     #[serde(rename = "linear")]
     Linear,
-    /// square root
+    /// Square root.
     #[serde(rename = "sqrt")]
     Sqrt,
-    /// cubic root
+    /// Cubic root.
     #[serde(rename = "cbrt")]
     Cbrt,
-    /// quadratic polynomial
+    /// Quadratic polynomial.
     #[serde(rename = "pow2")]
     Pow2,
-    /// cubic polynomial
+    /// Cubic polynomial.
     #[serde(rename = "pow3")]
     Pow3,
 }
@@ -270,7 +273,9 @@ impl Default for PressureCurve {
 }
 
 impl PressureCurve {
-    /// Expects pressure to be between range 0.0 to 1.0
+    /// Apply the pressure curve to a width and the given pressure.
+    ///
+    /// Expects pressure to be between range [0.0 - 1.0].
     pub fn apply(&self, width: f64, pressure: f64) -> f64 {
         match self {
             Self::Const => width,

--- a/rnote-compose/src/style/rough/mod.rs
+++ b/rnote-compose/src/style/rough/mod.rs
@@ -1,11 +1,11 @@
+// Modules
 /// The module for the rough style.
 pub mod roughoptions;
 
-use p2d::bounding_volume::{Aabb, BoundingVolume};
 // Re-exports
 pub use roughoptions::RoughOptions;
-use roughr::Point2D;
 
+// Imports
 use super::Composer;
 use crate::helpers::Vector2Helpers;
 use crate::shapes::Arrow;
@@ -14,6 +14,8 @@ use crate::shapes::Rectangle;
 use crate::shapes::{CubicBezier, ShapeBehaviour};
 use crate::shapes::{Ellipse, QuadraticBezier};
 use crate::Color;
+use p2d::bounding_volume::{Aabb, BoundingVolume};
+use roughr::Point2D;
 
 fn generate_roughr_options(options: &RoughOptions) -> roughr::core::Options {
     let mut roughr_options = roughr::core::OptionsBuilder::default();

--- a/rnote-compose/src/style/rough/roughoptions.rs
+++ b/rnote-compose/src/style/rough/roughoptions.rs
@@ -1,28 +1,28 @@
+// Imports
+use crate::Color;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
-use crate::Color;
-
-/// The rough options
+/// Options for shapes that can be drawn in a rough style.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename = "rough_options")]
 pub struct RoughOptions {
-    /// the stroke color. When set to None, no stroke outline is produced
+    /// Stroke color. When set to None, the stroke outline is not drawn.
     #[serde(rename = "stroke_color")]
     pub stroke_color: Option<Color>,
-    /// the stroke width
+    /// Stroke width.
     #[serde(rename = "stroke_width", with = "crate::serialize::f64_dp3")]
     pub stroke_width: f64,
-    /// an optional fill color. When set to None no fill is produced.
+    /// Fill color. When set to None the fill is not drawn.
     #[serde(rename = "fill_color")]
     pub fill_color: Option<Color>,
-    /// the fill style
+    /// Fill style.
     #[serde(rename = "fill_style")]
     pub fill_style: FillStyle,
-    /// the hachure angle (in rad)
+    /// Hachure angle (in radians).
     #[serde(rename = "hachure_angle", with = "crate::serialize::f64_dp3")]
     pub hachure_angle: f64,
-    /// An optional seed to generate reproducible shapes
+    /// An optional seed to generate reproducible shapes.
     #[serde(rename = "seed")]
     pub seed: Option<u64>,
 }
@@ -42,18 +42,17 @@ impl Default for RoughOptions {
 }
 
 impl RoughOptions {
-    /// The margin for the bounds of composed rough shapes
-    ///
-    /// TODO: make this not a fixed value, but dependent on the shape size, roughness, etc.
+    /// The margin for the bounds of composed rough shapes.
+    // TODO: make this not a fixed value, but dependent on the shape size, roughness, etc.
     pub const ROUGH_BOUNDS_MARGIN: f64 = 20.0;
 
-    /// Advances the seed
+    /// Advance the seed, if it is set to `Some()`.
     pub fn advance_seed(&mut self) {
         self.seed = self.seed.map(crate::utils::seed_advance)
     }
 }
 
-/// available Fill styles
+/// Available fill styles.
 #[derive(
     Debug,
     Clone,
@@ -69,27 +68,27 @@ impl RoughOptions {
 )]
 #[serde(rename = "fill_style")]
 pub enum FillStyle {
-    /// Solid
+    /// Solid.
     // pre v0.5.9 the fill style was always set to `Hachure` (capitalized), even though the app rendered a solid fill.
     // For compatibility reasons we need set this alias.
     #[serde(rename = "solid", alias = "Hachure")]
     Solid,
-    /// Hachure
+    /// Hachure.
     #[serde(rename = "hachure")]
     Hachure,
-    /// Zig zag
+    /// Zig zag.
     #[serde(rename = "zig_zag")]
     ZigZag,
-    /// Zig zag line
+    /// Zig zag line.
     #[serde(rename = "zig_zag_line")]
     ZigZagLine,
-    /// Crosshatch
+    /// Crosshatch.
     #[serde(rename = "crosshatch")]
     Crosshatch,
-    /// Dots
+    /// Dots.
     #[serde(rename = "dots")]
     Dots,
-    /// Dashed
+    /// Dashed.
     #[serde(rename = "dashed")]
     Dashed,
 }

--- a/rnote-compose/src/style/smooth/mod.rs
+++ b/rnote-compose/src/style/smooth/mod.rs
@@ -1,9 +1,10 @@
+// Modules
 mod smoothoptions;
 
-use kurbo::Shape;
 // Re-exports
 pub use smoothoptions::SmoothOptions;
 
+// Imports
 use super::Composer;
 use crate::helpers::Vector2Helpers;
 use crate::penpath::{self, Segment};
@@ -14,7 +15,7 @@ use crate::shapes::Rectangle;
 use crate::shapes::ShapeBehaviour;
 use crate::shapes::{Arrow, CubicBezier};
 use crate::PenPath;
-
+use kurbo::Shape;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 
 impl Composer<SmoothOptions> for Line {
@@ -272,7 +273,7 @@ impl Composer<SmoothOptions> for crate::Shape {
     }
 }
 
-// Composes lines with variable width. Must be drawn with only a fill
+/// Composes lines with variable width. Must be drawn with only a fill.
 fn compose_lines_variable_width(
     lines: &[Line],
     start_width: f64,

--- a/rnote-compose/src/style/smooth/smoothoptions.rs
+++ b/rnote-compose/src/style/smooth/smoothoptions.rs
@@ -1,22 +1,22 @@
+// Imports
 use crate::style::PressureCurve;
 use crate::Color;
-
 use serde::{Deserialize, Serialize};
 
-/// Options for shapes that can be drawn smoothly
+/// Options for shapes that can be drawn in a smooth style.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename = "smooth_options")]
 pub struct SmoothOptions {
-    /// The stroke width
+    /// Stroke width.
     #[serde(rename = "stroke_width", with = "crate::serialize::f64_dp3")]
     pub stroke_width: f64,
-    /// The stroke color
+    /// Stroke color. When set to None, the stroke outline is not drawn.
     #[serde(rename = "stroke_color")]
     pub stroke_color: Option<Color>,
-    /// The fill color
+    /// Fill color. When set to None, the fill is not drawn.
     #[serde(rename = "fill_color")]
     pub fill_color: Option<Color>,
-    /// Pressure curve
+    /// Pressure curve.
     #[serde(rename = "pressure_curve")]
     pub pressure_curve: PressureCurve,
 }

--- a/rnote-compose/src/style/textured/mod.rs
+++ b/rnote-compose/src/style/textured/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 mod textureddotsdistribution;
 mod texturedoptions;
 
@@ -5,16 +6,15 @@ mod texturedoptions;
 pub use textureddotsdistribution::TexturedDotsDistribution;
 pub use texturedoptions::TexturedOptions;
 
+// Imports
+use super::Composer;
 use crate::helpers::Vector2Helpers;
 use crate::penpath::Segment;
 use crate::shapes::{Line, ShapeBehaviour};
 use crate::PenPath;
 use kurbo::Shape;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
-
 use rand_distr::{Distribution, Uniform};
-
-use super::Composer;
 
 impl Composer<TexturedOptions> for Line {
     fn composed_bounds(&self, options: &TexturedOptions) -> Aabb {

--- a/rnote-compose/src/style/textured/textureddotsdistribution.rs
+++ b/rnote-compose/src/style/textured/textureddotsdistribution.rs
@@ -1,9 +1,10 @@
-use std::ops::Range;
-
+// Imports
 use anyhow::Context;
 use rand_distr::Distribution;
 use serde::{Deserialize, Serialize};
+use std::ops::Range;
 
+/// The distribution for the spread of dots across the fill of a textured shape.
 #[derive(
     Debug,
     Eq,
@@ -15,15 +16,14 @@ use serde::{Deserialize, Serialize};
     num_derive::FromPrimitive,
     num_derive::ToPrimitive,
 )]
-/// The distribution for the spread of dots across the width of a textured shape
 pub enum TexturedDotsDistribution {
-    /// Uniform distribution
+    /// Uniform distribution.
     Uniform = 0,
-    /// Normal distribution
+    /// Normal distribution.
     Normal,
-    /// Exponential distribution distribution, from the outline increasing in probability symmetrical to the center
+    /// Exponential distribution distribution, from the outline increasing in probability symmetrical to the center.
     Exponential,
-    /// Exponential distribution distribution, from the center increasing in probability symmetrical outwards to the outline
+    /// Exponential distribution distribution, from the center increasing in probability symmetrical outwards to the outline.
     ReverseExponential,
 }
 
@@ -44,7 +44,9 @@ impl TryFrom<u32> for TexturedDotsDistribution {
 }
 
 impl TexturedDotsDistribution {
-    /// Samples a value for the given range, symmetrical to the center of the range. For distributions that are open ended, samples are clipped to the range
+    /// Sample a value for the given range, symmetrical to the center of the range.
+    ///
+    /// For distributions that are open ended, samples are clipped to the range.
     pub fn sample_for_range_symmetrical_clipped<G: rand::Rng + ?Sized>(
         &self,
         rng: &mut G,

--- a/rnote-compose/src/style/textured/texturedoptions.rs
+++ b/rnote-compose/src/style/textured/texturedoptions.rs
@@ -1,31 +1,29 @@
-use serde::{Deserialize, Serialize};
-
+// Imports
+use super::textureddotsdistribution::TexturedDotsDistribution;
 use crate::style::PressureCurve;
 use crate::Color;
+use serde::{Deserialize, Serialize};
 
-use super::textureddotsdistribution::TexturedDotsDistribution;
-
-/// The options for a textured shape
-
+/// Options for shapes that can be drawn in a textured style.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename = "textured_options")]
 pub struct TexturedOptions {
-    /// An optional seed to generate reproducible shapes
+    /// An optional seed to generate reproducible shapes.
     #[serde(rename = "seed")]
     pub seed: Option<u64>,
-    /// The width
+    /// Stroke width.
     #[serde(rename = "stroke_width", with = "crate::serialize::f64_dp3")]
     pub stroke_width: f64,
-    /// The color of the stroke
+    /// Stroke color. When set to None, the stroke is not drawn.
     #[serde(rename = "stroke_color")]
     pub stroke_color: Option<Color>,
-    /// Amount dots per 10x10 area
+    /// Amount of dots of the texture per 10x10 area.
     #[serde(rename = "density", with = "crate::serialize::f64_dp3")]
     pub density: f64,
-    /// the distribution type
+    /// Texture dots distribution type.
     #[serde(rename = "distribution")]
     pub distribution: TexturedDotsDistribution,
-    /// Pressure curve
+    /// Pressure curve.
     #[serde(rename = "pressure_curve")]
     pub pressure_curve: PressureCurve,
 }
@@ -44,16 +42,16 @@ impl Default for TexturedOptions {
 }
 
 impl TexturedOptions {
-    /// dots dadii default (without width weight)
+    /// Dots dadii default, without width weight.
     pub(super) const DOTS_RADII_DEFAULT: na::Vector2<f64> = na::vector![1.2, 0.3];
-    /// The weight factor the stroke width has to the radii of the dots
+    /// Weight factor the stroke width has to the radii of the dots.
     pub(super) const STROKE_WIDTH_RADII_WEIGHT: f64 = 0.1;
-    /// The minimum dots density
+    /// Minimum dots density.
     pub const DENSITY_MIN: f64 = 0.1;
-    /// The maximum dots density
+    /// Maximum dots density.
     pub const DENSITY_MAX: f64 = 100.0;
 
-    /// Advances the seed
+    /// Advances the seed.
     pub fn advance_seed(&mut self) {
         self.seed = self.seed.map(crate::utils::seed_advance)
     }

--- a/rnote-compose/src/transform/mod.rs
+++ b/rnote-compose/src/transform/mod.rs
@@ -1,14 +1,15 @@
+// Modules
 mod transformbehaviour;
 
-use p2d::bounding_volume::Aabb;
 // Re-exports
 pub use transformbehaviour::TransformBehaviour;
 
+// Imports
+use crate::helpers::{AabbHelpers, Affine2Helpers};
+use p2d::bounding_volume::Aabb;
 use serde::{Deserialize, Serialize};
 
-use crate::helpers::{AabbHelpers, Affine2Helpers};
-
-/// A (affine) transform
+/// An affine transformation.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(default, rename = "transform")]
 pub struct Transform {
@@ -55,34 +56,36 @@ impl TransformBehaviour for Transform {
 }
 
 impl Transform {
-    /// A new transform given the affine
+    /// Construct a new transform given the [`na::Affine2<f64>`].
     pub fn new(transform: na::Affine2<f64>) -> Self {
         Self { affine: transform }
     }
 
-    /// A new transform given the isometry
+    /// Construct a new transform given the [`na::Isometry2<f64>`].
     pub fn new_w_isometry(isometry: na::Isometry2<f64>) -> Self {
         Self {
             affine: na::convert(isometry),
         }
     }
 
-    /// Returns the translation part of the transform
+    /// The translation part of the transform.
     pub fn translation_part(&self) -> na::Vector2<f64> {
         (self.affine * na::point![0.0, 0.0]).coords
     }
 
-    /// transforms a point by the transform
+    /// Transform a point by the transform.
     pub fn transform_point(&self, point: na::Point2<f64>) -> na::Point2<f64> {
         self.affine * point
     }
 
-    /// transform a vec ( translation will be ignored! )
+    /// Transform a [`na::Vector2<f64>`].
+    ///
+    /// The translational part will be ignored!
     pub fn transform_vec(&self, vec: na::Vector2<f64>) -> na::Vector2<f64> {
         self.affine * vec
     }
 
-    /// Transforms the aabbs vertices and calculates a new that contains them
+    /// Transforms the Aabb vertices and calculates a new that contains them.
     pub fn transform_aabb(&self, aabb: Aabb) -> Aabb {
         let p0 = self.affine * na::point![aabb.mins[0], aabb.mins[1]];
         let p1 = self.affine * na::point![aabb.mins[0], aabb.maxs[1]];
@@ -97,19 +100,19 @@ impl Transform {
         Aabb::new_positive(na::point![min_x, min_y], na::point![max_x, max_y])
     }
 
-    /// appends a translation to the transform
+    /// Append a translation to the transform.
     pub fn append_translation_mut(&mut self, offset: na::Vector2<f64>) {
         self.affine = na::Translation2::from(offset) * self.affine;
     }
 
-    /// appends a rotation around a point to the transform
+    /// Append a rotation around a point to the transform.
     pub fn append_rotation_wrt_point_mut(&mut self, angle: f64, center: na::Point2<f64>) {
         self.affine = na::Translation2::from(-center.coords) * self.affine;
         self.affine = na::Rotation2::new(angle) * self.affine;
         self.affine = na::Translation2::from(center.coords) * self.affine;
     }
 
-    /// appends a scale to the transform
+    /// Append a scale to the transform.
     pub fn append_scale_mut(&mut self, scale: na::Vector2<f64>) {
         self.affine = na::try_convert(
             na::Scale2::<f64>::from(scale).to_homogeneous() * self.affine.to_homogeneous(),
@@ -117,7 +120,7 @@ impl Transform {
         .unwrap();
     }
 
-    /// converts the transform to a svg attribute string, insertable into svg elements
+    /// Convert the transform to a Svg attribute string, insertable into svg elements.
     pub fn to_svg_transform_attr_str(&self) -> String {
         let matrix = self.affine;
 
@@ -132,7 +135,7 @@ impl Transform {
         )
     }
 
-    /// to kurbo
+    /// Convert to [kurbo::Affine]
     pub fn to_kurbo(&self) -> kurbo::Affine {
         self.affine.to_kurbo()
     }

--- a/rnote-compose/src/transform/transformbehaviour.rs
+++ b/rnote-compose/src/transform/transformbehaviour.rs
@@ -1,9 +1,9 @@
-/// Specifies that a type can be (geometrically) transformed
+/// Trait for types that can be (geometrically) transformed.
 pub trait TransformBehaviour {
-    /// translates (as in moves) the stroke with offset
+    /// Translate (as in moves) by the given offset.
     fn translate(&mut self, offset: na::Vector2<f64>);
-    /// rotates in angle (rad)
+    /// Rotate by the given angle (in radians).
     fn rotate(&mut self, angle: f64, center: na::Point2<f64>);
-    /// scales by the desired scale
+    /// Scale by the given scale-factor.
     fn scale(&mut self, scale: na::Vector2<f64>);
 }

--- a/rnote-compose/src/utils.rs
+++ b/rnote-compose/src/utils.rs
@@ -1,15 +1,17 @@
+// Imports
 use p2d::bounding_volume::Aabb;
 use rand::{Rng, SeedableRng};
 
+/// Matches when a Xml header is present
 const XML_HEADER_REGEX: &str = r#"<\?xml[^\?>]*\?>"#;
 
-/// Check if a xml header is present
+/// Check if a Xml header is present
 pub fn check_xml_header(svg: &str) -> bool {
     let re = regex::Regex::new(XML_HEADER_REGEX).unwrap();
     re.is_match(svg)
 }
 
-/// Adds a xml header to the &str
+/// Adds a Xml header to the &str
 pub fn add_xml_header(svg: &str) -> String {
     let re = regex::Regex::new(XML_HEADER_REGEX).unwrap();
     if !re.is_match(svg) {
@@ -19,13 +21,13 @@ pub fn add_xml_header(svg: &str) -> String {
     }
 }
 
-/// Removes the xml header from the &str, if present
+/// Remove the Xml header from the &str, if present.
 pub fn remove_xml_header(svg: &str) -> String {
     let re = regex::Regex::new(XML_HEADER_REGEX).unwrap();
     String::from(re.replace_all(svg, ""))
 }
 
-/// Wraps a svg str in a svg root element
+/// Wrap a Svg root element around the Svg string.
 pub fn wrap_svg_root(
     svg_data: &str,
     bounds: Option<Aabb>,
@@ -81,7 +83,7 @@ pub fn wrap_svg_root(
     svg_node_to_string(&svg_root).unwrap()
 }
 
-/// Converting a svg::Node to a String
+/// Convert a [svg::Node] to a String
 pub fn svg_node_to_string<N>(node: &N) -> Result<String, anyhow::Error>
 where
     N: svg::Node,
@@ -91,7 +93,9 @@ where
     Ok(String::from_utf8(document_buffer)?)
 }
 
-/// A new random number generator with the pcg64 algorithm. Used for seedable, reproducible random numbers.
+/// A new random number generator with the pcg64 algorithm.
+///
+/// Used for seedable, reproducible random numbers.
 pub fn new_rng_default_pcg64(seed: Option<u64>) -> rand_pcg::Pcg64 {
     if let Some(seed) = seed {
         rand_pcg::Pcg64::seed_from_u64(seed)
@@ -100,7 +104,7 @@ pub fn new_rng_default_pcg64(seed: Option<u64>) -> rand_pcg::Pcg64 {
     }
 }
 
-/// generates a alphanumeric random prefix for svg ids to avoid id collisions.
+/// Generate a alphanumeric random prefix for Svg Id's to avoid Id collisions.
 pub fn svg_random_id_prefix() -> String {
     rand::thread_rng()
         .sample_iter(&rand::distributions::Alphanumeric)
@@ -109,7 +113,7 @@ pub fn svg_random_id_prefix() -> String {
         .collect::<String>()
 }
 
-/// returns a new seed by generating a random value seeded from the old seed using the Pcg algorithm
+/// Generate a new seed by generating a random value seeded from the old seed using the Pcg algorithm.
 pub fn seed_advance(seed: u64) -> u64 {
     let mut rng = rand_pcg::Pcg64::seed_from_u64(seed);
     rng.gen()

--- a/rnote-engine/src/audioplayer.rs
+++ b/rnote-engine/src/audioplayer.rs
@@ -1,17 +1,17 @@
-use std::collections::HashMap;
-use std::fs::File;
-use std::path::PathBuf;
-use std::time::{self, Duration};
-
+// Imports
 use anyhow::Context;
 use rand::Rng;
 use rnote_compose::penevents::KeyboardKey;
 use rodio::source::Buffered;
 use rodio::{Decoder, Source};
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::PathBuf;
+use std::time::{self, Duration};
 
-/// The audio player for pen sounds
+/// The audio player for pen sounds.
 pub struct AudioPlayer {
-    // we need to hold the output streams, even if they are not used
+    // we need to hold the output streams, even if they are not used.
     #[allow(unused)]
     marker_outputstream: rodio::OutputStream,
     marker_outputstream_handle: rodio::OutputStreamHandle,
@@ -48,8 +48,8 @@ impl AudioPlayer {
     pub const N_SOUND_FILES_TYPEWRITER: usize = 30;
     pub const SOUND_FILE_BRUSH_SEEK_TIMES_SEC: [f64; 5] = [0.0, 0.91, 4.129, 6.0, 8.56];
 
-    /// create and initialize new audioplayer.
-    /// pkg_data_dir is the app data directory which has a "sounds" subfolder containing the sound files
+    /// Create and initialize new audioplayer.
+    /// `pkg_data_dir` is the app data directory which has a "sounds" subfolder containing the sound files
     pub fn new_init(mut pkg_data_dir: PathBuf) -> Result<Self, anyhow::Error> {
         pkg_data_dir.push("sounds/");
 
@@ -171,7 +171,7 @@ impl AudioPlayer {
         }
     }
 
-    /// Play a typewriter sound that fits the given key type, or a generic sound when None
+    /// Play a typewriter sound that fits the given key type, or a generic sound when None.
     pub fn play_typewriter_key_sound(&self, keyboard_key: Option<KeyboardKey>) {
         match rodio::Sink::try_new(&self.typewriter_outputstream_handle) {
             Ok(sink) => match keyboard_key {

--- a/rnote-engine/src/document/background.rs
+++ b/rnote-engine/src/document/background.rs
@@ -1,11 +1,11 @@
+// Imports
+use crate::render;
 use anyhow::Context;
 use p2d::bounding_volume::Aabb;
+use rnote_compose::Color;
 use serde::{Deserialize, Serialize};
 use svg::node::element;
 use svg::Node;
-
-use crate::render;
-use rnote_compose::Color;
 
 #[derive(
     Debug,
@@ -408,7 +408,7 @@ impl Background {
         na::vector![tile_width, tile_height]
     }
 
-    /// Generates the background svg, without xml header or svg root
+    /// Generate the background svg, without Xml header or Svg root.
     pub fn gen_svg(&self, bounds: Aabb, with_pattern: bool) -> Result<render::Svg, anyhow::Error> {
         // background color
         let mut color_rect = element::Rectangle::new().set("fill", self.color.to_css_color_attr());

--- a/rnote-engine/src/document/format.rs
+++ b/rnote-engine/src/document/format.rs
@@ -1,7 +1,7 @@
+// Imports
 use gtk4::glib;
-use serde::{Deserialize, Serialize};
-
 use rnote_compose::{color, Color};
+use serde::{Deserialize, Serialize};
 
 #[derive(
     Debug,

--- a/rnote-engine/src/document/mod.rs
+++ b/rnote-engine/src/document/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 pub mod background;
 pub mod format;
 
@@ -6,13 +7,11 @@ pub use background::Background;
 pub use format::Format;
 
 // Imports
-use rnote_compose::Color;
-
 use crate::{Camera, StrokeStore};
-use rnote_compose::helpers::AabbHelpers;
-
 use gtk4::{glib, prelude::*};
 use p2d::bounding_volume::{Aabb, BoundingVolume};
+use rnote_compose::helpers::AabbHelpers;
+use rnote_compose::Color;
 use serde::{Deserialize, Serialize};
 
 #[derive(
@@ -121,7 +120,9 @@ impl Document {
         )
     }
 
-    // Generates bounds for each page for the doc bounds, extended to fit the format. May contain many empty pages (in infinite mode)
+    /// Generate bounds for each page for the doc bounds, extended to fit the format.
+    ///
+    /// May contain many empty pages (in infinite mode)
     pub fn pages_bounds(&self) -> Vec<Aabb> {
         let doc_bounds = self.bounds();
 

--- a/rnote-engine/src/drawbehaviour.rs
+++ b/rnote-engine/src/drawbehaviour.rs
@@ -1,24 +1,29 @@
+// Imports
+use crate::engine::EngineView;
+use crate::utils::GrapheneRectHelpers;
 use gtk4::{graphene, prelude::*};
 use p2d::bounding_volume::Aabb;
 use piet::RenderContext;
 use rnote_compose::helpers::{AabbHelpers, Affine2Helpers};
 
-use crate::engine::EngineView;
-use crate::utils::GrapheneRectHelpers;
-
 /// Trait for types that can draw themselves on the document.
+///
 /// In the coordinate space of the document
 pub trait DrawOnDocBehaviour {
-    /// The current bounds on the document
+    /// Bounds on the document.
     fn bounds_on_doc(&self, engine_view: &EngineView) -> Option<Aabb>;
-    /// draws itself on the document. the implementors are expected to save / restore context
+    /// Draw itself on the document.
+    ///
+    /// The implementors are expected to save/restore the drawing context.
     fn draw_on_doc(
         &self,
         cx: &mut piet_cairo::CairoRenderContext,
         engine_view: &EngineView,
     ) -> anyhow::Result<()>;
 
-    /// Expects snapshot untransformed in surface coordinate space.
+    /// Draw itself on the snapshot.
+    ///
+    /// The snapshot is expected to be untransformed in surface coordinate space.
     fn draw_on_doc_to_gtk_snapshot(
         &self,
         snapshot: &gtk4::Snapshot,
@@ -44,7 +49,7 @@ pub trait DrawOnDocBehaviour {
                 snapshot.append_cairo(&graphene::Rect::from_p2d_aabb(bounds_transformed));
             let mut piet_cx = piet_cairo::CairoRenderContext::new(&cairo_cx);
 
-            // Transform to doc coordinate space
+            // Transform to document coordinate space
             piet_cx.transform(engine_view.camera.transform().to_kurbo());
 
             self.draw_on_doc(&mut piet_cx, engine_view)?;
@@ -55,9 +60,12 @@ pub trait DrawOnDocBehaviour {
     }
 }
 
-/// Trait for types that can draw themselves on a piet RenderContext.
+/// Trait for types that can draw themselves on a [piet::RenderContext].
 pub trait DrawBehaviour {
-    /// draws itself. the implementors are expected save / restore context
-    /// image_scale is the scalefactor of generated pixel images within the type. the content should not be zoomed by it!
+    /// Draw itself.
+    /// The implementors are expected to save/restore the drawing context.
+    ///
+    /// `image_scale` is the scale-factor of generated images within the type.
+    /// The content should not be zoomed by it!
     fn draw(&self, cx: &mut impl piet::RenderContext, image_scale: f64) -> anyhow::Result<()>;
 }

--- a/rnote-engine/src/engine/export.rs
+++ b/rnote-engine/src/engine/export.rs
@@ -1,21 +1,19 @@
+// Imports
+use super::{EngineConfig, EngineSnapshot, RnoteEngine};
+use crate::store::StrokeKey;
+use crate::strokes::Stroke;
+use crate::{render, DrawBehaviour};
 use anyhow::Context;
 use futures::channel::oneshot;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use piet::RenderContext;
-use serde::{Deserialize, Serialize};
-
 use rnote_compose::helpers::Vector2Helpers;
 use rnote_compose::transform::TransformBehaviour;
 use rnote_fileformats::rnoteformat::RnoteFile;
 use rnote_fileformats::{xoppformat, FileFormatSaver};
+use serde::{Deserialize, Serialize};
 
-use crate::store::StrokeKey;
-use crate::strokes::Stroke;
-use crate::{render, DrawBehaviour};
-
-use super::{EngineConfig, EngineSnapshot, RnoteEngine};
-
-/// Document export format
+/// Document export format.
 #[derive(
     Debug,
     Clone,
@@ -59,7 +57,7 @@ impl TryFrom<u32> for DocExportFormat {
 }
 
 impl DocExportFormat {
-    /// File extension for the format
+    /// File extension for the format.
     pub fn file_ext(self) -> String {
         match self {
             DocExportFormat::Svg => String::from("svg"),
@@ -69,17 +67,17 @@ impl DocExportFormat {
     }
 }
 
-/// Document export preferences
+/// Document export preferences.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(default, rename = "doc_export_prefs")]
 pub struct DocExportPrefs {
-    /// whether the background should be exported
+    /// Whether the background should be exported.
     #[serde(rename = "with_background")]
     pub with_background: bool,
-    /// Whether the background pattern should be exported
+    /// Whether the background pattern should be exported.
     #[serde(rename = "with_pattern")]
     pub with_pattern: bool,
-    /// The export format
+    /// The export format.
     #[serde(rename = "export_format")]
     pub export_format: DocExportFormat,
 }
@@ -94,7 +92,7 @@ impl Default for DocExportPrefs {
     }
 }
 
-/// document pages export format
+/// Document pages export format.
 #[derive(
     Debug,
     Clone,
@@ -124,23 +122,23 @@ impl Default for DocPagesExportFormat {
     }
 }
 
-/// Document pages export preferences
+/// Document pages export preferences.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(default, rename = "doc_pages_export_prefs")]
 pub struct DocPagesExportPrefs {
-    /// whether the background should be exported
+    /// Whether the background should be exported.
     #[serde(rename = "with_background")]
     pub with_background: bool,
-    /// Whether the background pattern should be exported
+    /// Whether the background pattern should be exported.
     #[serde(rename = "with_pattern")]
     pub with_pattern: bool,
     /// Export format
     #[serde(rename = "export_format")]
     pub export_format: DocPagesExportFormat,
-    /// The bitmap scale-factor in relation to the actual size
+    /// The bitmap scale-factor in relation to the actual size.
     #[serde(rename = "bitmap_scalefactor")]
     pub bitmap_scalefactor: f64,
-    /// Quality when exporting as jpeg
+    /// Quality when exporting as Jpeg.
     #[serde(rename = "jpg_quality")]
     pub jpeg_quality: u8,
 }
@@ -180,7 +178,7 @@ impl DocPagesExportFormat {
     }
 }
 
-/// Selection export format
+/// Selection export format.
 #[derive(
     Debug,
     Clone,
@@ -236,22 +234,22 @@ impl TryFrom<u32> for SelectionExportFormat {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(default, rename = "selection_export_prefs")]
 pub struct SelectionExportPrefs {
-    /// whether the background should be exported
+    /// Whether the background should be exported.
     #[serde(rename = "with_background")]
     pub with_background: bool,
-    /// whether the background pattern should be exported
+    /// Whether the background pattern should be exported.
     #[serde(rename = "with_pattern")]
     pub with_pattern: bool,
-    /// Export format
+    /// Export format.
     #[serde(rename = "export_format")]
     pub export_format: SelectionExportFormat,
-    /// The bitmap scale-factor in relation to the actual size
+    /// The bitmap scale-factor in relation to the actual size.
     #[serde(rename = "bitmap_scalefactor")]
     pub bitmap_scalefactor: f64,
-    /// Quality when exporting as jpeg
+    /// Quality when exporting as Jpeg.
     #[serde(rename = "jpg_quality")]
     pub jpeg_quality: u8,
-    /// The margins of the export extending the bounds of the selection
+    /// The margins of the export extending the bounds of the selection.
     #[serde(rename = "margin")]
     pub margin: f64,
 }
@@ -269,17 +267,17 @@ impl Default for SelectionExportPrefs {
     }
 }
 
-/// Export preferences
+/// Export preferences.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 #[serde(default, rename = "export_prefs")]
 pub struct ExportPrefs {
-    /// Document export preferences
+    /// Document export preferences.
     #[serde(rename = "doc_export_prefs")]
     pub doc_export_prefs: DocExportPrefs,
-    //// Document pages export preferences
+    //// Document pages export preferences.
     #[serde(rename = "doc_pages_export_prefs")]
     pub doc_pages_export_prefs: DocPagesExportPrefs,
-    /// Selection export preferences
+    /// Selection export preferences.
     #[serde(rename = "selection_export_prefs")]
     pub selection_export_prefs: SelectionExportPrefs,
 }
@@ -288,7 +286,7 @@ impl RnoteEngine {
     /// The used image scale-factor for any strokes that are converted to bitmap images on export.
     pub const STROKE_EXPORT_IMAGE_SCALE: f64 = 1.8;
 
-    /// Saves the current document as a .rnote file.
+    /// Save the current document as a .rnote file.
     pub fn save_as_rnote_bytes(
         &self,
         file_name: String,
@@ -314,7 +312,7 @@ impl RnoteEngine {
         Ok(oneshot_receiver)
     }
 
-    /// Extracts the current engine config.
+    /// Extract the current engine configuration.
     pub fn extract_engine_config(&self) -> EngineConfig {
         EngineConfig {
             document: self.document,
@@ -326,19 +324,19 @@ impl RnoteEngine {
         }
     }
 
-    /// Exports the current engine config as JSON string.
+    /// Export the current engine config as Json string.
     pub fn export_engine_config_as_json(&self) -> anyhow::Result<String> {
         Ok(serde_json::to_string(&self.extract_engine_config())?)
     }
 
-    /// Exports the entire engine state as JSON string.
+    /// Export the entire engine state as Json string.
     ///
-    /// Only use for debugging
+    /// Only intended to be used for debugging.
     pub fn export_state_as_json(&self) -> anyhow::Result<String> {
         Ok(serde_json::to_string_pretty(self)?)
     }
 
-    /// Exports the document.
+    /// Export the document.
     pub fn export_doc(
         &self,
         title: String,
@@ -356,7 +354,7 @@ impl RnoteEngine {
         }
     }
 
-    /// Exports the doc with the strokes as a SVG string.
+    /// Export the doc with the strokes as Svg.
     pub fn export_doc_as_svg_bytes(
         &self,
         doc_export_prefs_override: Option<DocExportPrefs>,
@@ -395,7 +393,7 @@ impl RnoteEngine {
         oneshot_receiver
     }
 
-    /// Exports the doc with the strokes as a PDF file.
+    /// Export the doc with the strokes as Pdf.
     pub fn export_doc_as_pdf_bytes(
         &self,
         title: String,
@@ -419,7 +417,6 @@ impl RnoteEngine {
             })
             .collect::<Vec<(Aabb, Vec<StrokeKey>)>>();
 
-        // Fill the pdf surface on a separate thread to avoid blocking the UI
         rayon::spawn(move || {
             let result = || -> anyhow::Result<Vec<u8>> {
                 let format_size = na::vector![
@@ -468,7 +465,7 @@ impl RnoteEngine {
                         }
                         cairo_cx.restore()?;
 
-                        // Draw the strokes with piet
+                        // Draw the strokes with piet.
                         let mut piet_cx = piet_cairo::CairoRenderContext::new(&cairo_cx);
                         piet_cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
@@ -517,7 +514,7 @@ impl RnoteEngine {
         oneshot_receiver
     }
 
-    /// Exports the document as a Xournal++ .xopp file.
+    /// Export the document as a Xournal++ .xopp file.
     pub fn export_doc_as_xopp_bytes(
         &self,
         title: String,
@@ -554,7 +551,8 @@ impl RnoteEngine {
                     },
                 };
 
-                // xopp spec needs at least one page in vec, but its fine because pages_bounds_w_content() always produces at least one
+                // xopp spec needs at least one page in vec,
+                // but it is fine because pages_bounds_w_content() always produces at least one.
                 let pages = pages_strokes
                     .into_iter()
                     .map(|(page_bounds, strokes)| {
@@ -604,7 +602,8 @@ impl RnoteEngine {
                             })
                             .collect::<Vec<xoppformat::XoppImage>>();
 
-                        // In Rnote, images are always rendered below strokes and text. To accurately reflect this behaviour, images are separated into another layer.
+                        // In Rnote images are always rendered below strokes and text.
+                        // To match this behaviour accurately, images are separated into another layer.
                         let image_layer = xoppformat::XoppLayer {
                             name: None,
                             strokes: vec![],
@@ -655,7 +654,7 @@ impl RnoteEngine {
         oneshot_receiver
     }
 
-    /// Exports the document pages.
+    /// Export the document pages.
     pub fn export_doc_pages(
         &self,
         doc_pages_export_prefs_override: Option<DocPagesExportPrefs>,
@@ -673,7 +672,7 @@ impl RnoteEngine {
         }
     }
 
-    /// Exports the document as SVG.
+    /// Export the document as Svg.
     pub fn export_doc_pages_as_svgs_bytes(
         &self,
         doc_pages_export_prefs_override: Option<DocPagesExportPrefs>,
@@ -727,9 +726,9 @@ impl RnoteEngine {
         oneshot_receiver
     }
 
-    /// Exports the document pages as bitmap images.
+    /// Export the document pages as bitmap.
     ///
-    /// Returns an Error if the format pref is not set to a bitmap variant.
+    /// Returns an error if the format pref is not set to a bitmap variant.
     pub fn export_doc_pages_as_bitmap_bytes(
         &self,
         doc_pages_export_prefs_override: Option<DocPagesExportPrefs>,
@@ -803,7 +802,7 @@ impl RnoteEngine {
         }
     }
 
-    /// Exports the selection as SVG.
+    /// Exports the selection as Svg.
     pub fn export_selection_as_svg_bytes(
         &self,
         selection_export_prefs_override: Option<SelectionExportPrefs>,
@@ -851,7 +850,7 @@ impl RnoteEngine {
         oneshot_receiver
     }
 
-    /// Exports the selection a bitmap bytes.
+    /// Export the selection a bitmap bytes.
     ///
     /// Returns an error if the format pref is not set to a bitmap format
     pub fn export_selection_as_bitmap_bytes(
@@ -908,9 +907,9 @@ impl RnoteEngine {
     }
 }
 
-/// generates the doc svg.
+/// Generates the doc Svg.
 ///
-/// without root or xml header.
+/// Without root or Xml header.
 fn gen_doc_svg(
     doc_w_content_bounds: Aabb,
     stroke_keys: Vec<StrokeKey>,
@@ -950,9 +949,9 @@ fn gen_doc_svg(
     Ok(doc_svg)
 }
 
-/// generates the doc pages svgs.
+/// Generates the doc pages Svg's.
 ///
-/// without root or xml header.
+/// Without root or Xml header.
 fn gen_doc_pages_svgs(
     pages_strokes: Vec<(Aabb, Vec<StrokeKey>)>,
     snapshot: &EngineSnapshot,
@@ -996,9 +995,9 @@ fn gen_doc_pages_svgs(
     Ok(pages_svgs)
 }
 
-/// generates the selection svg.
+/// Generates the selection Svg.
 ///
-/// without root or xml header.
+/// Without root or Xml header.
 fn gen_selection_svg(
     selection_keys: Vec<StrokeKey>,
     selection_bounds: Aabb,

--- a/rnote-engine/src/engine/mod.rs
+++ b/rnote-engine/src/engine/mod.rs
@@ -33,7 +33,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
-/// An immutable view into the the engine, excluding the penholder.
+/// An immutable view into the engine, excluding the penholder.
 #[derive(Debug)]
 pub struct EngineView<'a> {
     pub tasks_tx: EngineTaskSender,

--- a/rnote-engine/src/engine/rendering.rs
+++ b/rnote-engine/src/engine/rendering.rs
@@ -1,3 +1,7 @@
+// Imports
+use super::{visual_debug, EngineView};
+use crate::utils::{GdkRGBAHelpers, GrapheneRectHelpers};
+use crate::{Document, DrawOnDocBehaviour, RnoteEngine};
 use anyhow::Context;
 use gtk4::{gdk, graphene, gsk, prelude::*, Snapshot};
 use p2d::bounding_volume::{Aabb, BoundingVolume};
@@ -5,15 +9,10 @@ use piet::RenderContext;
 use rnote_compose::color;
 use rnote_compose::helpers::AabbHelpers;
 
-use crate::utils::{GdkRGBAHelpers, GrapheneRectHelpers};
-use crate::{Document, DrawOnDocBehaviour, RnoteEngine};
-
-use super::{visual_debug, EngineView};
-
 impl RnoteEngine {
-    /// Updates the background rendering for the current viewport.
+    /// Update the background rendering for the current viewport.
     ///
-    /// if the background pattern or zoom has changed, background_regenerate_pattern() needs to be called first.
+    /// If the background pattern or zoom has changed, the background pattern needs to be regenerated first.
     pub fn update_background_rendering_current_viewport(&mut self) -> anyhow::Result<()> {
         let viewport = self.camera.viewport();
         let mut rendernodes: Vec<gsk::RenderNode> = vec![];
@@ -42,7 +41,7 @@ impl RnoteEngine {
         Ok(())
     }
 
-    /// Updates the content rendering for the current viewport.
+    /// Update the content rendering for the current viewport.
     pub fn update_content_rendering_current_viewport(&mut self) {
         let viewport = self.camera.viewport();
         let image_scale = self.camera.image_scale();
@@ -55,9 +54,9 @@ impl RnoteEngine {
         );
     }
 
-    /// Updates the content and background rendering for the current viewport.
+    /// Update the content and background rendering for the current viewport.
     ///
-    /// if the background pattern or zoom has changed, background_regenerate_pattern() needs to be called first.
+    /// If the background pattern or zoom has changed, the background pattern needs to be regenerated first.
     pub fn update_rendering_current_viewport(&mut self) -> anyhow::Result<()> {
         self.update_background_rendering_current_viewport()?;
         self.update_content_rendering_current_viewport();
@@ -65,14 +64,14 @@ impl RnoteEngine {
         Ok(())
     }
 
-    /// Clears the rendering of the entire engine (e.g. when it becomes off-screen)
+    /// Clear the rendering of the entire engine (e.g. when it becomes off-screen).
     pub fn clear_rendering(&mut self) {
         self.store.clear_rendering();
         self.background_tile_image.take();
         self.background_rendernodes.clear();
     }
 
-    /// Regenerates the background tile image and updates the rendering.
+    /// Regenerate the background tile image and updates the background rendering.
     pub fn background_regenerate_pattern(&mut self) -> anyhow::Result<()> {
         let image_scale = self.camera.image_scale();
         self.background_tile_image = self.document.background.gen_tile_image(image_scale)?;
@@ -118,12 +117,10 @@ impl RnoteEngine {
             snapshot.save();
             snapshot.transform(Some(&camera_transform));
 
-            // visual debugging
             visual_debug::draw_debug_to_gtk_snapshot(snapshot, self, surface_bounds)?;
 
             snapshot.restore();
 
-            // draw the statistics overlay
             visual_debug::draw_statistics_overlay_to_gtk_snapshot(snapshot, self, surface_bounds)?;
         }
 

--- a/rnote-engine/src/engine/visual_debug.rs
+++ b/rnote-engine/src/engine/visual_debug.rs
@@ -1,13 +1,12 @@
+// Imports
+use super::EngineView;
+use crate::utils::{GdkRGBAHelpers, GrapheneRectHelpers};
+use crate::{DrawOnDocBehaviour, RnoteEngine};
 use gtk4::{gdk, graphene, gsk, prelude::*, Snapshot};
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use piet::{RenderContext, Text, TextLayoutBuilder};
 use rnote_compose::helpers::{AabbHelpers, Vector2Helpers};
-
-use crate::utils::{GdkRGBAHelpers, GrapheneRectHelpers};
-use crate::{DrawOnDocBehaviour, RnoteEngine};
 use rnote_compose::Color;
-
-use super::EngineView;
 
 pub const COLOR_POS: Color = Color {
     r: 1.0,
@@ -121,8 +120,9 @@ pub(crate) fn draw_fill_to_gtk_snapshot(snapshot: &Snapshot, rect: Aabb, color: 
     );
 }
 
-// Draw bounds, positions, .. for visual debugging purposes
-// Expects snapshot in surface coords
+/// Draw bounds, positions, .. for visual debugging purposes.
+///
+/// Expects that the snapshot is transformed in surface coords.
 pub(crate) fn draw_statistics_overlay_to_gtk_snapshot(
     snapshot: &Snapshot,
     engine: &RnoteEngine,
@@ -186,7 +186,7 @@ pub(crate) fn draw_statistics_overlay_to_gtk_snapshot(
     Ok(())
 }
 
-// Draw bounds, positions, .. for visual debugging purposes
+/// Draw bounds, positions, .. for visual debugging purposes.
 pub(crate) fn draw_debug_to_gtk_snapshot(
     snapshot: &Snapshot,
     engine: &RnoteEngine,
@@ -207,12 +207,12 @@ pub(crate) fn draw_debug_to_gtk_snapshot(
         border_widths,
     );
 
-    // Draw the strokes and selection
+    // Draw the strokes
     engine
         .store
         .draw_debug_to_gtk_snapshot(snapshot, engine, surface_bounds)?;
 
-    // Draw the pens bounds
+    // Draw the current pen bounds
     if let Some(bounds) = engine.penholder.bounds_on_doc(&EngineView {
         tasks_tx: engine.tasks_tx(),
         pens_config: &engine.pens_config,

--- a/rnote-engine/src/lib.rs
+++ b/rnote-engine/src/lib.rs
@@ -4,9 +4,11 @@
 #![allow(clippy::derivable_impls)]
 //#![warn(missing_docs)]
 
-//! The rnote-engine crate is the core of rnote. It holds the strokes store, the pens, has methods for importing / exporting, rendering, etc..
-//! The main entry point is the RnoteEngine struct.
+//! The rnote-engine crate is the core of Rnote. It holds the strokes store, the pens, has methods for importing / exporting, rendering, etc.. .
+//!
+//! The main entry point is the [RnoteEngine] struct.
 
+// Modules
 pub mod audioplayer;
 pub mod camera;
 pub mod document;
@@ -30,5 +32,6 @@ pub use pens::PenHolder;
 pub use store::StrokeStore;
 pub use widgetflags::WidgetFlags;
 
+// Renames
 extern crate nalgebra as na;
 extern crate parry2d_f64 as p2d;

--- a/rnote-engine/src/pens/brush.rs
+++ b/rnote-engine/src/pens/brush.rs
@@ -1,5 +1,4 @@
-use std::time::Instant;
-
+// Imports
 use super::penbehaviour::{PenBehaviour, PenProgress};
 use super::pensconfig::brushconfig::BrushStyle;
 use super::PenStyle;
@@ -8,17 +7,17 @@ use crate::store::StrokeKey;
 use crate::strokes::BrushStroke;
 use crate::strokes::Stroke;
 use crate::{DrawOnDocBehaviour, WidgetFlags};
+use p2d::bounding_volume::{Aabb, BoundingVolume};
+use piet::RenderContext;
+use rnote_compose::builders::PenPathBuilderType;
 use rnote_compose::builders::{
     PenPathBuilderBehaviour, PenPathBuilderCreator, PenPathBuilderProgress, PenPathModeledBuilder,
 };
 use rnote_compose::builders::{PenPathCurvedBuilder, PenPathSimpleBuilder};
 use rnote_compose::penevents::PenEvent;
-use rnote_compose::Constraints;
-
-use p2d::bounding_volume::{Aabb, BoundingVolume};
-use piet::RenderContext;
-use rnote_compose::builders::PenPathBuilderType;
 use rnote_compose::penpath::Element;
+use rnote_compose::Constraints;
+use std::time::Instant;
 
 #[derive(Debug)]
 enum BrushState {

--- a/rnote-engine/src/pens/brush.rs
+++ b/rnote-engine/src/pens/brush.rs
@@ -264,17 +264,6 @@ impl DrawOnDocBehaviour for Brush {
                             .pens_config
                             .brush_config
                             .style_for_current_options();
-
-                        /*
-                                               // Change color for debugging
-                                               match &mut style {
-                                                   Style::Smooth(options) => {
-                                                       options.stroke_color = Some(rnote_compose::Color::RED)
-                                                   }
-                                                   Style::Rough(_) | Style::Textured(_) => {}
-                                               }
-                        */
-
                         path_builder.draw_styled(cx, &style, engine_view.camera.total_zoom());
                     }
                 }

--- a/rnote-engine/src/pens/eraser.rs
+++ b/rnote-engine/src/pens/eraser.rs
@@ -1,18 +1,17 @@
-use std::time::Instant;
-
+// Imports
 use super::penbehaviour::{PenBehaviour, PenProgress};
 use super::pensconfig::eraserconfig::EraserStyle;
 use super::PenStyle;
 use crate::engine::{EngineView, EngineViewMut};
 use crate::{DrawOnDocBehaviour, WidgetFlags};
 use once_cell::sync::Lazy;
+use p2d::bounding_volume::{Aabb, BoundingVolume};
 use piet::RenderContext;
 use rnote_compose::color;
 use rnote_compose::helpers::AabbHelpers;
 use rnote_compose::penevents::PenEvent;
 use rnote_compose::penpath::Element;
-
-use p2d::bounding_volume::{Aabb, BoundingVolume};
+use std::time::Instant;
 
 #[derive(Debug, Clone, Copy)]
 pub enum EraserState {

--- a/rnote-engine/src/pens/mod.rs
+++ b/rnote-engine/src/pens/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 pub mod brush;
 pub mod eraser;
 pub mod penbehaviour;
@@ -24,15 +25,14 @@ pub use tools::Tools;
 pub use typewriter::Typewriter;
 
 // Imports
+use self::penbehaviour::PenProgress;
+use crate::engine::{EngineView, EngineViewMut};
+use crate::{DrawOnDocBehaviour, WidgetFlags};
 use gtk4::glib;
 use piet_cairo::CairoRenderContext;
 use rnote_compose::penevents::PenEvent;
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
-
-use self::penbehaviour::PenProgress;
-use crate::engine::{EngineView, EngineViewMut};
-use crate::{DrawOnDocBehaviour, WidgetFlags};
 
 #[derive(Debug)]
 pub enum Pen {

--- a/rnote-engine/src/pens/penbehaviour.rs
+++ b/rnote-engine/src/pens/penbehaviour.rs
@@ -1,21 +1,19 @@
-use std::time::Instant;
-
-use rnote_compose::penevents::PenEvent;
-
+// Imports
+use super::PenStyle;
 use crate::engine::{EngineView, EngineViewMut};
 use crate::{DrawOnDocBehaviour, WidgetFlags};
+use rnote_compose::penevents::PenEvent;
+use std::time::Instant;
 
-use super::PenStyle;
-
-/// types that are pens and can handle pen events
+/// Types that are pens.
 pub trait PenBehaviour: DrawOnDocBehaviour {
-    // gives what pen style it is
+    // The pen style.
     fn style(&self) -> PenStyle;
 
-    /// init the pen with initial state with the engine view
+    /// Update the state from the engine.
     fn update_state(&mut self, engine_view: &mut EngineViewMut) -> WidgetFlags;
 
-    /// Handles a pen event
+    /// Handle a pen event.
     fn handle_event(
         &mut self,
         event: PenEvent,
@@ -23,7 +21,7 @@ pub trait PenBehaviour: DrawOnDocBehaviour {
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags);
 
-    /// fetches clipboard content from the pen
+    /// Fetch clipboard content from the pen.
     #[allow(clippy::type_complexity)]
     fn fetch_clipboard_content(
         &self,
@@ -32,7 +30,7 @@ pub trait PenBehaviour: DrawOnDocBehaviour {
         Ok((None, WidgetFlags::default()))
     }
 
-    /// cut clipboard content from the pen
+    /// Cut clipboard content from the pen.
     #[allow(clippy::type_complexity)]
     fn cut_clipboard_content(
         &mut self,

--- a/rnote-engine/src/pens/penholder.rs
+++ b/rnote-engine/src/pens/penholder.rs
@@ -161,8 +161,6 @@ impl PenHolder {
     ) -> WidgetFlags {
         let mut widget_flags = WidgetFlags::default();
 
-        //log::debug!("current_style_override: {:?}, new_style_override: {:?}", self.style_override, new_style_override);
-
         if self.pen_mode_state.style_override() != new_style_override {
             // Deselecting when changing the style override
             let all_strokes = engine_view.store.selection_keys_as_rendered();
@@ -225,13 +223,7 @@ impl PenHolder {
         engine_view: &mut EngineViewMut,
     ) -> WidgetFlags {
         let mut widget_flags = WidgetFlags::default();
-        /*
-               log::debug!(
-                   "handle_pen_event(), event: {:?}, pen_mode_state: {:?}",
-                   event,
-                   self.pen_mode_state,
-               );
-        */
+
         if let Some(pen_mode) = pen_mode {
             widget_flags.merge(self.change_pen_mode(pen_mode, engine_view));
         }

--- a/rnote-engine/src/pens/penholder.rs
+++ b/rnote-engine/src/pens/penholder.rs
@@ -1,9 +1,4 @@
-use p2d::bounding_volume::Aabb;
-use piet::RenderContext;
-use rnote_compose::penevents::{PenEvent, ShortcutKey};
-use serde::{Deserialize, Serialize};
-use std::time::{Duration, Instant};
-
+// Imports
 use super::penbehaviour::PenProgress;
 use super::penmode::PenModeState;
 use super::shortcuts::ShortcutMode;
@@ -15,6 +10,11 @@ use crate::engine::{EngineView, EngineViewMut};
 use crate::pens::shortcuts::ShortcutAction;
 use crate::widgetflags::WidgetFlags;
 use crate::DrawOnDocBehaviour;
+use p2d::bounding_volume::Aabb;
+use piet::RenderContext;
+use rnote_compose::penevents::{PenEvent, ShortcutKey};
+use serde::{Deserialize, Serialize};
+use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum BacklogPolicy {
@@ -23,7 +23,7 @@ pub enum BacklogPolicy {
     DisableBacklog,
 }
 
-/// This holds the pens and related state and handles pen events.
+/// The Penholder holds the pens and related state and handles pen events.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default, rename = "penholder")]
 pub struct PenHolder {
@@ -31,7 +31,7 @@ pub struct PenHolder {
     pub shortcuts: Shortcuts,
     #[serde(rename = "pen_mode_state")]
     pub pen_mode_state: PenModeState,
-    /// Indicates the policy for the retrieval of the event backlog
+    /// The policy for the retrieval of input event backlogs.
     #[serde(skip)]
     pub backlog_policy: BacklogPolicy,
 
@@ -73,22 +73,22 @@ impl PenHolder {
     pub fn clear_shortcuts(&mut self) {
         self.shortcuts.clear();
     }
-    /// Registers a shortcut key and action
+    /// Register a shortcut key and action.
     pub fn register_shortcut(&mut self, key: ShortcutKey, action: ShortcutAction) {
         self.shortcuts.insert(key, action);
     }
 
-    /// Removes the shortcut action for the given shortcut key, if it is registered
+    /// Remove the shortcut action for the given shortcut key, if it is registered.
     pub fn remove_shortcut(&mut self, key: ShortcutKey) -> Option<ShortcutAction> {
         self.shortcuts.remove(&key)
     }
 
-    // Gets the current registered action the the given shortcut key
+    // Get the current registered action the the given shortcut key.
     pub fn get_shortcut_action(&self, key: ShortcutKey) -> Option<ShortcutAction> {
         self.shortcuts.get(&key).cloned()
     }
 
-    /// Lists all current registered shortcut keys and their action
+    /// List all current registered shortcut keys and their action.
     pub fn list_current_shortcuts(&self) -> Vec<(ShortcutKey, ShortcutAction)> {
         self.shortcuts
             .iter()
@@ -96,17 +96,17 @@ impl PenHolder {
             .collect()
     }
 
-    /// Gets the style without the temporary override.
+    /// Get the style without the temporary override.
     pub fn current_pen_style(&self) -> PenStyle {
         self.pen_mode_state.style()
     }
 
-    /// Gets the current style, or the override if it is set.
+    /// Get the current style, or the override if it is set.
     pub fn current_pen_style_w_override(&self) -> PenStyle {
         self.pen_mode_state.current_style_w_override()
     }
 
-    /// the current pen progress
+    /// The current pen progress.
     pub fn current_pen_progress(&self) -> PenProgress {
         self.pen_progress
     }
@@ -119,7 +119,7 @@ impl PenHolder {
         &mut self.current_pen
     }
 
-    /// change the pen style
+    /// Change the pen style.
     pub fn change_style(
         &mut self,
         new_style: PenStyle,
@@ -153,7 +153,7 @@ impl PenHolder {
         widget_flags
     }
 
-    /// change the style override
+    /// Change the style override.
     pub fn change_style_override(
         &mut self,
         new_style_override: Option<PenStyle>,
@@ -176,7 +176,9 @@ impl PenHolder {
         widget_flags
     }
 
-    /// change the pen mode (pen, eraser, etc.). Relevant for stylus input
+    /// Change the pen mode (pen, eraser, etc.).
+    ///
+    /// Relevant for stylus input.
     pub fn change_pen_mode(
         &mut self,
         new_pen_mode: PenMode,
@@ -197,7 +199,7 @@ impl PenHolder {
         self.current_pen.update_state(engine_view)
     }
 
-    /// Installs the pen for the current style
+    /// Reinstall the pen for the current style.
     pub fn reinstall_pen_current_style(&mut self, engine_view: &mut EngineViewMut) -> WidgetFlags {
         // first cancel the current pen
         let (_, mut widget_flags) =
@@ -214,7 +216,7 @@ impl PenHolder {
         widget_flags
     }
 
-    /// Handle a pen event
+    /// Handle a pen event.
     pub fn handle_pen_event(
         &mut self,
         event: PenEvent,
@@ -291,7 +293,7 @@ impl PenHolder {
         widget_flags
     }
 
-    /// Handle a pressed shortcut key
+    /// Handle a pressed shortcut key.
     pub fn handle_pressed_shortcut_key(
         &mut self,
         shortcut_key: ShortcutKey,
@@ -339,7 +341,7 @@ impl PenHolder {
         widget_flags
     }
 
-    /// fetches clipboard content from the current pen
+    /// Fetch clipboard content from the current pen.
     #[allow(clippy::type_complexity)]
     pub fn fetch_clipboard_content(
         &self,
@@ -348,7 +350,7 @@ impl PenHolder {
         self.current_pen.fetch_clipboard_content(engine_view)
     }
 
-    /// cuts clipboard content from the current pen
+    /// Cut clipboard content from the current pen.
     #[allow(clippy::type_complexity)]
     pub fn cut_clipboard_content(
         &mut self,

--- a/rnote-engine/src/pens/penmode.rs
+++ b/rnote-engine/src/pens/penmode.rs
@@ -1,20 +1,21 @@
+// Imports
+use super::PenStyle;
 use serde::{Deserialize, Serialize};
 
-use super::PenStyle;
-
-/// The pen mode
+/// The pen mode.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename = "pen_mode")]
 pub enum PenMode {
-    /// as pen (usually the default "side" of a stylus / when no buttons are pressed)
+    /// "Normal" pen mode.
+    /// Usually the default "side" of a stylus, when no buttons are pressed.
     #[serde(rename = "pen")]
     Pen,
-    /// as eraser
+    /// Eraser mode.
     #[serde(rename = "eraser")]
     Eraser,
 }
 
-/// the pen mode state, holding the current mode and pen styles for all pen modes
+/// The pen mode state, holding the current mode and pen styles for all pen modes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename = "pen_mode_state")]
 pub struct PenModeState {

--- a/rnote-engine/src/pens/pensconfig/brushconfig.rs
+++ b/rnote-engine/src/pens/pensconfig/brushconfig.rs
@@ -1,3 +1,5 @@
+// Imports
+use crate::store::chrono_comp::StrokeLayer;
 use rand::{Rng, SeedableRng};
 use rnote_compose::builders::PenPathBuilderType;
 use rnote_compose::style::smooth::SmoothOptions;
@@ -5,8 +7,6 @@ use rnote_compose::style::textured::TexturedOptions;
 use rnote_compose::style::PressureCurve;
 use rnote_compose::Style;
 use serde::{Deserialize, Serialize};
-
-use crate::store::chrono_comp::StrokeLayer;
 
 #[derive(
     Debug,

--- a/rnote-engine/src/pens/pensconfig/eraserconfig.rs
+++ b/rnote-engine/src/pens/pensconfig/eraserconfig.rs
@@ -1,3 +1,4 @@
+// Imports
 use p2d::bounding_volume::Aabb;
 use rnote_compose::penpath::Element;
 use serde::{Deserialize, Serialize};

--- a/rnote-engine/src/pens/pensconfig/mod.rs
+++ b/rnote-engine/src/pens/pensconfig/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 pub mod brushconfig;
 pub mod eraserconfig;
 pub mod selectorconfig;
@@ -5,7 +6,7 @@ pub mod shaperconfig;
 pub mod toolsconfig;
 pub mod typewriterconfig;
 
-// Re-Exports
+// Re-exports
 pub use brushconfig::BrushConfig;
 pub use eraserconfig::EraserConfig;
 pub use selectorconfig::SelectorConfig;
@@ -13,7 +14,7 @@ pub use shaperconfig::ShaperConfig;
 pub use toolsconfig::ToolsConfig;
 pub use typewriterconfig::TypewriterConfig;
 
-// Dependencies
+// Imports
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/rnote-engine/src/pens/pensconfig/selectorconfig.rs
+++ b/rnote-engine/src/pens/pensconfig/selectorconfig.rs
@@ -1,3 +1,4 @@
+// Imports
 use serde::{Deserialize, Serialize};
 
 #[derive(

--- a/rnote-engine/src/pens/pensconfig/shaperconfig.rs
+++ b/rnote-engine/src/pens/pensconfig/shaperconfig.rs
@@ -1,3 +1,4 @@
+// Imports
 use rand::{Rng, SeedableRng};
 use rnote_compose::builders::ShapeBuilderType;
 use rnote_compose::constraints::ConstraintRatio;

--- a/rnote-engine/src/pens/pensconfig/toolsconfig.rs
+++ b/rnote-engine/src/pens/pensconfig/toolsconfig.rs
@@ -1,3 +1,4 @@
+// Imports
 use serde::{Deserialize, Serialize};
 
 #[derive(

--- a/rnote-engine/src/pens/pensconfig/typewriterconfig.rs
+++ b/rnote-engine/src/pens/pensconfig/typewriterconfig.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
-
+// Imports
 use crate::strokes::textstroke::TextStyle;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default, rename = "typewriter_config")]

--- a/rnote-engine/src/pens/selector/mod.rs
+++ b/rnote-engine/src/pens/selector/mod.rs
@@ -120,8 +120,6 @@ impl PenBehaviour for Selector {
         now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
-        //log::debug!("selector state: {:?}, event: {:?}", &self.state, &event);
-
         match event {
             PenEvent::Down {
                 element,

--- a/rnote-engine/src/pens/selector/mod.rs
+++ b/rnote-engine/src/pens/selector/mod.rs
@@ -1,7 +1,7 @@
+// Modules
 mod penevents;
 
-use std::time::Instant;
-
+// Imports
 use super::penbehaviour::{PenBehaviour, PenProgress};
 use super::pensconfig::selectorconfig::SelectorStyle;
 use super::PenStyle;
@@ -10,6 +10,7 @@ use crate::store::StrokeKey;
 use crate::{Camera, DrawOnDocBehaviour, WidgetFlags};
 use kurbo::Shape;
 use once_cell::sync::Lazy;
+use p2d::bounding_volume::{Aabb, BoundingSphere, BoundingVolume};
 use p2d::query::PointQuery;
 use piet::RenderContext;
 use rnote_compose::helpers::{AabbHelpers, Vector2Helpers};
@@ -18,8 +19,7 @@ use rnote_compose::penpath::Element;
 use rnote_compose::shapes::ShapeBehaviour;
 use rnote_compose::style::indicators;
 use rnote_compose::{color, Color};
-
-use p2d::bounding_volume::{Aabb, BoundingSphere, BoundingVolume};
+use std::time::Instant;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(super) enum ResizeCorner {
@@ -397,9 +397,9 @@ static SELECTION_FILL_COLOR: Lazy<piet::Color> =
     Lazy::new(|| color::GNOME_BRIGHTS[2].with_alpha(0.050));
 
 impl Selector {
-    /// The threshold where a translation is applied ( in offset magnitude, surface coords )
+    /// The threshold magnitude where above it the translation is applied. In surface coordinates.
     const TRANSLATE_MAGNITUDE_THRESHOLD: f64 = 1.414;
-    /// The threshold angle (rad) where a rotation is applied
+    /// The threshold angle (in radians) where above it the rotation is applied.
     const ROTATE_ANGLE_THRESHOLD: f64 = ((2.0 * std::f64::consts::PI) / 360.0) * 0.2;
 
     const SELECTION_OUTLINE_WIDTH: f64 = 1.5;
@@ -407,9 +407,9 @@ impl Selector {
 
     const SINGLE_SELECTING_CIRCLE_RADIUS: f64 = 4.0;
 
-    /// resize node size, in surface coords
+    /// Resize node size, in surface coordinates.
     const RESIZE_NODE_SIZE: na::Vector2<f64> = na::vector![18.0, 18.0];
-    /// rotate node size, in surface coords
+    /// Rotate node size, in surface coordinates.
     const ROTATE_NODE_SIZE: f64 = 18.0;
 
     fn add_to_select_path(style: SelectorStyle, path: &mut Vec<Element>, element: Element) {

--- a/rnote-engine/src/pens/selector/penevents.rs
+++ b/rnote-engine/src/pens/selector/penevents.rs
@@ -1,17 +1,15 @@
-use std::time::Instant;
-
+// Imports
+use super::{ModifyState, ResizeCorner, Selector, SelectorState};
+use crate::engine::EngineViewMut;
+use crate::pens::penbehaviour::PenProgress;
+use crate::pens::pensconfig::selectorconfig::SelectorStyle;
+use crate::{DrawOnDocBehaviour, WidgetFlags};
 use p2d::bounding_volume::Aabb;
 use p2d::query::PointQuery;
 use rnote_compose::helpers::{AabbHelpers, Vector2Helpers};
 use rnote_compose::penevents::{KeyboardKey, ModifierKey};
 use rnote_compose::penpath::Element;
-
-use crate::engine::EngineViewMut;
-use crate::pens::penbehaviour::PenProgress;
-use crate::pens::pensconfig::selectorconfig::SelectorStyle;
-use crate::{DrawOnDocBehaviour, WidgetFlags};
-
-use super::{ModifyState, ResizeCorner, Selector, SelectorState};
+use std::time::Instant;
 
 impl Selector {
     pub(super) fn handle_pen_event_down(

--- a/rnote-engine/src/pens/shaper.rs
+++ b/rnote-engine/src/pens/shaper.rs
@@ -1,12 +1,10 @@
-use std::time::Instant;
-
+// Imports
 use super::penbehaviour::{PenBehaviour, PenProgress};
 use super::PenStyle;
 use crate::engine::{EngineView, EngineViewMut};
 use crate::strokes::ShapeStroke;
 use crate::strokes::Stroke;
 use crate::{DrawOnDocBehaviour, WidgetFlags};
-
 use p2d::bounding_volume::Aabb;
 use piet::RenderContext;
 use rnote_compose::builders::{ArrowBuilder, GridBuilder};
@@ -18,6 +16,7 @@ use rnote_compose::builders::{CubBezBuilder, QuadBezBuilder, ShapeBuilderType};
 use rnote_compose::builders::{ShapeBuilderCreator, ShapeBuilderProgress};
 use rnote_compose::penevents::{KeyboardKey, ModifierKey, PenEvent};
 use rnote_compose::penpath::Element;
+use std::time::Instant;
 
 #[derive(Debug)]
 enum ShaperState {

--- a/rnote-engine/src/pens/shortcuts.rs
+++ b/rnote-engine/src/pens/shortcuts.rs
@@ -1,9 +1,9 @@
+// Imports
+use super::PenStyle;
 use rnote_compose::penevents::ShortcutKey;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
-
-use super::PenStyle;
 
 #[repr(u32)]
 #[derive(
@@ -49,7 +49,7 @@ pub enum ShortcutAction {
     },
 }
 
-/// holds the registered shortcut actions for the given shortcut keys
+/// The registered shortcut actions for the given shortcut keys.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename = "shortcuts")]
 pub struct Shortcuts(HashMap<ShortcutKey, ShortcutAction>);

--- a/rnote-engine/src/pens/tools.rs
+++ b/rnote-engine/src/pens/tools.rs
@@ -1,19 +1,17 @@
-use std::time::Instant;
-
+// Imports
+use super::penbehaviour::{PenBehaviour, PenProgress};
+use super::pensconfig::toolsconfig::ToolStyle;
+use super::PenStyle;
 use crate::engine::{EngineView, EngineViewMut};
 use crate::store::StrokeKey;
 use crate::{DrawOnDocBehaviour, WidgetFlags};
 use once_cell::sync::Lazy;
+use p2d::bounding_volume::Aabb;
 use piet::RenderContext;
 use rnote_compose::color;
 use rnote_compose::helpers::{AabbHelpers, Vector2Helpers};
 use rnote_compose::penevents::PenEvent;
-
-use p2d::bounding_volume::Aabb;
-
-use super::penbehaviour::{PenBehaviour, PenProgress};
-use super::pensconfig::toolsconfig::ToolStyle;
-use super::PenStyle;
+use std::time::Instant;
 
 #[derive(Clone, Debug)]
 pub struct VerticalSpaceTool {
@@ -209,7 +207,7 @@ impl PenBehaviour for Tools {
 
                         self.verticalspace_tool.strokes_below = engine_view
                             .store
-                            .keys_below_y_pos(self.verticalspace_tool.current_pos_y);
+                            .keys_below_y(self.verticalspace_tool.current_pos_y);
                     }
                     ToolStyle::OffsetCamera => {
                         self.offsetcamera_tool.start = element.pos;

--- a/rnote-engine/src/pens/typewriter/mod.rs
+++ b/rnote-engine/src/pens/typewriter/mod.rs
@@ -318,14 +318,6 @@ impl PenBehaviour for Typewriter {
         now: Instant,
         engine_view: &mut EngineViewMut,
     ) -> (PenProgress, WidgetFlags) {
-        /*
-               log::debug!(
-                   "typewriter handle_event: state: {:#?}, event: {:#?}",
-                   self.state,
-                   event
-               );
-        */
-
         let (pen_progress, widget_flags) = match event {
             PenEvent::Down {
                 element,

--- a/rnote-engine/src/pens/typewriter/mod.rs
+++ b/rnote-engine/src/pens/typewriter/mod.rs
@@ -1,6 +1,15 @@
+// Modules
 mod penevents;
 
 // Imports
+use super::penbehaviour::PenProgress;
+use super::PenBehaviour;
+use super::PenStyle;
+use crate::engine::{EngineView, EngineViewMut};
+use crate::store::StrokeKey;
+use crate::strokes::textstroke::{RangedTextAttribute, TextAttribute, TextStyle};
+use crate::strokes::{Stroke, TextStroke};
+use crate::{AudioPlayer, Camera, DrawOnDocBehaviour, WidgetFlags};
 use once_cell::sync::Lazy;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use piet::RenderContext;
@@ -13,22 +22,15 @@ use std::ops::Range;
 use std::time::Instant;
 use unicode_segmentation::GraphemeCursor;
 
-use super::penbehaviour::PenProgress;
-use super::PenBehaviour;
-use super::PenStyle;
-use crate::engine::{EngineView, EngineViewMut};
-use crate::store::StrokeKey;
-use crate::strokes::textstroke::{RangedTextAttribute, TextAttribute, TextStyle};
-use crate::strokes::{Stroke, TextStroke};
-use crate::{AudioPlayer, Camera, DrawOnDocBehaviour, WidgetFlags};
-
 #[derive(Debug, Clone)]
 pub(super) enum ModifyState {
     Up,
     Hover(na::Vector2<f64>),
     Selecting {
         selection_cursor: GraphemeCursor,
-        /// If selecting is finished ( if true, will get reset on the next click )
+        /// Whether selecting is finished.
+        ///
+        /// If true, the state will get reset on the next click.
         finished: bool,
     },
     Translating {
@@ -195,7 +197,7 @@ impl DrawOnDocBehaviour for Typewriter {
                         }
                         _ => PenState::Up,
                     };
-                    indicators::draw_triangular_down_node(
+                    indicators::draw_triangular_node(
                         cx,
                         adjust_text_width_node_state,
                         Self::adjust_text_width_node_center(
@@ -476,7 +478,7 @@ impl PenBehaviour for Typewriter {
     }
 }
 
-// Updates the cursors to valid positions and new text length.
+// Update the cursors to valid positions and new text length.
 fn update_cursors_for_textstroke(
     textstroke: &TextStroke,
     cursor: &mut GraphemeCursor,
@@ -497,13 +499,13 @@ fn update_cursors_for_textstroke(
 }
 
 impl Typewriter {
-    // The size of the translate node, located in the upper left corner
+    // The size of the translate node, located in the upper left corner.
     const TRANSLATE_NODE_SIZE: na::Vector2<f64> = na::vector![18.0, 18.0];
-    /// The threshold where a translation is applied ( as offset magnitude, surface coords )
+    /// The threshold magniuted where above it the translation is applied. In surface coordinates.
     const TRANSLATE_MAGNITUDE_THRESHOLD: f64 = 1.414;
-    /// The threshold in x-axis direction where adjusting the text width is applied ( as offset, surface coords )
+    /// The threshold in x-axis direction where above it adjustments to the text width are applied. In surface coordinates.
     const ADJ_TEXT_WIDTH_THRESHOLD: f64 = 1.0;
-    // The size of the translate node, located in the upper left corner
+    // The size of the translate node, located in the upper right corner.
     const ADJUST_TEXT_WIDTH_NODE_SIZE: na::Vector2<f64> = na::vector![18.0, 18.0];
 
     fn start_audio(keyboard_key: Option<KeyboardKey>, audioplayer: &mut Option<AudioPlayer>) {
@@ -512,7 +514,7 @@ impl Typewriter {
         }
     }
 
-    /// the bounds of the text rect enclosing the textstroke
+    /// The bounds of the text rect enclosing the textstroke.
     fn text_rect_bounds(text_width: f64, textstroke: &TextStroke) -> Aabb {
         let origin = textstroke.transform.translation_part();
         Aabb::new(
@@ -522,7 +524,7 @@ impl Typewriter {
         .merged(&textstroke.bounds())
     }
 
-    /// the bounds of the translate node
+    /// The bounds of the translate node.
     fn translate_node_bounds(typewriter_bounds: Aabb, camera: &Camera) -> Aabb {
         let total_zoom = camera.total_zoom();
         Aabb::from_half_extents(
@@ -533,7 +535,7 @@ impl Typewriter {
         )
     }
 
-    /// the center of the adjust text width node
+    /// The center of the adjust text width node.
     fn adjust_text_width_node_center(
         text_rect_origin: na::Vector2<f64>,
         text_width: f64,
@@ -546,7 +548,7 @@ impl Typewriter {
         ]
     }
 
-    /// the bounds of the adjust text width node
+    /// The bounds of the adjust text width node.
     fn adjust_text_width_node_bounds(
         text_rect_origin: na::Vector2<f64>,
         text_width: f64,
@@ -560,7 +562,7 @@ impl Typewriter {
         )
     }
 
-    /// Returns the range of the current selection, if available
+    /// The range of the current selection, if available.
     pub fn selection_range(&self) -> Option<(Range<usize>, StrokeKey)> {
         if let TypewriterState::Modifying {
             modify_state:
@@ -581,8 +583,9 @@ impl Typewriter {
         }
     }
 
-    /// Inserts text either at the current cursor position or,
-    /// if the state is idle, a new textstroke (at the preferred position, if supplied. Else at a default offset).
+    /// Insert text either at the current cursor position or, if the state is idle, in a new textstroke.
+    ///
+    /// Inserts at the given position, if supplied. Else at a default offset.
     pub fn insert_text(
         &mut self,
         text: String,
@@ -729,7 +732,7 @@ impl Typewriter {
         widget_flags
     }
 
-    // changes the text style of the text stroke that is currently being modified
+    // Change the text style of the text stroke that is currently being modified.
     pub fn change_text_style_in_modifying_stroke<F>(
         &mut self,
         modify_func: F,

--- a/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/rnote-engine/src/pens/typewriter/penevents.rs
@@ -1,14 +1,14 @@
-use rnote_compose::penevents::{KeyboardKey, ModifierKey};
-use rnote_compose::penpath::Element;
-use std::time::Instant;
-use unicode_segmentation::GraphemeCursor;
-
+// Imports
 use super::{ModifyState, Typewriter, TypewriterState};
 use crate::engine::EngineViewMut;
 use crate::pens::penbehaviour::PenProgress;
 use crate::pens::PenBehaviour;
 use crate::strokes::{Stroke, TextStroke};
 use crate::{DrawOnDocBehaviour, StrokeStore, WidgetFlags};
+use rnote_compose::penevents::{KeyboardKey, ModifierKey};
+use rnote_compose::penpath::Element;
+use std::time::Instant;
+use unicode_segmentation::GraphemeCursor;
 
 impl Typewriter {
     pub(super) fn handle_pen_event_down(

--- a/rnote-engine/src/store/chrono_comp.rs
+++ b/rnote-engine/src/store/chrono_comp.rs
@@ -1,11 +1,10 @@
-use std::cmp::Ordering;
-use std::sync::Arc;
-
+// Imports
+use super::{StrokeKey, StrokeStore};
 use p2d::bounding_volume::Aabb;
 use rayon::slice::ParallelSliceMut;
 use serde::{Deserialize, Serialize};
-
-use super::{StrokeKey, StrokeStore};
+use std::cmp::Ordering;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq)]
 #[serde(rename = "stroke_layer")]
@@ -100,7 +99,7 @@ impl StrokeStore {
         }
     }
 
-    /// Returns the keys in chronological order, as in first: gets drawn first, last: gets drawn last
+    /// Returns the keys in chronological order, as in first: gets drawn first, last: gets drawn last.
     pub fn keys_sorted_chrono(&self) -> Vec<StrokeKey> {
         let chrono_components = &self.chrono_components;
 

--- a/rnote-engine/src/store/keytree.rs
+++ b/rnote-engine/src/store/keytree.rs
@@ -1,8 +1,9 @@
+use super::StrokeKey;
+/// Imports
 use p2d::bounding_volume::Aabb;
 use rstar::primitives::GeomWithData;
 
-use super::StrokeKey;
-
+/// The rtree object that holds the bounds and [StrokeKey].
 type KeyTreeObject = GeomWithData<rstar::primitives::Rectangle<[f64; 2]>, StrokeKey>;
 
 fn new_keytree_object(key: StrokeKey, bounds: Aabb) -> KeyTreeObject {
@@ -16,29 +17,33 @@ fn new_keytree_object(key: StrokeKey, bounds: Aabb) -> KeyTreeObject {
 }
 
 #[derive(Debug, Default)]
-/// A Rtree with StrokeKeys as associated data. Used for faster spatial queries
+/// A Rtree with [StrokeKey]'s as associated data.
+///
+/// Used for faster spatial queries.
 pub(super) struct KeyTree(rstar::RTree<KeyTreeObject, rstar::DefaultParams>);
 
 impl KeyTree {
-    /// Inserts a new tree object with the given key, bounds
+    /// Insert a new tree object with the given [StrokeKey] and bounds.
     pub fn insert_with_key(&mut self, key: StrokeKey, bounds: Aabb) {
         self.0.insert(new_keytree_object(key, bounds));
     }
 
-    /// has to iterate through the entire tree in no particular order
+    /// Removes the [KeyTreeObject] for the given key.
     pub fn remove_with_key(&mut self, key: StrokeKey) -> Option<KeyTreeObject> {
         let object_to_remove = self.0.iter().find(|&object| object.data == key)?.to_owned();
 
         self.0.remove(&object_to_remove)
     }
 
-    /// has to be called when the geometry of the stroke with the given key has changed.
+    /// Update the Tree with new bounds for the given key.
+    ///
+    /// Has to be called when the geometry of the stroke has changed.
     pub fn update_with_key(&mut self, key: StrokeKey, new_bounds: Aabb) {
         self.remove_with_key(key);
         self.insert_with_key(key, new_bounds);
     }
 
-    /// Returns the keys that intersect with the given bounds
+    /// Return the keys that intersect with the given bounds.
     pub fn keys_intersecting_bounds(&self, bounds: Aabb) -> Vec<StrokeKey> {
         self.0
             .locate_in_envelope_intersecting(&rstar::AABB::from_corners(
@@ -49,7 +54,7 @@ impl KeyTree {
             .collect()
     }
 
-    /// Returns the keys that completely are in the given bounds
+    /// Return the keys that are completely contained in the given bounds.
     pub fn keys_in_bounds(&self, bounds: Aabb) -> Vec<StrokeKey> {
         self.0
             .locate_in_envelope(&rstar::AABB::from_corners(
@@ -60,7 +65,7 @@ impl KeyTree {
             .collect()
     }
 
-    /// Reloads the entire tree from the given Vec of (key, bounds).
+    /// Reload the entire tree from the given Vec of (key, bounds).
     pub fn reload_with_vec(&mut self, strokes: Vec<(StrokeKey, Aabb)>) {
         let objects = strokes
             .into_iter()
@@ -70,7 +75,7 @@ impl KeyTree {
         self.0 = rstar::RTree::bulk_load(objects);
     }
 
-    ///  Clears the entire tree
+    ///  Clear the entire tree.
     pub fn clear(&mut self) {
         *self = Self::default()
     }

--- a/rnote-engine/src/store/mod.rs
+++ b/rnote-engine/src/store/mod.rs
@@ -188,10 +188,11 @@ impl StrokeStore {
 
         // Since we don't store the rtree in the history, we need to reload it.
         self.reload_rtree();
-        // render_components are also not stored in the history, but for the duration of the running app we don't ever remove it,
-        // so we can actually skip rebuilding it when importing a history entry. This avoids flickering where we have already rebuilt the components
-        // and can't display anything until the asynchronous rendering is finished
-        // self.reload_render_components_slotmap();
+        // render components are also not stored in the history, but for the duration of the running app we don't ever remove them,
+        // so we can actually skip rebuilding them when importing a history entry.
+        // This avoids flickering when we have already rebuilt the components
+        // and wouldn't be able to display anything until the rendering is finished.
+        //self.reload_render_components_slotmap();
 
         let all_strokes = self.stroke_keys_unordered();
         self.set_rendering_dirty_for_strokes(&all_strokes);
@@ -199,63 +200,21 @@ impl StrokeStore {
 
     /// Record the current state and saves it in the history.
     pub fn record(&mut self, _now: Instant) -> WidgetFlags {
-        /*
-               log::debug!(
-                   "before record - history len: {}, pos: {:?}",
-                   self.history.len(),
-                   self.history_pos
-               );
-        */
         self.simple_style_record()
-        /*
-               log::debug!(
-                   "after record - history len: {}, pos: {:?}",
-                   self.history.len(),
-                   self.history_pos
-               );
-        */
     }
 
     /// Undo the latest changes.
     ///
     /// Should only be called inside the engine undo wrapper function.
     pub(super) fn undo(&mut self, _now: Instant) -> WidgetFlags {
-        /*
-               log::debug!(
-                   "before undo - history len: {}, pos: {:?}",
-                   self.history.len(),
-                   self.history_pos
-               );
-        */
         self.simple_style_undo()
-        /*
-               log::debug!(
-                   "after undo - history len: {}, pos: {:?}",
-                   self.history.len(),
-                   self.history_pos
-               );
-        */
     }
 
     /// Redo the latest changes.
     ///
     /// Should only be called inside the engine redo wrapper function.
     pub(super) fn redo(&mut self, _now: Instant) -> WidgetFlags {
-        /*
-               log::debug!(
-                   "before redo - history len: {}, pos: {:?}",
-                   self.history.len(),
-                   self.history_pos
-               );
-        */
         self.simple_style_redo()
-        /*
-               log::debug!(
-                   "after redo - history len: {}, pos: {:?}",
-                   self.history.len(),
-                   self.history_pos
-               );
-        */
     }
 
     pub(super) fn can_undo(&self) -> bool {

--- a/rnote-engine/src/store/mod.rs
+++ b/rnote-engine/src/store/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 pub mod chrono_comp;
 pub mod keytree;
 pub mod render_comp;
@@ -12,18 +13,17 @@ pub use render_comp::RenderComponent;
 pub use selection_comp::SelectionComponent;
 pub use trash_comp::TrashComponent;
 
-use std::collections::VecDeque;
-use std::sync::Arc;
-use std::time::Instant;
-
+// Imports
+use self::chrono_comp::StrokeLayer;
 use crate::engine::EngineSnapshot;
 use crate::strokes::Stroke;
 use crate::WidgetFlags;
 use rnote_compose::shapes::ShapeBehaviour;
 use serde::{Deserialize, Serialize};
 use slotmap::{HopSlotMap, SecondaryMap};
-
-use self::chrono_comp::StrokeLayer;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::Instant;
 
 slotmap::new_key_type! {
     pub struct StrokeKey;
@@ -60,16 +60,18 @@ impl Default for HistoryEntry {
 
 /// StrokeStore implements a Entity - Component - System pattern.
 /// The Entities are the StrokeKey's, which represent a stroke. There are different components for them:
-///     * 'stroke_components': Hold geometric data. These components are special in that they are the primary map. A new stroke must have this component. (could also be called geometric components)
-///     * 'trash_components': Hold state whether the strokes are trashed
-///     * 'selection_components': Hold state whether the strokes are selected
-///     * 'chrono_components': Hold state about the chronological ordering
-///     * 'render_components': Hold state about the current rendering of the strokes.
+///     * 'stroke_components': Holds state about geometric properties. These components are special in the way that they are the primary map.
+///         A new stroke must have this component. (another name for them could be 'geometric_components')
+///     * 'trash_components': Holds state whether the strokes are trashed
+///     * 'selection_components': Holds state whether the strokes are selected
+///     * 'chrono_components': Holds state about the chronological ordering
+///     * 'render_components': Holds state about the rendering.
 ///
 /// The systems are implemented as methods on StrokesStore, loosely categorized to the different components (but often modify others as well).
 /// Most systems take a key or a slice of keys, and iterate with them over the different components.
-/// There also is a different category of methods which return filtered keys, (e.g. `.keys_sorted_chrono` returns the keys in chronological ordering,
-///     `.stroke_keys_in_order_rendering` filters and returns keys in the order which they should be rendered)
+/// There also is a different category of methods which return filtered keys.
+/// For example: [StrokeStore::keys_sorted_chrono] returns the keys in chronological ordering,
+///     [StrokeStore::selection_keys_as_rendered] filters and returns only the selection keys in the order which should be drawn/rendered).
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default, rename = "stroke_store")]
@@ -86,18 +88,19 @@ pub struct StrokeStore {
     #[serde(skip)]
     render_components: SecondaryMap<StrokeKey, RenderComponent>,
 
-    // The history
     #[serde(skip)]
     history: VecDeque<Arc<HistoryEntry>>,
     #[serde(skip)]
     history_pos: Option<usize>,
 
-    // A rtree backed by the slotmap, for faster spatial queries. Needs to be updated with update_with_key() when strokes changed their geometry or position!
+    /// An rtree backed by the slotmap store, for faster spatial queries.
+    /// Needs to be updated with update_with_key() when strokes changed their geometry or position!
     #[serde(skip)]
     key_tree: KeyTree,
 
-    // Other state
-    /// incrementing counter for chrono_components. value must be equal chrono_component of the newest inserted or modified stroke.
+    /// Incrementing counter for chrono_components.
+    ///
+    /// Value must be equal to the [ChronoComponent] of the newest inserted or modified stroke.
     #[serde(rename = "chrono_counter")]
     chrono_counter: u32,
 }
@@ -122,11 +125,12 @@ impl Default for StrokeStore {
 }
 
 impl StrokeStore {
-    /// The max length of the history
+    /// Max length of the history.
     pub(crate) const HISTORY_MAX_LEN: usize = 100;
 
-    /// imports from a engine snapshot. A loaded strokes store should always be imported with this method.
-    /// the store then needs to update its rendering
+    /// Import from a engine snapshot. A loaded strokes store should always be imported with this method.
+    ///
+    /// The store then needs to update its rendering.
     pub fn import_from_snapshot(&mut self, snapshot: &EngineSnapshot) {
         self.clear();
         self.stroke_components = Arc::clone(&snapshot.stroke_components);
@@ -139,11 +143,11 @@ impl StrokeStore {
         self.rebuild_selection_components_slotmap();
         self.rebuild_trash_components_slotmap();
         self.rebuild_render_components_slotmap();
-        self.reload_tree();
+        self.reload_rtree();
     }
 
-    /// Reloads the rtree with the current bounds of the strokes.
-    pub fn reload_tree(&mut self) {
+    /// Reload the rtree with the current bounds of the strokes.
+    pub fn reload_rtree(&mut self) {
         let tree_objects = self
             .stroke_components
             .iter()
@@ -152,7 +156,7 @@ impl StrokeStore {
         self.key_tree.reload_with_vec(tree_objects);
     }
 
-    /// Returns true if the current state is pointer equal to the given history entry
+    /// Checks the pointer equality of current state to the given history entry.
     fn ptr_eq_w_history_entry(&self, history_entry: &Arc<HistoryEntry>) -> bool {
         Arc::ptr_eq(&self.stroke_components, &history_entry.stroke_components)
             && Arc::ptr_eq(&self.trash_components, &history_entry.trash_components)
@@ -163,7 +167,7 @@ impl StrokeStore {
             && Arc::ptr_eq(&self.chrono_components, &history_entry.chrono_components)
     }
 
-    /// Returns a history entry created from the current state
+    /// Create a history entry from the current state.
     pub fn history_entry_from_current_state(&self) -> Arc<HistoryEntry> {
         Arc::new(HistoryEntry {
             stroke_components: Arc::clone(&self.stroke_components),
@@ -174,17 +178,16 @@ impl StrokeStore {
         })
     }
 
-    /// Imports a given history entry and replaces the current state with it.
+    /// Import the given history entry and replaces the current state with it.
     fn import_history_entry(&mut self, history_entry: &Arc<HistoryEntry>) {
         self.stroke_components = Arc::clone(&history_entry.stroke_components);
         self.trash_components = Arc::clone(&history_entry.trash_components);
         self.selection_components = Arc::clone(&history_entry.selection_components);
         self.chrono_components = Arc::clone(&history_entry.chrono_components);
-
         self.chrono_counter = history_entry.chrono_counter;
 
-        // Since we don't store the tree in the history, we need to reload it.
-        self.reload_tree();
+        // Since we don't store the rtree in the history, we need to reload it.
+        self.reload_rtree();
         // render_components are also not stored in the history, but for the duration of the running app we don't ever remove it,
         // so we can actually skip rebuilding it when importing a history entry. This avoids flickering where we have already rebuilt the components
         // and can't display anything until the asynchronous rendering is finished
@@ -194,7 +197,7 @@ impl StrokeStore {
         self.set_rendering_dirty_for_strokes(&all_strokes);
     }
 
-    /// records the current state and saves it in the history
+    /// Record the current state and saves it in the history.
     pub fn record(&mut self, _now: Instant) -> WidgetFlags {
         /*
                log::debug!(
@@ -213,8 +216,9 @@ impl StrokeStore {
         */
     }
 
-    /// Undo the latest changes
-    /// Should only be called inside the engine undo wrapper function
+    /// Undo the latest changes.
+    ///
+    /// Should only be called inside the engine undo wrapper function.
     pub(super) fn undo(&mut self, _now: Instant) -> WidgetFlags {
         /*
                log::debug!(
@@ -233,8 +237,9 @@ impl StrokeStore {
         */
     }
 
-    /// Redo the latest changes. The actual behaviour might differ depending on the history mode (simple style, emacs style, ..)
-    /// Should only be called inside the engine redo wrapper function
+    /// Redo the latest changes.
+    ///
+    /// Should only be called inside the engine redo wrapper function.
     pub(super) fn redo(&mut self, _now: Instant) -> WidgetFlags {
         /*
                log::debug!(
@@ -348,7 +353,8 @@ impl StrokeStore {
         widget_flags
     }
 
-    /// Saves the current state in the history.
+    /// Save the current state in the history.
+    ///
     /// Only to be used in combination with emacs_style_break_undo_chain() and emacs_style_undo()
     #[allow(unused)]
     fn emacs_style_record(&mut self) {
@@ -371,9 +377,11 @@ impl StrokeStore {
         }
     }
 
-    /// emacs style undo, where the undo operation is pushed to the history as well.
-    /// after that, regenerate rendering for the current viewport.
+    /// Emacs style undo, where the undo operation is pushed to the history as well.
+    ///
     /// Only to be used in combination with emacs_style_break_undo_chain() and emacs_style_record()
+    ///
+    /// The store then needs to update its rendering.
     #[allow(unused)]
     fn emacs_style_undo(&mut self) {
         let index = self.history_pos.unwrap_or(self.history.len());
@@ -392,6 +400,7 @@ impl StrokeStore {
     }
 
     /// Breaks the undo chain, to enable redo by undoing the undos, emacs-style.
+    ///
     /// Only to be used in combination with emacs_style_undo() and emacs_style_record()
     #[allow(unused)]
     fn emacs_style_break_undo_chain(&mut self) {
@@ -399,13 +408,17 @@ impl StrokeStore {
         self.history_pos = None;
     }
 
+    /// Clear the entire history.
     pub fn clear_history(&mut self) {
         self.history.clear();
         self.history_pos = None;
     }
 
-    /// inserts a new stroke into the store. Optionally a desired layer can be specified, or the default stroke layer is used.
-    /// stroke then needs to update its rendering
+    /// Insert a new stroke into the store.
+    ///
+    /// Optionally a desired layer can be specified, or the default stroke layer is used.
+    ///
+    /// The stroke then needs to update its rendering.
     pub fn insert_stroke(&mut self, stroke: Stroke, layer: Option<StrokeLayer>) -> StrokeKey {
         let bounds = stroke.bounds();
         let layer = layer.unwrap_or_else(|| stroke.extract_default_layer());
@@ -427,7 +440,7 @@ impl StrokeStore {
         key
     }
 
-    /// permanently removes a stroke with the given key from the store
+    /// Permanently removes a stroke with the given key from the store.
     pub fn remove_stroke(&mut self, key: StrokeKey) -> Option<Stroke> {
         Arc::make_mut(&mut self.trash_components).remove(key);
         Arc::make_mut(&mut self.selection_components).remove(key);
@@ -440,7 +453,7 @@ impl StrokeStore {
             .map(|stroke| (*stroke).clone())
     }
 
-    /// Clears the entire store
+    /// Clears the entire store.
     pub(super) fn clear(&mut self) {
         Arc::make_mut(&mut self.stroke_components).clear();
         Arc::make_mut(&mut self.trash_components).clear();

--- a/rnote-engine/src/store/selection_comp.rs
+++ b/rnote-engine/src/store/selection_comp.rs
@@ -1,8 +1,8 @@
+// Imports
 use super::render_comp::RenderCompState;
 use super::{StrokeKey, StrokeStore};
 use crate::strokes::strokebehaviour::GeneratedStrokeImages;
 use crate::strokes::Stroke;
-
 use p2d::bounding_volume::Aabb;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -26,8 +26,9 @@ impl SelectionComponent {
     }
 }
 
+/// Systems that are related to selecting.
 impl StrokeStore {
-    /// Reloads the slotmap with empty selection components from the keys returned from the primary map, stroke_components.
+    /// Reload the slotmap with empty selection components with the keys returned from the stroke components.
     pub fn rebuild_selection_components_slotmap(&mut self) {
         self.selection_components = Arc::new(slotmap::SecondaryMap::new());
         self.stroke_components.keys().for_each(|key| {
@@ -36,7 +37,7 @@ impl StrokeStore {
         });
     }
 
-    /// Returns false if selecting is unsupported
+    /// Ability if selecting is supported.
     pub fn can_select(&self, key: StrokeKey) -> bool {
         self.selection_components.get(key).is_some()
     }
@@ -47,7 +48,7 @@ impl StrokeStore {
             .map(|selection_comp| selection_comp.selected)
     }
 
-    /// Sets if the stroke is currently selected
+    /// Set if the stroke is currently selected.
     pub fn set_selected(&mut self, key: StrokeKey, selected: bool) {
         if let Some(selection_comp) = Arc::make_mut(&mut self.selection_components)
             .get_mut(key)
@@ -74,8 +75,9 @@ impl StrokeStore {
             .collect()
     }
 
-    /// Returns the selection keys in the order that they should be rendered.
-    /// Does not return the not-selected stroke keys.
+    /// Return the selection keys in the order that they should be rendered.
+    ///
+    /// Does not return the non-selected stroke keys.
     pub fn selection_keys_as_rendered(&self) -> Vec<StrokeKey> {
         let keys_sorted_chrono = self.keys_sorted_chrono();
 
@@ -87,8 +89,9 @@ impl StrokeStore {
             .collect::<Vec<StrokeKey>>()
     }
 
-    /// Returns the selection keys in the order that they should be rendered that intersect the given bounds.
-    /// Does not return the not-selected stroke keys.
+    /// Return the selection keys in the order that they should be rendered that intersect the given bounds.
+    ///
+    /// Does not return the non-selected stroke keys.
     pub fn selection_keys_as_rendered_intersecting_bounds(&self, bounds: Aabb) -> Vec<StrokeKey> {
         self.keys_sorted_chrono_intersecting_bounds(bounds)
             .into_iter()
@@ -98,14 +101,16 @@ impl StrokeStore {
             .collect::<Vec<StrokeKey>>()
     }
 
-    /// Generates the bounds that include all selected strokes.
+    /// Generate the bounds that include all selected strokes.
+    ///
     /// None if no strokes are selected
     pub fn gen_selection_bounds(&self) -> Option<Aabb> {
         self.bounds_for_strokes(&self.selection_keys_unordered())
     }
 
-    /// Duplicates the selected keys
-    /// the returned, duplicated strokes then need to update their geometry and rendering
+    /// Duplicate the selected keys.
+    ///
+    /// The returned, duplicated strokes then need to update their geometry and rendering.
     pub fn duplicate_selection(&mut self) -> Vec<StrokeKey> {
         let old_selected = self.selection_keys_as_rendered();
         self.set_selected_keys(&old_selected, false);

--- a/rnote-engine/src/store/trash_comp.rs
+++ b/rnote-engine/src/store/trash_comp.rs
@@ -1,8 +1,8 @@
+// Imports
 use super::chrono_comp::StrokeLayer;
 use super::{StrokeKey, StrokeStore};
 use crate::strokes::{BrushStroke, Stroke};
 use crate::WidgetFlags;
-
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use rnote_compose::shapes::ShapeBehaviour;
 use rnote_compose::PenPath;
@@ -22,9 +22,9 @@ impl Default for TrashComponent {
     }
 }
 
-/// Systems that are related trashing
+/// Systems that are related to trashing.
 impl StrokeStore {
-    /// Rebuilds the slotmap with default trash components from the keys returned from the primary map, stroke_components.
+    /// Reload the slotmap with empty trash components with the keys returned from the stroke components.
     pub fn rebuild_trash_components_slotmap(&mut self) {
         self.trash_components = Arc::new(slotmap::SecondaryMap::new());
         self.stroke_components.keys().for_each(|key| {
@@ -33,6 +33,7 @@ impl StrokeStore {
         });
     }
 
+    /// Ability if trashing is supported.
     pub fn can_trash(&self, key: StrokeKey) -> bool {
         self.trash_components.get(key).is_some()
     }
@@ -86,7 +87,7 @@ impl StrokeStore {
         }
     }
 
-    /// trash strokes that collide with the given bounds
+    /// Trash strokes that collide with the given bounds.
     pub fn trash_colliding_strokes(&mut self, eraser_bounds: Aabb, viewport: Aabb) -> WidgetFlags {
         let mut widget_flags = WidgetFlags::default();
 
@@ -125,9 +126,12 @@ impl StrokeStore {
         widget_flags
     }
 
-    /// remove colliding stroke segments with the given bounds. The stroke is then split. For strokes that don't have segments, trash the entire stroke.
+    /// Remove colliding stroke segments with the given bounds.
+    /// The stroke is then split. Strokes that don't have segments are trashed completely.
+    ///
     /// Returns the keys of all created or modified strokes.
-    /// returned strokes need to update their rendering.
+    ///
+    /// The returned strokes need to update their rendering.
     pub fn split_colliding_strokes(
         &mut self,
         eraser_bounds: Aabb,

--- a/rnote-engine/src/strokes/bitmapimage.rs
+++ b/rnote-engine/src/strokes/bitmapimage.rs
@@ -1,11 +1,13 @@
-use std::ops::Range;
-
+// Imports
 use super::strokebehaviour::GeneratedStrokeImages;
 use super::{Stroke, StrokeBehaviour};
 use crate::document::Format;
 use crate::engine::import::{PdfImportPageSpacing, PdfImportPrefs};
 use crate::render;
 use crate::DrawBehaviour;
+use anyhow::Context;
+use gtk4::{cairo, glib};
+use p2d::bounding_volume::{Aabb, BoundingVolume};
 use piet::RenderContext;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rnote_compose::color;
@@ -14,16 +16,16 @@ use rnote_compose::shapes::Rectangle;
 use rnote_compose::shapes::ShapeBehaviour;
 use rnote_compose::transform::Transform;
 use rnote_compose::transform::TransformBehaviour;
-
-use anyhow::Context;
-use gtk4::{cairo, glib};
-use p2d::bounding_volume::{Aabb, BoundingVolume};
 use serde::{Deserialize, Serialize};
+use std::ops::Range;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename = "bitmapimage")]
 pub struct BitmapImage {
-    /// The bounds field of the image should not be used to determine the stroke bounds. Use rectangle.bounds() instead.
+    /// The bitmap image.
+    ///
+    /// The bounds field of the image should not be used to determine the stroke bounds.
+    /// Use rectangle.bounds() instead.
     #[serde(rename = "image")]
     pub image: render::Image,
     #[serde(rename = "rectangle")]

--- a/rnote-engine/src/strokes/brushstroke.rs
+++ b/rnote-engine/src/strokes/brushstroke.rs
@@ -213,7 +213,7 @@ impl TransformBehaviour for BrushStroke {
 }
 
 impl BrushStroke {
-    /// The treshold where when above it, images are generated for each segment instead of one for the entire stroke.
+    /// The threshold where when above it, images are generated for each segment instead of one for the entire stroke.
     pub const IMAGES_SEGMENTS_THRESHOLD: f64 = 1000.0;
 
     pub fn new(start: Element, style: Style) -> Self {

--- a/rnote-engine/src/strokes/mod.rs
+++ b/rnote-engine/src/strokes/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 pub mod bitmapimage;
 pub mod brushstroke;
 pub mod shapestroke;

--- a/rnote-engine/src/strokes/shapestroke.rs
+++ b/rnote-engine/src/strokes/shapestroke.rs
@@ -1,6 +1,8 @@
+// Imports
 use super::strokebehaviour::GeneratedStrokeImages;
 use super::StrokeBehaviour;
 use crate::{render, DrawBehaviour};
+use p2d::bounding_volume::{Aabb, BoundingVolume};
 use piet::RenderContext;
 use rnote_compose::helpers::Vector2Helpers;
 use rnote_compose::shapes::Shape;
@@ -8,8 +10,6 @@ use rnote_compose::shapes::ShapeBehaviour;
 use rnote_compose::style::Composer;
 use rnote_compose::transform::TransformBehaviour;
 use rnote_compose::Style;
-
-use p2d::bounding_volume::{Aabb, BoundingVolume};
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
@@ -20,7 +20,7 @@ pub struct ShapeStroke {
     #[serde(rename = "style")]
     pub style: Style,
     #[serde(skip)]
-    // since the shape can have many hitboxes, we store them for faster queries and update them when the stroke geometry changes
+    // since the shape can have many hitboxes, we store them and update them when the stroke geometry changes
     hitboxes: Vec<Aabb>,
 }
 

--- a/rnote-engine/src/strokes/stroke.rs
+++ b/rnote-engine/src/strokes/stroke.rs
@@ -1,3 +1,13 @@
+// Imports
+use super::bitmapimage::BitmapImage;
+use super::brushstroke::BrushStroke;
+use super::shapestroke::ShapeStroke;
+use super::strokebehaviour::GeneratedStrokeImages;
+use super::vectorimage::VectorImage;
+use super::{StrokeBehaviour, TextStroke};
+use crate::store::chrono_comp::StrokeLayer;
+use crate::{render, RnoteEngine};
+use crate::{utils, DrawBehaviour};
 use base64::Engine;
 use p2d::bounding_volume::Aabb;
 use rnote_compose::helpers::AabbHelpers;
@@ -9,16 +19,6 @@ use rnote_compose::transform::TransformBehaviour;
 use rnote_compose::{Color, PenPath, Style};
 use rnote_fileformats::xoppformat::{self, XoppColor};
 use serde::{Deserialize, Serialize};
-
-use super::bitmapimage::BitmapImage;
-use super::brushstroke::BrushStroke;
-use super::shapestroke::ShapeStroke;
-use super::strokebehaviour::GeneratedStrokeImages;
-use super::vectorimage::VectorImage;
-use super::{StrokeBehaviour, TextStroke};
-use crate::store::chrono_comp::StrokeLayer;
-use crate::{render, RnoteEngine};
-use crate::{utils, DrawBehaviour};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename = "stroke")]
@@ -158,7 +158,7 @@ impl TransformBehaviour for Stroke {
 }
 
 impl Stroke {
-    /// The default offset in surface coords when importing a stroke
+    /// The default offset in surface coords when importing a stroke.
     pub const IMPORT_OFFSET_DEFAULT: na::Vector2<f64> = na::vector![32.0, 32.0];
 
     pub fn extract_default_layer(&self) -> StrokeLayer {
@@ -399,32 +399,8 @@ impl Stroke {
                 ))
             }
             Stroke::TextStroke(textstroke) => {
-                // Xournal++ text strokes do not support affine transformations, so we have to convert on best effort here. The best solution for now is to export as an image
-                /*
-                                let origin = textstroke.transform.translation_part();
-                                let untransformed_text_size = textstroke.text_style.untransformed_size(
-                                    &mut piet_cairo::CairoText::new(),
-                                    textstroke.text.clone(),
-                                )?;
-                                let font_scale = textstroke
-                                    .bounds()
-                                    .extents()
-                                    .component_div(&untransformed_text_size);
-                                let scaled_font_size = (textstroke.text_style.font_size * font_scale).mean();
-
-                                Some(xoppformat::XoppStrokeType::XoppText(xoppformat::XoppText {
-                                    x: utils::convert_value_dpi(origin[0], current_dpi, xoppformat::XoppFile::DPI),
-                                    y: utils::convert_value_dpi(origin[1], current_dpi, xoppformat::XoppFile::DPI),
-                                    size: utils::convert_value_dpi(
-                                        scaled_font_size,
-                                        current_dpi,
-                                        xoppformat::XoppFile::DPI,
-                                    ),
-                                    font: textstroke.text_style.font_family,
-                                    color: XoppColor::from(textstroke.text_style.color),
-                                    text: textstroke.text.clone(),
-                                }))
-                */
+                // Xournal++ text strokes do not support affine transformations, so we have to convert on best effort here.
+                // The best solution for now seems to be to export them as a bitmap image.
                 let png_data = match textstroke.export_as_bitmapimage_bytes(
                     image::ImageOutputFormat::Png,
                     RnoteEngine::STROKE_EXPORT_IMAGE_SCALE,

--- a/rnote-engine/src/strokes/strokebehaviour.rs
+++ b/rnote-engine/src/strokes/strokebehaviour.rs
@@ -1,40 +1,44 @@
+// Imports
 use crate::render;
 use crate::DrawBehaviour;
-
 use p2d::bounding_volume::Aabb;
 use rnote_compose::shapes::ShapeBehaviour;
 
 #[derive(Debug, Clone)]
-/// Generated stroke images. Some stroke types may only support generating (an) image(s) for the whole stroke
+/// Generated stroke images.
+///
+/// Some stroke types may only support generating image(s) for the whole stroke.
 pub enum GeneratedStrokeImages {
-    /// only part of the stroke was rendered (e.g. part of it is out of the viewport)
+    /// Only part of the stroke was rendered (for example when part of it is out of the current viewport).
     Partial {
         images: Vec<render::Image>,
         viewport: Aabb,
     },
-    /// All stroke images were rendered
+    /// All stroke images were rendered.
     Full(Vec<render::Image>),
 }
 
-/// Specifying that a type is a stroke.
-/// Also needs to implement drawbehaviour and shapebehaviour.
+/// Types that are strokes.
 pub trait StrokeBehaviour: DrawBehaviour + ShapeBehaviour
 where
     Self: Sized,
 {
-    /// generates the svg, without the xml header or the svg root. used for exporting.
-    /// implementors should translate the stroke drawing so that the svg has origin 0.0, 0.0
+    /// Generate Svg, without the xml header or the svg root. Used when exporting.
+    ///
+    /// Implementors should translate the stroke drawing so that the svg has origin (0.0, 0.0).
     fn gen_svg(&self) -> Result<render::Svg, anyhow::Error>;
 
-    /// generates pixel images for this stroke
-    /// a larger image_scale value renders them in a higher than native resolution (usually set as the camera zoom). the bounds stay the same.
+    /// Generates bitmap images.
+    ///
+    /// A larger `image_scale` value renders them in a higher than native resolution (usually set as the camera zoom).
+    /// The bounds are not scaled by it.
     fn gen_images(
         &self,
         viewport: Aabb,
         image_scale: f64,
     ) -> Result<GeneratedStrokeImages, anyhow::Error>;
 
-    /// Exporting as encoded image bytes (Png / Jpg, etc.)
+    /// Export as encoded bitmap image (Png/Jpg/..).
     fn export_as_bitmapimage_bytes(
         &self,
         format: image::ImageOutputFormat,

--- a/rnote-engine/src/strokes/textstroke.rs
+++ b/rnote-engine/src/strokes/textstroke.rs
@@ -591,7 +591,7 @@ impl TextStroke {
 
     /// Get a cursor matching best for the given coordinate.
     ///
-    /// The coordinte must be in global coordinate space.
+    /// `coord` must be in global coordinate space.
     pub fn get_cursor_for_global_coord(
         &self,
         coord: na::Vector2<f64>,

--- a/rnote-engine/src/strokes/textstroke.rs
+++ b/rnote-engine/src/strokes/textstroke.rs
@@ -1,3 +1,7 @@
+// Imports
+use super::strokebehaviour::GeneratedStrokeImages;
+use super::StrokeBehaviour;
+use crate::{render, Camera, DrawBehaviour};
 use gtk4::pango;
 use kurbo::Shape;
 use once_cell::sync::Lazy;
@@ -10,10 +14,6 @@ use rnote_compose::{color, Color, Transform};
 use serde::{Deserialize, Serialize};
 use std::ops::Range;
 use unicode_segmentation::{GraphemeCursor, UnicodeSegmentation};
-
-use super::strokebehaviour::GeneratedStrokeImages;
-use super::StrokeBehaviour;
-use crate::{render, Camera, DrawBehaviour};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename = "font_style")]
@@ -128,13 +128,13 @@ pub enum TextAttribute {
     /// The font size, in points.
     #[serde(rename = "font_size")]
     FontSize(f64),
-    /// The font weight
+    /// The font weight.
     #[serde(rename = "font_weight")]
     FontWeight(u16),
     /// The foreground color of the text.
     #[serde(rename = "text_color")]
     TextColor(Color),
-    /// The font style
+    /// The font style.
     #[serde(rename = "font_style")]
     Style(FontStyle),
     /// Underline.
@@ -234,41 +234,6 @@ impl TextStyle {
     pub const FONT_WEIGHT_DEFAULT: u16 = 500;
     pub const FONT_COLOR_DEFAULT: Color = Color::BLACK;
 
-    pub fn load_pango_font_desc(&mut self, pango_font_desc: pango::FontDescription) {
-        if let Some(font_family) = pango_font_desc.family() {
-            self.font_family = font_family.to_string();
-        }
-
-        let font_size = f64::from(pango_font_desc.size()) / f64::from(pango::SCALE);
-        // Is <= 0.0 when no font size is selected
-        if font_size > 0.0 {
-            self.font_size = font_size;
-        }
-
-        self.font_weight = crate::utils::pango_font_weight_to_raw(pango_font_desc.weight());
-        self.font_style = pango_font_desc.style().into();
-    }
-
-    pub fn extract_pango_font_desc(&self) -> pango::FontDescription {
-        let mut pango_font_desc = pango::FontDescription::new();
-        pango_font_desc.set_family(self.font_family.as_str());
-        pango_font_desc.set_size((self.font_size * f64::from(pango::SCALE)).round() as i32);
-        pango_font_desc.set_weight(crate::utils::raw_font_weight_to_pango(self.font_weight));
-        pango_font_desc.set_style(self.font_style.into());
-
-        /*
-               log::debug!(
-                   "extract_pango_font_descr\nfamily: {:?}; size: {:?}, weight: {:?}, style: {:?}",
-                   pango_font_desc.family(),
-                   pango_font_desc.size(),
-                   pango_font_desc.weight(),
-                   pango_font_desc.style()
-               );
-        */
-
-        pango_font_desc
-    }
-
     pub fn build_text_layout<T>(
         &self,
         piet_text: &mut T,
@@ -295,7 +260,9 @@ impl TextStyle {
             text_layout_builder = text_layout_builder.max_width(max_width);
         }
 
-        // We need to sort the ranges before adding them to the text layout, else attributes might be skipped. (the cairo backend asserts for it in debug builds)
+        // We need to sort the ranges before adding them to the text layout, else attributes might be skipped.
+        // The cairo backend asserts for it in debug builds.
+        //
         // see https://docs.rs/piet/latest/piet/trait.TextLayoutBuilder.html#tymethod.range_attribute
         let mut ranged_text_attributes = self.ranged_text_attributes.clone();
         ranged_text_attributes
@@ -329,8 +296,7 @@ impl TextStyle {
         Some(na::vector![size.width, size.height])
     }
 
-    /// the cursors line metric relative to the textstroke bounds.
-    /// Index must be at a grapheme boundary
+    /// The cursors line metric relative to the textstroke bounds.
     pub fn lines<T>(&self, piet_text: &mut T, text: String) -> anyhow::Result<Vec<piet::LineMetric>>
     where
         T: piet::Text,
@@ -342,8 +308,9 @@ impl TextStyle {
             .collect::<Vec<piet::LineMetric>>())
     }
 
-    /// the cursors line metric relative to the textstroke bounds.
-    /// Index must be at a grapheme boundary
+    /// The cursors line metric relative to the textstroke bounds.
+    ///
+    /// Index must be at a grapheme boundary.
     pub fn cursor_line_metric<T>(
         &self,
         piet_text: &mut T,
@@ -392,7 +359,7 @@ impl TextStyle {
         Ok(text_layout.rects_for_range(range))
     }
 
-    /// The line metric is relative to the transform
+    /// Draw the cursor.
     pub fn draw_cursor(
         &self,
         cx: &mut impl piet::RenderContext,
@@ -462,7 +429,9 @@ impl TextStyle {
 pub struct TextStroke {
     #[serde(rename = "text")]
     pub text: String,
-    /// The translation part is the position of the upper left corner
+    /// The transformation.
+    ///
+    /// The translation part Is the position of the upper left corner
     #[serde(rename = "transform")]
     pub transform: Transform,
     #[serde(rename = "text_style")]
@@ -620,7 +589,9 @@ impl TextStroke {
         &self.text[range]
     }
 
-    // Gets a cursor matching best for the given coord. The coord is in global coordinate space
+    /// Get a cursor matching best for the given coordinate.
+    ///
+    /// The coordinte must be in global coordinate space.
     pub fn get_cursor_for_global_coord(
         &self,
         coord: na::Vector2<f64>,
@@ -759,7 +730,9 @@ impl TextStroke {
         );
     }
 
-    // Translates the ranged text attributes after the given cursor. Overlapping ranges are extended / shrunk
+    /// Translate the ranged text attributes after the given cursor.
+    ///
+    /// Overlapping ranges are extended / shrunk
     fn translate_attrs_after_cursor(&mut self, from_pos: usize, offset: i32) {
         for attr in self.text_style.ranged_text_attributes.iter_mut() {
             if attr.range.start > from_pos {
@@ -798,7 +771,7 @@ impl TextStroke {
         }
     }
 
-    /// Removes all attr in the given range
+    /// Remove all attributes in the given range.
     pub fn remove_attrs_for_range(&mut self, range: Range<usize>) {
         // partition into attrs that intersect the range, and those who don't and will be retained
         let (intersecting_attrs, mut retained_attrs): (

--- a/rnote-engine/src/strokes/textstroke.rs
+++ b/rnote-engine/src/strokes/textstroke.rs
@@ -788,8 +788,6 @@ impl TextStroke {
         let truncated_attrs = intersecting_attrs
             .into_iter()
             .flat_map(|mut attr| {
-                //log::debug!("attr.range: {:?}, range: {:?}", attr.range, range);
-
                 if attr.range.start <= range.start && attr.range.end >= range.end {
                     // if the attribute completely contains the given range, split it
                     let mut first_split_attr = attr.clone();

--- a/rnote-engine/src/strokes/vectorimage.rs
+++ b/rnote-engine/src/strokes/vectorimage.rs
@@ -1,3 +1,9 @@
+// Imports
+use super::strokebehaviour::GeneratedStrokeImages;
+use super::{Stroke, StrokeBehaviour};
+use crate::document::Format;
+use crate::engine::import::{PdfImportPageSpacing, PdfImportPrefs};
+use crate::{render, DrawBehaviour};
 use gtk4::glib;
 use p2d::bounding_volume::Aabb;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -10,12 +16,6 @@ use rnote_compose::transform::TransformBehaviour;
 use serde::{Deserialize, Serialize};
 use std::ops::Range;
 use usvg::{TreeParsing, TreeTextToPath, TreeWriting};
-
-use super::strokebehaviour::GeneratedStrokeImages;
-use super::{Stroke, StrokeBehaviour};
-use crate::document::Format;
-use crate::engine::import::{PdfImportPageSpacing, PdfImportPrefs};
-use crate::{render, DrawBehaviour};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename = "vectorimage")]
@@ -93,7 +93,8 @@ impl StrokeBehaviour for VectorImage {
 }
 
 // Because we can't render svgs directly in piet, so we need to overwrite the gen_svgs() default implementation and call it in draw().
-// There we use a svg renderer to generate pixel images. In this way we ensure to export an actual svg when calling gen_svgs(), but can also draw it onto piet.
+// here we use a svg renderer to generate the bitmap images.
+// This way we ensure to export an actual svg when calling gen_svgs(),but are also able to draw it onto piet.
 impl DrawBehaviour for VectorImage {
     fn draw(&self, cx: &mut impl piet::RenderContext, image_scale: f64) -> anyhow::Result<()> {
         cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;

--- a/rnote-engine/src/utils.rs
+++ b/rnote-engine/src/utils.rs
@@ -1,11 +1,11 @@
-use std::ops::Range;
-
+// Imports
 use geo::line_string;
 use gtk4::{gdk, gio, glib, graphene, gsk, pango, prelude::*};
 use p2d::bounding_volume::Aabb;
 use rnote_compose::Color;
 use rnote_compose::Transform;
 use rnote_fileformats::xoppformat;
+use std::ops::Range;
 
 pub trait GdkRGBAHelpers
 where
@@ -178,7 +178,7 @@ pub fn raw_font_weight_to_pango(raw_font_weight: u16) -> pango::Weight {
     }
 }
 
-/// Converts a Aabb to a geo::Polygon
+/// Convert an [Aabb] to [`geo::Polygon<f64>`]
 pub fn p2d_aabb_to_geo_polygon(aabb: Aabb) -> geo::Polygon<f64> {
     let line_string = line_string![
         (x: aabb.mins[0], y: aabb.mins[1]),

--- a/rnote-engine/src/widgetflags.rs
+++ b/rnote-engine/src/widgetflags.rs
@@ -1,25 +1,26 @@
-/// Flags returned to the widget holding the engine
+/// Flags returned to the UI widget that holds the engine.
 #[must_use]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct WidgetFlags {
-    /// needs surface redrawing
+    /// Needs surface redrawing.
     pub redraw: bool,
-    /// needs surface resizing
+    /// Needs surface resizing.
     pub resize: bool,
-    /// refresh the UI with the engine state
+    /// Refresh the UI with the engine state.
     pub refresh_ui: bool,
-    /// whether the store was modified, i.e. new strokes inserted, modified, etc.
+    /// Whether the store was modified, i.e. new strokes inserted, modified, etc. .
     pub store_modified: bool,
-    /// update the current view offsets and size
+    /// Update the current view offsets and size.
     pub update_view: bool,
-    /// deselect the elements of the global color picker
+    /// Deselect the elements of the global color picker.
     pub deselect_color_setters: bool,
-    /// Is Some when undo button visibility should be changed. Is None if should not be changed
+    /// Is Some when undo button visibility should be changed. Is None if should not be changed.
     pub hide_undo: Option<bool>,
-    /// Is Some when redo button visibility should be changed. Is None if should not be changed
+    /// Is Some when redo button visibility should be changed. Is None if should not be changed.
     pub hide_redo: Option<bool>,
-    /// Changes whether text preprocessing should be enabled. Meaning, instead of key events text events are then emitted
-    /// for regular unicode text. Used when writing text with the typewriter
+    /// Changes whether text preprocessing in the UI toolkit should be enabled.
+    /// Meaning, when enabled instead of key events, text events are then emitted
+    /// for regular unicode text. Used when writing text with the typewriter.
     pub enable_text_preprocessing: Option<bool>,
 }
 
@@ -40,7 +41,7 @@ impl Default for WidgetFlags {
 }
 
 impl WidgetFlags {
-    /// Merging with another WidgetFlags struct, prioritizing other for conflicting values.
+    /// Merge with another WidgetFlags struct, prioritizing other for conflicting values.
     pub fn merge(&mut self, other: Self) {
         self.redraw |= other.redraw;
         self.resize |= other.resize;

--- a/rnote-fileformats/src/lib.rs
+++ b/rnote-fileformats/src/lib.rs
@@ -2,63 +2,65 @@
 #![warn(missing_docs)]
 #![allow(clippy::single_match)]
 
-//! The rnote-fileformats crate is a helper crate for loading / saving from and to various file formats used by note taking and drawing applications.
+//! The rnote-fileformats crate is a helper crate for loading/saving from and to various file formats
+//! used by note taking and drawing applications.
 //!
 //! Crates used for loading and writing:  
-//! XML: loading: `roxmltree`, writing: `xmlwriter`  
-//! Json: loading and writing `serde`, `serde-json`  
+//! Xml: loading: [roxmltree], writing: [xmlwriter]  
+//! Json: loading and writing [serde], [serde_json]  
 //!
-//! it includes the following formats:
+//! The following formats are currently included:
 //!
-//! | Format | file ending | XML | JSON | info |
-//! | --- | --- | --- | --- | --- |
-//! | Rnote | .rnote | - | native | see <https://github.com/flxzt/rnote> |
-//! | Xournal++ | .xopp | native | x | see <https://github.com/xournalpp/xournalpp> |
+//! - Rnote - `.rnote`
+//! - Xournal++ - `.xopp`
 
-use roxmltree::Node;
-
-/// The Rnote `.rnote` file format
+// Modules
+/// The Rnote `.rnote` file format.
 pub mod rnoteformat;
-/// The Xournal++ `.xopp` file format
+/// The Xournal++ `.xopp` file format.
 pub mod xoppformat;
 
+// Renames
 extern crate nalgebra as na;
 
-/// The file format loader trait, implemented by <Format>File types
+// Imports
+use roxmltree::Node;
+
+/// The file format loader trait, implemented by `<Format>File` types.
 pub trait FileFormatLoader {
-    /// load type from bytes
+    /// load from bytes.
     fn load_from_bytes(bytes: &[u8]) -> anyhow::Result<Self>
     where
         Self: Sized;
 }
 
-/// The file format saver trait, implemented by <Format>File types
+/// The file format saver trait, implemented by `<Format>File` types.
 pub trait FileFormatSaver {
-    /// Save type as bytes
+    /// Save as bytes.
     fn save_as_bytes(&self, file_name: &str) -> anyhow::Result<Vec<u8>>;
 }
 
-/// Implemented on types that are loadable from a XML. Using roxmltree as parser
+/// Implemented on types that are loadable from a Xml. Using roxmltree as parser.
 pub trait XmlLoadable {
-    /// load from an XML node
+    /// load from an Xml node.
     fn load_from_xml(&mut self, node: Node) -> anyhow::Result<()>;
 }
 
-/// Implemented on types that can write to a XML. Using xmlwriter as writer
+/// Implemented on types that can write to a Xml. Using xmlwriter as writer.
 pub trait XmlWritable {
-    /// Write to the xml writer
+    /// Write to the xml writer.
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter);
 }
 
-/// Implemented on types that are represented as a XML attribute value
+/// Implemented on types that can be represented as a Xml attribute value.
 pub trait AsXmlAttributeValue {
-    /// Type as XML attribute value
+    /// Type as Xml attribute value.
     fn as_xml_attr_value(&self) -> String;
 }
 
-/// Implemented on types that can be loaded from a XML attribute value
+/// Implemented on types that can be loaded from a Xml attribute value.
 pub trait FromXmlAttributeValue {
-    /// loading from a XML attribute value str
+    /// load from a Xml attribute value string.
     fn from_xml_attr_value(s: &str) -> Result<Self, anyhow::Error>
     where
         Self: Sized;

--- a/rnote-fileformats/src/rnoteformat/maj0min5patch8.rs
+++ b/rnote-fileformats/src/rnoteformat/maj0min5patch8.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
-
+// Imports
 use super::maj0min5patch9::RnoteFileMaj0Min5Patch9;
+use serde::{Deserialize, Serialize};
 
 impl TryFrom<RnoteFileMaj0Min5Patch8> for RnoteFileMaj0Min5Patch9 {
     type Error = anyhow::Error;
@@ -102,13 +102,13 @@ impl TryFrom<RnoteFileMaj0Min5Patch8> for RnoteFileMaj0Min5Patch9 {
     }
 }
 
-/// Rnote file in version: maj 0 min 5 patch 8
+/// Rnote file in version: maj 0 min 5 patch 8.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RnoteFileMaj0Min5Patch8 {
-    /// the document
+    /// The document.
     #[serde(rename = "document", alias = "sheet")]
     pub document: serde_json::Value,
-    /// A snapshot of the store
+    /// The snapshot of the store.
     #[serde(rename = "store_snapshot")]
     pub store_snapshot: serde_json::Value,
 }

--- a/rnote-fileformats/src/rnoteformat/maj0min5patch9.rs
+++ b/rnote-fileformats/src/rnoteformat/maj0min5patch9.rs
@@ -1,14 +1,14 @@
+// Imports
+use super::RnoteFile;
 use serde::{Deserialize, Serialize};
 
-use super::RnoteFile;
-
-/// Rnote file in version: maj 0 min 5 patch 9
+/// Rnote file in version: maj 0 min 5 patch 9.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RnoteFileMaj0Min5Patch9 {
-    /// the document
+    /// The document.
     #[serde(rename = "document", alias = "sheet")]
     pub document: serde_json::Value,
-    /// A snapshot of the store
+    /// The snapshot of the store.
     #[serde(rename = "store_snapshot")]
     pub store_snapshot: serde_json::Value,
 }

--- a/rnote-fileformats/src/rnoteformat/mod.rs
+++ b/rnote-fileformats/src/rnoteformat/mod.rs
@@ -1,21 +1,21 @@
-//! The file format is expected only to break on minor versions in prelease (0.x.x) and on major versions after 1.0.0 release. (equivalent to API's conforming to the semver spec)
-//! Older formats can be added, with the naming scheme RnoteFileMaj<X>Min<Y>, where X: semver major, Y: semver minor version.
-//! Then TryFrom is implemented to allow conversions and chaining from older to newer versions.
+//! Loading and saving Rnote's `.rnote` file format
+//!
+//! Older formats can be added, with the naming scheme `RnoteFileMaj<X>Min<Y>`, where X: semver major, Y: semver minor version.
+//! Then [TryFrom] can be implemented to allow conversions and chaining from older to newer versions.
 
+// Modules
 pub(crate) mod maj0min5patch8;
 pub(crate) mod maj0min5patch9;
 
+// Imports
+use crate::{FileFormatLoader, FileFormatSaver};
 use anyhow::Context;
 use maj0min5patch8::RnoteFileMaj0Min5Patch8;
-
+use maj0min5patch9::RnoteFileMaj0Min5Patch9;
 use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
 
-use crate::{FileFormatLoader, FileFormatSaver};
-
-use self::maj0min5patch9::RnoteFileMaj0Min5Patch9;
-
-/// Compress bytes with gzip
+/// Compress bytes with gzip.
 fn compress_to_gzip(to_compress: &[u8], file_name: &str) -> Result<Vec<u8>, anyhow::Error> {
     let compressed_bytes = Vec::<u8>::new();
 
@@ -28,7 +28,7 @@ fn compress_to_gzip(to_compress: &[u8], file_name: &str) -> Result<Vec<u8>, anyh
     Ok(encoder.finish()?)
 }
 
-/// Decompress from gzip
+/// Decompress from gzip.
 fn decompress_from_gzip(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
     let mut decoder = flate2::read::MultiGzDecoder::new(compressed);
     let mut bytes: Vec<u8> = Vec::new();
@@ -37,7 +37,9 @@ fn decompress_from_gzip(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
     Ok(bytes)
 }
 
-/// The rnote file wrapper. used to extract and match to the version up front, before deserializing the actual data.
+/// The rnote file wrapper.
+///
+/// Used to extract and match to the version up front, before deserializing the actual data.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename = "rnotefile_wrapper")]
 struct RnotefileWrapper {
@@ -47,12 +49,13 @@ struct RnotefileWrapper {
     data: serde_json::Value,
 }
 
-/// the Rnote file in the newest format version. The actual (de-) serialization into strong types is happening in `rnote-engine`.
+/// The Rnote file in the newest format version. The actual (de-) serialization into strong types is happening in `rnote-engine`.
+///
 /// This struct exists to allow for upgrading older versions before loading the file in.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename = "rnotefile")]
 pub struct RnoteFile {
-    /// A snapshot of the engine
+    /// A snapshot of the engine.
     #[serde(rename = "engine_snapshot")]
     pub engine_snapshot: serde_json::Value,
 }

--- a/rnote-fileformats/src/xoppformat.rs
+++ b/rnote-fileformats/src/xoppformat.rs
@@ -1,16 +1,18 @@
-use std::io::{Read, Write};
+//! Loading and saving Xournal++'s `.xopp` file format
+//!
+//!
 
+// Imports
+use super::{AsXmlAttributeValue, FileFormatLoader, FileFormatSaver, XmlLoadable, XmlWritable};
+use crate::FromXmlAttributeValue;
 use roxmltree::{Node, NodeType};
 use serde::{Deserialize, Serialize};
+use std::io::{Read, Write};
 
-use crate::FromXmlAttributeValue;
-
-use super::{AsXmlAttributeValue, FileFormatLoader, FileFormatSaver, XmlLoadable, XmlWritable};
-
-/// The decimal places when serializing values
+/// The decimal places when serializing values.
 pub const VALS_DEC_PLACES: usize = 3;
 
-/// Compress bytes with gzip
+/// Compress bytes with gzip.
 fn compress_to_gzip(to_compress: &[u8], file_name: &str) -> Result<Vec<u8>, anyhow::Error> {
     let compressed_bytes = Vec::<u8>::new();
 
@@ -23,7 +25,7 @@ fn compress_to_gzip(to_compress: &[u8], file_name: &str) -> Result<Vec<u8>, anyh
     Ok(encoder.finish()?)
 }
 
-/// Decompress from gzip
+/// Decompress from gzip.
 fn decompress_from_gzip(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
     let mut decoder = flate2::read::MultiGzDecoder::new(compressed);
     let mut bytes: Vec<u8> = Vec::new();
@@ -33,11 +35,13 @@ fn decompress_from_gzip(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
 }
 
 /// Represents a Xournal++ `.xopp` file.
-/// The original Xournal spec can be found here: <http://xournal.sourceforge.net/manual.html#file-format>
+///
 /// The coordinates units saved to a .xopp are in 72dpi, meaning a vector of (1,0) has a length of 1 / 72 inch.
+///
+/// The original Xournal spec can be found here: <http://xournal.sourceforge.net/manual.html#file-format>
 #[derive(Debug)]
 pub struct XoppFile {
-    /// The .xopp XML root element
+    /// The .xopp Xml root element.
     pub xopp_root: XoppRoot,
 }
 
@@ -69,20 +73,20 @@ impl FileFormatSaver for XoppFile {
 }
 
 impl XoppFile {
-    /// The DPI of the Xopp file, is hardcoded to 72 DPI
+    /// The DPI of `.xopp` files, which is hardcoded to 72 DPI.
     pub const DPI: f64 = 72.0;
 }
 
-/// Represents a Xournal++ XML root element
+/// A Xournal++ Xml root element.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct XoppRoot {
-    /// The file version
+    /// The file version.
     pub fileversion: String,
-    /// The file title
+    /// The file title.
     pub title: String,
-    /// A preview image, encoded as base64
+    /// A preview image, encoded as base64.
     pub preview: String,
-    /// The pages elements
+    /// The pages elements.
     pub pages: Vec<XoppPage>,
 }
 
@@ -140,16 +144,16 @@ impl XmlWritable for XoppRoot {
     }
 }
 
-/// Represents a Xopp Page
+/// A Xopp Page.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct XoppPage {
-    /// The width of the page
+    /// The width of the page.
     pub width: f64,
-    /// The height of the page
+    /// The height of the page.
     pub height: f64,
-    /// The Background of the page
+    /// The Background of the page.
     pub background: XoppBackground,
-    /// The layers of the page
+    /// The layers of the page.
     pub layers: Vec<XoppLayer>,
 }
 
@@ -209,24 +213,24 @@ impl XmlWritable for XoppPage {
     }
 }
 
-/// Represents a Xopp Background type
+/// A Xopp Background type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum XoppBackgroundType {
-    /// A solid background with a color and style
+    /// A solid background with a color and style.
     Solid {
-        /// The color
+        /// The color.
         color: XoppColor,
-        /// The solid background style
+        /// The solid background style.
         style: XoppBackgroundSolidStyle,
     },
-    /// A background with a pixmap
+    /// A background with a pixmap.
     Pixmap {
-        /// The domain for the pixmap
+        /// The domain for the pixmap.
         domain: XoppBackgroundPixmapDomain,
-        /// The filename that is to the image for the pixmap
+        /// The filename that is to the image for the pixmap.
         filename: String,
     },
-    /// A background with a pdf ( NOT IMPLEMENTED )
+    /// A background with a pdf. Currently **UNIMPLEMENTED**.
     Pdf,
 }
 
@@ -264,24 +268,24 @@ impl Default for XoppBackgroundType {
     }
 }
 
-/// The xopp background style
+/// The xopp background style.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum XoppBackgroundSolidStyle {
-    /// The plain background style
+    /// Plain.
     Plain,
-    /// The lined background style
+    /// Lined.
     Lined,
-    /// The ruled background style
+    /// Ruled.
     Ruled,
-    /// The staves background style
+    /// Staves.
     Staves,
-    /// The graph background style
+    /// Graph.
     Graph,
-    /// The graph background style
+    /// Dotted.
     Dotted,
-    /// The isometric dotted background style
+    /// Isometric dotted.
     IsometricDotted,
-    /// The isometric graph background style
+    /// Isometric graph.
     IsometricGraph,
 }
 
@@ -328,14 +332,14 @@ impl FromXmlAttributeValue for XoppBackgroundSolidStyle {
     }
 }
 
-/// The Xopp background pixmap domain
+/// The Xopp background pixmap domain.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum XoppBackgroundPixmapDomain {
-    /// absolute
+    /// Absolute.
     Absolute,
-    /// attach
+    /// Attach.
     Attach,
-    /// clone
+    /// Clone.
     Clone,
 }
 
@@ -350,18 +354,17 @@ impl AsXmlAttributeValue for XoppBackgroundPixmapDomain {
 }
 
 impl Default for XoppBackgroundPixmapDomain {
-    /// The default pipxmap domain
     fn default() -> Self {
         Self::Absolute
     }
 }
 
-/// The Xopp Background
+/// The Xopp Background.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct XoppBackground {
-    /// Optional background name
+    /// Optional background name.
     pub name: Option<String>,
-    /// The background type
+    /// The background type.
     pub bg_type: XoppBackgroundType,
 }
 
@@ -438,16 +441,16 @@ impl XmlWritable for XoppBackground {
     }
 }
 
-/// A Xopp Layer
+/// A Xopp Layer.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct XoppLayer {
-    /// Optional layer name
+    /// Optional layer name.
     pub name: Option<String>,
-    /// Strokes on this layer
+    /// Strokes on this layer.
     pub strokes: Vec<XoppStroke>,
-    /// Texts on this layer
+    /// Texts on this layer.
     pub texts: Vec<XoppText>,
-    /// Images on this layer
+    /// Images on this layer.
     pub images: Vec<XoppImage>,
 }
 
@@ -503,16 +506,18 @@ impl XmlWritable for XoppLayer {
     }
 }
 
-/// A Xopp Color (represented in xml as hex values in format #RRGGBBAA )
+/// A Xopp Color.
+///
+/// Represented in Xml as hexadecimal values in format `#RRGGBBAA`.
 #[derive(Default, Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct XoppColor {
-    /// red from 0 to 255
+    /// Red ranging [0 - 255].
     pub red: u8,
-    /// green from 0 to 255
+    /// Green ranging [0 - 255].
     pub green: u8,
-    /// blue from 0 to 255
+    /// Blue ranging [0 - 255].
     pub blue: u8,
-    /// alpha from 0 to 255
+    /// Alpha ranging [0 - 255].
     pub alpha: u8,
 }
 
@@ -526,7 +531,7 @@ impl AsXmlAttributeValue for XoppColor {
 }
 
 impl XoppColor {
-    /// Parsing from a attribute avlue that is the format #RRGGBBAA
+    /// Parse the color from a attribute vallue that is format `#RRGGBBAA`.
     fn from_hexcolor_attr_value(s: &str) -> Result<Self, anyhow::Error> {
         let s = s.trim().replace('#', "");
 
@@ -542,7 +547,7 @@ impl XoppColor {
         Ok(color)
     }
 
-    /// Parsing from a color attribute value in a stroke
+    /// Parse the color from a color attribute value in a stroke.
     pub fn from_strokecolor_attr_value(s: &str) -> Result<Self, anyhow::Error> {
         match s {
             "black" => Ok(Self {
@@ -615,7 +620,7 @@ impl XoppColor {
         }
     }
 
-    /// Parsing from a color attribute value in the background
+    /// Parse the color from a color attribute value in the background.
     fn from_backgroundcolor_attr_value(s: &str) -> Result<Self, anyhow::Error> {
         match s {
             "white" => Ok(Self {
@@ -659,35 +664,41 @@ impl XoppColor {
     }
 }
 
-/// Helper to bundle stroke types into one type
+/// The stroke type.
+///
+/// Helper to bundle different strokes into one type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum XoppStrokeType {
-    /// A stroke
+    /// A stroke.
     XoppStroke(XoppStroke),
-    /// A text
+    /// A text.
     XoppText(XoppText),
-    /// An image
+    /// An image.
     XoppImage(XoppImage),
 }
 
-/// A Xopp Stroke
+/// A Xopp Stroke.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct XoppStroke {
-    /// the stroke tool
+    /// The stroke tool.
     pub tool: XoppTool,
-    /// The stroke color
+    /// The stroke color.
     pub color: XoppColor,
-    /// Stroke fill. None if is not filled, 255 if fully opaque filled
+    /// Stroke fill. None if is not filled, 255 if fully opaque.
     pub fill: Option<i32>,
     /// The stroke widths.
-    /// The first element is the width of the entire stroke, and if existent, every following is a absolute width for the corresponding coordinate.
-    /// If they don't exist, the stroke has the first width as constant width
+    ///
+    /// The first element is the width of the entire stroke, and if existent,
+    /// every following is a absolute width for the corresponding coordinate.
+    /// If they don't exist, the stroke has the first width as constant width.
     pub width: Vec<f64>,
-    /// The stroke coordinates ( as points where a vec (1.0, 0.0) has length of 1 / 72inch )
+    /// The stroke coordinates.
+    ///
+    /// As points where the vector (1.0, 0.0) has length 1/72 inch.
     pub coords: Vec<na::Vector2<f64>>,
-    /// Optional timestamp
+    /// Optional timestamp.
     pub timestamp: Option<u64>,
-    /// Optional audio filename
+    /// Optional audio filename.
     pub audio_filename: Option<String>,
 }
 
@@ -806,14 +817,16 @@ impl XmlWritable for XoppStroke {
     }
 }
 
-/// A xopp stroke tool
+/// A Xopp stroke tool.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum XoppTool {
-    /// the Xopp Pen
+    /// The Xopp Pen.
     Pen,
-    /// the xopp highlighter ( alpha = 0.5 )
+    /// The Xopp highlighter.
+    ///
+    /// (alpha = 0.5).
     Highlighter,
-    /// the xopp eraser
+    /// The Xopp eraser.
     Eraser,
 }
 
@@ -833,20 +846,20 @@ impl Default for XoppTool {
     }
 }
 
-/// A xopp text
+/// A Xopp text.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct XoppText {
-    /// The text font
+    /// The text font.
     pub font: String,
-    /// The text size
+    /// The text size.
     pub size: f64,
-    /// The x position of the upper left corner
+    /// The x position of the upper left corner.
     pub x: f64,
-    /// The y position of the upper left corner
+    /// The y position of the upper left corner.
     pub y: f64,
-    /// The text color
+    /// The text color.
     pub color: XoppColor,
-    /// The text string
+    /// The text string.
     pub text: String,
 }
 
@@ -924,18 +937,18 @@ impl XmlWritable for XoppText {
     }
 }
 
-/// a Xopp image
+/// A Xopp image.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct XoppImage {
-    /// The left x position
+    /// The left x position.
     pub left: f64,
-    /// The top y position
+    /// The top y position.
     pub top: f64,
-    /// The right x position
+    /// The right x position.
     pub right: f64,
-    /// The bottom y position
+    /// The bottom y position.
     pub bottom: f64,
-    /// The image data encoded as PNG base64
+    /// The image data encoded as Png base64.
     pub data: String,
 }
 
@@ -1036,9 +1049,8 @@ mod tests {
 
         let xopp_format_loader = super::XoppFile::load_from_bytes(&bytes)?;
 
-        // Dumping a json with serde
-        let xpp_json = serde_json::to_string_pretty(&xopp_format_loader.xopp_root)?;
-        std::fs::write(to_save, xpp_json)?;
+        let xopp_json = serde_json::to_string_pretty(&xopp_format_loader.xopp_root)?;
+        std::fs::write(to_save, xopp_json)?;
 
         Ok(())
     }
@@ -1052,9 +1064,8 @@ mod tests {
 
         let xopp_format_loader = super::XoppFile::load_from_bytes(&bytes)?;
 
-        // Dumping a json with serde
-        let xpp_json = serde_json::to_string_pretty(&xopp_format_loader.xopp_root)?;
-        std::fs::write(to_save, xpp_json)?;
+        let xopp_json = serde_json::to_string_pretty(&xopp_format_loader.xopp_root)?;
+        std::fs::write(to_save, xopp_json)?;
 
         Ok(())
     }

--- a/rnote-fileformats/src/xoppformat.rs
+++ b/rnote-fileformats/src/xoppformat.rs
@@ -531,7 +531,7 @@ impl AsXmlAttributeValue for XoppColor {
 }
 
 impl XoppColor {
-    /// Parse the color from a attribute vallue that is format `#RRGGBBAA`.
+    /// Parse the color from a attribute value that is format `#RRGGBBAA`.
     fn from_hexcolor_attr_value(s: &str) -> Result<Self, anyhow::Error> {
         let s = s.trim().replace('#', "");
 

--- a/rnote-ui/data/app.metainfo.xml.in.in
+++ b/rnote-ui/data/app.metainfo.xml.in.in
@@ -42,7 +42,7 @@
     <screenshot>
       <image>
         https://raw.githubusercontent.com/flxzt/rnote/main/rnote-ui/data/screenshots/pdf_annotation.png</image>
-      <caption>A PDF annotation</caption>
+      <caption>A Pdf annotation</caption>
     </screenshot>
     <screenshot>
       <image>
@@ -245,7 +245,7 @@ Breakages in the file format will be explicitly announced (but we'll work as har
           <li>improvement: Add zoom buttons to the quick-actions overlay</li>
           <li>improvement: By default use the workspace directory for import and export dialogs, and
             document file for save dialogs</li>
-          <li>fix: PDF export and print sometimes produced empty pages</li>
+          <li>fix: Pdf export and print sometimes produced empty pages</li>
           <li>fix: workspace files list not refreshing after modifying the workspace path</li>
           <li>fix: Selector being canceled when attempting to interact with the selection when
             "touch-drawing" was enabled</li>
@@ -269,7 +269,7 @@ Breakages in the file format will be explicitly announced (but we'll work as har
           <li>fix: background pattern tile rendering size</li>
           <li>fix: scrolling with touchpad was not possible when the "permanent hidden scrollbars"
             option was enabled</li>
-          <li>fix: broken SVG export</li>
+          <li>fix: broken Svg export</li>
           <li>fix: image layers when exporting to .xopp</li>
         </ul>
       </description>
@@ -358,7 +358,7 @@ Breakages in the file format will be explicitly announced (but we'll work as har
           <li>disclaimer: breaking file format compatibility</li>
           <li>feature: configurable button shortcuts (stylus, mouse)</li>
           <li>change: moved the marker into the brush pen as a style</li>
-          <li>improvement: faster PDF export &amp; fix export with large sheet dimensions</li>
+          <li>improvement: faster Pdf export &amp; fix export with large sheet dimensions</li>
           <li>bug fixes</li>
         </ul>
       </description>
@@ -391,7 +391,7 @@ Breakages in the file format will be explicitly announced (but we'll work as har
       <description>
         <p>this release changes:</p>
         <ul>
-          <li>new feature: Export as PDF</li>
+          <li>new feature: Export as Pdf</li>
           <li>bug fixes</li>
         </ul>
       </description>
@@ -443,7 +443,7 @@ Breakages in the file format will be explicitly announced (but we'll work as har
       <description>
         <p>this release changes:</p>
         <ul>
-          <li>PDF import as vector images</li>
+          <li>Pdf import as vector images</li>
           <li>bug fixes</li>
         </ul>
       </description>
@@ -474,7 +474,7 @@ Breakages in the file format will be explicitly announced (but we'll work as har
           <li>an updated file format. !!! Breaks compatibility to older versions. Please export
             existing files before upgrading / downgrade temporarily (explained how to downgrade at
             github.com/flxzt/rnote)</li>
-          <li>new features: PDF import, clipboard and drag&amp;drop support</li>
+          <li>new features: Pdf import, clipboard and drag&amp;drop support</li>
           <li>performance improvements in stroke rendering, selecting, erasing by parallelizing
             these operations</li>
           <li>UI improvements</li>

--- a/rnote-ui/data/ui/dialogs/import.ui
+++ b/rnote-ui/data/ui/dialogs/import.ui
@@ -16,7 +16,7 @@
   <object class="GtkDialog" id="dialog_import_pdf_w_prefs">
     <property name="use-header-bar">1</property>
     <property name="modal">true</property>
-    <property name="title" translatable="yes">Import PDF</property>
+    <property name="title" translatable="yes">Import Pdf</property>
     <child type="action">
       <object class="GtkButton" id="import_pdf_button_cancel">
         <property name="label" translatable="yes">Cancel</property>
@@ -88,7 +88,7 @@
             </child>
             <child>
               <object class="AdwPreferencesGroup">
-                <property name="title" translatable="yes">PDF Import Preferences</property>
+                <property name="title" translatable="yes">Pdf Import Preferences</property>
                 <property name="halign">fill</property>
                 <child>
                   <object class="AdwActionRow">
@@ -123,7 +123,7 @@
                 <child>
                   <object class="AdwActionRow" id="pdf_import_width_row">
                     <property name="title" translatable="yes">Page Width (%)</property>
-                    <property name="subtitle" translatable="yes">Set the width of imported PDF's in percentage to the format width</property>
+                    <property name="subtitle" translatable="yes">Set the width of imported Pdf's in percentage to the format width</property>
                     <child type="suffix">
                       <object class="GtkAdjustment" id="pdf_import_width_perc_adj">
                         <property name="step-increment">1</property>
@@ -144,7 +144,7 @@
                 <child>
                   <object class="AdwComboRow" id="pdf_import_page_spacing_row">
                     <property name="title" translatable="yes">Page Spacing</property>
-                    <property name="subtitle" translatable="yes">How PDF pages are spaced</property>
+                    <property name="subtitle" translatable="yes">How Pdf pages are spaced</property>
                     <property name="model">
                       <object class="GtkStringList">
                         <items>
@@ -158,7 +158,7 @@
                 <child>
                   <object class="AdwActionRow" id="pdf_import_pages_type_row">
                     <property name="title" translatable="yes">Pages Type</property>
-                    <property name="subtitle" translatable="yes">Set whether PDFs should be imported as vector or bitmap images</property>
+                    <property name="subtitle" translatable="yes">Set whether Pdf's should be imported as vector or bitmap images</property>
                     <child type="suffix">
                       <object class="GtkBox">
                         <property name="orientation">horizontal</property>

--- a/rnote-ui/po/rnote.pot
+++ b/rnote-ui/po/rnote.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rnote\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-09 00:04+0200\n"
+"POT-Creation-Date: 2023-05-12 18:52+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: rnote-ui/data/app.desktop.in.in:5 rnote-ui/data/app.metainfo.xml.in.in:9
-#: rnote-ui/src/dialogs/mod.rs:32
+#: rnote-ui/src/dialogs/mod.rs:35
 msgid "Sketch and take handwritten notes"
 msgstr ""
 
@@ -52,14 +52,14 @@ msgid "Lecture Note 1"
 msgstr ""
 
 #: rnote-ui/data/app.metainfo.xml.in.in:45
-msgid "A PDF annotation"
+msgid "A Pdf annotation"
 msgstr ""
 
 #: rnote-ui/data/app.metainfo.xml.in.in:50
 msgid "Lecture Note 2"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:5 rnote-ui/data/ui/shortcuts.ui:168
+#: rnote-ui/data/ui/dialogs/dialogs.ui:5 rnote-ui/data/ui/shortcuts.ui:173
 msgid "Clear Document"
 msgstr ""
 
@@ -69,19 +69,13 @@ msgstr ""
 
 #: rnote-ui/data/ui/dialogs/dialogs.ui:10
 #: rnote-ui/data/ui/dialogs/dialogs.ui:22
-#: rnote-ui/data/ui/dialogs/dialogs.ui:34
-#: rnote-ui/data/ui/dialogs/dialogs.ui:51
-#: rnote-ui/data/ui/dialogs/dialogs.ui:63 rnote-ui/data/ui/dialogs/import.ui:10
+#: rnote-ui/data/ui/dialogs/dialogs.ui:39
+#: rnote-ui/data/ui/dialogs/dialogs.ui:56
+#: rnote-ui/data/ui/dialogs/dialogs.ui:68 rnote-ui/data/ui/dialogs/import.ui:10
 #: rnote-ui/data/ui/dialogs/import.ui:22 rnote-ui/data/ui/dialogs/import.ui:223
 #: rnote-ui/data/ui/dialogs/export.ui:10 rnote-ui/data/ui/dialogs/export.ui:136
 #: rnote-ui/data/ui/dialogs/export.ui:348
-#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:172
-#: rnote-ui/src/dialogs/export.rs:27 rnote-ui/src/dialogs/export.rs:227
-#: rnote-ui/src/dialogs/export.rs:500 rnote-ui/src/dialogs/export.rs:748
-#: rnote-ui/src/dialogs/export.rs:818 rnote-ui/src/dialogs/export.rs:882
-#: rnote-ui/src/dialogs/import.rs:89 rnote-ui/src/dialogs/import.rs:142
-#: rnote-ui/src/dialogs/mod.rs:394
-#: rnote-ui/src/workspacebrowser/widgethelper.rs:33
+#: rnote-ui/src/workspacebrowser/widgethelper.rs:34
 msgid "Cancel"
 msgstr ""
 
@@ -90,7 +84,7 @@ msgid "Clear"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/dialogs.ui:16 rnote-ui/data/ui/mainheader.ui:18
-#: rnote-ui/data/ui/shortcuts.ui:144 rnote-ui/src/canvas/mod.rs:498
+#: rnote-ui/data/ui/shortcuts.ui:149 rnote-ui/src/canvas/mod.rs:498
 msgid "New Document"
 msgstr ""
 
@@ -101,14 +95,14 @@ msgid ""
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/dialogs.ui:23
-#: rnote-ui/data/ui/dialogs/dialogs.ui:35 rnote-ui/data/ui/dialogs/import.ui:11
+#: rnote-ui/data/ui/dialogs/dialogs.ui:40 rnote-ui/data/ui/dialogs/import.ui:11
 msgid "Discard"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/dialogs.ui:24
-#: rnote-ui/data/ui/dialogs/dialogs.ui:36
-#: rnote-ui/data/ui/dialogs/dialogs.ui:53 rnote-ui/data/ui/dialogs/import.ui:12
-#: rnote-ui/src/dialogs/export.rs:26
+#: rnote-ui/data/ui/dialogs/dialogs.ui:41
+#: rnote-ui/data/ui/dialogs/dialogs.ui:58 rnote-ui/data/ui/dialogs/import.ui:12
+#: rnote-ui/src/dialogs/export.rs:30
 msgid "Save"
 msgstr ""
 
@@ -122,73 +116,74 @@ msgid ""
 "permanently lost."
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:41
+#: rnote-ui/data/ui/dialogs/dialogs.ui:46
 msgid "Close Window"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:42
+#: rnote-ui/data/ui/dialogs/dialogs.ui:47
 msgid ""
 "Some opened files contain unsaved changes. Changes which are not saved will "
 "be permanently lost."
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:47
+#: rnote-ui/data/ui/dialogs/dialogs.ui:52
 msgid "Unsaved Documents"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:52
+#: rnote-ui/data/ui/dialogs/dialogs.ui:57
 msgid "Discard All"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:60
+#: rnote-ui/data/ui/dialogs/dialogs.ui:65
 msgid "Edit Workspace"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:68 rnote-ui/data/ui/settingspanel.ui:267
-#: rnote-ui/src/workspacebrowser/widgethelper.rs:38
+#: rnote-ui/data/ui/dialogs/dialogs.ui:73 rnote-ui/data/ui/settingspanel.ui:270
+#: rnote-ui/src/workspacebrowser/widgethelper.rs:39
 msgid "Apply"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:110
+#: rnote-ui/data/ui/dialogs/dialogs.ui:115
 msgid "Workspace Name"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:115
+#: rnote-ui/data/ui/dialogs/dialogs.ui:120
 msgid "Icon"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:116
+#: rnote-ui/data/ui/dialogs/dialogs.ui:121
 msgid "Change the workspace icon"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:135
-#: rnote-ui/data/ui/settingspanel.ui:283
+#: rnote-ui/data/ui/dialogs/dialogs.ui:141
+#: rnote-ui/data/ui/settingspanel.ui:286
 msgid "Color"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:136
+#: rnote-ui/data/ui/dialogs/dialogs.ui:142
 msgid "Change the workspace color"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:149
+#: rnote-ui/data/ui/dialogs/dialogs.ui:156
 msgid "Directory"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:150
+#: rnote-ui/data/ui/dialogs/dialogs.ui:157
 msgid "Change the workspace directory"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:159
-#: rnote-ui/data/ui/dialogs/export.ui:223 rnote-ui/src/dialogs/export.rs:346
-#: rnote-ui/src/dialogs/export.rs:384 rnote-ui/src/dialogs/mod.rs:455
+#: rnote-ui/data/ui/dialogs/dialogs.ui:166
+#: rnote-ui/data/ui/dialogs/export.ui:223 rnote-ui/src/dialogs/export.rs:307
+#: rnote-ui/src/dialogs/export.rs:346 rnote-ui/src/dialogs/export.rs:354
+#: rnote-ui/src/dialogs/mod.rs:512
 msgid "- no directory selected -"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:174
+#: rnote-ui/data/ui/dialogs/dialogs.ui:181
 msgid "Change the directory"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/import.ui:5 rnote-ui/src/dialogs/import.rs:85
+#: rnote-ui/data/ui/dialogs/import.ui:5 rnote-ui/src/dialogs/import.rs:88
 msgid "Open File"
 msgstr ""
 
@@ -199,11 +194,11 @@ msgid ""
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/import.ui:19
-msgid "Import PDF"
+msgid "Import Pdf"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/import.ui:27 rnote-ui/data/ui/dialogs/import.ui:228
-#: rnote-ui/src/dialogs/import.rs:141
+#: rnote-ui/src/dialogs/import.rs:126
 msgid "Import"
 msgstr ""
 
@@ -212,7 +207,7 @@ msgid "Info"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/import.ui:91
-msgid "PDF Import Preferences"
+msgid "Pdf Import Preferences"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/import.ui:95
@@ -228,7 +223,7 @@ msgid "Page Width (%)"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/import.ui:126
-msgid "Set the width of imported PDF's in percentage to the format width"
+msgid "Set the width of imported Pdf's in percentage to the format width"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/import.ui:146
@@ -236,7 +231,7 @@ msgid "Page Spacing"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/import.ui:147
-msgid "How PDF pages are spaced"
+msgid "How Pdf pages are spaced"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/import.ui:151
@@ -252,7 +247,7 @@ msgid "Pages Type"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/import.ui:161
-msgid "Set whether PDFs should be imported as vector or bitmap images"
+msgid "Set whether Pdf's should be imported as vector or bitmap images"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/import.ui:173
@@ -293,13 +288,13 @@ msgstr ""
 msgid "Set the preferred DPI for the Xournal++ file"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/export.ui:7 rnote-ui/src/dialogs/export.rs:223
+#: rnote-ui/data/ui/dialogs/export.ui:7 rnote-ui/src/dialogs/export.rs:203
 msgid "Export Document"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/export.ui:15 rnote-ui/data/ui/dialogs/export.ui:141
-#: rnote-ui/data/ui/dialogs/export.ui:353 rnote-ui/src/dialogs/export.rs:817
-#: rnote-ui/src/dialogs/export.rs:881
+#: rnote-ui/data/ui/dialogs/export.ui:353 rnote-ui/src/dialogs/export.rs:745
+#: rnote-ui/src/dialogs/export.rs:791
 msgid "Export"
 msgstr ""
 
@@ -313,9 +308,10 @@ msgstr ""
 
 #. force the user to pick another file
 #: rnote-ui/data/ui/dialogs/export.ui:59 rnote-ui/data/ui/dialogs/export.ui:397
-#: rnote-ui/src/dialogs/export.rs:120 rnote-ui/src/dialogs/export.rs:146
-#: rnote-ui/src/dialogs/export.rs:175 rnote-ui/src/dialogs/export.rs:623
-#: rnote-ui/src/dialogs/export.rs:649 rnote-ui/src/dialogs/export.rs:684
+#: rnote-ui/src/dialogs/export.rs:102 rnote-ui/src/dialogs/export.rs:126
+#: rnote-ui/src/dialogs/export.rs:133 rnote-ui/src/dialogs/export.rs:157
+#: rnote-ui/src/dialogs/export.rs:564 rnote-ui/src/dialogs/export.rs:595
+#: rnote-ui/src/dialogs/export.rs:602 rnote-ui/src/dialogs/export.rs:632
 msgid "- no file selected -"
 msgstr ""
 
@@ -357,20 +353,20 @@ msgstr ""
 
 #: rnote-ui/data/ui/dialogs/export.ui:114
 #: rnote-ui/data/ui/dialogs/export.ui:283
-#: rnote-ui/data/ui/dialogs/export.ui:452 rnote-ui/src/dialogs/export.rs:256
-#: rnote-ui/src/dialogs/export.rs:535 rnote-ui/src/dialogs/export.rs:781
+#: rnote-ui/data/ui/dialogs/export.ui:452 rnote-ui/src/dialogs/export.rs:213
+#: rnote-ui/src/dialogs/export.rs:479 rnote-ui/src/dialogs/export.rs:704
 msgid "Svg"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/export.ui:115 rnote-ui/src/dialogs/export.rs:261
+#: rnote-ui/data/ui/dialogs/export.ui:115 rnote-ui/src/dialogs/export.rs:218
 msgid "Pdf"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/export.ui:116 rnote-ui/src/dialogs/export.rs:266
+#: rnote-ui/data/ui/dialogs/export.ui:116 rnote-ui/src/dialogs/export.rs:223
 msgid "Xopp"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/export.ui:133 rnote-ui/src/dialogs/export.rs:496
+#: rnote-ui/data/ui/dialogs/export.ui:133 rnote-ui/src/dialogs/export.rs:457
 msgid "Export Document Pages"
 msgstr ""
 
@@ -391,14 +387,14 @@ msgid "Export Files Stem Name"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/export.ui:284
-#: rnote-ui/data/ui/dialogs/export.ui:453 rnote-ui/src/dialogs/export.rs:540
-#: rnote-ui/src/dialogs/export.rs:786
+#: rnote-ui/data/ui/dialogs/export.ui:453 rnote-ui/src/dialogs/export.rs:484
+#: rnote-ui/src/dialogs/export.rs:709
 msgid "Png"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/export.ui:285
-#: rnote-ui/data/ui/dialogs/export.ui:454 rnote-ui/src/dialogs/export.rs:546
-#: rnote-ui/src/dialogs/export.rs:792
+#: rnote-ui/data/ui/dialogs/export.ui:454 rnote-ui/src/dialogs/export.rs:490
+#: rnote-ui/src/dialogs/export.rs:715
 msgid "Jpeg"
 msgstr ""
 
@@ -412,7 +408,7 @@ msgstr ""
 msgid "Set the quality of the Jpeg image (1 - 100)"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/export.ui:345 rnote-ui/src/dialogs/export.rs:744
+#: rnote-ui/data/ui/dialogs/export.ui:345 rnote-ui/src/dialogs/export.rs:690
 msgid "Export Selection"
 msgstr ""
 
@@ -578,37 +574,37 @@ msgstr ""
 
 #: rnote-ui/data/ui/penssidebar/penssidebar.ui:17
 #: rnote-ui/data/ui/overlays.ui:45
-#: rnote-ui/src/settingspanel/penshortcutmodels.rs:78
+#: rnote-ui/src/settingspanel/penshortcutmodels.rs:79
 msgid "Brush"
 msgstr ""
 
 #: rnote-ui/data/ui/penssidebar/penssidebar.ui:33
 #: rnote-ui/data/ui/overlays.ui:52
-#: rnote-ui/src/settingspanel/penshortcutmodels.rs:79
+#: rnote-ui/src/settingspanel/penshortcutmodels.rs:80
 msgid "Shaper"
 msgstr ""
 
 #: rnote-ui/data/ui/penssidebar/penssidebar.ui:49
 #: rnote-ui/data/ui/overlays.ui:60
-#: rnote-ui/src/settingspanel/penshortcutmodels.rs:80
+#: rnote-ui/src/settingspanel/penshortcutmodels.rs:81
 msgid "Typewriter"
 msgstr ""
 
 #: rnote-ui/data/ui/penssidebar/penssidebar.ui:65
 #: rnote-ui/data/ui/overlays.ui:68
-#: rnote-ui/src/settingspanel/penshortcutmodels.rs:81
+#: rnote-ui/src/settingspanel/penshortcutmodels.rs:82
 msgid "Eraser"
 msgstr ""
 
 #: rnote-ui/data/ui/penssidebar/penssidebar.ui:81
 #: rnote-ui/data/ui/overlays.ui:76
-#: rnote-ui/src/settingspanel/penshortcutmodels.rs:82
+#: rnote-ui/src/settingspanel/penshortcutmodels.rs:83
 msgid "Selector"
 msgstr ""
 
 #: rnote-ui/data/ui/penssidebar/penssidebar.ui:97
 #: rnote-ui/data/ui/overlays.ui:84
-#: rnote-ui/src/settingspanel/penshortcutmodels.rs:83
+#: rnote-ui/src/settingspanel/penshortcutmodels.rs:84
 msgid "Tools"
 msgstr ""
 
@@ -641,7 +637,7 @@ msgid "Deselect All Strokes"
 msgstr ""
 
 #: rnote-ui/data/ui/penssidebar/selectorpage.ui:105
-#: rnote-ui/data/ui/shortcuts.ui:207
+#: rnote-ui/data/ui/shortcuts.ui:212
 msgid "Duplicate Selection"
 msgstr ""
 
@@ -709,7 +705,7 @@ msgid "Crosshatch"
 msgstr ""
 
 #: rnote-ui/data/ui/penssidebar/shaperpage.ui:178
-#: rnote-ui/data/ui/settingspanel.ui:309
+#: rnote-ui/data/ui/settingspanel.ui:315
 msgid "Dots"
 msgstr ""
 
@@ -753,62 +749,48 @@ msgid "Insert Vertical Space"
 msgstr ""
 
 #: rnote-ui/data/ui/penssidebar/toolspage.ui:29
-#: rnote-ui/data/ui/shortcuts.ui:91
+#: rnote-ui/data/ui/shortcuts.ui:96
 msgid "Move View"
 msgstr ""
 
-#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:16
-msgid ""
-"Font Chooser\n"
-"(double-click, click on select\n"
-"or press Enter to select a new font)"
-msgstr ""
-
-#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:48
+#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:43
 msgid "Pick And Insert Emoji"
 msgstr ""
 
-#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:73
+#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:68
 msgid "Reset Text Attributes"
 msgstr ""
 
-#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:82
+#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:77
 msgid "Bold"
 msgstr ""
 
-#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:91
+#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:86
 msgid "Italic"
 msgstr ""
 
-#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:100
+#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:95
 msgid "Underline"
 msgstr ""
 
-#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:109
+#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:104
 msgid "Strikethrough"
 msgstr ""
 
-#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:131
+#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:126
 msgid "Align Left"
 msgstr ""
 
-#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:138
+#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:133
 msgid "Align Center"
 msgstr ""
 
-#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:145
+#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:140
 msgid "Align Right"
 msgstr ""
 
-#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:152
+#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:147
 msgid "Fill"
-msgstr ""
-
-#: rnote-ui/data/ui/penssidebar/typewriterpage.ui:184
-#: rnote-ui/data/ui/colorpicker.ui:116 rnote-ui/src/dialogs/export.rs:226
-#: rnote-ui/src/dialogs/export.rs:499 rnote-ui/src/dialogs/export.rs:747
-#: rnote-ui/src/dialogs/mod.rs:393
-msgid "Select"
 msgstr ""
 
 #: rnote-ui/data/ui/appmenu.ui:24
@@ -987,8 +969,8 @@ msgstr ""
 msgid "_Return to Origin Page"
 msgstr ""
 
-#: rnote-ui/data/ui/canvasmenu.ui:105 rnote-ui/data/ui/shortcuts.ui:115
-#: rnote-ui/data/ui/shortcuts.ui:121 rnote-ui/data/ui/shortcuts.ui:127
+#: rnote-ui/data/ui/canvasmenu.ui:105 rnote-ui/data/ui/shortcuts.ui:120
+#: rnote-ui/data/ui/shortcuts.ui:126 rnote-ui/data/ui/shortcuts.ui:132
 msgid "Zoom out"
 msgstr ""
 
@@ -996,8 +978,8 @@ msgstr ""
 msgid "Reset Zoom"
 msgstr ""
 
-#: rnote-ui/data/ui/canvasmenu.ui:121 rnote-ui/data/ui/shortcuts.ui:97
-#: rnote-ui/data/ui/shortcuts.ui:103 rnote-ui/data/ui/shortcuts.ui:109
+#: rnote-ui/data/ui/canvasmenu.ui:121 rnote-ui/data/ui/shortcuts.ui:102
+#: rnote-ui/data/ui/shortcuts.ui:108 rnote-ui/data/ui/shortcuts.ui:114
 msgid "Zoom in"
 msgstr ""
 
@@ -1013,12 +995,12 @@ msgstr ""
 msgid "Fill Color"
 msgstr ""
 
-#: rnote-ui/data/ui/filerow.ui:58 rnote-ui/src/dialogs/import.rs:88
+#: rnote-ui/data/ui/filerow.ui:58 rnote-ui/src/dialogs/import.rs:90
 msgid "Open"
 msgstr ""
 
 #: rnote-ui/data/ui/filerow.ui:62
-#: rnote-ui/src/workspacebrowser/filerow/actions/rename.rs:58
+#: rnote-ui/src/workspacebrowser/filerow/actions/rename.rs:56
 msgid "Rename"
 msgstr ""
 
@@ -1034,7 +1016,7 @@ msgstr ""
 msgid "Draft"
 msgstr ""
 
-#: rnote-ui/data/ui/mainheader.ui:39 rnote-ui/data/ui/mainheader.ui:117
+#: rnote-ui/data/ui/mainheader.ui:39 rnote-ui/data/ui/mainheader.ui:124
 msgid "Reveal/Hide Flap"
 msgstr ""
 
@@ -1042,11 +1024,11 @@ msgstr ""
 msgid "New Tab"
 msgstr ""
 
-#: rnote-ui/data/ui/mainheader.ui:68 rnote-ui/data/ui/shortcuts.ui:213
+#: rnote-ui/data/ui/mainheader.ui:68 rnote-ui/data/ui/shortcuts.ui:218
 msgid "Undo"
 msgstr ""
 
-#: rnote-ui/data/ui/mainheader.ui:76 rnote-ui/data/ui/shortcuts.ui:219
+#: rnote-ui/data/ui/mainheader.ui:76 rnote-ui/data/ui/shortcuts.ui:224
 msgid "Redo"
 msgstr ""
 
@@ -1055,10 +1037,14 @@ msgid "Add Page"
 msgstr ""
 
 #: rnote-ui/data/ui/mainheader.ui:94
+msgid "Remove Page"
+msgstr ""
+
+#: rnote-ui/data/ui/mainheader.ui:101
 msgid "Resize Document to Fit Strokes"
 msgstr ""
 
-#: rnote-ui/data/ui/mainheader.ui:109 rnote-ui/data/ui/shortcuts.ui:156
+#: rnote-ui/data/ui/mainheader.ui:116 rnote-ui/data/ui/shortcuts.ui:161
 msgid "Save Document"
 msgstr ""
 
@@ -1114,258 +1100,258 @@ msgstr ""
 msgid "Set the format border color"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:94
+#: rnote-ui/data/ui/settingspanel.ui:97
 msgid "Show Scrollbars"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:95
+#: rnote-ui/data/ui/settingspanel.ui:98
 msgid "Set whether the scrollbars on the canvas are shown"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:105
+#: rnote-ui/data/ui/settingspanel.ui:108
 msgid "Regular Cursor"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:106
+#: rnote-ui/data/ui/settingspanel.ui:109
 msgid "Set the regular cursor"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:128
+#: rnote-ui/data/ui/settingspanel.ui:131
 msgid "Drawing Cursor"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:129
+#: rnote-ui/data/ui/settingspanel.ui:132
 msgid "Set the drawing cursor"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:154
+#: rnote-ui/data/ui/settingspanel.ui:157
 msgid "Page Format"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:157
+#: rnote-ui/data/ui/settingspanel.ui:160
 msgid "Format"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:158
+#: rnote-ui/data/ui/settingspanel.ui:161
 msgid "Choose a format"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:162
+#: rnote-ui/data/ui/settingspanel.ui:165
 msgid "A6"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:163
+#: rnote-ui/data/ui/settingspanel.ui:166
 msgid "A5"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:164
+#: rnote-ui/data/ui/settingspanel.ui:167
 msgid "A4"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:165
+#: rnote-ui/data/ui/settingspanel.ui:168
 msgid "A3"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:166
+#: rnote-ui/data/ui/settingspanel.ui:169
 msgid "A2"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:167
+#: rnote-ui/data/ui/settingspanel.ui:170
 msgid "US letter"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:168
+#: rnote-ui/data/ui/settingspanel.ui:171
 msgid "US legal"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:169
+#: rnote-ui/data/ui/settingspanel.ui:172
 msgid "Custom"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:177
+#: rnote-ui/data/ui/settingspanel.ui:180
 msgid "Orientation"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:178
+#: rnote-ui/data/ui/settingspanel.ui:181
 msgid "Set the format orientation"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:190
+#: rnote-ui/data/ui/settingspanel.ui:193
 msgid "Portrait"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:196
+#: rnote-ui/data/ui/settingspanel.ui:199
 msgid "Landscape"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:206
+#: rnote-ui/data/ui/settingspanel.ui:209
 msgid "Width"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:207
+#: rnote-ui/data/ui/settingspanel.ui:210
 msgid "Set the format width"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:220
+#: rnote-ui/data/ui/settingspanel.ui:223
 msgid "Height"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:221
+#: rnote-ui/data/ui/settingspanel.ui:224
 msgid "Set the format height"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:234
+#: rnote-ui/data/ui/settingspanel.ui:237
 msgid "Dpi"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:235
+#: rnote-ui/data/ui/settingspanel.ui:238
 msgid "Set the Dpi (dots per inch). Defaults to 96."
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:258
+#: rnote-ui/data/ui/settingspanel.ui:261
 msgid "Revert"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:280
+#: rnote-ui/data/ui/settingspanel.ui:283
 msgid "Document Background"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:284
+#: rnote-ui/data/ui/settingspanel.ui:287
 msgid "Set the background color"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:301
+#: rnote-ui/data/ui/settingspanel.ui:307
 msgid "Pattern"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:302
+#: rnote-ui/data/ui/settingspanel.ui:308
 msgid "Choose a background pattern"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:306
+#: rnote-ui/data/ui/settingspanel.ui:312
 msgid "None"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:307
+#: rnote-ui/data/ui/settingspanel.ui:313
 msgid "Lines"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:308
+#: rnote-ui/data/ui/settingspanel.ui:314
 #: rnote-ui/src/penssidebar/shaperpage.rs:388
 msgid "Grid"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:310
+#: rnote-ui/data/ui/settingspanel.ui:316
 msgid "Isometric Grid"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:311
+#: rnote-ui/data/ui/settingspanel.ui:317
 msgid "Isometric Dots"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:319
+#: rnote-ui/data/ui/settingspanel.ui:325
 msgid "Pattern Color"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:320
+#: rnote-ui/data/ui/settingspanel.ui:326
 msgid "Set the background pattern color"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:337
+#: rnote-ui/data/ui/settingspanel.ui:346
 msgid "Pattern Width"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:338
+#: rnote-ui/data/ui/settingspanel.ui:347
 msgid "Set the background pattern width"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:351
+#: rnote-ui/data/ui/settingspanel.ui:360
 msgid "Pattern Height"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:352
+#: rnote-ui/data/ui/settingspanel.ui:361
 msgid "Set the background pattern height"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:368
+#: rnote-ui/data/ui/settingspanel.ui:377
 msgid "Button Shortcuts"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:371
+#: rnote-ui/data/ui/settingspanel.ui:380
 msgid "Stylus Primary Button Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:372
+#: rnote-ui/data/ui/settingspanel.ui:381
 msgid ""
 "Set the action for the\n"
 "primary stylus button"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:384
+#: rnote-ui/data/ui/settingspanel.ui:393
 msgid "Stylus Secondary Button Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:385
+#: rnote-ui/data/ui/settingspanel.ui:394
 msgid ""
 "Set the action for the\n"
 "secondary stylus button"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:397
+#: rnote-ui/data/ui/settingspanel.ui:406
 msgid "Mouse Secondary Button Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:398
+#: rnote-ui/data/ui/settingspanel.ui:407
 msgid ""
 "Set the action for the\n"
 "secondary mouse button"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:410
+#: rnote-ui/data/ui/settingspanel.ui:419
 msgid "Touch Two-Finger Long-Press Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:411
+#: rnote-ui/data/ui/settingspanel.ui:420
 msgid ""
 "Set the action for the touch\n"
 "two-finger long-press gesture"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:423
+#: rnote-ui/data/ui/settingspanel.ui:432
 msgid "Drawing Pad Button 1 Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:424
+#: rnote-ui/data/ui/settingspanel.ui:433
 msgid ""
 "Set the action for button 1\n"
 "on a drawing pad"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:436
+#: rnote-ui/data/ui/settingspanel.ui:445
 msgid "Drawing Pad Button 2 Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:437
+#: rnote-ui/data/ui/settingspanel.ui:446
 msgid ""
 "Set the action for button 2\n"
 "on a drawing pad"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:449
+#: rnote-ui/data/ui/settingspanel.ui:458
 msgid "Drawing Pad Button 3 Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:450
+#: rnote-ui/data/ui/settingspanel.ui:459
 msgid ""
 "Set the action for button 3\n"
 "on a drawing pad"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:462
+#: rnote-ui/data/ui/settingspanel.ui:471
 msgid "Drawing Pad Button 4 Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:463
+#: rnote-ui/data/ui/settingspanel.ui:472
 msgid ""
 "Set the action for button 4\n"
 "on a drawing pad"
@@ -1419,63 +1405,67 @@ msgstr ""
 msgid "Switch to the 'Tools'"
 msgstr ""
 
-#: rnote-ui/data/ui/shortcuts.ui:92
+#: rnote-ui/data/ui/shortcuts.ui:93
+msgid "View"
+msgstr ""
+
+#: rnote-ui/data/ui/shortcuts.ui:97
 msgid "Alt + Drag"
 msgstr ""
 
-#: rnote-ui/data/ui/shortcuts.ui:133
+#: rnote-ui/data/ui/shortcuts.ui:138
 msgid "Zoom in/out"
 msgstr ""
 
-#: rnote-ui/data/ui/shortcuts.ui:134
+#: rnote-ui/data/ui/shortcuts.ui:139
 msgid "Alt + Shift + Drag"
 msgstr ""
 
-#: rnote-ui/data/ui/shortcuts.ui:141 rnote-ui/src/dialogs/mod.rs:562
+#: rnote-ui/data/ui/shortcuts.ui:146 rnote-ui/src/dialogs/mod.rs:613
 msgid "Document"
 msgstr ""
 
-#: rnote-ui/data/ui/shortcuts.ui:150
+#: rnote-ui/data/ui/shortcuts.ui:155
 msgid "Open Document"
 msgstr ""
 
-#: rnote-ui/data/ui/shortcuts.ui:162 rnote-ui/src/dialogs/export.rs:23
+#: rnote-ui/data/ui/shortcuts.ui:167 rnote-ui/src/dialogs/export.rs:28
 msgid "Save Document As"
 msgstr ""
 
-#: rnote-ui/data/ui/shortcuts.ui:174
+#: rnote-ui/data/ui/shortcuts.ui:179
 msgid "Print Document"
 msgstr ""
 
-#: rnote-ui/data/ui/shortcuts.ui:180 rnote-ui/src/dialogs/import.rs:138
+#: rnote-ui/data/ui/shortcuts.ui:185 rnote-ui/src/dialogs/import.rs:124
 msgid "Import File"
 msgstr ""
 
-#: rnote-ui/data/ui/shortcuts.ui:186
+#: rnote-ui/data/ui/shortcuts.ui:191
 msgid "Drawing"
 msgstr ""
 
-#: rnote-ui/data/ui/shortcuts.ui:189
+#: rnote-ui/data/ui/shortcuts.ui:194
 msgid "Copy to Clipboard"
 msgstr ""
 
-#: rnote-ui/data/ui/shortcuts.ui:195
+#: rnote-ui/data/ui/shortcuts.ui:200
 msgid "Cut to Clipboard"
 msgstr ""
 
-#: rnote-ui/data/ui/shortcuts.ui:201
+#: rnote-ui/data/ui/shortcuts.ui:206
 msgid "Paste Clipboard"
 msgstr ""
 
-#: rnote-ui/data/ui/workspacebrowser.ui:43
+#: rnote-ui/data/ui/workspacebrowser.ui:64
 msgid "Move Directory up"
 msgstr ""
 
-#: rnote-ui/data/ui/workspacebrowser.ui:70
+#: rnote-ui/data/ui/workspacebrowser.ui:81
 msgid "Workspace Directory Actions"
 msgstr ""
 
-#: rnote-ui/data/ui/workspacebrowser.ui:121
+#: rnote-ui/data/ui/workspacebrowser.ui:161
 msgid "Create new Folder"
 msgstr ""
 
@@ -1499,423 +1489,428 @@ msgstr ""
 msgid "Edit Selected Workspace"
 msgstr ""
 
-#: rnote-ui/src/appwindow/mod.rs:508
+#: rnote-ui/src/appwindow/mod.rs:496
 msgid "Opening .rnote file failed"
 msgstr ""
 
-#: rnote-ui/src/appwindow/mod.rs:519
+#: rnote-ui/src/appwindow/mod.rs:507
 msgid "Opening vector image file failed"
 msgstr ""
 
-#: rnote-ui/src/appwindow/mod.rs:530
+#: rnote-ui/src/appwindow/mod.rs:518
 msgid "Opening bitmap image file failed"
 msgstr ""
 
-#: rnote-ui/src/appwindow/mod.rs:541 rnote-ui/src/dialogs/import.rs:394
+#: rnote-ui/src/appwindow/mod.rs:529 rnote-ui/src/dialogs/import.rs:364
 msgid "Opening Xournal++ file failed"
 msgstr ""
 
-#: rnote-ui/src/appwindow/mod.rs:552 rnote-ui/src/dialogs/import.rs:335
-msgid "Opening PDF file failed"
+#: rnote-ui/src/appwindow/mod.rs:540 rnote-ui/src/dialogs/import.rs:305
+msgid "Opening Pdf file failed"
 msgstr ""
 
-#: rnote-ui/src/appwindow/mod.rs:561
+#: rnote-ui/src/appwindow/mod.rs:549
 msgid "Failed to open file, tried to open folder as file"
 msgstr ""
 
-#: rnote-ui/src/appwindow/mod.rs:566
+#: rnote-ui/src/appwindow/mod.rs:554
 msgid "Failed to open file, unsupported file type"
 msgstr ""
 
-#: rnote-ui/src/appwindow/imp.rs:265
-#: rnote-ui/src/appwindow/appwindowactions.rs:578
-#: rnote-ui/src/dialogs/export.rs:71 rnote-ui/src/dialogs/import.rs:51
-#: rnote-ui/src/dialogs/mod.rs:147 rnote-ui/src/dialogs/mod.rs:200
-#: rnote-ui/src/dialogs/mod.rs:328
+#: rnote-ui/src/appwindow/imp.rs:261
+#: rnote-ui/src/appwindow/appwindowactions.rs:605
+#: rnote-ui/src/dialogs/export.rs:65 rnote-ui/src/dialogs/import.rs:54
+#: rnote-ui/src/dialogs/mod.rs:144 rnote-ui/src/dialogs/mod.rs:250
+#: rnote-ui/src/dialogs/mod.rs:390
 msgid "Saving document failed"
 msgstr ""
 
-#: rnote-ui/src/appwindow/imp.rs:481
+#: rnote-ui/src/appwindow/imp.rs:477
 msgid "Button 1"
 msgstr ""
 
-#: rnote-ui/src/appwindow/imp.rs:488
+#: rnote-ui/src/appwindow/imp.rs:484
 msgid "Button 2"
 msgstr ""
 
-#: rnote-ui/src/appwindow/imp.rs:495
+#: rnote-ui/src/appwindow/imp.rs:491
 msgid "Button 3"
 msgstr ""
 
-#: rnote-ui/src/appwindow/imp.rs:502
+#: rnote-ui/src/appwindow/imp.rs:498
 msgid "Button 4"
 msgstr ""
 
-#: rnote-ui/src/appwindow/appwindowactions.rs:699
+#: rnote-ui/src/appwindow/appwindowactions.rs:728
 msgid "Printing document failed"
 msgstr ""
 
-#: rnote-ui/src/appwindow/appwindowactions.rs:727
+#: rnote-ui/src/appwindow/appwindowactions.rs:763
 msgid "Exporting selection failed, nothing selected"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:696
+#: rnote-ui/src/canvas/mod.rs:698
 msgid "- invalid file name -"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:709
+#: rnote-ui/src/canvas/mod.rs:711
 msgid "- invalid folder path -"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:733
+#: rnote-ui/src/canvas/mod.rs:735
 msgid "Opened file was modified on disk"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:734
+#: rnote-ui/src/canvas/mod.rs:736
 msgid "Reload"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:740
+#: rnote-ui/src/canvas/mod.rs:742
 msgid "Reloading .rnote file from disk failed"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:789
+#: rnote-ui/src/canvas/mod.rs:791
 msgid "Opened file was renamed on disk"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:802
+#: rnote-ui/src/canvas/mod.rs:804
 msgid "Opened file was moved or deleted on disk"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:20 rnote-ui/src/dialogs/import.rs:82
+#: rnote-ui/src/dialogs/export.rs:25 rnote-ui/src/dialogs/import.rs:85
 msgid ".rnote"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:62
+#: rnote-ui/src/dialogs/export.rs:54
 msgid "Saved document successfully"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:195
+#: rnote-ui/src/dialogs/export.rs:177
 msgid "Exporting document failed"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:197
+#: rnote-ui/src/dialogs/export.rs:179
 msgid "Exported document successfully"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:203
+#: rnote-ui/src/dialogs/export.rs:185
 msgid "Exporting document failed, no file selected"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:468
+#: rnote-ui/src/dialogs/export.rs:205 rnote-ui/src/dialogs/export.rs:459
+#: rnote-ui/src/dialogs/export.rs:692 rnote-ui/src/dialogs/mod.rs:494
+msgid "Select"
+msgstr ""
+
+#: rnote-ui/src/dialogs/export.rs:431
 msgid "Exporting document pages failed"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:470
+#: rnote-ui/src/dialogs/export.rs:433
 msgid "Exported document pages successfully"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:476
+#: rnote-ui/src/dialogs/export.rs:439
 msgid "Exporting document pages failed, no directory selected"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:716
+#: rnote-ui/src/dialogs/export.rs:664
 msgid "Exporting selection failed"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:718
+#: rnote-ui/src/dialogs/export.rs:666
 msgid "Exported selection successfully"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:724
+#: rnote-ui/src/dialogs/export.rs:672
 msgid "Exporting selection failed, no file selected"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:811 rnote-ui/src/dialogs/export.rs:875
+#: rnote-ui/src/dialogs/export.rs:735 rnote-ui/src/dialogs/export.rs:781
 msgid "Json"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:814
+#: rnote-ui/src/dialogs/export.rs:743
 msgid "Export Engine State"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:852
+#: rnote-ui/src/dialogs/export.rs:762
 msgid "Exporting engine state failed"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:854
+#: rnote-ui/src/dialogs/export.rs:766
 msgid "Exported engine state successfully"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:878
+#: rnote-ui/src/dialogs/export.rs:789
 msgid "Export Engine Config"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:916
+#: rnote-ui/src/dialogs/export.rs:808
 msgid "Exporting engine config failed"
 msgstr ""
 
-#: rnote-ui/src/dialogs/export.rs:918
+#: rnote-ui/src/dialogs/export.rs:812
 msgid "Exported engine config successfully"
 msgstr ""
 
-#: rnote-ui/src/dialogs/import.rs:34
+#: rnote-ui/src/dialogs/import.rs:37
 msgid "Opening file failed"
 msgstr ""
 
-#: rnote-ui/src/dialogs/import.rs:135
+#: rnote-ui/src/dialogs/import.rs:121
 msgid "Jpg, Pdf, Png, Svg, Xopp"
 msgstr ""
 
-#: rnote-ui/src/dialogs/import.rs:271
+#: rnote-ui/src/dialogs/import.rs:241
 msgid "- no file name -"
 msgstr ""
 
-#: rnote-ui/src/dialogs/import.rs:276
+#: rnote-ui/src/dialogs/import.rs:246
 msgid "- no title -"
 msgstr ""
 
-#: rnote-ui/src/dialogs/import.rs:279
+#: rnote-ui/src/dialogs/import.rs:249
 msgid "- no author -"
 msgstr ""
 
-#: rnote-ui/src/dialogs/import.rs:283
+#: rnote-ui/src/dialogs/import.rs:253
 msgid "- no date -"
 msgstr ""
 
-#: rnote-ui/src/dialogs/import.rs:290
+#: rnote-ui/src/dialogs/import.rs:260
 msgid "File name:"
 msgstr ""
 
-#: rnote-ui/src/dialogs/import.rs:294
+#: rnote-ui/src/dialogs/import.rs:264
 msgid "Title:"
 msgstr ""
 
-#: rnote-ui/src/dialogs/import.rs:298
+#: rnote-ui/src/dialogs/import.rs:268
 msgid "Author:"
 msgstr ""
 
-#: rnote-ui/src/dialogs/import.rs:302
+#: rnote-ui/src/dialogs/import.rs:272
 msgid "Modification date:"
 msgstr ""
 
-#: rnote-ui/src/dialogs/import.rs:306
+#: rnote-ui/src/dialogs/import.rs:276
 msgid "Pages:"
 msgstr ""
 
 #. TRANSLATORS: 'Name <email@domain.com>' or 'Name https://website.example'
-#: rnote-ui/src/dialogs/mod.rs:44
+#: rnote-ui/src/dialogs/mod.rs:47
 msgid "translator-credits"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:273
+#: rnote-ui/src/dialogs/mod.rs:218 rnote-ui/src/dialogs/mod.rs:336
 msgid "- unable to find a valid save folder -"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:390
+#: rnote-ui/src/dialogs/mod.rs:492
 msgid "Change Workspace Directory"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:549
+#: rnote-ui/src/dialogs/mod.rs:600
 msgid "Band-Aid"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:550
+#: rnote-ui/src/dialogs/mod.rs:601
 msgid "Bank"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:551
+#: rnote-ui/src/dialogs/mod.rs:602
 msgid "Bookmark"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:552
+#: rnote-ui/src/dialogs/mod.rs:603
 msgid "Book"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:553
+#: rnote-ui/src/dialogs/mod.rs:604
 msgid "Bread"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:554
+#: rnote-ui/src/dialogs/mod.rs:605
 msgid "Calendar"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:555
+#: rnote-ui/src/dialogs/mod.rs:606
 msgid "Camera"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:556
+#: rnote-ui/src/dialogs/mod.rs:607
 msgctxt "as in computer chip"
 msgid "Chip"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:557
+#: rnote-ui/src/dialogs/mod.rs:608
 msgid "Clock"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:558
+#: rnote-ui/src/dialogs/mod.rs:609
 msgid "Code"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:559
+#: rnote-ui/src/dialogs/mod.rs:610
 msgid "Compose"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:560
+#: rnote-ui/src/dialogs/mod.rs:611
 msgctxt "as in plant"
 msgid "Crop"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:561
+#: rnote-ui/src/dialogs/mod.rs:612
 msgid "Dictionary"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:563
+#: rnote-ui/src/dialogs/mod.rs:614
 msgid "Drinks"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:564
+#: rnote-ui/src/dialogs/mod.rs:615
 msgid "Flag"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:565
+#: rnote-ui/src/dialogs/mod.rs:616
 msgid "Folder"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:566
+#: rnote-ui/src/dialogs/mod.rs:617
 msgid "Footprints"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:567
+#: rnote-ui/src/dialogs/mod.rs:618
 msgid "Gamepad"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:568
+#: rnote-ui/src/dialogs/mod.rs:619
 msgid "Gear"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:569
+#: rnote-ui/src/dialogs/mod.rs:620
 msgid "Globe"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:570
+#: rnote-ui/src/dialogs/mod.rs:621
 msgid "Hammer"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:571
+#: rnote-ui/src/dialogs/mod.rs:622
 msgid "Heart"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:572
+#: rnote-ui/src/dialogs/mod.rs:623
 msgid "Hourglass"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:573
+#: rnote-ui/src/dialogs/mod.rs:624
 msgid "Key"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:574
+#: rnote-ui/src/dialogs/mod.rs:625
 msgid "Language"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:575
+#: rnote-ui/src/dialogs/mod.rs:626
 msgid "Library"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:576
+#: rnote-ui/src/dialogs/mod.rs:627
 msgid "Lightbulb"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:577
+#: rnote-ui/src/dialogs/mod.rs:628
 msgid "Mathematics"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:578
+#: rnote-ui/src/dialogs/mod.rs:629
 msgid "Meeting"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:579
+#: rnote-ui/src/dialogs/mod.rs:630
 msgid "Money"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:580
+#: rnote-ui/src/dialogs/mod.rs:631
 msgid "Musical Note"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:581
+#: rnote-ui/src/dialogs/mod.rs:632
 msgid "Nature"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:582
+#: rnote-ui/src/dialogs/mod.rs:633
 msgid "Open Book"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:583
+#: rnote-ui/src/dialogs/mod.rs:634
 msgid "Paintbrush"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:584
+#: rnote-ui/src/dialogs/mod.rs:635
 msgid "Pencil and Paper"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:585
+#: rnote-ui/src/dialogs/mod.rs:636
 msgid "People"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:586
+#: rnote-ui/src/dialogs/mod.rs:637
 msgid "Person"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:587
+#: rnote-ui/src/dialogs/mod.rs:638
 msgid "Projector"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:588
+#: rnote-ui/src/dialogs/mod.rs:639
 msgid "Science"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:589
+#: rnote-ui/src/dialogs/mod.rs:640
 msgid "Scratchpad"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:590
+#: rnote-ui/src/dialogs/mod.rs:641
 msgid "Shapes"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:591
+#: rnote-ui/src/dialogs/mod.rs:642
 msgid "Shopping"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:592
+#: rnote-ui/src/dialogs/mod.rs:643
 msgid "Speech Bubble"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:593
+#: rnote-ui/src/dialogs/mod.rs:644
 msgid "Speedometer"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:594
+#: rnote-ui/src/dialogs/mod.rs:645
 msgid "Star"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:596
+#: rnote-ui/src/dialogs/mod.rs:647
 msgctxt "as in terminal software"
 msgid "Terminal"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:598
+#: rnote-ui/src/dialogs/mod.rs:649
 msgid "Text"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:599
+#: rnote-ui/src/dialogs/mod.rs:650
 msgid "Travel"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:600
+#: rnote-ui/src/dialogs/mod.rs:651
 msgid "Weather"
 msgstr ""
 
-#: rnote-ui/src/dialogs/mod.rs:601
+#: rnote-ui/src/dialogs/mod.rs:652
 msgid "Weight"
 msgstr ""
 
@@ -2047,10 +2042,10 @@ msgstr ""
 msgid "Beam (Large)"
 msgstr ""
 
-#: rnote-ui/src/workspacebrowser/workspaceactions/createfolder.rs:57
+#: rnote-ui/src/workspacebrowser/workspaceactions/createfolder.rs:56
 msgid "Folder Name"
 msgstr ""
 
-#: rnote-ui/src/workspacebrowser/workspaceactions/createfolder.rs:65
+#: rnote-ui/src/workspacebrowser/workspaceactions/createfolder.rs:64
 msgid "New Folder"
 msgstr ""

--- a/rnote-ui/src/app/appactions.rs
+++ b/rnote-ui/src/app/appactions.rs
@@ -1,3 +1,4 @@
+// Imports
 use crate::RnApp;
 use adw::prelude::*;
 use gtk4::{gio, glib, glib::clone};

--- a/rnote-ui/src/app/mod.rs
+++ b/rnote-ui/src/app/mod.rs
@@ -1,11 +1,7 @@
+// Modules
 mod appactions;
 
 // Imports
-use adw::subclass::prelude::AdwApplicationImpl;
-use gtk4::{gio, glib, prelude::*, subclass::prelude::*};
-use rnote_engine::document::format::MeasureUnit;
-use rnote_engine::pens::PenStyle;
-
 use crate::{
     colorpicker::RnColorPad, colorpicker::RnColorSetter, config, globals, penssidebar::RnBrushPage,
     penssidebar::RnEraserPage, penssidebar::RnSelectorPage, penssidebar::RnShaperPage,
@@ -16,6 +12,10 @@ use crate::{
     RnCanvas, RnCanvasMenu, RnCanvasWrapper, RnColorPicker, RnIconPicker, RnMainHeader, RnOverlays,
     RnPensSideBar, RnSettingsPanel, RnStrokeWidthPicker, RnUnitEntry, RnWorkspaceBrowser,
 };
+use adw::subclass::prelude::AdwApplicationImpl;
+use gtk4::{gio, glib, prelude::*, subclass::prelude::*};
+use rnote_engine::document::format::MeasureUnit;
+use rnote_engine::pens::PenStyle;
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/appmenu.rs
+++ b/rnote-ui/src/appmenu.rs
@@ -1,3 +1,4 @@
+// Imports
 use crate::appwindow::RnAppWindow;
 use adw::{prelude::*, subclass::prelude::*};
 use gtk4::{gio, glib, CompositeTemplate, MenuButton, PopoverMenu, ToggleButton, Widget};

--- a/rnote-ui/src/appwindow/appsettings.rs
+++ b/rnote-ui/src/appwindow/appsettings.rs
@@ -1,10 +1,10 @@
+// Imports
+use crate::appwindow::RnAppWindow;
 use adw::prelude::*;
 use gtk4::{gdk, glib, glib::clone};
 
-use crate::appwindow::RnAppWindow;
-
 impl RnAppWindow {
-    /// Settings binds
+    /// Setup settings binds.
     pub(crate) fn setup_settings_binds(&self) {
         let app = self.app();
 
@@ -340,7 +340,9 @@ impl RnAppWindow {
             .build();
     }
 
-    /// load settings at startup that are not bound as binding. Setting changes through gsettings / dconf might not be applied until app restarts
+    /// Load settings that are not bound as binds.
+    ///
+    /// Settings changes through gsettings / dconf might not be applied until the app restarts.
     pub(crate) fn load_settings(&self) {
         let _app = self.app();
 
@@ -374,7 +376,7 @@ impl RnAppWindow {
         }
     }
 
-    /// Save all settings at shutdown that are not bound in setup_settings
+    /// Save settings that are not bound as binds.
     pub(crate) fn save_to_settings(&self) -> anyhow::Result<()> {
         let _app = self.app();
 

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -779,8 +779,6 @@ impl RnAppWindow {
 
             match content {
                 Some((data, mime_type)) => {
-                    //log::debug!("set clipboard with data: {:02x?}, mime-type: {}", data, mime_type);
-
                     let content = gdk::ContentProvider::for_bytes(mime_type.as_str(), &glib::Bytes::from_owned(data));
 
                     if let Err(e) = appwindow.clipboard().set_content(Some(&content)) {

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -1,3 +1,5 @@
+// Imports
+use crate::{config, dialogs, RnAppWindow, RnCanvas};
 use gettextrs::gettext;
 use gtk4::{
     gdk, gio, glib, glib::clone, prelude::*, PrintOperation, PrintOperationAction, Unit,
@@ -13,15 +15,13 @@ use rnote_engine::{render, Camera, DrawBehaviour, RnoteEngine};
 use std::path::PathBuf;
 use std::time::Instant;
 
-use crate::{config, dialogs, RnAppWindow, RnCanvas};
-
 const CLIPBOARD_INPUT_STREAM_BUFSIZE: usize = 4096;
 
 impl RnAppWindow {
     /// Boolean actions have no target, and a boolean state. They have a default implementation for the activate signal,
     /// which requests the state to be inverted, and the default implementation for change_state, which sets the state to the request.
     /// We generally want to connect to the change_state signal. (but then have to set the state with action.set_state() )
-    /// We can then either toggle the state through activating the action, or set the state explicitly through action.change_state(<request>)
+    /// We can then either toggle the state through activating the action, or set the state explicitly through `action.change_state(<request>)`
     pub(crate) fn setup_actions(&self) {
         let action_fullscreen = gio::PropertyAction::new("fullscreen", self, "fullscreened");
         self.add_action(&action_fullscreen);

--- a/rnote-ui/src/appwindow/imp.rs
+++ b/rnote-ui/src/appwindow/imp.rs
@@ -1,19 +1,18 @@
+// Imports
+use crate::{
+    config, RnOverlays, RnSettingsPanel, RnWorkspaceBrowser, {dialogs, RnMainHeader},
+};
 use adw::{prelude::*, subclass::prelude::*};
 use gettextrs::gettext;
-use gtk4::PadActionType;
 use gtk4::{
     gdk, gio, glib, glib::clone, Align, ArrowType, Box, Button, CompositeTemplate, CornerType,
-    CssProvider, GestureDrag, Grid, Inhibit, PackType, PadController, PositionType,
+    CssProvider, GestureDrag, Grid, Inhibit, PackType, PadActionType, PadController, PositionType,
     PropagationPhase,
 };
 use once_cell::sync::Lazy;
 use std::{
     cell::{Cell, RefCell},
     rc::Rc,
-};
-
-use crate::{
-    config, RnOverlays, RnSettingsPanel, RnWorkspaceBrowser, {dialogs, RnMainHeader},
 };
 
 #[derive(Debug, CompositeTemplate)]

--- a/rnote-ui/src/appwindow/mod.rs
+++ b/rnote-ui/src/appwindow/mod.rs
@@ -1,12 +1,16 @@
+// Modules
 mod appsettings;
 mod appwindowactions;
 mod imp;
 
 // Imports
+use crate::{
+    config, RnApp, RnCanvas, RnCanvasWrapper, RnOverlays, RnSettingsPanel, RnWorkspaceBrowser,
+    {dialogs, RnMainHeader},
+};
 use adw::{prelude::*, subclass::prelude::*};
 use gettextrs::gettext;
-use gtk4::gdk;
-use gtk4::{gio, glib, glib::clone, Application, Box, Button, IconTheme};
+use gtk4::{gdk, gio, glib, glib::clone, Application, Box, Button, IconTheme};
 use rnote_compose::Color;
 use rnote_engine::pens::pensconfig::brushconfig::BrushStyle;
 use rnote_engine::pens::pensconfig::shaperconfig::ShaperStyle;
@@ -14,11 +18,6 @@ use rnote_engine::pens::PenStyle;
 use rnote_engine::utils::GdkRGBAHelpers;
 use rnote_engine::{engine::EngineTask, WidgetFlags};
 use std::path::Path;
-
-use crate::{
-    config, RnApp, RnCanvas, RnCanvasWrapper, RnOverlays, RnSettingsPanel, RnWorkspaceBrowser,
-    {dialogs, RnMainHeader},
-};
 
 glib::wrapper! {
     pub(crate) struct RnAppWindow(ObjectSubclass<imp::RnAppWindow>)
@@ -538,7 +537,7 @@ impl RnAppWindow {
                         Ok((bytes, _)) => {
                             if let Err(e) = canvas.load_in_pdf_bytes(bytes.to_vec(), target_pos, None).await {
                                 log::error!("load_in_pdf_bytes() failed with Err: {e:?}");
-                                appwindow.overlays().dispatch_toast_error(&gettext("Opening PDF file failed"));
+                                appwindow.overlays().dispatch_toast_error(&gettext("Opening Pdf file failed"));
                             }
                         }
                         Err(e) => log::error!("failed to load bytes, Err: {e:?}"),

--- a/rnote-ui/src/canvas/canvaslayout.rs
+++ b/rnote-ui/src/canvas/canvaslayout.rs
@@ -1,3 +1,5 @@
+// Imports
+use crate::canvas::RnCanvas;
 use gtk4::{
     glib, prelude::*, subclass::prelude::*, LayoutManager, Orientation, SizeRequestMode, Widget,
 };
@@ -5,8 +7,6 @@ use p2d::bounding_volume::{Aabb, BoundingVolume};
 use rnote_compose::helpers::AabbHelpers;
 use rnote_engine::{document::Layout, render};
 use std::cell::Cell;
-
-use crate::canvas::RnCanvas;
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/canvas/canvaslayout.rs
+++ b/rnote-ui/src/canvas/canvaslayout.rs
@@ -148,13 +148,6 @@ mod imp {
             // which can also take up quite some time on the main UI thread.
             let old_viewport_extended = old_viewport
                 .extend_by(old_viewport.extents() * render::VIEWPORT_EXTENTS_MARGIN_FACTOR * 0.8);
-            /*
-                       log::debug!(
-                           "viewport: {:#?}\nold_viewport_extended: {:#?}",
-                           viewport,
-                           old_viewport_extended
-                       );
-            */
 
             // always update the background rendering
             if let Err(e) = engine.update_background_rendering_current_viewport() {

--- a/rnote-ui/src/canvas/imexport.rs
+++ b/rnote-ui/src/canvas/imexport.rs
@@ -1,14 +1,13 @@
-use std::ops::Range;
-use std::path::Path;
-
+// Imports
+use super::RnCanvas;
 use futures::channel::oneshot;
 use gtk4::{gio, prelude::*};
 use rnote_compose::helpers::Vector2Helpers;
 use rnote_engine::engine::export::{DocExportPrefs, DocPagesExportPrefs, SelectionExportPrefs};
 use rnote_engine::engine::{EngineSnapshot, StrokeContent};
 use rnote_engine::strokes::Stroke;
-
-use super::RnCanvas;
+use std::ops::Range;
+use std::path::Path;
 
 impl RnCanvas {
     pub(crate) async fn load_in_rnote_bytes<P>(

--- a/rnote-ui/src/canvas/input.rs
+++ b/rnote-ui/src/canvas/input.rs
@@ -1,3 +1,5 @@
+// Imports
+use super::RnCanvas;
 use gtk4::{gdk, prelude::*, Inhibit, Native};
 use rnote_compose::penevents::ShortcutKey;
 use rnote_compose::penevents::{KeyboardKey, PenState};
@@ -7,8 +9,6 @@ use rnote_engine::pens::penholder::BacklogPolicy;
 use rnote_engine::pens::PenMode;
 use rnote_engine::WidgetFlags;
 use std::time::{Duration, Instant};
-
-use super::RnCanvas;
 
 // Returns whether the event should be inhibited from propagating, and the new pen state
 pub(crate) fn handle_pointer_controller_event(

--- a/rnote-ui/src/canvas/input.rs
+++ b/rnote-ui/src/canvas/input.rs
@@ -164,7 +164,7 @@ pub(crate) fn handle_pointer_controller_event(
         let pen_mode = retrieve_pen_mode(event);
 
         for (element, event_time) in elements {
-            //log::debug!("handle event, state: {state:?}, event_time_d: {:?}, modifier_keys: {modifier_keys:?}, pen_mode: {pen_mode:?}", now.duration_since(event_time));
+            //log::debug!("handle pen event, state: {state:?}, event_time_d: {:?}, modifier_keys: {modifier_keys:?}, pen_mode: {pen_mode:?}", now.duration_since(event_time));
 
             match state {
                 PenState::Up => {
@@ -223,8 +223,6 @@ pub(crate) fn handle_key_controller_key_pressed(
     let now = Instant::now();
     let keyboard_key = retrieve_keyboard_key(key);
     let modifier_keys = retrieve_modifier_keys(modifier);
-
-    //log::debug!("keyboard key: {:?}", keyboard_key);
 
     let widget_flags = canvas.engine().borrow_mut().handle_pen_event(
         PenEvent::KeyPressed {
@@ -410,8 +408,6 @@ fn retrieve_pen_mode(event: &gdk::Event) -> Option<PenMode> {
 }
 
 pub(crate) fn retrieve_keyboard_key(gdk_key: gdk::Key) -> KeyboardKey {
-    //log::debug!("gdk: pressed key: {:?}", gdk_key);
-
     if let Some(keychar) = gdk_key.to_unicode() {
         KeyboardKey::Unicode(keychar).filter_convert_unicode_control_chars()
     } else {

--- a/rnote-ui/src/canvas/mod.rs
+++ b/rnote-ui/src/canvas/mod.rs
@@ -431,6 +431,7 @@ mod imp {
             self.key_controller.connect_key_pressed(clone!(@weak obj as canvas => @default-return Inhibit(false), move |_, key, _raw, modifier| {
                 super::input::handle_key_controller_key_pressed(&canvas, key, modifier)
             }));
+
             /*
                        self.key_controller.connect_key_released(
                            clone!(@weak inst as canvas => move |_key_controller, _key, _raw, _modifier| {

--- a/rnote-ui/src/canvas/mod.rs
+++ b/rnote-ui/src/canvas/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 mod canvaslayout;
 pub(crate) mod imexport;
 mod input;
@@ -6,6 +7,8 @@ mod input;
 pub(crate) use canvaslayout::RnCanvasLayout;
 
 // Imports
+use crate::RnCanvasWrapper;
+use crate::{config, RnAppWindow};
 use futures::StreamExt;
 use gettextrs::gettext;
 use gtk4::{
@@ -23,9 +26,6 @@ use rnote_engine::{RnoteEngine, WidgetFlags};
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::time::Duration;
-
-use crate::RnCanvasWrapper;
-use crate::{config, RnAppWindow};
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, glib::Boxed)]
 #[boxed_type(name = "WidgetFlagsBoxed")]

--- a/rnote-ui/src/canvasmenu.rs
+++ b/rnote-ui/src/canvasmenu.rs
@@ -1,5 +1,5 @@
+// Imports
 use crate::appwindow::RnAppWindow;
-
 use gtk4::{
     gio, glib, prelude::*, subclass::prelude::*, Button, CompositeTemplate, MenuButton,
     PopoverMenu, Widget,

--- a/rnote-ui/src/canvaswrapper.rs
+++ b/rnote-ui/src/canvaswrapper.rs
@@ -1,6 +1,7 @@
-use gtk4::CornerType;
+// Imports
+use crate::{RnAppWindow, RnCanvas};
 use gtk4::{
-    gdk, glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate,
+    gdk, glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate, CornerType,
     EventControllerMotion, EventControllerScroll, EventControllerScrollFlags, EventSequenceState,
     GestureDrag, GestureLongPress, GestureZoom, Inhibit, PropagationPhase, ScrolledWindow, Widget,
 };
@@ -11,10 +12,7 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::time::Instant;
 
-use crate::{RnAppWindow, RnCanvas};
-
 mod imp {
-
     use super::*;
 
     #[derive(Debug, CompositeTemplate)]

--- a/rnote-ui/src/colorpicker/colorpad.rs
+++ b/rnote-ui/src/colorpicker/colorpad.rs
@@ -1,11 +1,11 @@
-use std::cell::Cell;
-
+// Imports
 use gtk4::{
     gdk, glib, prelude::*, subclass::prelude::*, Align, Button, CssProvider, ToggleButton, Widget,
 };
 use once_cell::sync::Lazy;
 use rnote_compose::{color, Color};
 use rnote_engine::utils::GdkRGBAHelpers;
+use std::cell::Cell;
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/colorpicker/colorsetter.rs
+++ b/rnote-ui/src/colorpicker/colorsetter.rs
@@ -1,13 +1,12 @@
-use std::cell::Cell;
-
+// Imports
 use gtk4::{
     gdk, glib, prelude::*, subclass::prelude::*, Align, Button, CssProvider, PositionType,
     ToggleButton, Widget,
 };
-
 use once_cell::sync::Lazy;
 use rnote_compose::{color, Color};
 use rnote_engine::utils::GdkRGBAHelpers;
+use std::cell::Cell;
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/colorpicker/mod.rs
+++ b/rnote-ui/src/colorpicker/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 mod colorpad;
 mod colorsetter;
 
@@ -6,18 +7,15 @@ pub(crate) use colorpad::RnColorPad;
 pub(crate) use colorsetter::RnColorSetter;
 
 // Imports
-use std::cell::{Cell, RefCell};
-
+use crate::RnAppWindow;
 use gtk4::{
     gdk, glib, glib::clone, prelude::*, subclass::prelude::*, BoxLayout, Button, ColorDialog,
     CompositeTemplate, Orientation, PositionType, Widget,
 };
-
 use once_cell::sync::Lazy;
 use rnote_compose::{color, Color};
 use rnote_engine::utils::GdkRGBAHelpers;
-
-use crate::RnAppWindow;
+use std::cell::{Cell, RefCell};
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/config.rs.in
+++ b/rnote-ui/src/config.rs.in
@@ -27,7 +27,7 @@ pub(crate) const PROFILE: &str = @PROFILE@;
 #[allow(unused)]
 pub(crate) const GETTEXT_PACKAGE: &str = @GETTEXT_PACKAGE@;
 
-// These are only allowed to be used from the `env` module
+// These are only allowed to be used in the `env` module
 #[allow(unused)]
 pub(crate) const LOCALEDIR: &str = @LOCALEDIR@;
 #[allow(unused)]

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -1,9 +1,9 @@
 // gtk4::Dialog is deprecated, but the replacement adw::ToolbarView is not yet stable
 #![allow(deprecated)]
 
-use std::cell::RefCell;
-use std::rc::Rc;
-
+// Imports
+use crate::canvas::{self, RnCanvas};
+use crate::{config, RnAppWindow};
 use adw::prelude::*;
 use gettextrs::gettext;
 use gtk4::{
@@ -15,9 +15,8 @@ use rnote_engine::engine::export::{
     DocExportFormat, DocExportPrefs, DocPagesExportFormat, DocPagesExportPrefs,
     SelectionExportFormat, SelectionExportPrefs,
 };
-
-use crate::canvas::{self, RnCanvas};
-use crate::{config, RnAppWindow};
+use std::cell::RefCell;
+use std::rc::Rc;
 
 pub(crate) async fn dialog_save_doc_as(appwindow: &RnAppWindow, canvas: &RnCanvas) {
     let filter = FileFilter::new();

--- a/rnote-ui/src/dialogs/import.rs
+++ b/rnote-ui/src/dialogs/import.rs
@@ -1,6 +1,9 @@
 // gtk4::Dialog is deprecated, but the replacement adw::ToolbarView is not yet stable
 #![allow(deprecated)]
 
+// Imports
+use crate::canvas::RnCanvas;
+use crate::{config, RnAppWindow};
 use adw::prelude::*;
 use gettextrs::gettext;
 use gtk4::{
@@ -9,9 +12,6 @@ use gtk4::{
 };
 use num_traits::ToPrimitive;
 use rnote_engine::engine::import::{PdfImportPageSpacing, PdfImportPagesType};
-
-use crate::canvas::RnCanvas;
-use crate::{config, RnAppWindow};
 
 /// Asks to open the given file as rnote file and overwrites the current document.
 #[allow(unused)]
@@ -302,7 +302,7 @@ pub(crate) fn dialog_import_pdf_w_prefs(
 
                         if let Ok((file_bytes, _)) = result {
                             if let Err(e) = canvas.load_in_pdf_bytes(file_bytes.to_vec(), target_pos, Some(page_range)).await {
-                                appwindow.overlays().dispatch_toast_error(&gettext("Opening PDF file failed"));
+                                appwindow.overlays().dispatch_toast_error(&gettext("Opening Pdf file failed"));
                                 log::error!(
                                     "load_in_rnote_bytes() failed in dialog import pdf with Err: {e:?}"
                                 );

--- a/rnote-ui/src/dialogs/mod.rs
+++ b/rnote-ui/src/dialogs/mod.rs
@@ -1,22 +1,23 @@
 // gtk4::Dialog is deprecated, but the replacement adw::ToolbarView is not yet stable
 #![allow(deprecated)]
 
+// Modules
 pub(crate) mod export;
 pub(crate) mod import;
 
-use adw::prelude::*;
-use gettextrs::{gettext, pgettext};
-use gtk4::{
-    gio, glib, glib::clone, Builder, Button, CheckButton, ColorDialogButton, Dialog, FileDialog,
-    Label, MenuButton, ResponseType, ShortcutsWindow, StringList,
-};
-
+// Imports
 use crate::appwindow::RnAppWindow;
 use crate::canvas::RnCanvas;
 use crate::canvaswrapper::RnCanvasWrapper;
 use crate::config;
 use crate::workspacebrowser::workspacesbar::RnWorkspaceRow;
 use crate::{globals, RnIconPicker};
+use adw::prelude::*;
+use gettextrs::{gettext, pgettext};
+use gtk4::{
+    gio, glib, glib::clone, Builder, Button, CheckButton, ColorDialogButton, Dialog, FileDialog,
+    Label, MenuButton, ResponseType, ShortcutsWindow, StringList,
+};
 
 // About Dialog
 pub(crate) fn dialog_about(appwindow: &RnAppWindow) {

--- a/rnote-ui/src/env.rs
+++ b/rnote-ui/src/env.rs
@@ -1,7 +1,7 @@
+// Imports
+use crate::config;
 use std::ffi::OsStr;
 use std::path::{Component, Path, PathBuf};
-
-use crate::config;
 
 pub(crate) fn lib_dir() -> anyhow::Result<PathBuf> {
     if cfg!(target_os = "windows") {

--- a/rnote-ui/src/groupediconpicker/group.rs
+++ b/rnote-ui/src/groupediconpicker/group.rs
@@ -1,3 +1,5 @@
+// Imports
+use crate::RnGroupedIconPicker;
 use cairo::glib::clone;
 use gtk4::{glib, prelude::*, subclass::prelude::*, CompositeTemplate};
 use gtk4::{subclass::prelude::ObjectSubclass, ListBoxRow};
@@ -5,8 +7,6 @@ use gtk4::{
     Align, Box, FlowBox, FlowBoxChild, IconSize, Image, Label, StringList, StringObject,
     TemplateChild, Widget,
 };
-
-use crate::RnGroupedIconPicker;
 
 pub(crate) struct GroupedIconPickerGroupData {
     pub(crate) name: String,

--- a/rnote-ui/src/groupediconpicker/mod.rs
+++ b/rnote-ui/src/groupediconpicker/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 mod group;
 
 // Re-exports
@@ -6,9 +7,9 @@ pub(crate) use group::RnGroupedIconPickerGroup;
 
 // Imports
 use gtk4::{
-    glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate, ListBox, Widget,
+    glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate, Label, ListBox,
+    StringList, StringObject, Widget,
 };
-use gtk4::{Label, StringList, StringObject};
 use once_cell::sync::Lazy;
 use std::cell::RefCell;
 

--- a/rnote-ui/src/iconpicker.rs
+++ b/rnote-ui/src/iconpicker.rs
@@ -1,16 +1,14 @@
+// Imports
 use cairo::glib::closure;
 use gtk4::{
-    glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate, GridView, Label, Widget,
-};
-use gtk4::{
-    Align, ConstantExpression, IconSize, Image, ListItem, PropertyExpression,
-    SignalListItemFactory, SingleSelection, StringList, StringObject,
+    glib, glib::clone, prelude::*, subclass::prelude::*, Align, CompositeTemplate,
+    ConstantExpression, GridView, IconSize, Image, Label, ListItem, PropertyExpression,
+    SignalListItemFactory, SingleSelection, StringList, StringObject, Widget,
 };
 use once_cell::sync::Lazy;
+use std::cell::RefCell;
 
 mod imp {
-    use std::cell::RefCell;
-
     use super::*;
 
     #[derive(Debug, CompositeTemplate)]

--- a/rnote-ui/src/main.rs
+++ b/rnote-ui/src/main.rs
@@ -3,6 +3,7 @@
 // Hides console window on windows
 #![windows_subsystem = "windows"]
 
+// Modules
 mod app;
 mod appmenu;
 mod appwindow;
@@ -43,9 +44,11 @@ pub(crate) use strokewidthpicker::RnStrokeWidthPicker;
 pub(crate) use unitentry::RnUnitEntry;
 pub(crate) use workspacebrowser::RnWorkspaceBrowser;
 
+// Renames
 extern crate nalgebra as na;
 extern crate parry2d_f64 as p2d;
 
+// Imports
 use gtk4::{glib, prelude::*};
 
 fn main() -> glib::ExitCode {

--- a/rnote-ui/src/mainheader.rs
+++ b/rnote-ui/src/mainheader.rs
@@ -1,3 +1,4 @@
+// Imports
 use crate::{appmenu::RnAppMenu, appwindow::RnAppWindow, canvasmenu::RnCanvasMenu};
 use gtk4::{
     glib, prelude::*, subclass::prelude::*, Button, CompositeTemplate, Label, ToggleButton, Widget,

--- a/rnote-ui/src/overlays.rs
+++ b/rnote-ui/src/overlays.rs
@@ -1,3 +1,7 @@
+// Imports
+use crate::canvaswrapper::RnCanvasWrapper;
+use crate::RnPensSideBar;
+use crate::{dialogs, RnAppWindow, RnColorPicker};
 use gtk4::{
     gio, glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate, Overlay,
     ProgressBar, ScrolledWindow, ToggleButton, Widget,
@@ -6,10 +10,6 @@ use rnote_engine::engine::EngineViewMut;
 use rnote_engine::pens::{Pen, PenStyle};
 use rnote_engine::utils::GdkRGBAHelpers;
 use std::cell::RefCell;
-
-use crate::canvaswrapper::RnCanvasWrapper;
-use crate::RnPensSideBar;
-use crate::{dialogs, RnAppWindow, RnColorPicker};
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/penssidebar/brushpage.rs
+++ b/rnote-ui/src/penssidebar/brushpage.rs
@@ -1,3 +1,5 @@
+// Imports
+use crate::{RnAppWindow, RnCanvasWrapper, RnStrokeWidthPicker};
 use adw::prelude::*;
 use gtk4::{
     glib, glib::clone, subclass::prelude::*, CompositeTemplate, ListBox, MenuButton, Popover,
@@ -9,8 +11,6 @@ use rnote_compose::style::textured::{TexturedDotsDistribution, TexturedOptions};
 use rnote_compose::style::PressureCurve;
 use rnote_engine::pens::pensconfig::brushconfig::{BrushStyle, SolidOptions};
 use rnote_engine::pens::pensconfig::BrushConfig;
-
-use crate::{RnAppWindow, RnCanvasWrapper, RnStrokeWidthPicker};
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/penssidebar/eraserpage.rs
+++ b/rnote-ui/src/penssidebar/eraserpage.rs
@@ -1,10 +1,10 @@
+// Imports
+use crate::RnStrokeWidthPicker;
+use crate::{RnAppWindow, RnCanvasWrapper};
 use adw::prelude::*;
 use gtk4::{glib, glib::clone, subclass::prelude::*, CompositeTemplate, ToggleButton};
 use rnote_engine::pens::pensconfig::eraserconfig::EraserStyle;
 use rnote_engine::pens::pensconfig::EraserConfig;
-
-use crate::RnStrokeWidthPicker;
-use crate::{RnAppWindow, RnCanvasWrapper};
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/penssidebar/mod.rs
+++ b/rnote-ui/src/penssidebar/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 mod brushpage;
 mod eraserpage;
 mod selectorpage;
@@ -14,12 +15,12 @@ pub(crate) use shaperpage::RnShaperPage;
 pub(crate) use toolspage::RnToolsPage;
 pub(crate) use typewriterpage::RnTypewriterPage;
 
+// Imports
+use crate::RnAppWindow;
 use gtk4::{
     glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate, Stack, StackPage,
     Widget,
 };
-
-use crate::RnAppWindow;
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/penssidebar/selectorpage.rs
+++ b/rnote-ui/src/penssidebar/selectorpage.rs
@@ -1,7 +1,7 @@
+// Imports
+use crate::{RnAppWindow, RnCanvasWrapper};
 use gtk4::{glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate, ToggleButton};
 use rnote_engine::pens::pensconfig::selectorconfig::SelectorStyle;
-
-use crate::{RnAppWindow, RnCanvasWrapper};
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/penssidebar/shaperpage.rs
+++ b/rnote-ui/src/penssidebar/shaperpage.rs
@@ -1,3 +1,8 @@
+// Imports
+use crate::{
+    groupediconpicker::GroupedIconPickerGroupData, RnAppWindow, RnCanvasWrapper,
+    RnGroupedIconPicker, RnStrokeWidthPicker,
+};
 use adw::{prelude::*, subclass::prelude::*};
 use gettextrs::gettext;
 use gtk4::{
@@ -11,11 +16,6 @@ use rnote_compose::style::rough::roughoptions::FillStyle;
 use rnote_compose::style::smooth::SmoothOptions;
 use rnote_engine::pens::pensconfig::shaperconfig::ShaperStyle;
 use rnote_engine::pens::pensconfig::ShaperConfig;
-
-use crate::{
-    groupediconpicker::GroupedIconPickerGroupData, RnAppWindow, RnCanvasWrapper,
-    RnGroupedIconPicker, RnStrokeWidthPicker,
-};
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/penssidebar/toolspage.rs
+++ b/rnote-ui/src/penssidebar/toolspage.rs
@@ -1,7 +1,7 @@
+// Imports
+use crate::{RnAppWindow, RnCanvasWrapper};
 use gtk4::{glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate, ToggleButton};
 use rnote_engine::pens::pensconfig::toolsconfig::ToolStyle;
-
-use crate::{RnAppWindow, RnCanvasWrapper};
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/penssidebar/typewriterpage.rs
+++ b/rnote-ui/src/penssidebar/typewriterpage.rs
@@ -1,3 +1,5 @@
+// Imports
+use crate::{RnAppWindow, RnCanvasWrapper};
 use gtk4::{
     glib, glib::clone, pango, prelude::*, subclass::prelude::*, Button, CompositeTemplate,
     EmojiChooser, FontDialog, SpinButton, ToggleButton,
@@ -7,8 +9,6 @@ use rnote_engine::pens::Pen;
 use rnote_engine::strokes::textstroke::TextStyle;
 use rnote_engine::strokes::textstroke::{FontStyle, TextAlignment, TextAttribute};
 use std::cell::RefCell;
-
-use crate::{RnAppWindow, RnCanvasWrapper};
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/settingspanel/mod.rs
+++ b/rnote-ui/src/settingspanel/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 mod penshortcutmodels;
 mod penshortcutrow;
 
@@ -5,6 +6,7 @@ mod penshortcutrow;
 pub(crate) use penshortcutrow::RnPenShortcutRow;
 
 // Imports
+use crate::{RnAppWindow, RnCanvasWrapper, RnIconPicker, RnUnitEntry};
 use adw::prelude::*;
 use gettextrs::gettext;
 use gtk4::{
@@ -19,8 +21,6 @@ use rnote_engine::document::format::{self, Format, PredefinedFormat};
 use rnote_engine::utils::GdkRGBAHelpers;
 use std::cell::RefCell;
 use std::rc::Rc;
-
-use crate::{RnAppWindow, RnCanvasWrapper, RnIconPicker, RnUnitEntry};
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/settingspanel/penshortcutmodels.rs
+++ b/rnote-ui/src/settingspanel/penshortcutmodels.rs
@@ -1,3 +1,4 @@
+// Imports
 use gettextrs::gettext;
 use gtk4::Align;
 use gtk4::{

--- a/rnote-ui/src/settingspanel/penshortcutrow.rs
+++ b/rnote-ui/src/settingspanel/penshortcutrow.rs
@@ -1,3 +1,4 @@
+// Imports
 use super::penshortcutmodels::{
     ChangePenStyleIconFactory, ChangePenStyleListFactory, ChangePenStyleListModel,
 };
@@ -11,7 +12,6 @@ use rnote_engine::pens::PenStyle;
 use std::cell::RefCell;
 
 mod imp {
-
     use super::*;
 
     #[derive(Debug, CompositeTemplate)]

--- a/rnote-ui/src/strokewidthpicker/mod.rs
+++ b/rnote-ui/src/strokewidthpicker/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 mod previewstyle;
 mod strokewidthpreview;
 mod strokewidthsetter;

--- a/rnote-ui/src/strokewidthpicker/previewstyle.rs
+++ b/rnote-ui/src/strokewidthpicker/previewstyle.rs
@@ -1,3 +1,4 @@
+// Imports
 use gtk4::glib;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, glib::Enum)]

--- a/rnote-ui/src/strokewidthpicker/strokewidthpreview.rs
+++ b/rnote-ui/src/strokewidthpicker/strokewidthpreview.rs
@@ -1,12 +1,11 @@
 // Imports
+use super::StrokeWidthPreviewStyle;
 use gtk4::{
     gdk, glib, graphene, prelude::*, subclass::prelude::*, Align, Orientation, Overflow,
     SizeRequestMode, Widget,
 };
 use once_cell::sync::Lazy;
 use std::cell::Cell;
-
-use super::StrokeWidthPreviewStyle;
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/unitentry.rs
+++ b/rnote-ui/src/unitentry.rs
@@ -1,14 +1,14 @@
+// Imports
 use gtk4::{
     glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate, DropDown, SpinButton,
     Widget,
 };
 use once_cell::sync::Lazy;
 use rnote_engine::document::format;
+use rnote_engine::document::format::MeasureUnit;
 use std::cell::Cell;
 
 mod imp {
-    use rnote_engine::document::format::MeasureUnit;
-
     use super::*;
 
     #[derive(Debug, CompositeTemplate)]

--- a/rnote-ui/src/utils.rs
+++ b/rnote-ui/src/utils.rs
@@ -1,10 +1,10 @@
+// Imports
+use gtk4::{gdk, gio, glib, prelude::*, Widget};
+use p2d::bounding_volume::Aabb;
 use std::cell::Ref;
 use std::slice::Iter;
 
-use gtk4::{gdk, gio, glib, prelude::*, Widget};
-use p2d::bounding_volume::Aabb;
-
-/// File types supported by Rnote
+/// File types supported by Rnote.
 #[derive(Debug)]
 pub(crate) enum FileType {
     Folder,
@@ -88,6 +88,7 @@ impl FileType {
     }
 }
 
+/// Checks if the file is a temporary goutputstream file.
 pub(crate) fn is_goutputstream_file(file: &gio::File) -> bool {
     if let Some(path) = file.path() {
         if let Some(file_name) = path.file_name() {
@@ -100,7 +101,7 @@ pub(crate) fn is_goutputstream_file(file: &gio::File) -> bool {
     false
 }
 
-/// Translates a Aabb to the coordinate space of the dest_widget. None if the widgets don't have a common ancestor
+/// Translates a Aabb from the the coordinate space of `widget` to `dest_widget`. None if the widgets don't have a common ancestor.
 #[allow(unused)]
 pub(crate) fn translate_aabb_to_widget(
     aabb: Aabb,
@@ -118,7 +119,7 @@ pub(crate) fn translate_aabb_to_widget(
     Some(Aabb::new(mins, maxs))
 }
 
-/// Create a new file or replace if it already exists, asynchronously
+/// Create a new file or replace if it already exists, asynchronously.
 pub(crate) async fn create_replace_file_future(
     bytes: Vec<u8>,
     file: &gio::File,
@@ -167,7 +168,7 @@ pub(crate) fn str_from_u8_nul_utf8(utf8_src: &[u8]) -> Result<&str, std::str::Ut
 
 /// Gets the index of the AxisUse enum
 ///
-/// TODO: Report to gtk-rs that AxisUse needs a Into<Index> implementation for usage to retrieve pointer axes in `TimeCoord`
+/// TODO: Report to gtk-rs that [gdk::AxisUse] needs a [`Into<std::ops::Index>`] implementation for usage to retrieve pointer axes in [gdk::TimeCoord]
 pub(crate) fn axis_use_idx(a: gdk::AxisUse) -> usize {
     match a {
         gdk::AxisUse::Ignore => 0,
@@ -186,7 +187,7 @@ pub(crate) fn axis_use_idx(a: gdk::AxisUse) -> usize {
     }
 }
 
-/// Wrapper type that enables iterating over RefCell<Vec<T>>
+/// Wrapper type that enables iterating over [`std::cell::RefCell<Vec<T>>`]
 pub(crate) struct VecRefWrapper<'a, T: 'a> {
     r: Ref<'a, Vec<T>>,
 }

--- a/rnote-ui/src/workspacebrowser/filerow/actions/duplicate.rs
+++ b/rnote-ui/src/workspacebrowser/filerow/actions/duplicate.rs
@@ -1,27 +1,28 @@
-use std::ffi::{OsStr, OsString};
-use std::path::{Path, PathBuf};
-
+// Imports
+use crate::workspacebrowser::RnFileRow;
+use crate::RnAppWindow;
 use fs_extra::dir::{CopyOptions, TransitProcessResult};
 use fs_extra::{copy_items_with_progress, TransitProcess};
 use gtk4::prelude::FileExt;
 use gtk4::{gio, glib, glib::clone};
 use regex::Regex;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
 
-use crate::workspacebrowser::RnFileRow;
-use crate::RnAppWindow;
-
-///                                 - Look for `.dup` pattern
-///                                 |   - Look for `.dup1`/`.dup123`/`.dup1234`/...
-///                                 |   |        - Look for the text after the `.dup<num>` part
-///                                 |   |       |       - At the end of the word (here: file-path)
-///                                 |  \d*      |       $
-///                                 |           |
-///                               \.dup   (?P<rest>(.*))
+/// ```text
+/// - Look for `.dup` pattern
+/// |   - Look for `.dup1`/`.dup123`/`.dup1234`/...
+/// |   |        - Look for the text after the `.dup<num>` part
+/// |   |       |       - At the end of the word (here: file-path)
+/// |  \d*      |       $
+/// |           |
+/// \.dup   (?P<rest>(.*))
+/// ```
 const DUP_REGEX_PATTERN: &str = r"\.dup\d*(?P<rest>(.*))$";
 const DUPLICATE_SUFFIX: &str = ".dup";
 const DOT: &str = ".";
 
-/// Creates a new `duplicate` action
+/// Create a new `duplicate` action.
 pub(crate) fn duplicate(filerow: &RnFileRow, appwindow: &RnAppWindow) -> gio::SimpleAction {
     let action = gio::SimpleAction::new("duplicate", None);
 
@@ -48,8 +49,8 @@ pub(crate) fn duplicate(filerow: &RnFileRow, appwindow: &RnAppWindow) -> gio::Si
     action
 }
 
-/// returns the progress handler for
-/// [copy_items_with_progress](https://docs.rs/fs_extra/1.2.0/fs_extra/fn.copy_items_with_progress.html)
+/// Returns the progress handler for
+/// [copy_items_with_progress](https://docs.rs/fs_extra/1.2.0/fs_extra/fn.copy_items_with_progress.html).
 fn create_process_evaluator(
     appwindow: RnAppWindow,
 ) -> impl Fn(TransitProcess) -> TransitProcessResult {
@@ -100,7 +101,7 @@ where
 }
 
 /// returns a suitable destination path from the given source path
-/// by adding `.dup` as often as needed to the source-path
+/// by adding `.dup` as often as needed to the source-path.
 fn get_destination_path(source_path: &PathBuf) -> Option<PathBuf> {
     let mut duplicate_index = 0;
     let mut destination_path = source_path.clone();
@@ -131,7 +132,7 @@ fn get_destination_path(source_path: &PathBuf) -> Option<PathBuf> {
 
 /// Creates the duplicate-filename by the given information about the source.
 ///
-/// ## Example
+/// For example:
 /// "test.txt" => "test.dup.txt" => "test.dup1.txt"
 fn generate_duplicate_filename(
     source_stem: &OsStr,

--- a/rnote-ui/src/workspacebrowser/filerow/actions/mod.rs
+++ b/rnote-ui/src/workspacebrowser/filerow/actions/mod.rs
@@ -1,8 +1,10 @@
+// Modules
 mod duplicate;
 mod open;
 mod rename;
 mod trash;
 
+// Re-exports
 pub(crate) use duplicate::duplicate;
 pub(crate) use open::open;
 pub(crate) use rename::rename;

--- a/rnote-ui/src/workspacebrowser/filerow/actions/open.rs
+++ b/rnote-ui/src/workspacebrowser/filerow/actions/open.rs
@@ -1,9 +1,9 @@
-use gtk4::{gio, glib, glib::clone};
-
+// Imports
 use crate::workspacebrowser::RnFileRow;
 use crate::RnAppWindow;
+use gtk4::{gio, glib, glib::clone};
 
-/// Creates a new `open` action
+/// Create a new `open` action.
 pub(crate) fn open(filerow: &RnFileRow, appwindow: &RnAppWindow) -> gio::SimpleAction {
     let action_open_file = gio::SimpleAction::new("open-file", None);
     action_open_file.connect_activate(

--- a/rnote-ui/src/workspacebrowser/filerow/actions/rename.rs
+++ b/rnote-ui/src/workspacebrowser/filerow/actions/rename.rs
@@ -1,5 +1,6 @@
-use std::path::{Path, PathBuf};
-
+// Imports
+use crate::workspacebrowser::{widgethelper, RnFileRow};
+use gettextrs::gettext;
 use gtk4::{
     gio, glib,
     glib::clone,
@@ -8,12 +9,9 @@ use gtk4::{
     traits::{BoxExt, ButtonExt, EditableExt, PopoverExt, WidgetExt},
     Align, Button, Entry, Label, Popover,
 };
+use std::path::{Path, PathBuf};
 
-use gettextrs::gettext;
-
-use crate::workspacebrowser::{widgethelper, RnFileRow};
-
-/// Creates a new `rename` action
+/// Create a new `rename` action.
 pub(crate) fn rename(filerow: &RnFileRow) -> gio::SimpleAction {
     let rename_action = gio::SimpleAction::new("rename-file", None);
 

--- a/rnote-ui/src/workspacebrowser/filerow/actions/trash.rs
+++ b/rnote-ui/src/workspacebrowser/filerow/actions/trash.rs
@@ -1,8 +1,8 @@
+// Imports
+use crate::workspacebrowser::RnFileRow;
 use gtk4::{gio, glib, glib::clone, prelude::FileExt};
 
-use crate::workspacebrowser::RnFileRow;
-
-/// Creates a new `trash` action
+/// Create a new `trash` action.
 pub(crate) fn trash(filerow: &RnFileRow) -> gio::SimpleAction {
     let action_trash_file = gio::SimpleAction::new("trash-file", None);
     action_trash_file.connect_activate(clone!(@weak filerow => move |_action_trash_file, _| {

--- a/rnote-ui/src/workspacebrowser/filerow/mod.rs
+++ b/rnote-ui/src/workspacebrowser/filerow/mod.rs
@@ -1,5 +1,7 @@
+// Modules
 mod actions;
 
+// Imports
 use crate::RnAppWindow;
 use gtk4::{
     gdk, gio, glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate, DragSource,
@@ -9,7 +11,6 @@ use once_cell::sync::Lazy;
 use std::cell::RefCell;
 
 mod imp {
-
     use super::*;
 
     #[derive(Debug, CompositeTemplate)]

--- a/rnote-ui/src/workspacebrowser/mod.rs
+++ b/rnote-ui/src/workspacebrowser/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 mod filerow;
 mod widgethelper;
 mod workspaceactions;
@@ -8,6 +9,7 @@ pub(crate) use filerow::RnFileRow;
 pub(crate) use workspacesbar::RnWorkspacesBar;
 
 // Imports
+use crate::appwindow::RnAppWindow;
 use gtk4::{
     gdk, gio, glib, glib::clone, glib::closure, prelude::*, subclass::prelude::*, Button,
     CompositeTemplate, ConstantExpression, CustomFilter, CustomSorter, DirectoryList, FileFilter,
@@ -16,8 +18,6 @@ use gtk4::{
     SortListModel, SorterChange, Widget,
 };
 use std::path::PathBuf;
-
-use crate::appwindow::RnAppWindow;
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/workspacebrowser/widgethelper.rs
+++ b/rnote-ui/src/workspacebrowser/widgethelper.rs
@@ -1,3 +1,4 @@
+// Imports
 use gettextrs::gettext;
 use gtk4::{
     glib,
@@ -6,22 +7,22 @@ use gtk4::{
     Align, Button, Entry, Grid, Label, Popover, PositionType,
 };
 
-pub(crate) type ApplyButton = Button;
-
 /// A template-function to create a simple dialog widget for an action:
 ///
+/// ```text
 /// -------------------------
 /// |         <Label>       |
 /// | <        Entry      > |
 /// | <Cancel>      <Apply> |
 /// -------------------------
+/// ```
 ///
 /// Just create the `apply` button and the label.
 /// Everything else is done in this function.
 ///
 /// Only `ApplyButton` and `Popover` are returned because you likely want to
 /// apply a connection to them.
-pub(crate) fn create_entry_dialog(entry: &Entry, label: &Label) -> (ApplyButton, Popover) {
+pub(crate) fn create_entry_dialog(entry: &Entry, label: &Label) -> (Button, Popover) {
     let grid = Grid::builder()
         .margin_top(6)
         .margin_bottom(6)

--- a/rnote-ui/src/workspacebrowser/workspaceactions/createfolder.rs
+++ b/rnote-ui/src/workspacebrowser/workspaceactions/createfolder.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
-
+// Imports
+use crate::{workspacebrowser::widgethelper, RnWorkspaceBrowser};
 use gettextrs::gettext;
 use gtk4::{
     gio, glib,
@@ -9,10 +9,9 @@ use gtk4::{
     traits::{BoxExt, ButtonExt, EditableExt, PopoverExt, WidgetExt},
     Align, Button, Entry, Label, Popover,
 };
+use std::path::PathBuf;
 
-use crate::{workspacebrowser::widgethelper, RnWorkspaceBrowser};
-
-/// Creates a new `create_folder` action
+/// Create a new `create_folder` action.
 pub(crate) fn create_folder(workspacebrowser: &RnWorkspaceBrowser) -> gio::SimpleAction {
     let new_folder_action = gio::SimpleAction::new("create-folder", None);
 

--- a/rnote-ui/src/workspacebrowser/workspaceactions/mod.rs
+++ b/rnote-ui/src/workspacebrowser/workspaceactions/mod.rs
@@ -1,3 +1,5 @@
+// Modules
 mod createfolder;
 
+// Re-exports
 pub(crate) use createfolder::create_folder;

--- a/rnote-ui/src/workspacebrowser/workspacesbar/mod.rs
+++ b/rnote-ui/src/workspacebrowser/workspacesbar/mod.rs
@@ -1,3 +1,4 @@
+// Modules
 mod workspacelist;
 mod workspacelistentry;
 mod workspacerow;
@@ -11,7 +12,6 @@ pub(crate) use workspacerow::RnWorkspaceRow;
 // Imports
 use crate::appwindow::RnAppWindow;
 use crate::dialogs;
-
 use gtk4::{
     gdk, gio, glib, glib::clone, prelude::*, subclass::prelude::*, Button, CompositeTemplate,
     ListBox, ScrolledWindow, Widget,

--- a/rnote-ui/src/workspacebrowser/workspacesbar/workspacelist.rs
+++ b/rnote-ui/src/workspacebrowser/workspacesbar/workspacelist.rs
@@ -1,9 +1,8 @@
+// Imports
+use super::RnWorkspaceListEntry;
+use crate::utils::VecRefWrapper;
 use gtk4::{gio, glib, prelude::*, subclass::prelude::*};
 use std::cell::RefCell;
-
-use crate::utils::VecRefWrapper;
-
-use super::RnWorkspaceListEntry;
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/workspacebrowser/workspacesbar/workspacelistentry.rs
+++ b/rnote-ui/src/workspacebrowser/workspacesbar/workspacelistentry.rs
@@ -1,3 +1,5 @@
+// Imports
+use self::imp::RnWorkspaceListEntryInner;
 use gtk4::prelude::*;
 use gtk4::subclass::prelude::*;
 use gtk4::{gdk, glib};
@@ -6,8 +8,6 @@ use rnote_compose::color;
 use rnote_engine::utils::GdkRGBAHelpers;
 use std::cell::RefCell;
 use std::path::PathBuf;
-
-use self::imp::RnWorkspaceListEntryInner;
 
 mod imp {
     use super::*;

--- a/rnote-ui/src/workspacebrowser/workspacesbar/workspacerow.rs
+++ b/rnote-ui/src/workspacebrowser/workspacesbar/workspacerow.rs
@@ -1,3 +1,5 @@
+// Imports
+use super::RnWorkspaceListEntry;
 use crate::RnAppWindow;
 use gtk4::{
     glib, glib::clone, prelude::*, subclass::prelude::*, CompositeTemplate, CssProvider, Image,
@@ -5,14 +7,11 @@ use gtk4::{
 };
 use once_cell::sync::Lazy;
 use rnote_compose::{color, Color};
+use rnote_engine::utils::GdkRGBAHelpers;
 use std::cell::RefCell;
 use unicode_segmentation::UnicodeSegmentation;
 
-use super::RnWorkspaceListEntry;
-
 mod imp {
-    use rnote_engine::utils::GdkRGBAHelpers;
-
     use super::*;
 
     #[derive(Debug, CompositeTemplate)]


### PR DESCRIPTION
This PR adds the `app-cargo-doc` and `cli-cargo-doc` targets to meson, fixes all rust-doc warnings, improves the documentation and does a general "spring clean" of the code-base to improve readability and consistency between the source files.