### PR TITLE
add option to toggle drawing cursor visibility

### DIFF
--- a/rnote-ui/data/app.gschema.xml.in
+++ b/rnote-ui/data/app.gschema.xml.in
@@ -145,6 +145,10 @@
       <default>"cursor-dot-medium"</default>
       <summary>The regular cursor</summary>
     </key>
+    <key name="show-drawing-cursor" type="b">
+      <default>true</default>
+      <summary>Whether the drawing cursor is visible</summary>
+    </key>
     <key name="drawing-cursor" type="s">
       <default>"cursor-dot-small"</default>
       <summary>The drawing cursor</summary>

--- a/rnote-ui/data/icons/scalable/actions/cursor-invisible.svg
+++ b/rnote-ui/data/icons/scalable/actions/cursor-invisible.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64"
+   height="64"
+   id="svg5594"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs5596" />
+  <metadata
+     id="metadata5599">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/rnote-ui/data/resources.gresource.xml.in
+++ b/rnote-ui/data/resources.gresource.xml.in
@@ -70,6 +70,7 @@
         <file compressed="true">icons/scalable/actions/cursor-dot-small.svg</file>
         <file compressed="true">icons/scalable/actions/cursor-dot-medium.svg</file>
         <file compressed="true">icons/scalable/actions/cursor-dot-large.svg</file>
+        <file compressed="true">icons/scalable/actions/cursor-invisible.svg</file>
         <file compressed="true">icons/scalable/actions/cursor-teardrop-n-small.svg</file>
         <file compressed="true">icons/scalable/actions/cursor-teardrop-n-medium.svg</file>
         <file compressed="true">icons/scalable/actions/cursor-teardrop-n-large.svg</file>

--- a/rnote-ui/data/ui/settingspanel.ui
+++ b/rnote-ui/data/ui/settingspanel.ui
@@ -127,6 +127,21 @@
                       </object>
                     </child>
                     <child>
+                      <object class="AdwActionRow" id="general_show_drawing_cursor_row">
+                        <property name="title" translatable="yes">Show Drawing Cursor</property>
+                        <property name="subtitle" translatable="yes">Set whether the drawing cursor is visible</property>
+                        <child type="suffix">
+                          <object class="GtkSwitch" id="general_show_drawing_cursor_switch">
+                            <property name="active">true</property>
+                            <property name="hexpand">false</property>
+                            <property name="hexpand">false</property>
+                            <property name="valign">center</property>
+                            <property name="halign">end</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
                       <object class="AdwActionRow" id="general_drawing_cursor_picker_row">
                         <property name="title" translatable="yes">Drawing Cursor</property>
                         <property name="subtitle" translatable="yes">Set the drawing cursor</property>

--- a/rnote-ui/po/rnote.pot
+++ b/rnote-ui/po/rnote.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rnote\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-12 18:52+0200\n"
+"POT-Creation-Date: 2023-05-13 20:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -84,7 +84,7 @@ msgid "Clear"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/dialogs.ui:16 rnote-ui/data/ui/mainheader.ui:18
-#: rnote-ui/data/ui/shortcuts.ui:149 rnote-ui/src/canvas/mod.rs:498
+#: rnote-ui/data/ui/shortcuts.ui:149 rnote-ui/src/canvas/mod.rs:534
 msgid "New Document"
 msgstr ""
 
@@ -138,7 +138,7 @@ msgstr ""
 msgid "Edit Workspace"
 msgstr ""
 
-#: rnote-ui/data/ui/dialogs/dialogs.ui:73 rnote-ui/data/ui/settingspanel.ui:270
+#: rnote-ui/data/ui/dialogs/dialogs.ui:73 rnote-ui/data/ui/settingspanel.ui:285
 #: rnote-ui/src/workspacebrowser/widgethelper.rs:39
 msgid "Apply"
 msgstr ""
@@ -156,7 +156,7 @@ msgid "Change the workspace icon"
 msgstr ""
 
 #: rnote-ui/data/ui/dialogs/dialogs.ui:141
-#: rnote-ui/data/ui/settingspanel.ui:286
+#: rnote-ui/data/ui/settingspanel.ui:301
 msgid "Color"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgid "Crosshatch"
 msgstr ""
 
 #: rnote-ui/data/ui/penssidebar/shaperpage.ui:178
