### PR TITLE
feature: export page order

### DIFF
--- a/rnote-compose/src/helpers.rs
+++ b/rnote-compose/src/helpers.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
     num_derive::FromPrimitive,
     num_derive::ToPrimitive,
 )]
-#[serde(rename = "split_direction")]
-pub enum SplitDirection {
+#[serde(rename = "split_order")]
+pub enum SplitOrder {
     /// Split in row-major order.
     #[serde(rename = "row_major")]
     RowMajor,
@@ -24,21 +24,18 @@ pub enum SplitDirection {
     ColumnMajor,
 }
 
-impl Default for SplitDirection {
+impl Default for SplitOrder {
     fn default() -> Self {
         Self::RowMajor
     }
 }
 
-impl TryFrom<u32> for SplitDirection {
+impl TryFrom<u32> for SplitOrder {
     type Error = anyhow::Error;
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         num_traits::FromPrimitive::from_u32(value).ok_or_else(|| {
-            anyhow::anyhow!(
-                "SplitDirection try_from::<u32>() for value {} failed",
-                value
-            )
+            anyhow::anyhow!("SplitOrder try_from::<u32>() for value {} failed", value)
         })
     }
 }
@@ -199,7 +196,7 @@ where
     fn split_extended_origin_aligned(
         self,
         split_size: na::Vector2<f64>,
-        split_direction: SplitDirection,
+        split_order: SplitOrder,
     ) -> Vec<Self>;
     /// Converts a Aabb to a kurbo Rectangle
     fn to_kurbo_rect(&self) -> kurbo::Rect;
@@ -422,7 +419,7 @@ impl AabbHelpers for Aabb {
     fn split_extended_origin_aligned(
         self,
         split_size: na::Vector2<f64>,
-        split_direction: SplitDirection,
+        split_order: SplitOrder,
     ) -> Vec<Self> {
         let mut split_aabbs = Vec::new();
 
@@ -430,9 +427,9 @@ impl AabbHelpers for Aabb {
             return vec![];
         }
 
-        let (outer_idx, inner_idx) = match split_direction {
-            SplitDirection::RowMajor => (1, 0),
-            SplitDirection::ColumnMajor => (0, 1),
+        let (outer_idx, inner_idx) = match split_order {
+            SplitOrder::RowMajor => (1, 0),
+            SplitOrder::ColumnMajor => (0, 1),
         };
 
         let mut offset_outer =
@@ -443,9 +440,9 @@ impl AabbHelpers for Aabb {
                 (self.mins[inner_idx] / split_size[inner_idx]).floor() * split_size[inner_idx];
 
             while offset_inner < self.maxs[inner_idx] {
-                let mins = match split_direction {
-                    SplitDirection::RowMajor => na::point![offset_inner, offset_outer],
-                    SplitDirection::ColumnMajor => na::point![offset_outer, offset_inner],
+                let mins = match split_order {
+                    SplitOrder::RowMajor => na::point![offset_inner, offset_outer],
+                    SplitOrder::ColumnMajor => na::point![offset_outer, offset_inner],
                 };
 
                 split_aabbs.push(Aabb::new(mins, mins + split_size));

--- a/rnote-compose/src/helpers.rs
+++ b/rnote-compose/src/helpers.rs
@@ -1,5 +1,47 @@
 // Imports
 use p2d::bounding_volume::Aabb;
+use serde::{Deserialize, Serialize};
+
+/// Page split direction.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    num_derive::FromPrimitive,
+    num_derive::ToPrimitive,
+)]
+#[serde(rename = "split_direction")]
+pub enum SplitDirection {
+    /// Split in row-major order.
+    #[serde(rename = "row_major")]
+    RowMajor,
+    /// Split in column-major order.
+    #[serde(rename = "column_major")]
+    ColumnMajor,
+}
+
+impl Default for SplitDirection {
+    fn default() -> Self {
+        Self::RowMajor
+    }
+}
+
+impl TryFrom<u32> for SplitDirection {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        num_traits::FromPrimitive::from_u32(value).ok_or_else(|| {
+            anyhow::anyhow!(
+                "SplitDirection try_from::<u32>() for value {} failed",
+                value
+            )
+        })
+    }
+}
 
 /// Helpers that extend the Vector2 type
 pub trait Vector2Helpers
@@ -154,7 +196,11 @@ where
     /// splits a aabb into multiple of the given size. Their union contains the given aabb.
     /// It is also guaranteed that bounding boxes are aligned to the origin, meaning (0.0,0.0) is the corner of four boxes.
     /// The boxes on the edges most likely extend beyond the given aabb.
-    fn split_extended_origin_aligned(self, split_size: na::Vector2<f64>) -> Vec<Self>;
+    fn split_extended_origin_aligned(
+        self,
+        split_size: na::Vector2<f64>,
+        split_direction: SplitDirection,
+    ) -> Vec<Self>;
     /// Converts a Aabb to a kurbo Rectangle
     fn to_kurbo_rect(&self) -> kurbo::Rect;
     /// Converts a kurbo Rectangle to Aabb
@@ -373,26 +419,41 @@ impl AabbHelpers for Aabb {
         split_aabbs
     }
 
-    fn split_extended_origin_aligned(self, split_size: na::Vector2<f64>) -> Vec<Self> {
+    fn split_extended_origin_aligned(
+        self,
+        split_size: na::Vector2<f64>,
+        split_direction: SplitDirection,
+    ) -> Vec<Self> {
         let mut split_aabbs = Vec::new();
 
         if split_size[0] <= 0.0 || split_size[1] <= 0.0 {
             return vec![];
         }
 
-        let mut offset_y = (self.mins[1] / split_size[1]).floor() * split_size[1];
+        let (outer_idx, inner_idx) = match split_direction {
+            SplitDirection::RowMajor => (1, 0),
+            SplitDirection::ColumnMajor => (0, 1),
+        };
 
-        while offset_y < self.maxs[1] {
-            let mut offset_x = (self.mins[0] / split_size[0]).floor() * split_size[0];
+        let mut offset_outer =
+            (self.mins[outer_idx] / split_size[outer_idx]).floor() * split_size[outer_idx];
 
-            while offset_x < self.maxs[0] {
-                let mins = na::point![offset_x, offset_y];
+        while offset_outer < self.maxs[outer_idx] {
+            let mut offset_inner =
+                (self.mins[inner_idx] / split_size[inner_idx]).floor() * split_size[inner_idx];
+
+            while offset_inner < self.maxs[inner_idx] {
+                let mins = match split_direction {
+                    SplitDirection::RowMajor => na::point![offset_inner, offset_outer],
+                    SplitDirection::ColumnMajor => na::point![offset_outer, offset_inner],
+                };
+
                 split_aabbs.push(Aabb::new(mins, mins + split_size));
 
-                offset_x += split_size[0];
+                offset_inner += split_size[inner_idx];
             }
 
-            offset_y += split_size[1];
+            offset_outer += split_size[outer_idx];
         }
 
         split_aabbs

--- a/rnote-engine/src/document/mod.rs
+++ b/rnote-engine/src/document/mod.rs
@@ -9,7 +9,7 @@ pub use format::Format;
 // Imports
 use crate::{Camera, StrokeStore, WidgetFlags};
 use p2d::bounding_volume::{Aabb, BoundingVolume};
-use rnote_compose::helpers::AabbHelpers;
+use rnote_compose::helpers::{AabbHelpers, SplitDirection};
 use rnote_compose::Color;
 use serde::{Deserialize, Serialize};
 
@@ -137,8 +137,10 @@ impl Document {
         let doc_bounds = self.bounds();
 
         if self.format.height > 0.0 && self.format.width > 0.0 {
-            doc_bounds
-                .split_extended_origin_aligned(na::vector![self.format.width, self.format.height])
+            doc_bounds.split_extended_origin_aligned(
+                na::vector![self.format.width, self.format.height],
+                SplitDirection::default(),
+            )
         } else {
             vec![]
         }

--- a/rnote-engine/src/document/mod.rs
+++ b/rnote-engine/src/document/mod.rs
@@ -9,7 +9,7 @@ pub use format::Format;
 // Imports
 use crate::{Camera, StrokeStore, WidgetFlags};
 use p2d::bounding_volume::{Aabb, BoundingVolume};
-use rnote_compose::helpers::{AabbHelpers, SplitDirection};
+use rnote_compose::helpers::{AabbHelpers, SplitOrder};
 use rnote_compose::Color;
 use serde::{Deserialize, Serialize};
 
@@ -133,13 +133,13 @@ impl Document {
     /// Generate bounds for each page for the doc bounds, extended to fit the format.
     ///
     /// May contain many empty pages (in infinite mode)
-    pub fn pages_bounds(&self, split_direction: SplitDirection) -> Vec<Aabb> {
+    pub fn pages_bounds(&self, split_order: SplitOrder) -> Vec<Aabb> {
         let doc_bounds = self.bounds();
 
         if self.format.height > 0.0 && self.format.width > 0.0 {
             doc_bounds.split_extended_origin_aligned(
                 na::vector![self.format.width, self.format.height],
-                split_direction,
+                split_order,
             )
         } else {
             vec![]

--- a/rnote-engine/src/document/mod.rs
+++ b/rnote-engine/src/document/mod.rs
@@ -133,13 +133,13 @@ impl Document {
     /// Generate bounds for each page for the doc bounds, extended to fit the format.
     ///
     /// May contain many empty pages (in infinite mode)
-    pub fn pages_bounds(&self) -> Vec<Aabb> {
+    pub fn pages_bounds(&self, split_direction: SplitDirection) -> Vec<Aabb> {
         let doc_bounds = self.bounds();
 
         if self.format.height > 0.0 && self.format.width > 0.0 {
             doc_bounds.split_extended_origin_aligned(
                 na::vector![self.format.width, self.format.height],
-                SplitDirection::default(),
+                split_direction,
             )
         } else {
             vec![]

--- a/rnote-engine/src/engine/export.rs
+++ b/rnote-engine/src/engine/export.rs
@@ -80,7 +80,7 @@ pub struct DocExportPrefs {
     /// The export format.
     #[serde(rename = "export_format")]
     pub export_format: DocExportFormat,
-    /// The page order when exporting an infinite layout to a finite layout.
+    /// The page order when documents with layouts that expand in horizontal and vertical directions are cut into pages.
     #[serde(rename = "page_order")]
     pub page_order: SplitOrder,
 }
@@ -139,7 +139,7 @@ pub struct DocPagesExportPrefs {
     /// Export format
     #[serde(rename = "export_format")]
     pub export_format: DocPagesExportFormat,
-    /// The page order when exporting an infinite layout to a finite layout.
+    /// The page order when documents with layouts that expand in horizontal and vertical directions are cut into pages.
     #[serde(rename = "page_order")]
     pub page_order: SplitOrder,
     /// The bitmap scale-factor in relation to the actual size.

--- a/rnote-engine/src/engine/export.rs
+++ b/rnote-engine/src/engine/export.rs
@@ -65,15 +65,6 @@ impl DocExportFormat {
             DocExportFormat::Xopp => String::from("xopp"),
         }
     }
-
-    /// Whether or not the format is finite, i.e. infinite layouts will be split into pages.
-    pub fn is_finite(self) -> bool {
-        match self {
-            DocExportFormat::Svg => false,
-            DocExportFormat::Pdf => true,
-            DocExportFormat::Xopp => true,
-        }
-    }
 }
 
 /// Document export preferences.

--- a/rnote-engine/src/engine/export.rs
+++ b/rnote-engine/src/engine/export.rs
@@ -7,7 +7,7 @@ use anyhow::Context;
 use futures::channel::oneshot;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use piet::RenderContext;
-use rnote_compose::helpers::{SplitDirection, Vector2Helpers};
+use rnote_compose::helpers::{SplitOrder, Vector2Helpers};
 use rnote_compose::transform::TransformBehaviour;
 use rnote_fileformats::rnoteformat::RnoteFile;
 use rnote_fileformats::{xoppformat, FileFormatSaver};
@@ -80,9 +80,9 @@ pub struct DocExportPrefs {
     /// The export format.
     #[serde(rename = "export_format")]
     pub export_format: DocExportFormat,
-    /// The read direction when exporting an infinite layout to a finite layout.
-    #[serde(rename = "page_direction")]
-    pub page_direction: SplitDirection,
+    /// The page order when exporting an infinite layout to a finite layout.
+    #[serde(rename = "page_order")]
+    pub page_order: SplitOrder,
 }
 
 impl Default for DocExportPrefs {
@@ -91,7 +91,7 @@ impl Default for DocExportPrefs {
             with_background: true,
             with_pattern: true,
             export_format: DocExportFormat::default(),
-            page_direction: SplitDirection::default(),
+            page_order: SplitOrder::default(),
         }
     }
 }
@@ -139,9 +139,9 @@ pub struct DocPagesExportPrefs {
     /// Export format
     #[serde(rename = "export_format")]
     pub export_format: DocPagesExportFormat,
-    /// The read direction when exporting an infinite layout to a finite layout.
-    #[serde(rename = "page_direction")]
-    pub page_direction: SplitDirection,
+    /// The page order when exporting an infinite layout to a finite layout.
+    #[serde(rename = "page_order")]
+    pub page_order: SplitOrder,
     /// The bitmap scale-factor in relation to the actual size.
     #[serde(rename = "bitmap_scalefactor")]
     pub bitmap_scalefactor: f64,
@@ -156,7 +156,7 @@ impl Default for DocPagesExportPrefs {
             with_background: true,
             with_pattern: true,
             export_format: DocPagesExportFormat::default(),
-            page_direction: SplitDirection::default(),
+            page_order: SplitOrder::default(),
             bitmap_scalefactor: 1.8,
             jpeg_quality: 85,
         }
@@ -414,7 +414,7 @@ impl RnoteEngine {
         let snapshot = self.take_snapshot();
 
         let pages_strokes = self
-            .pages_bounds_w_content(doc_export_prefs.page_direction)
+            .pages_bounds_w_content(doc_export_prefs.page_order)
             .into_iter()
             .map(|page_bounds| {
                 let strokes_in_viewport = self
@@ -535,7 +535,7 @@ impl RnoteEngine {
         let snapshot = self.take_snapshot();
 
         let pages_strokes: Vec<(Aabb, Vec<Stroke>)> = self
-            .pages_bounds_w_content(doc_export_prefs.page_direction)
+            .pages_bounds_w_content(doc_export_prefs.page_order)
             .into_iter()
             .map(|page_bounds| {
                 let page_keys = self
@@ -695,7 +695,7 @@ impl RnoteEngine {
         let snapshot = self.take_snapshot();
 
         let pages_strokes: Vec<(Aabb, Vec<StrokeKey>)> = self
-            .pages_bounds_w_content(doc_pages_export_prefs.page_direction)
+            .pages_bounds_w_content(doc_pages_export_prefs.page_order)
             .into_iter()
             .map(|page_bounds| {
                 let page_strokes = self
@@ -751,7 +751,7 @@ impl RnoteEngine {
         let snapshot = self.take_snapshot();
 
         let pages_strokes: Vec<(Aabb, Vec<StrokeKey>)> = self
-            .pages_bounds_w_content(doc_pages_export_prefs.page_direction)
+            .pages_bounds_w_content(doc_pages_export_prefs.page_order)
             .into_iter()
             .map(|page_bounds| {
                 let page_strokes = self

--- a/rnote-engine/src/engine/mod.rs
+++ b/rnote-engine/src/engine/mod.rs
@@ -24,7 +24,7 @@ use anyhow::Context;
 use futures::channel::{mpsc, oneshot};
 use gtk4::gsk;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
-use rnote_compose::helpers::{AabbHelpers, SplitDirection};
+use rnote_compose::helpers::{AabbHelpers, SplitOrder};
 use rnote_compose::penevents::{PenEvent, ShortcutKey};
 use rnote_compose::shapes::ShapeBehaviour;
 use rnote_fileformats::{rnoteformat, xoppformat, FileFormatLoader};
@@ -776,7 +776,7 @@ impl RnoteEngine {
     }
 
     /// Generate bounds for each page on the document which contains content.
-    pub fn pages_bounds_w_content(&self, split_direction: SplitDirection) -> Vec<Aabb> {
+    pub fn pages_bounds_w_content(&self, split_order: SplitOrder) -> Vec<Aabb> {
         let doc_bounds = self.document.bounds();
         let keys = self.store.stroke_keys_as_rendered();
 
@@ -785,7 +785,7 @@ impl RnoteEngine {
         let pages_bounds = doc_bounds
             .split_extended_origin_aligned(
                 na::vector![self.document.format.width, self.document.format.height],
-                split_direction,
+                split_order,
             )
             .into_iter()
             .filter(|page_bounds| {
@@ -809,7 +809,7 @@ impl RnoteEngine {
 
     /// Generates bounds which contain all pages on the doc with content, extended to fit the current format.
     pub fn bounds_w_content_extended(&self) -> Option<Aabb> {
-        let pages_bounds = self.pages_bounds_w_content(SplitDirection::default());
+        let pages_bounds = self.pages_bounds_w_content(SplitOrder::default());
 
         if pages_bounds.is_empty() {
             return None;

--- a/rnote-engine/src/engine/mod.rs
+++ b/rnote-engine/src/engine/mod.rs
@@ -808,8 +808,8 @@ impl RnoteEngine {
     }
 
     /// Generates bounds which contain all pages on the doc with content, extended to fit the current format.
-    pub fn bounds_w_content_extended(&self, split_direction: SplitDirection) -> Option<Aabb> {
-        let pages_bounds = self.pages_bounds_w_content(split_direction);
+    pub fn bounds_w_content_extended(&self) -> Option<Aabb> {
+        let pages_bounds = self.pages_bounds_w_content(SplitDirection::default());
 
         if pages_bounds.is_empty() {
             return None;

--- a/rnote-engine/src/engine/rendering.rs
+++ b/rnote-engine/src/engine/rendering.rs
@@ -6,7 +6,7 @@ use gtk4::{gdk, graphene, gsk, prelude::*, Snapshot};
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use piet::RenderContext;
 use rnote_compose::color;
-use rnote_compose::helpers::{AabbHelpers, Affine2Helpers, SplitDirection};
+use rnote_compose::helpers::{AabbHelpers, Affine2Helpers, SplitOrder};
 
 impl RnoteEngine {
     /// Update the background rendering for the current viewport.
@@ -30,7 +30,7 @@ impl RnoteEngine {
 
             for split_bounds in viewport.split_extended_origin_aligned(
                 self.document.background.tile_size(),
-                SplitDirection::default(),
+                SplitOrder::default(),
             ) {
                 rendernodes.push(
                     gsk::TextureNode::new(
@@ -202,7 +202,7 @@ impl RnoteEngine {
 
             for page_bounds in doc_bounds.split_extended_origin_aligned(
                 na::vector![self.document.format.width, self.document.format.height],
-                SplitDirection::default(),
+                SplitOrder::default(),
             ) {
                 if !page_bounds.intersects(&viewport) {
                     continue;

--- a/rnote-engine/src/engine/rendering.rs
+++ b/rnote-engine/src/engine/rendering.rs
@@ -6,7 +6,7 @@ use gtk4::{gdk, graphene, gsk, prelude::*, Snapshot};
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use piet::RenderContext;
 use rnote_compose::color;
-use rnote_compose::helpers::{AabbHelpers, Affine2Helpers};
+use rnote_compose::helpers::{AabbHelpers, Affine2Helpers, SplitDirection};
 
 impl RnoteEngine {
     /// Update the background rendering for the current viewport.
@@ -28,9 +28,10 @@ impl RnoteEngine {
                 }
             };
 
-            for split_bounds in
-                viewport.split_extended_origin_aligned(self.document.background.tile_size())
-            {
+            for split_bounds in viewport.split_extended_origin_aligned(
+                self.document.background.tile_size(),
+                SplitDirection::default(),
+            ) {
                 rendernodes.push(
                     gsk::TextureNode::new(
                         &new_texture,
@@ -199,10 +200,10 @@ impl RnoteEngine {
 
             snapshot.push_clip(&graphene::Rect::from_p2d_aabb(doc_bounds.loosened(2.0)));
 
-            for page_bounds in doc_bounds.split_extended_origin_aligned(na::vector![
-                self.document.format.width,
-                self.document.format.height
-            ]) {
+            for page_bounds in doc_bounds.split_extended_origin_aligned(
+                na::vector![self.document.format.width, self.document.format.height],
+                SplitDirection::default(),
+            ) {
                 if !page_bounds.intersects(&viewport) {
                     continue;
                 }

--- a/rnote-ui/data/ui/dialogs/export.ui
+++ b/rnote-ui/data/ui/dialogs/export.ui
@@ -122,7 +122,8 @@
                 <child>
                   <object class="AdwComboRow" id="export_doc_page_order_row">
                     <property name="title" translatable="yes">Page Order</property>
-                    <property name="subtitle" translatable="yes">The page order when exporting an infinite layout to a finite layout</property>
+                    <property name="subtitle" translatable="yes">The page order when documents with layouts that expand 
+in horizontal and vertical directions are cut into pages</property>
                     <property name="model">
                       <object class="GtkStringList">
                         <items>
@@ -305,7 +306,8 @@
                 <child>
                   <object class="AdwComboRow" id="export_doc_pages_page_order_row">
                     <property name="title" translatable="yes">Page Order</property>
-                    <property name="subtitle" translatable="yes">The page order when exporting an infinite layout to a finite layout</property>
+                    <property name="subtitle" translatable="yes">The page order when documents with layouts that expand
+in horizontal and vertical directions are cut into pages</property>
                     <property name="model">
                       <object class="GtkStringList">
                         <items>

--- a/rnote-ui/data/ui/dialogs/export.ui
+++ b/rnote-ui/data/ui/dialogs/export.ui
@@ -120,9 +120,9 @@
                   </object>
                 </child>
                 <child>
-                  <object class="AdwComboRow" id="export_doc_page_direction_row">
-                    <property name="title" translatable="yes">Page Direction</property>
-                    <property name="subtitle" translatable="yes">The read direction when exporting an infinite layout to a finite layout</property>
+                  <object class="AdwComboRow" id="export_doc_page_order_row">
+                    <property name="title" translatable="yes">Page Order</property>
+                    <property name="subtitle" translatable="yes">The page order when exporting an infinite layout to a finite layout</property>
                     <property name="model">
                       <object class="GtkStringList">
                         <items>
@@ -303,9 +303,9 @@
                   </object>
                 </child>
                 <child>
-                  <object class="AdwComboRow" id="export_doc_pages_page_direction_row">
-                    <property name="title" translatable="yes">Page Direction</property>
-                    <property name="subtitle" translatable="yes">The read direction when exporting an infinite layout to a finite layout</property>
+                  <object class="AdwComboRow" id="export_doc_pages_page_order_row">
+                    <property name="title" translatable="yes">Page Order</property>
+                    <property name="subtitle" translatable="yes">The page order when exporting an infinite layout to a finite layout</property>
                     <property name="model">
                       <object class="GtkStringList">
                         <items>

--- a/rnote-ui/data/ui/dialogs/export.ui
+++ b/rnote-ui/data/ui/dialogs/export.ui
@@ -120,8 +120,8 @@
                   </object>
                 </child>
                 <child>
-                  <object class="AdwComboRow" id="export_doc_direction_row">
-                    <property name="title" translatable="yes">Direction</property>
+                  <object class="AdwComboRow" id="export_doc_page_direction_row">
+                    <property name="title" translatable="yes">Page Direction</property>
                     <property name="subtitle" translatable="yes">The read direction when exporting an infinite layout to a finite layout</property>
                     <property name="model">
                       <object class="GtkStringList">
@@ -297,6 +297,20 @@
                           <item translatable="yes">Svg</item>
                           <item translatable="yes">Png</item>
                           <item translatable="yes">Jpeg</item>
+                        </items>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwComboRow" id="export_doc_pages_page_direction_row">
+                    <property name="title" translatable="yes">Page Direction</property>
+                    <property name="subtitle" translatable="yes">The read direction when exporting an infinite layout to a finite layout</property>
+                    <property name="model">
+                      <object class="GtkStringList">
+                        <items>
+                          <item translatable="yes">Horizontal First</item>
+                          <item translatable="yes">Vertical First</item>
                         </items>
                       </object>
                     </property>

--- a/rnote-ui/data/ui/dialogs/export.ui
+++ b/rnote-ui/data/ui/dialogs/export.ui
@@ -119,6 +119,20 @@
                     </property>
                   </object>
                 </child>
+                <child>
+                  <object class="AdwComboRow" id="export_doc_direction_row">
+                    <property name="title" translatable="yes">Direction</property>
+                    <property name="subtitle" translatable="yes">The read direction when exporting an infinite layout to a finite layout</property>
+                    <property name="model">
+                      <object class="GtkStringList">
+                        <items>
+                          <item translatable="yes">Horizontal First</item>
+                          <item translatable="yes">Vertical First</item>
+                        </items>
+                      </object>
+                    </property>
+                  </object>
+                </child>
               </object>
             </child>
           </object>

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -6,7 +6,7 @@ use gtk4::{
     UriLauncher, Window,
 };
 use piet::RenderContext;
-use rnote_compose::helpers::Vector2Helpers;
+use rnote_compose::helpers::{SplitDirection, Vector2Helpers};
 use rnote_compose::penevents::ShortcutKey;
 use rnote_engine::document::Layout;
 use rnote_engine::engine::StrokeContent;
@@ -632,7 +632,7 @@ impl RnAppWindow {
         action_print_doc.connect_activate(clone!(@weak self as appwindow => move |_, _| {
             let canvas = appwindow.active_tab().canvas();
 
-            let pages_bounds = canvas.engine_ref().pages_bounds_w_content();
+            let pages_bounds = canvas.engine_ref().pages_bounds_w_content(SplitDirection::default());
             let n_pages = pages_bounds.len();
             let engine_snapshot = canvas.engine_ref().take_snapshot();
             let doc_bounds = engine_snapshot.document.bounds();

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -632,14 +632,15 @@ impl RnAppWindow {
         action_print_doc.connect_activate(clone!(@weak self as appwindow => move |_, _| {
             let canvas = appwindow.active_tab().canvas();
 
-            let pages_bounds = canvas.engine_ref().pages_bounds_w_content(SplitDirection::default());
+            // TODO: Exposing this as a setting in the print dialog
+            let with_background = true;
+            let page_direction = SplitDirection::default();
+
+            let pages_bounds = canvas.engine_ref().pages_bounds_w_content(page_direction);
             let n_pages = pages_bounds.len();
             let engine_snapshot = canvas.engine_ref().take_snapshot();
             let doc_bounds = engine_snapshot.document.bounds();
             let format_size = na::vector![engine_snapshot.document.format.width, engine_snapshot.document.format.height];
-
-            // TODO: Exposing this as a setting in the print dialog
-            let with_background = true;
 
             appwindow.overlays().start_pulsing_progressbar();
 

--- a/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/rnote-ui/src/appwindow/appwindowactions.rs
@@ -6,7 +6,7 @@ use gtk4::{
     UriLauncher, Window,
 };
 use piet::RenderContext;
-use rnote_compose::helpers::{SplitDirection, Vector2Helpers};
+use rnote_compose::helpers::{SplitOrder, Vector2Helpers};
 use rnote_compose::penevents::ShortcutKey;
 use rnote_engine::document::Layout;
 use rnote_engine::engine::StrokeContent;
@@ -634,9 +634,9 @@ impl RnAppWindow {
 
             // TODO: Exposing this as a setting in the print dialog
             let with_background = true;
-            let page_direction = SplitDirection::default();
+            let page_order = SplitOrder::default();
 
-            let pages_bounds = canvas.engine_ref().pages_bounds_w_content(page_direction);
+            let pages_bounds = canvas.engine_ref().pages_bounds_w_content(page_order);
             let n_pages = pages_bounds.len();
             let engine_snapshot = canvas.engine_ref().take_snapshot();
             let doc_bounds = engine_snapshot.document.bounds();

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -88,7 +88,8 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
     let with_pattern_row: adw::ActionRow = builder.object("export_doc_with_pattern_row").unwrap();
     let with_pattern_switch: Switch = builder.object("export_doc_with_pattern_switch").unwrap();
     let export_format_row: adw::ComboRow = builder.object("export_doc_export_format_row").unwrap();
-    let direction_row: adw::ComboRow = builder.object("export_doc_direction_row").unwrap();
+    let page_direction_row: adw::ComboRow =
+        builder.object("export_doc_page_direction_row").unwrap();
     let export_file_label: Label = builder.object("export_doc_export_file_label").unwrap();
     let export_file_button: Button = builder.object("export_doc_export_file_button").unwrap();
 
@@ -101,7 +102,7 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
     with_background_switch.set_active(initial_doc_export_prefs.with_background);
     with_pattern_switch.set_active(initial_doc_export_prefs.with_pattern);
     export_format_row.set_selected(initial_doc_export_prefs.export_format.to_u32().unwrap());
-    direction_row.set_selected(initial_doc_export_prefs.direction.to_u32().unwrap());
+    page_direction_row.set_selected(initial_doc_export_prefs.page_direction.to_u32().unwrap());
     export_file_label.set_label(&gettext("- no file selected -"));
     button_confirm.set_sensitive(false);
 
@@ -152,9 +153,12 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
         canvas.engine_mut().export_prefs.doc_export_prefs.with_pattern = with_pattern_switch.is_active();
     }));
 
-    export_format_row.connect_selected_notify(clone!(@strong selected_file, @weak export_file_label, @weak button_confirm, @weak canvas, @weak appwindow => move |row| {
+    export_format_row.connect_selected_notify(clone!(@strong selected_file, @weak export_file_label, @weak page_direction_row, @weak button_confirm, @weak canvas, @weak appwindow => move |row| {
         let export_format = DocExportFormat::try_from(row.selected()).unwrap();
         canvas.engine_mut().export_prefs.doc_export_prefs.export_format = export_format;
+
+        // enable page direction row when export format is finite
+        page_direction_row.set_sensitive(export_format.is_finite());
 
         // force the user to pick another file
         export_file_label.set_label(&gettext("- no file selected -"));
@@ -162,10 +166,12 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
         selected_file.replace(None);
     }));
 
-    direction_row.connect_selected_notify(clone!(@weak canvas, @weak appwindow => move |row| {
-        let direction = SplitDirection::try_from(row.selected()).unwrap();
-        canvas.engine_mut().export_prefs.doc_export_prefs.direction = direction;
-    }));
+    page_direction_row.connect_selected_notify(
+        clone!(@weak canvas, @weak appwindow => move |row| {
+            let page_direction = SplitDirection::try_from(row.selected()).unwrap();
+            canvas.engine_mut().export_prefs.doc_export_prefs.page_direction = page_direction;
+        }),
+    );
 
     let response = dialog.run_future().await;
     dialog.close();
@@ -261,6 +267,9 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
     let export_format_row: adw::ComboRow = builder
         .object("export_doc_pages_export_format_row")
         .unwrap();
+    let page_direction_row: adw::ComboRow = builder
+        .object("export_doc_pages_page_direction_row")
+        .unwrap();
     let bitmap_scalefactor_row: adw::ActionRow = builder
         .object("export_doc_pages_bitmap_scalefactor_row")
         .unwrap();
@@ -294,6 +303,12 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
     export_format_row.set_selected(
         initial_doc_pages_export_prefs
             .export_format
+            .to_u32()
+            .unwrap(),
+    );
+    page_direction_row.set_selected(
+        initial_doc_pages_export_prefs
+            .page_direction
             .to_u32()
             .unwrap(),
     );
@@ -395,6 +410,13 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
                     + &canvas.engine_mut().export_prefs.doc_pages_export_prefs.export_format.file_ext()
             ));
     }));
+
+    page_direction_row.connect_selected_notify(
+        clone!(@weak canvas, @weak appwindow => move |row| {
+            let page_direction = SplitDirection::try_from(row.selected()).unwrap();
+            canvas.engine_mut().export_prefs.doc_pages_export_prefs.page_direction = page_direction;
+        }),
+    );
 
     bitmap_scalefactor_spinbutton.connect_value_changed(clone!(@weak canvas, @weak appwindow => move |bitmap_scalefactor_spinbutton| {
         canvas.engine_mut().export_prefs.doc_pages_export_prefs.bitmap_scalefactor = bitmap_scalefactor_spinbutton.value();

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -104,6 +104,10 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
     export_format_row.set_selected(initial_doc_export_prefs.export_format.to_u32().unwrap());
     page_direction_row.set_selected(initial_doc_export_prefs.page_direction.to_u32().unwrap());
     export_file_label.set_label(&gettext("- no file selected -"));
+    page_direction_row.set_sensitive(
+        initial_doc_export_prefs.export_format == DocExportFormat::Pdf
+            || initial_doc_export_prefs.export_format == DocExportFormat::Xopp,
+    );
     button_confirm.set_sensitive(false);
 
     // Update prefs
@@ -157,8 +161,8 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
         let export_format = DocExportFormat::try_from(row.selected()).unwrap();
         canvas.engine_mut().export_prefs.doc_export_prefs.export_format = export_format;
 
-        // enable page direction row when export format is finite
-        page_direction_row.set_sensitive(export_format.is_finite());
+        // enable page direction row when export format is finite, i.e. infinite layouts will be split into pages
+        page_direction_row.set_sensitive(export_format == DocExportFormat::Pdf || export_format == DocExportFormat::Xopp);
 
         // force the user to pick another file
         export_file_label.set_label(&gettext("- no file selected -"));

--- a/rnote-ui/src/dialogs/export.rs
+++ b/rnote-ui/src/dialogs/export.rs
@@ -11,6 +11,7 @@ use gtk4::{
     SpinButton, Switch,
 };
 use num_traits::ToPrimitive;
+use rnote_compose::helpers::SplitDirection;
 use rnote_engine::engine::export::{
     DocExportFormat, DocExportPrefs, DocPagesExportFormat, DocPagesExportPrefs,
     SelectionExportFormat, SelectionExportPrefs,
@@ -87,6 +88,7 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
     let with_pattern_row: adw::ActionRow = builder.object("export_doc_with_pattern_row").unwrap();
     let with_pattern_switch: Switch = builder.object("export_doc_with_pattern_switch").unwrap();
     let export_format_row: adw::ComboRow = builder.object("export_doc_export_format_row").unwrap();
+    let direction_row: adw::ComboRow = builder.object("export_doc_direction_row").unwrap();
     let export_file_label: Label = builder.object("export_doc_export_file_label").unwrap();
     let export_file_button: Button = builder.object("export_doc_export_file_button").unwrap();
 
@@ -99,6 +101,7 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
     with_background_switch.set_active(initial_doc_export_prefs.with_background);
     with_pattern_switch.set_active(initial_doc_export_prefs.with_pattern);
     export_format_row.set_selected(initial_doc_export_prefs.export_format.to_u32().unwrap());
+    direction_row.set_selected(initial_doc_export_prefs.direction.to_u32().unwrap());
     export_file_label.set_label(&gettext("- no file selected -"));
     button_confirm.set_sensitive(false);
 
@@ -157,6 +160,11 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
         export_file_label.set_label(&gettext("- no file selected -"));
         button_confirm.set_sensitive(false);
         selected_file.replace(None);
+    }));
+
+    direction_row.connect_selected_notify(clone!(@weak canvas, @weak appwindow => move |row| {
+        let direction = SplitDirection::try_from(row.selected()).unwrap();
+        canvas.engine_mut().export_prefs.doc_export_prefs.direction = direction;
     }));
 
     let response = dialog.run_future().await;


### PR DESCRIPTION
Adds an option to export dialogs for changing the order in which the pages of infinite layouts are exported. It is disabled if the document layout is not (semi-)infinite or if the export format is not finite. The default is the current standard, i.e. "Horizontal First".

![image](https://github.com/flxzt/rnote/assets/49598842/9b843ff8-b32a-403f-92fc-8cf5721c0c0c)

### Things to Discuss

- Name and description of this option.
- It might be better to create separate AABB helper functions for every `SplitOrder` instead of having a single one (`split_extended_origin_aligned`). That would be more readable but less DRY.
- `SplitOrder` is currently used directly within the export preferences structs and the values have different names than the options in the UI (`RowMajor` <-> "Horizontal First").
