### PR TITLE
Improving selection highlights for brush-strokes

### DIFF
--- a/rnote-engine/src/drawbehaviour.rs
+++ b/rnote-engine/src/drawbehaviour.rs
@@ -6,9 +6,19 @@ use p2d::bounding_volume::Aabb;
 use piet::RenderContext;
 use rnote_compose::helpers::{AabbHelpers, Affine2Helpers};
 
+/// Trait for types that can draw themselves on a [piet::RenderContext].
+pub trait DrawBehaviour {
+    /// Draw itself.
+    /// The implementors are expected to save/restore the drawing context.
+    ///
+    /// `image_scale` is the scale-factor of generated images within the type.
+    /// The content should not be zoomed by it!
+    fn draw(&self, cx: &mut impl piet::RenderContext, image_scale: f64) -> anyhow::Result<()>;
+}
+
 /// Trait for types that can draw themselves on the document.
 ///
-/// In the coordinate space of the document
+/// In the coordinate space of the document.
 pub trait DrawOnDocBehaviour {
     /// Bounds on the document.
     fn bounds_on_doc(&self, engine_view: &EngineView) -> Option<Aabb>;
@@ -58,14 +68,4 @@ pub trait DrawOnDocBehaviour {
         snapshot.restore();
         Ok(())
     }
-}
-
-/// Trait for types that can draw themselves on a [piet::RenderContext].
-pub trait DrawBehaviour {
-    /// Draw itself.
-    /// The implementors are expected to save/restore the drawing context.
-    ///
-    /// `image_scale` is the scale-factor of generated images within the type.
-    /// The content should not be zoomed by it!
-    fn draw(&self, cx: &mut impl piet::RenderContext, image_scale: f64) -> anyhow::Result<()>;
 }

--- a/rnote-engine/src/pens/selector/mod.rs
+++ b/rnote-engine/src/pens/selector/mod.rs
@@ -7,6 +7,7 @@ use super::pensconfig::selectorconfig::SelectorStyle;
 use super::PenStyle;
 use crate::engine::{EngineView, EngineViewMut, RNOTE_STROKE_CONTENT_MIME_TYPE};
 use crate::store::StrokeKey;
+use crate::strokes::StrokeBehaviour;
 use crate::{Camera, DrawOnDocBehaviour, WidgetFlags};
 use kurbo::Shape;
 use once_cell::sync::Lazy;
@@ -16,7 +17,6 @@ use piet::RenderContext;
 use rnote_compose::helpers::{AabbHelpers, Vector2Helpers};
 use rnote_compose::penevents::{ModifierKey, PenEvent, PenState};
 use rnote_compose::penpath::Element;
-use rnote_compose::shapes::ShapeBehaviour;
 use rnote_compose::style::indicators;
 use rnote_compose::{color, Color};
 use std::time::Instant;
@@ -347,16 +347,11 @@ impl DrawOnDocBehaviour for Selector {
                 selection,
                 selection_bounds,
             } => {
-                // Draw the bounds outlines for the selected strokes
-                static SELECTED_BOUNDS_COLOR: Lazy<piet::Color> =
-                    Lazy::new(|| color::GNOME_BLUES[1].with_alpha(0.376));
-
+                // Draw the highlight for the selected strokes
                 for stroke in engine_view.store.get_strokes_ref(selection) {
-                    cx.stroke(
-                        stroke.bounds().to_kurbo_rect(),
-                        &*SELECTED_BOUNDS_COLOR,
-                        Self::SELECTION_OUTLINE_WIDTH / total_zoom,
-                    );
+                    if let Err(e) = stroke.draw_highlight(cx, engine_view.camera.total_zoom()) {
+                        log::error!("failed to draw stroke highlight, Err: {e:?}");
+                    }
                 }
 
                 Self::draw_selection_overlay(

--- a/rnote-engine/src/store/stroke_comp.rs
+++ b/rnote-engine/src/store/stroke_comp.rs
@@ -2,7 +2,7 @@
 use super::render_comp::RenderCompState;
 use super::StrokeKey;
 use crate::engine::StrokeContent;
-use crate::strokes::Stroke;
+use crate::strokes::{Stroke, StrokeBehaviour};
 use crate::{render, StrokeStore, WidgetFlags};
 use geo::intersects::Intersects;
 use geo::prelude::Contains;
@@ -107,16 +107,7 @@ impl StrokeStore {
             .get_mut(key)
             .map(Arc::make_mut)
         {
-            match stroke {
-                Stroke::BrushStroke(ref mut brushstroke) => {
-                    brushstroke.update_geometry();
-                }
-                Stroke::ShapeStroke(shapestroke) => {
-                    shapestroke.update_geometry();
-                }
-                Stroke::TextStroke(_) | Stroke::VectorImage(_) | Stroke::BitmapImage(_) => {}
-            }
-
+            stroke.update_geometry();
             self.key_tree.update_with_key(key, stroke.bounds());
             self.set_rendering_dirty(key);
         }

--- a/rnote-engine/src/strokes/bitmapimage.rs
+++ b/rnote-engine/src/strokes/bitmapimage.rs
@@ -99,6 +99,8 @@ impl StrokeBehaviour for BitmapImage {
         );
         Ok(())
     }
+
+    fn update_geometry(&mut self) {}
 }
 
 impl DrawBehaviour for BitmapImage {

--- a/rnote-engine/src/strokes/bitmapimage.rs
+++ b/rnote-engine/src/strokes/bitmapimage.rs
@@ -1,5 +1,5 @@
 // Imports
-use super::strokebehaviour::GeneratedStrokeImages;
+use super::strokebehaviour::{self, GeneratedStrokeImages};
 use super::{Stroke, StrokeBehaviour};
 use crate::document::Format;
 use crate::engine::import::{PdfImportPageSpacing, PdfImportPrefs};
@@ -84,6 +84,20 @@ impl StrokeBehaviour for BitmapImage {
                 viewport,
             })
         }