-#: rnote-ui/data/ui/settingspanel.ui:315
+#: rnote-ui/data/ui/settingspanel.ui:330
 msgid "Dots"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: rnote-ui/data/ui/mainheader.ui:19 rnote-ui/src/canvas/mod.rs:500
+#: rnote-ui/data/ui/mainheader.ui:19 rnote-ui/src/canvas/mod.rs:536
 msgid "Draft"
 msgstr ""
 
@@ -1117,241 +1117,249 @@ msgid "Set the regular cursor"
 msgstr ""
 
 #: rnote-ui/data/ui/settingspanel.ui:131
-msgid "Drawing Cursor"
+msgid "Show Drawing Cursor"
 msgstr ""
 
 #: rnote-ui/data/ui/settingspanel.ui:132
+msgid "Set whether the drawing cursor is visible"
+msgstr ""
+
+#: rnote-ui/data/ui/settingspanel.ui:146
+msgid "Drawing Cursor"
+msgstr ""
+
+#: rnote-ui/data/ui/settingspanel.ui:147
 msgid "Set the drawing cursor"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:157
+#: rnote-ui/data/ui/settingspanel.ui:172
 msgid "Page Format"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:160
+#: rnote-ui/data/ui/settingspanel.ui:175
 msgid "Format"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:161
+#: rnote-ui/data/ui/settingspanel.ui:176
 msgid "Choose a format"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:165
+#: rnote-ui/data/ui/settingspanel.ui:180
 msgid "A6"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:166
+#: rnote-ui/data/ui/settingspanel.ui:181
 msgid "A5"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:167
+#: rnote-ui/data/ui/settingspanel.ui:182
 msgid "A4"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:168
+#: rnote-ui/data/ui/settingspanel.ui:183
 msgid "A3"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:169
+#: rnote-ui/data/ui/settingspanel.ui:184
 msgid "A2"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:170
+#: rnote-ui/data/ui/settingspanel.ui:185
 msgid "US letter"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:171
+#: rnote-ui/data/ui/settingspanel.ui:186
 msgid "US legal"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:172
+#: rnote-ui/data/ui/settingspanel.ui:187
 msgid "Custom"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:180
+#: rnote-ui/data/ui/settingspanel.ui:195
 msgid "Orientation"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:181
+#: rnote-ui/data/ui/settingspanel.ui:196
 msgid "Set the format orientation"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:193
+#: rnote-ui/data/ui/settingspanel.ui:208
 msgid "Portrait"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:199
+#: rnote-ui/data/ui/settingspanel.ui:214
 msgid "Landscape"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:209
+#: rnote-ui/data/ui/settingspanel.ui:224
 msgid "Width"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:210
+#: rnote-ui/data/ui/settingspanel.ui:225
 msgid "Set the format width"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:223
+#: rnote-ui/data/ui/settingspanel.ui:238
 msgid "Height"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:224
+#: rnote-ui/data/ui/settingspanel.ui:239
 msgid "Set the format height"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:237
+#: rnote-ui/data/ui/settingspanel.ui:252
 msgid "Dpi"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:238
+#: rnote-ui/data/ui/settingspanel.ui:253
 msgid "Set the Dpi (dots per inch). Defaults to 96."
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:261
+#: rnote-ui/data/ui/settingspanel.ui:276
 msgid "Revert"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:283
+#: rnote-ui/data/ui/settingspanel.ui:298
 msgid "Document Background"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:287
+#: rnote-ui/data/ui/settingspanel.ui:302
 msgid "Set the background color"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:307
+#: rnote-ui/data/ui/settingspanel.ui:322
 msgid "Pattern"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:308
+#: rnote-ui/data/ui/settingspanel.ui:323
 msgid "Choose a background pattern"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:312
+#: rnote-ui/data/ui/settingspanel.ui:327
 msgid "None"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:313
+#: rnote-ui/data/ui/settingspanel.ui:328
 msgid "Lines"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:314
+#: rnote-ui/data/ui/settingspanel.ui:329
 #: rnote-ui/src/penssidebar/shaperpage.rs:388
 msgid "Grid"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:316
+#: rnote-ui/data/ui/settingspanel.ui:331
 msgid "Isometric Grid"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:317
+#: rnote-ui/data/ui/settingspanel.ui:332
 msgid "Isometric Dots"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:325
+#: rnote-ui/data/ui/settingspanel.ui:340
 msgid "Pattern Color"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:326
