### PR TITLE
Shortcut mode for holding a button (like Xournal++)

### DIFF
--- a/rnote-engine/src/engine/mod.rs
+++ b/rnote-engine/src/engine/mod.rs
@@ -698,6 +698,26 @@ impl RnoteEngine {
         )
     }
 
+    /// Handle a released shortcut key.
+    pub fn handle_released_shortcut_key(
+        &mut self,
+        shortcut_key: ShortcutKey,
+        now: Instant,
+    ) -> WidgetFlags {
+        self.penholder.handle_released_shortcut_key(
+            shortcut_key,
+            now,
+            &mut EngineViewMut {
+                tasks_tx: self.tasks_tx(),
+                pens_config: &mut self.pens_config,
+                doc: &mut self.document,
+                store: &mut self.store,
+                camera: &mut self.camera,
+                audioplayer: &mut self.audioplayer,
+            },
+        )
+    }
+
     /// Change the pen style.
     pub fn change_pen_style(&mut self, new_style: PenStyle) -> WidgetFlags {
         self.penholder.change_style(

--- a/rnote-engine/src/pens/penholder.rs
+++ b/rnote-engine/src/pens/penholder.rs
@@ -304,7 +304,7 @@ impl PenHolder {
         if let Some(action) = self.get_shortcut_action(shortcut_key) {
             match action {
                 ShortcutAction::ChangePenStyle { style, mode } => match mode {
-                    ShortcutMode::Temporary => {
+                    ShortcutMode::Temporary | ShortcutMode::Hold => {
                         widget_flags.merge(self.change_style_override(Some(style), engine_view));
                     }
                     ShortcutMode::Permanent => {

--- a/rnote-engine/src/pens/shortcuts.rs
+++ b/rnote-engine/src/pens/shortcuts.rs
@@ -25,6 +25,8 @@ pub enum ShortcutMode {
     Permanent,
     #[serde(rename = "toggle")]
     Toggle,
+    #[serde(rename = "hold")]
+    Hold,
 }
 
 impl TryFrom<u32> for ShortcutMode {

--- a/rnote-ui/data/ui/penshortcutrow.ui
+++ b/rnote-ui/data/ui/penshortcutrow.ui
@@ -11,6 +11,7 @@
               <item translatable="yes">Temporary</item>
               <item translatable="yes">Permanent</item>
               <item translatable="yes">Toggle</item>
+              <item translatable="yes">Hold</item>
             </items>
           </object>
         </property>

--- a/rnote-ui/src/canvas/input.rs
+++ b/rnote-ui/src/canvas/input.rs
@@ -121,6 +121,16 @@ pub(crate) fn handle_pointer_controller_event(
                     inhibit = true;
                 }
             };
+
+            let shortcut_key = retrieve_button_shortcut_key(gdk_button, is_stylus);
+
+            if let Some(shortcut_key) = shortcut_key {
+                widget_flags.merge(
+                    canvas
+                        .engine_mut()
+                        .handle_released_shortcut_key(shortcut_key, now),
+                );
+            }
         }
         gdk::EventType::ProximityIn => {
             state = PenState::Proximity;


### PR DESCRIPTION
I recently discovered rnote and I really like it. However I need to have a pen mode like the one in Xournal++ where you hold the shortcut button to activate the tool and once you release it, it goes back to the previous tool.

I don't have much experience with rust so any feedback on code quality is very welcome. Also I'm not quite sure if the name "Hold" is good or not so input is welcome there too.

Otherwise I hope you like it :)