+    }
+
+    fn draw_highlight(
+        &self,
+        cx: &mut impl piet::RenderContext,
+        total_zoom: f64,
+    ) -> anyhow::Result<()> {
+        const HIGHLIGHT_STROKE_WIDTH: f64 = 1.5;
+        cx.stroke(
+            self.bounds().to_kurbo_rect(),
+            &*strokebehaviour::STROKE_HIGHLIGHT_COLOR,
+            HIGHLIGHT_STROKE_WIDTH / total_zoom,
+        );
+        Ok(())
     }
 }
 

--- a/rnote-engine/src/strokes/brushstroke.rs
+++ b/rnote-engine/src/strokes/brushstroke.rs
@@ -23,9 +23,12 @@ pub struct BrushStroke {
     pub path: PenPath,
     #[serde(default, rename = "style")]
     pub style: Style,
-    #[serde(skip)]
     // since the path can have many hitboxes, we store them here and update them when the stroke geometry changes
+    #[serde(skip)]
     hitboxes: Vec<Aabb>,
+    // store the highlight path as well
+    #[serde(skip)]
+    highlight_path: kurbo::BezPath,
 }
 
 impl StrokeBehaviour for BrushStroke {
@@ -177,8 +180,7 @@ impl StrokeBehaviour for BrushStroke {
     ) -> anyhow::Result<()> {
         const HIGHLIGHT_STROKE_WIDTH: f64 = 5.0;
         cx.stroke_styled(
-            // The drawn highlights not need to be very precise
-            self.path.to_kurbo_flattened(1.0),
+            &self.highlight_path,
             &*strokebehaviour::STROKE_HIGHLIGHT_COLOR,
             (HIGHLIGHT_STROKE_WIDTH / total_zoom).max(self.style.stroke_width() + 2.0 / total_zoom),
             &piet::StrokeStyle::new()
@@ -186,6 +188,11 @@ impl StrokeBehaviour for BrushStroke {
                 .line_cap(piet::LineCap::Round),
         );
         Ok(())
+    }
+
+    fn update_geometry(&mut self) {
+        self.hitboxes = self.gen_hitboxes_int();
+        self.highlight_path = self.gen_highlight_path_int();
     }
 }
 
@@ -224,12 +231,21 @@ impl ShapeBehaviour for BrushStroke {
 impl TransformBehaviour for BrushStroke {
     fn translate(&mut self, offset: na::Vector2<f64>) {
         self.path.translate(offset);
+        self.highlight_path
+            .apply_affine(kurbo::Affine::translate(offset.to_kurbo_vec()));
     }
     fn rotate(&mut self, angle: f64, center: na::Point2<f64>) {
         self.path.rotate(angle, center);
+        self.highlight_path
+            .apply_affine(kurbo::Affine::rotate_about(
+                angle,
+                center.coords.to_kurbo_point(),
+            ))
     }
     fn scale(&mut self, scale: na::Vector2<f64>) {
         self.path.scale(scale);
+        self.highlight_path
+            .apply_affine(kurbo::Affine::scale_non_uniform(scale[0], scale[1]));
     }
 }
 
@@ -249,6 +265,7 @@ impl BrushStroke {
             path,
             style,
             hitboxes: vec![],
+            highlight_path: kurbo::BezPath::new(),
         };
         new_brushstroke.update_geometry();
 
@@ -261,10 +278,6 @@ impl BrushStroke {
 
     pub fn extend_w_segments(&mut self, segments: impl IntoIterator<Item = Segment>) {
         self.path.extend(segments);
-    }
-
-    pub fn update_geometry(&mut self) {
-        self.hitboxes = self.gen_hitboxes_int();
     }
 
     /// Replace the current path with the given new one. the new path must not be empty.
@@ -282,6 +295,11 @@ impl BrushStroke {
             .into_iter()
             .map(|hb| hb.loosened(stroke_width * 0.5))
             .collect()
+    }
+
+    fn gen_highlight_path_int(&self) -> kurbo::BezPath {
+        // The drawn highlight does not need to be very precise
+        self.path.to_kurbo_flattened(1.0)
     }
 
     pub fn gen_image_for_last_segments(

--- a/rnote-engine/src/strokes/brushstroke.rs
+++ b/rnote-engine/src/strokes/brushstroke.rs
@@ -1,8 +1,11 @@
 // Imports
 use super::strokebehaviour::GeneratedStrokeImages;
 use super::StrokeBehaviour;
-use crate::render::{self};
 use crate::DrawBehaviour;
+use crate::{
+    render::{self},
+    strokes::strokebehaviour,
+};
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use piet::RenderContext;
 use rnote_compose::helpers::Vector2Helpers;
@@ -165,6 +168,24 @@ impl StrokeBehaviour for BrushStroke {
         } else {
             Ok(GeneratedStrokeImages::Full(images))
         }
+    }
+
+    fn draw_highlight(
+        &self,
+        cx: &mut impl piet::RenderContext,
+        total_zoom: f64,
+    ) -> anyhow::Result<()> {
+        const HIGHLIGHT_STROKE_WIDTH: f64 = 5.0;
+        cx.stroke_styled(
+            // The drawn highlights not need to be very precise
+            self.path.to_kurbo_flattened(1.0),
+            &*strokebehaviour::STROKE_HIGHLIGHT_COLOR,
+            (HIGHLIGHT_STROKE_WIDTH / total_zoom).max(self.style.stroke_width() + 2.0 / total_zoom),
+            &piet::StrokeStyle::new()
+                .line_join(piet::LineJoin::Round)
+                .line_cap(piet::LineCap::Round),
+        );
+        Ok(())
     }
 }
 

--- a/rnote-engine/src/strokes/shapestroke.rs
+++ b/rnote-engine/src/strokes/shapestroke.rs
@@ -82,6 +82,10 @@ impl StrokeBehaviour for ShapeStroke {
         );
         Ok(())
     }
+
+    fn update_geometry(&mut self) {
+        self.hitboxes = self.gen_hitboxes_int();
+    }
 }
 
 impl DrawBehaviour for ShapeStroke {
@@ -133,11 +137,7 @@ impl ShapeStroke {
         shapestroke
     }
 
-    pub fn update_geometry(&mut self) {
-        self.hitboxes = self.gen_hitboxes();
-    }
-
-    fn gen_hitboxes(&self) -> Vec<Aabb> {
+    fn gen_hitboxes_int(&self) -> Vec<Aabb> {
         let width = self.style.stroke_width();
 
         self.shape

--- a/rnote-engine/src/strokes/shapestroke.rs
+++ b/rnote-engine/src/strokes/shapestroke.rs
@@ -1,10 +1,10 @@
 // Imports
 use super::strokebehaviour::GeneratedStrokeImages;
 use super::StrokeBehaviour;
-use crate::{render, DrawBehaviour};
+use crate::{render, strokes::strokebehaviour, DrawBehaviour};
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use piet::RenderContext;
-use rnote_compose::helpers::Vector2Helpers;
+use rnote_compose::helpers::{AabbHelpers, Vector2Helpers};
 use rnote_compose::shapes::Shape;
 use rnote_compose::shapes::ShapeBehaviour;
 use rnote_compose::style::Composer;
@@ -67,6 +67,20 @@ impl StrokeBehaviour for ShapeStroke {
                 viewport,
             })
         }
+    }
+
+    fn draw_highlight(
+        &self,
+        cx: &mut impl piet::RenderContext,
+        total_zoom: f64,
+    ) -> anyhow::Result<()> {
+        const HIGHLIGHT_STROKE_WIDTH: f64 = 1.5;
+        cx.stroke(
+            self.bounds().to_kurbo_rect(),
+            &*strokebehaviour::STROKE_HIGHLIGHT_COLOR,
+            HIGHLIGHT_STROKE_WIDTH / total_zoom,
+        );
+        Ok(())
     }
 }
 