+#: rnote-ui/data/ui/settingspanel.ui:341
 msgid "Set the background pattern color"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:346
+#: rnote-ui/data/ui/settingspanel.ui:361
 msgid "Pattern Width"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:347
+#: rnote-ui/data/ui/settingspanel.ui:362
 msgid "Set the background pattern width"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:360
+#: rnote-ui/data/ui/settingspanel.ui:375
 msgid "Pattern Height"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:361
+#: rnote-ui/data/ui/settingspanel.ui:376
 msgid "Set the background pattern height"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:377
+#: rnote-ui/data/ui/settingspanel.ui:392
 msgid "Button Shortcuts"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:380
+#: rnote-ui/data/ui/settingspanel.ui:395
 msgid "Stylus Primary Button Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:381
+#: rnote-ui/data/ui/settingspanel.ui:396
 msgid ""
 "Set the action for the\n"
 "primary stylus button"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:393
+#: rnote-ui/data/ui/settingspanel.ui:408
 msgid "Stylus Secondary Button Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:394
+#: rnote-ui/data/ui/settingspanel.ui:409
 msgid ""
 "Set the action for the\n"
 "secondary stylus button"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:406
+#: rnote-ui/data/ui/settingspanel.ui:421
 msgid "Mouse Secondary Button Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:407
+#: rnote-ui/data/ui/settingspanel.ui:422
 msgid ""
 "Set the action for the\n"
 "secondary mouse button"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:419
+#: rnote-ui/data/ui/settingspanel.ui:434
 msgid "Touch Two-Finger Long-Press Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:420
+#: rnote-ui/data/ui/settingspanel.ui:435
 msgid ""
 "Set the action for the touch\n"
 "two-finger long-press gesture"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:432
+#: rnote-ui/data/ui/settingspanel.ui:447
 msgid "Drawing Pad Button 1 Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:433
+#: rnote-ui/data/ui/settingspanel.ui:448
 msgid ""
 "Set the action for button 1\n"
 "on a drawing pad"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:445
+#: rnote-ui/data/ui/settingspanel.ui:460
 msgid "Drawing Pad Button 2 Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:446
+#: rnote-ui/data/ui/settingspanel.ui:461
 msgid ""
 "Set the action for button 2\n"
 "on a drawing pad"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:458
+#: rnote-ui/data/ui/settingspanel.ui:473
 msgid "Drawing Pad Button 3 Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:459
+#: rnote-ui/data/ui/settingspanel.ui:474
 msgid ""
 "Set the action for button 3\n"
 "on a drawing pad"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:471
+#: rnote-ui/data/ui/settingspanel.ui:486
 msgid "Drawing Pad Button 4 Action"
 msgstr ""
 
-#: rnote-ui/data/ui/settingspanel.ui:472
+#: rnote-ui/data/ui/settingspanel.ui:487
 msgid ""
 "Set the action for button 4\n"
 "on a drawing pad"
@@ -1549,31 +1557,31 @@ msgstr ""
 msgid "Exporting selection failed, nothing selected"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:698
+#: rnote-ui/src/canvas/mod.rs:750
 msgid "- invalid file name -"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:711
+#: rnote-ui/src/canvas/mod.rs:763
 msgid "- invalid folder path -"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:735
+#: rnote-ui/src/canvas/mod.rs:787
 msgid "Opened file was modified on disk"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:736
+#: rnote-ui/src/canvas/mod.rs:788
 msgid "Reload"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:742
+#: rnote-ui/src/canvas/mod.rs:794
 msgid "Reloading .rnote file from disk failed"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:791
+#: rnote-ui/src/canvas/mod.rs:843
 msgid "Opened file was renamed on disk"
 msgstr ""
 
-#: rnote-ui/src/canvas/mod.rs:804
+#: rnote-ui/src/canvas/mod.rs:856
 msgid "Opened file was moved or deleted on disk"
 msgstr ""
 
@@ -1970,75 +1978,75 @@ msgstr ""
 msgid "Cubic bezier curve"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:761
+#: rnote-ui/src/settingspanel/mod.rs:779
 msgid "Crosshair (Small)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:762
+#: rnote-ui/src/settingspanel/mod.rs:780
 msgid "Crosshair (Medium)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:763
+#: rnote-ui/src/settingspanel/mod.rs:781
 msgid "Crosshair (Large)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:764
+#: rnote-ui/src/settingspanel/mod.rs:782
 msgid "Dot (Small)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:765