--- a/rnote-engine/src/strokes/stroke.rs
+++ b/rnote-engine/src/strokes/stroke.rs
@@ -59,6 +59,20 @@ impl StrokeBehaviour for Stroke {
             Stroke::BitmapImage(bitmapimage) => bitmapimage.gen_images(viewport, image_scale),
         }
     }
+
+    fn draw_highlight(
+        &self,
+        cx: &mut impl piet::RenderContext,
+        total_zoom: f64,
+    ) -> anyhow::Result<()> {
+        match self {
+            Stroke::BrushStroke(brushstroke) => brushstroke.draw_highlight(cx, total_zoom),
+            Stroke::ShapeStroke(shapestroke) => shapestroke.draw_highlight(cx, total_zoom),
+            Stroke::TextStroke(textstroke) => textstroke.draw_highlight(cx, total_zoom),
+            Stroke::VectorImage(vectorimage) => vectorimage.draw_highlight(cx, total_zoom),
+            Stroke::BitmapImage(bitmapimage) => bitmapimage.draw_highlight(cx, total_zoom),
+        }
+    }
 }
 
 impl DrawBehaviour for Stroke {

--- a/rnote-engine/src/strokes/stroke.rs
+++ b/rnote-engine/src/strokes/stroke.rs
@@ -73,6 +73,16 @@ impl StrokeBehaviour for Stroke {
             Stroke::BitmapImage(bitmapimage) => bitmapimage.draw_highlight(cx, total_zoom),
         }
     }