+#: rnote-ui/src/settingspanel/mod.rs:783
 msgid "Dot (Medium)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:766
+#: rnote-ui/src/settingspanel/mod.rs:784
 msgid "Dot (Large)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:767
+#: rnote-ui/src/settingspanel/mod.rs:785
 msgid "Teardrop North-West (Small)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:768
+#: rnote-ui/src/settingspanel/mod.rs:786
 msgid "Teardrop North-West (Medium)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:769
+#: rnote-ui/src/settingspanel/mod.rs:787
 msgid "Teardrop North-West (Large)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:770
+#: rnote-ui/src/settingspanel/mod.rs:788
 msgid "Teardrop North-East (Small)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:771
+#: rnote-ui/src/settingspanel/mod.rs:789
 msgid "Teardrop North-East (Medium)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:772
+#: rnote-ui/src/settingspanel/mod.rs:790
 msgid "Teardrop North-East (Large)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:773
+#: rnote-ui/src/settingspanel/mod.rs:791
 msgid "Teardrop North (Small)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:774
+#: rnote-ui/src/settingspanel/mod.rs:792
 msgid "Teardrop North (Medium)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:775
+#: rnote-ui/src/settingspanel/mod.rs:793
 msgid "Teardrop North (Large)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:776
+#: rnote-ui/src/settingspanel/mod.rs:794
 msgid "Beam (Small)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:777
+#: rnote-ui/src/settingspanel/mod.rs:795
 msgid "Beam (Medium)"
 msgstr ""
 
-#: rnote-ui/src/settingspanel/mod.rs:778
+#: rnote-ui/src/settingspanel/mod.rs:796
 msgid "Beam (Large)"
 msgstr ""
 

--- a/rnote-ui/src/appwindow/appsettings.rs
+++ b/rnote-ui/src/appwindow/appsettings.rs
@@ -89,6 +89,16 @@ impl RnAppWindow {
             .get_no_changes()
             .build();
 
+        // show drawing cursor
+        self.app_settings()
+            .bind(
+                "show-drawing-cursor",
+                &self.settings_panel().general_show_drawing_cursor_switch(),
+                "active",
+            )
+            .get_no_changes()
+            .build();
+
         // colorpicker palette
         let gdk_color_mapping = |var: &glib::Variant, _: glib::Type| {
             let color = var.get::<(f64, f64, f64, f64)>()?;

--- a/rnote-ui/src/canvas/mod.rs
+++ b/rnote-ui/src/canvas/mod.rs
@@ -42,6 +42,7 @@ pub(crate) struct Handlers {
     pub(crate) appwindow_scalefactor: Option<glib::SignalHandlerId>,
     pub(crate) appwindow_unsaved_changes: Option<glib::SignalHandlerId>,
     pub(crate) appwindow_touch_drawing: Option<glib::Binding>,
+    pub(crate) appwindow_show_drawing_cursor: Option<glib::Binding>,
     pub(crate) appwindow_regular_cursor: Option<glib::Binding>,
     pub(crate) appwindow_drawing_cursor: Option<glib::Binding>,
     pub(crate) appwindow_drop_target: Option<glib::SignalHandlerId>,
@@ -60,10 +61,11 @@ mod imp {
         pub(crate) vadjustment: RefCell<Option<Adjustment>>,
         pub(crate) hscroll_policy: Cell<ScrollablePolicy>,
         pub(crate) vscroll_policy: Cell<ScrollablePolicy>,
-        pub(crate) regular_cursor: RefCell<gdk::Cursor>,
         pub(crate) regular_cursor_icon_name: RefCell<String>,
-        pub(crate) drawing_cursor: RefCell<gdk::Cursor>,
+        pub(crate) regular_cursor: RefCell<gdk::Cursor>,
         pub(crate) drawing_cursor_icon_name: RefCell<String>,
+        pub(crate) drawing_cursor: RefCell<gdk::Cursor>,
+        pub(crate) invisible_cursor: RefCell<gdk::Cursor>,
         pub(crate) pointer_controller: EventControllerLegacy,
         pub(crate) key_controller: EventControllerKey,
         pub(crate) key_controller_im_context: IMMulticontext,
@@ -81,6 +83,7 @@ mod imp {
         pub(crate) unsaved_changes: Cell<bool>,
         pub(crate) empty: Cell<bool>,
         pub(crate) touch_drawing: Cell<bool>,
+        pub(crate) show_drawing_cursor: Cell<bool>,
     }
 
     impl Default for RnCanvas {
@@ -129,6 +132,17 @@ mod imp {
                 gdk::Cursor::from_name("default", None).as_ref(),
             );
 
+            let invisible_cursor = gdk::Cursor::from_texture(
+                &gdk::Texture::from_resource(
+                    (String::from(config::APP_IDPATH)
+                        + "icons/scalable/actions/cursor-invisible.svg")
+                        .as_str(),
+                ),
+                32,
+                32,
+                gdk::Cursor::from_name("default", None).as_ref(),
+            );
+
             let engine = RnoteEngine::default();
 
             Self {
@@ -142,6 +156,7 @@ mod imp {
                 regular_cursor_icon_name: RefCell::new(regular_cursor_icon_name),
                 drawing_cursor: RefCell::new(drawing_cursor),
                 drawing_cursor_icon_name: RefCell::new(drawing_cursor_icon_name),
+                invisible_cursor: RefCell::new(invisible_cursor),
                 pointer_controller,
                 key_controller,
                 key_controller_im_context,
@@ -159,6 +174,7 @@ mod imp {
                 unsaved_changes: Cell::new(false),
                 empty: Cell::new(true),
                 touch_drawing: Cell::new(false),
+                show_drawing_cursor: Cell::new(false),
             }
         }
     }
@@ -238,6 +254,9 @@ mod imp {
                     glib::ParamSpecBoolean::builder("touch-drawing")
                         .default_value(false)
                         .build(),
+                    glib::ParamSpecBoolean::builder("show-drawing-cursor")
+                        .default_value(true)
+                        .build(),
                     glib::ParamSpecString::builder("regular-cursor")
                         .default_value(Some("cursor-dot-medium"))
                         .build(),
@@ -264,6 +283,7 @@ mod imp {
                 "hscroll-policy" => self.hscroll_policy.get().to_value(),
                 "vscroll-policy" => self.vscroll_policy.get().to_value(),
                 "touch-drawing" => self.touch_drawing.get().to_value(),
+                "show-drawing-cursor" => self.show_drawing_cursor.get().to_value(),
                 "regular-cursor" => self.regular_cursor_icon_name.borrow().to_value(),
                 "drawing-cursor" => self.drawing_cursor_icon_name.borrow().to_value(),
                 _ => unimplemented!(),
@@ -312,6 +332,21 @@ mod imp {
                     let touch_drawing: bool =
                         value.get().expect("The value needs to be of type `bool`");
                     self.touch_drawing.replace(touch_drawing);
+                }
+                "show-drawing-cursor" => {
+                    let show_drawing_cursor: bool =
+                        value.get().expect("The value needs to be of type `bool`");
+                    self.show_drawing_cursor.replace(show_drawing_cursor);
+
+                    if self.drawing_cursor_enabled.get() {
+                        if show_drawing_cursor {
+                            obj.set_cursor(Some(&*self.drawing_cursor.borrow()));
+                        } else {
+                            obj.set_cursor(Some(&*self.invisible_cursor.borrow()));
+                        }
+                    } else {
+                        obj.set_cursor(Some(&*self.regular_cursor.borrow()));
+                    }
                 }
                 "regular-cursor" => {
                     let icon_name = value.get().unwrap();
@@ -599,6 +634,18 @@ impl RnCanvas {
     }
 
     #[allow(unused)]
+    pub(crate) fn show_drawing_cursor(&self) -> bool {
+        self.property::<bool>("show-drawing-cursor")
+    }
+
+    #[allow(unused)]
+    pub(crate) fn set_show_drawing_cursor(&self, show_drawing_cursor: bool) {
+        if self.imp().show_drawing_cursor.get() != show_drawing_cursor {
+            self.set_property("show-drawing-cursor", show_drawing_cursor.to_value());
+        }
+    }
+
+    #[allow(unused)]
     fn emit_zoom_changed(&self) {
         self.emit_by_name::<()>("zoom-changed", &[]);
     }
@@ -682,7 +729,11 @@ impl RnCanvas {
         self.imp().drawing_cursor_enabled.set(drawing_cursor);
 
         if drawing_cursor {
-            self.set_cursor(Some(&*self.imp().drawing_cursor.borrow()));
+            if self.imp().show_drawing_cursor.get() {
+                self.set_cursor(Some(&*self.imp().drawing_cursor.borrow()));
+            } else {
+                self.set_cursor(Some(&*self.imp().invisible_cursor.borrow()));
+            }
         } else {
             self.set_cursor(Some(&*self.imp().regular_cursor.borrow()));
         }
@@ -890,7 +941,7 @@ impl RnCanvas {
 
         // one per-appwindow property for touch-drawing
         let appwindow_touch_drawing = appwindow
-            .bind_property("touch-drawing", self, "touch_drawing")
+            .bind_property("touch-drawing", self, "touch-drawing")
             .sync_create()
             .build();
 
@@ -908,6 +959,14 @@ impl RnCanvas {
             .general_drawing_cursor_picker()
             .bind_property("picked", self, "drawing-cursor")
             .transform_to(|_, v: Option<String>| v)
+            .sync_create()
+            .build();
+
+        // bind show-drawing-cursor
+        let appwindow_show_drawing_cursor = appwindow
+            .settings_panel()
+            .general_show_drawing_cursor_switch()
+            .bind_property("active", self, "show-drawing-cursor")
             .sync_create()
             .build();
 
@@ -978,6 +1037,12 @@ impl RnCanvas {
             old.unbind();
         }
         if let Some(old) = handlers
+            .appwindow_show_drawing_cursor
+            .replace(appwindow_show_drawing_cursor)
+        {
+            old.unbind();
+        }
+        if let Some(old) = handlers
             .appwindow_regular_cursor
             .replace(appwindow_regular_cursor)
         {
@@ -1024,6 +1089,9 @@ impl RnCanvas {
             self.disconnect(old);
         }
         if let Some(old) = handlers.appwindow_touch_drawing.take() {
+            old.unbind();
+        }
+        if let Some(old) = handlers.appwindow_show_drawing_cursor.take() {
             old.unbind();
         }
         if let Some(old) = handlers.appwindow_regular_cursor.take() {

--- a/rnote-ui/src/settingspanel/mod.rs
+++ b/rnote-ui/src/settingspanel/mod.rs
@@ -47,6 +47,10 @@ mod imp {
         #[template_child]
         pub(crate) general_regular_cursor_picker_menubutton: TemplateChild<MenuButton>,
         #[template_child]
+        pub(crate) general_show_drawing_cursor_switch: TemplateChild<Switch>,
+        #[template_child]
+        pub(crate) general_drawing_cursor_picker_row: TemplateChild<adw::ActionRow>,
+        #[template_child]
         pub(crate) general_drawing_cursor_picker: TemplateChild<RnIconPicker>,
         #[template_child]
         pub(crate) general_drawing_cursor_picker_menubutton: TemplateChild<MenuButton>,
@@ -347,6 +351,10 @@ impl RnSettingsPanel {
         self.imp().general_regular_cursor_picker.clone()
     }
 
+    pub(crate) fn general_show_drawing_cursor_switch(&self) -> Switch {
+        self.imp().general_show_drawing_cursor_switch.clone()
+    }
+
     pub(crate) fn general_drawing_cursor_picker(&self) -> RnIconPicker {
         self.imp().general_drawing_cursor_picker.clone()
     }
@@ -514,6 +522,16 @@ impl RnSettingsPanel {
                 "picked",
                 &*imp.general_regular_cursor_picker_menubutton,
                 "icon-name",
+            )
+            .sync_create()
+            .build();
+
+        // Show drawing cursor switch
+        imp.general_show_drawing_cursor_switch
+            .bind_property(
+                "active",
+                &*imp.general_drawing_cursor_picker_row,
+                "sensitive",
             )
             .sync_create()
             .build();

--- a/rnote-ui/src/settingspanel/mod.rs
+++ b/rnote-ui/src/settingspanel/mod.rs
@@ -526,7 +526,7 @@ impl RnSettingsPanel {
             .sync_create()
             .build();
 
-        // Show drawing cursor switch
+        // insensitive picker when drawing cursor is hidden
         imp.general_show_drawing_cursor_switch
             .bind_property(
                 "active",


### PR DESCRIPTION
This PR implements an option to toggle the visibility of the drawing cursor.

Because there doesn't seem to be any API in gtk-rs for using `GDK_BLANK_CURSOR`, I worked around that by adding an invisible cursor that gets used when the option is toggled on.

fixes #649 when merged.