+
+    fn update_geometry(&mut self) {
+        match self {
+            Stroke::BrushStroke(brushstroke) => brushstroke.update_geometry(),
+            Stroke::ShapeStroke(shapestroke) => shapestroke.update_geometry(),
+            Stroke::TextStroke(textstroke) => textstroke.update_geometry(),
+            Stroke::VectorImage(vectorimage) => vectorimage.update_geometry(),
+            Stroke::BitmapImage(bitmapimage) => bitmapimage.update_geometry(),
+        }
+    }
 }
 
 impl DrawBehaviour for Stroke {

--- a/rnote-engine/src/strokes/strokebehaviour.rs
+++ b/rnote-engine/src/strokes/strokebehaviour.rs
@@ -52,6 +52,11 @@ where
         total_zoom: f64,
     ) -> anyhow::Result<()>;
 
+    /// Update the geometry, possibly regenerating internally stored state.
+    ///
+    /// Must be called after the stroke has been (geometrically) modified or transformed.
+    fn update_geometry(&mut self);
+
     /// Export as encoded bitmap image (Png/Jpg/..).
     fn export_as_bitmapimage_bytes(
         &self,

--- a/rnote-engine/src/strokes/strokebehaviour.rs
+++ b/rnote-engine/src/strokes/strokebehaviour.rs
@@ -1,8 +1,9 @@
 // Imports
 use crate::render;
 use crate::DrawBehaviour;
+use once_cell::sync::Lazy;
 use p2d::bounding_volume::Aabb;
-use rnote_compose::shapes::ShapeBehaviour;
+use rnote_compose::{color, shapes::ShapeBehaviour};
 
 #[derive(Debug, Clone)]
 /// Generated stroke images.
@@ -17,6 +18,9 @@ pub enum GeneratedStrokeImages {
     /// All stroke images were rendered.
     Full(Vec<render::Image>),
 }
+
+pub(crate) static STROKE_HIGHLIGHT_COLOR: Lazy<piet::Color> =
+    Lazy::new(|| color::GNOME_BLUES[1].with_alpha(0.376));
 
 /// Types that are strokes.
 pub trait StrokeBehaviour: DrawBehaviour + ShapeBehaviour
@@ -37,6 +41,16 @@ where
         viewport: Aabb,
         image_scale: f64,
     ) -> Result<GeneratedStrokeImages, anyhow::Error>;
+
+    /// Draw it's highlight.
+    /// The implementors are expected to save/restore the drawing context.
+    ///
+    /// `total_zoom` is the zoom-factor of the surface that draws the highlight.
+    fn draw_highlight(
+        &self,
+        cx: &mut impl piet::RenderContext,
+        total_zoom: f64,
+    ) -> anyhow::Result<()>;
 
     /// Export as encoded bitmap image (Png/Jpg/..).
     fn export_as_bitmapimage_bytes(

--- a/rnote-engine/src/strokes/textstroke.rs
+++ b/rnote-engine/src/strokes/textstroke.rs
@@ -571,6 +571,8 @@ impl StrokeBehaviour for TextStroke {
         );
         Ok(())
     }
+
+    fn update_geometry(&mut self) {}
 }
 
 impl DrawBehaviour for TextStroke {

--- a/rnote-engine/src/strokes/textstroke.rs
+++ b/rnote-engine/src/strokes/textstroke.rs
@@ -1,7 +1,7 @@
 // Imports
 use super::strokebehaviour::GeneratedStrokeImages;
 use super::StrokeBehaviour;
-use crate::{render, Camera, DrawBehaviour};
+use crate::{render, strokes::strokebehaviour, Camera, DrawBehaviour};
 use gtk4::pango;
 use kurbo::Shape;
 use once_cell::sync::Lazy;
@@ -556,6 +556,20 @@ impl StrokeBehaviour for TextStroke {
                 viewport,
             })
         }
+    }
+
+    fn draw_highlight(
+        &self,
+        cx: &mut impl piet::RenderContext,
+        total_zoom: f64,
+    ) -> anyhow::Result<()> {
+        const HIGHLIGHT_STROKE_WIDTH: f64 = 1.5;
+        cx.stroke(
+            self.bounds().to_kurbo_rect(),
+            &*strokebehaviour::STROKE_HIGHLIGHT_COLOR,
+            HIGHLIGHT_STROKE_WIDTH / total_zoom,
+        );
+        Ok(())
     }
 }
 

--- a/rnote-engine/src/strokes/vectorimage.rs
+++ b/rnote-engine/src/strokes/vectorimage.rs
@@ -1,8 +1,8 @@
 // Imports
 use super::strokebehaviour::GeneratedStrokeImages;
 use super::{Stroke, StrokeBehaviour};
-use crate::document::Format;
 use crate::engine::import::{PdfImportPageSpacing, PdfImportPrefs};
+use crate::{document::Format, strokes::strokebehaviour};
 use crate::{render, DrawBehaviour};
 use gtk4::glib;
 use p2d::bounding_volume::Aabb;
@@ -89,6 +89,20 @@ impl StrokeBehaviour for VectorImage {
                 image_scale,
             )?,
         ]))
+    }
+
+    fn draw_highlight(
+        &self,
+        cx: &mut impl piet::RenderContext,
+        total_zoom: f64,
+    ) -> anyhow::Result<()> {
+        const HIGHLIGHT_STROKE_WIDTH: f64 = 1.5;
+        cx.stroke(
+            self.bounds().to_kurbo_rect(),
+            &*strokebehaviour::STROKE_HIGHLIGHT_COLOR,
+            HIGHLIGHT_STROKE_WIDTH / total_zoom,
+        );
+        Ok(())
     }
 }
 

--- a/rnote-engine/src/strokes/vectorimage.rs
+++ b/rnote-engine/src/strokes/vectorimage.rs
@@ -104,6 +104,8 @@ impl StrokeBehaviour for VectorImage {
         );
         Ok(())
     }
+
+    fn update_geometry(&mut self) {}
 }
 
 // Because we can't render svgs directly in piet, so we need to overwrite the gen_svgs() default implementation and call it in draw().


### PR DESCRIPTION
This PR adds a required method `draw_highlight()` on the `StrokeBehaviour` and implements a custom highlight for brush-strokes that follows the path.

Other strokes still draw their bounds as the highlight. In my opinion this is enough as an initial improvement, but we could extend this in the future so that shape-strokes also draw different highlights that follow the shape geometry.

I also moved and added `update_geometry()` as an additional required method on `StrokeBehaviour`, but implemented with an empty body for those strokes that don't cache any geometry internally (textstroke, bitmapimage, vectorimage).

fixes #564