### PR TITLE
refactor `Drawable`, `Content` traits to restore vectorized vectorimage export

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ On some devices one stylus button is mapped to a dedicated "Eraser" mode (which 
 
 A great way to contribute to the project without writing code is adding a new or start maintaining an existing translation language. The translations files are located in `crates/rnote-ui/po/`.
 
- Creating translations for new languages or updating existing ones can be done in mutliple ways:
+ Creating translations for new languages or updating existing ones can be done in multiple ways:
 - take the `rnote.pot` file and generate a new `.po` translation file from it, for example with "Poedit". Add the new translation language to `LINGUAS` and submit a PR with the changed files.
 - use [weblate](https://hosted.weblate.org/projects/rnote/repo/) for an easy way to translate in the browser without having to deal with git.
 

--- a/crates/rnote-engine/src/audioplayer.rs
+++ b/crates/rnote-engine/src/audioplayer.rs
@@ -248,8 +248,8 @@ fn load_sound_from_path(
 
         Ok(buffered)
     } else {
-        Err(anyhow::Error::msg(format!(
+        Err(anyhow::anyhow!(
             "failed to init audioplayer. File `{resource_path:?}` is missing."
-        )))
+        ))
     }
 }

--- a/crates/rnote-engine/src/camera.rs
+++ b/crates/rnote-engine/src/camera.rs
@@ -207,7 +207,7 @@ impl Camera {
         self.zoom * self.temporary_zoom
     }
 
-    /// The scaling factor for generating pixel images with the current permanent zoom.
+    /// The scaling factor for generating bitmap images with the current permanent zoom.
     ///
     /// Takes the scale factor in account
     pub fn image_scale(&self) -> f64 {

--- a/crates/rnote-engine/src/document/background.rs
+++ b/crates/rnote-engine/src/document/background.rs
@@ -475,10 +475,8 @@ impl Background {
     }
 
     pub fn gen_tile_image(&self, image_scale: f64) -> Result<render::Image, anyhow::Error> {
-        let tile_size = self.tile_size();
-        let tile_bounds = Aabb::new(na::point![0.0, 0.0], na::point![tile_size[0], tile_size[1]]);
-        let svg = self.gen_svg(tile_bounds, true)?;
-        render::Image::gen_image_from_svg(svg, tile_bounds, image_scale)
+        let tile_bounds = Aabb::new(na::point![0.0, 0.0], self.tile_size().into());
+        self.gen_svg(tile_bounds, true)?.gen_image(image_scale)
     }
 
     pub fn draw_to_cairo(
@@ -487,8 +485,8 @@ impl Background {
         bounds: Aabb,
         with_pattern: bool,
     ) -> anyhow::Result<()> {
-        let mut svg = self.gen_svg(bounds, with_pattern)?;
-        svg.wrap_svg_root(Some(bounds), Some(bounds), false);
-        svg.draw_to_cairo(cx)
+        let mut background_svg = self.gen_svg(bounds, with_pattern)?;
+        background_svg.wrap_svg_root(Some(bounds), Some(bounds), false);
+        background_svg.draw_to_cairo(cx)
     }
 }

--- a/crates/rnote-engine/src/drawable.rs
+++ b/crates/rnote-engine/src/drawable.rs
@@ -9,11 +9,19 @@ use rnote_compose::ext::{AabbExt, Affine2Ext};
 /// Trait for types that can draw themselves on a [piet::RenderContext].
 pub trait Drawable {
     /// Draw itself.
+    ///
     /// The implementors are expected to save/restore the drawing context.
     ///
     /// `image_scale` is the scale-factor of generated images within the type.
     /// The content should not be zoomed by it!
     fn draw(&self, cx: &mut impl piet::RenderContext, image_scale: f64) -> anyhow::Result<()>;
+
+    /// Draw itself to a [cairo::Context].
+    fn draw_to_cairo(&self, cx: &cairo::Context, image_scale: f64) -> anyhow::Result<()> {
+        let mut piet_cx = piet_cairo::CairoRenderContext::new(cx);
+        self.draw(&mut piet_cx, image_scale)?;
+        piet_cx.finish().map_err(|e| anyhow::anyhow!("{e:?}"))
+    }
 }
 
 /// Trait for types that can draw themselves on the document.
@@ -31,6 +39,17 @@ pub trait DrawableOnDoc {
         cx: &mut piet_cairo::CairoRenderContext,
         engine_view: &EngineView,
     ) -> anyhow::Result<()>;
+
+    /// Draw itself to a [cairo::Context]
+    fn draw_on_doc_to_cairo(
+        &self,
+        cx: &cairo::Context,
+        engine_view: &EngineView,
+    ) -> anyhow::Result<()> {
+        let mut piet_cx = piet_cairo::CairoRenderContext::new(cx);
+        self.draw_on_doc(&mut piet_cx, engine_view)?;
+        piet_cx.finish().map_err(|e| anyhow::anyhow!("{e:?}"))
+    }
 
     /// Draw itself on the snapshot.
     ///

--- a/crates/rnote-engine/src/engine/export.rs
+++ b/crates/rnote-engine/src/engine/export.rs
@@ -500,10 +500,10 @@ impl RnoteEngine {
                 }
                 let data = *target_surface
                     .finish_output_stream()
-                    .map_err(|e| anyhow::anyhow!("Finishing outputstream failed with Err: {e:?}"))?
+                    .map_err(|e| anyhow::anyhow!("Finishing outputstream failed, Err: {e:?}"))?
                     .downcast::<Vec<u8>>()
                     .map_err(|e| {
-                        anyhow::anyhow!("Downcasting finished output stream failed with Err: {e:?}")
+                        anyhow::anyhow!("Downcasting finished output stream failed, Err: {e:?}")
                     })?;
 
                 Ok(data)
@@ -834,7 +834,11 @@ impl RnoteEngine {
                 let Some(selection_content) = selection_content else {
                     return Ok(None);
                 };
-                let Some(selection_svg) = selection_content.gen_svg(selection_export_prefs.with_background, selection_export_prefs.with_pattern, selection_export_prefs.margin)? else {
+                let Some(selection_svg) = selection_content.gen_svg(
+                        selection_export_prefs.with_background,
+                        selection_export_prefs.with_pattern,
+                        selection_export_prefs.margin,
+                    )? else {
                     return Ok(None);
                 };
                 let bitmapimage_format = match selection_export_prefs.export_format {

--- a/crates/rnote-engine/src/engine/export.rs
+++ b/crates/rnote-engine/src/engine/export.rs
@@ -2,7 +2,6 @@
 use super::{EngineConfig, RnoteEngine, StrokeContent};
 use crate::fileformats::rnoteformat::RnoteFile;
 use crate::fileformats::{xoppformat, FileFormatSaver};
-use crate::render;
 use anyhow::Context;
 use futures::channel::oneshot;
 use rayon::prelude::*;
@@ -493,7 +492,7 @@ impl RnoteEngine {
                         )?;
                         cairo_cx.show_page().map_err(|e| {
                             anyhow::anyhow!(
-                                "Showing page failed when exporting page {i} as pdf, Err: {e:?}"
+                                "Showing page failed while exporting page {i} as pdf, Err: {e:?}"
                             )
                         })?;
                         cairo_cx.restore()?;
@@ -736,7 +735,7 @@ impl RnoteEngine {
                     .into_par_iter()
                     .enumerate()
                     .map(|(i, page_content)| {
-                        let page_svg = page_content
+                        page_content
                             .gen_svg(
                                 doc_pages_export_prefs.with_background,
                                 doc_pages_export_prefs.with_pattern,
@@ -744,15 +743,9 @@ impl RnoteEngine {
                             )?
                             .ok_or(anyhow::anyhow!(
                                 "Generating Svg for page {i} failed, returned None."
-                            ))?;
-                        let page_svg_bounds = page_svg.bounds;
-
-                        render::Image::gen_image_from_svg(
-                            page_svg,
-                            page_svg_bounds,
-                            doc_pages_export_prefs.bitmap_scalefactor,
-                        )?
-                        .into_encoded_bytes(bitmapimage_format.clone())
+                            ))?
+                            .gen_image(doc_pages_export_prefs.bitmap_scalefactor)?
+                            .into_encoded_bytes(bitmapimage_format.clone())
                     })
                     .collect()
             };
@@ -844,7 +837,6 @@ impl RnoteEngine {
                 let Some(selection_svg) = selection_content.gen_svg(selection_export_prefs.with_background, selection_export_prefs.with_pattern, selection_export_prefs.margin)? else {
                     return Ok(None);
                 };
-                let selection_svg_bounds = selection_svg.bounds;
                 let bitmapimage_format = match selection_export_prefs.export_format {
                     SelectionExportFormat::Svg => return Err(anyhow::anyhow!("Extracting bitmap image format from doc pages export prefs failed, not set to a bitmap format.")),
                     SelectionExportFormat::Png => image::ImageOutputFormat::Png,
@@ -854,12 +846,9 @@ impl RnoteEngine {
                 };
 
                 Ok(Some(
-                    render::Image::gen_image_from_svg(
-                        selection_svg,
-                        selection_svg_bounds,
-                        selection_export_prefs.bitmap_scalefactor,
-                    )?
-                    .into_encoded_bytes(bitmapimage_format)?,
+                    selection_svg
+                        .gen_image(selection_export_prefs.bitmap_scalefactor)?
+                        .into_encoded_bytes(bitmapimage_format)?,
                 ))
             };
             if let Err(_data) = oneshot_sender.send(result()) {

--- a/crates/rnote-engine/src/engine/import.rs
+++ b/crates/rnote-engine/src/engine/import.rs
@@ -192,7 +192,7 @@ impl RnoteEngine {
             let result = || -> anyhow::Result<VectorImage> {
                 let svg_str = String::from_utf8(bytes)?;
 
-                VectorImage::import_from_svg_str(&svg_str, pos, None)
+                VectorImage::from_svg_str(&svg_str, pos, None)
             };
 
             if let Err(_data) = oneshot_sender.send(result()) {
@@ -215,7 +215,7 @@ impl RnoteEngine {
 
         rayon::spawn(move || {
             let result = || -> anyhow::Result<BitmapImage> {
-                BitmapImage::import_from_image_bytes(&bytes, pos, None)
+                BitmapImage::from_image_bytes(&bytes, pos, None)
             };
 
             if let Err(_data) = oneshot_sender.send(result()) {
@@ -245,7 +245,7 @@ impl RnoteEngine {
             let result = || -> anyhow::Result<Vec<(Stroke, Option<StrokeLayer>)>> {
                 match pdf_import_prefs.pages_type {
                     PdfImportPagesType::Bitmap => {
-                        let bitmapimages = BitmapImage::import_from_pdf_bytes(
+                        let bitmapimages = BitmapImage::from_pdf_bytes(
                             &bytes,
                             pdf_import_prefs,
                             insert_pos,
@@ -258,7 +258,7 @@ impl RnoteEngine {
                         Ok(bitmapimages)
                     }
                     PdfImportPagesType::Vector => {
-                        let vectorimages = VectorImage::import_from_pdf_bytes(
+                        let vectorimages = VectorImage::from_pdf_bytes(
                             &bytes,
                             pdf_import_prefs,
                             insert_pos,

--- a/crates/rnote-engine/src/engine/import.rs
+++ b/crates/rnote-engine/src/engine/import.rs
@@ -192,7 +192,7 @@ impl RnoteEngine {
             let result = || -> anyhow::Result<VectorImage> {
                 let svg_str = String::from_utf8(bytes)?;
 
-                VectorImage::import_from_svg_data(&svg_str, pos, None)
+                VectorImage::import_from_svg_str(&svg_str, pos, None)
             };
 
             if let Err(_data) = oneshot_sender.send(result()) {

--- a/crates/rnote-engine/src/engine/snapshot.rs
+++ b/crates/rnote-engine/src/engine/snapshot.rs
@@ -139,7 +139,7 @@ impl EngineSnapshot {
                                 }
                                 Err(e) => {
                                     log::error!(
-                                        "from_xoppstroke() failed in open_from_xopp_bytes() with Err {:?}",
+                                        "from_xoppstroke() failed in open_from_xopp_bytes() , Err {:?}",
                                         e
                                     );
                                 }
@@ -158,7 +158,7 @@ impl EngineSnapshot {
                                 }
                                 Err(e) => {
                                     log::error!(
-                                        "from_xoppimage() failed in open_from_xopp_bytes() with Err {:?}",
+                                        "from_xoppimage() failed in open_from_xopp_bytes() , Err {:?}",
                                         e
                                     );
                                 }

--- a/crates/rnote-engine/src/engine/strokecontent.rs
+++ b/crates/rnote-engine/src/engine/strokecontent.rs
@@ -1,11 +1,9 @@
+use crate::Drawable;
 // Imports
 use crate::document::Background;
 use crate::render::Svg;
-use crate::strokes::Stroke;
-use crate::{Drawable, RnoteEngine};
+use crate::strokes::{Content, Stroke};
 use p2d::bounding_volume::{Aabb, BoundingVolume};
-use piet::RenderContext;
-use rnote_compose::ext::AabbExt;
 use rnote_compose::shapes::Shapeable;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -75,30 +73,23 @@ impl StrokeContent {
             return Ok(None);
         };
         let bounds_loosened = bounds.loosened(margin);
-        let mut svg = match (with_background, self.background) {
+        let mut content_svg = match (with_background, self.background) {
             (true, Some(background)) => background.gen_svg(bounds_loosened, with_pattern)?,
             _ => Svg {
                 svg_data: String::new(),
                 bounds,
             },
         };
-        svg.merge([Svg::gen_with_piet_cairo_backend(
-            |piet_cx| {
-                piet_cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
-                piet_cx.clip(bounds.to_kurbo_rect());
-                for stroke in self.strokes.iter() {
-                    stroke.draw(piet_cx, RnoteEngine::STROKE_EXPORT_IMAGE_SCALE)?;
-                }
-                piet_cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
-                Ok(())
-            },
-            bounds,
-        )?]);
+
+        for stroke in &self.strokes {
+            content_svg.merge(std::iter::once(stroke.gen_svg()?));
+        }
+
         // The simplification also moves the bounds to mins: [0.0, 0.0], maxs: extents
-        if let Err(e) = svg.simplify() {
-            log::warn!("simplifying Svg while exporting StrokeContent failed, Err: {e:?}");
+        if let Err(e) = content_svg.simplify() {
+            log::warn!("simplifying Svg while generating StrokeContent Svg failed, Err: {e:?}");
         };
-        Ok(Some(svg))
+        Ok(Some(content_svg))
     }
 
     pub fn draw_to_cairo(
@@ -127,6 +118,7 @@ impl StrokeContent {
             }
         }
 
+        cairo_cx.restore()?;
         cairo_cx.save()?;
         cairo_cx.rectangle(
             bounds.mins[0],
@@ -136,12 +128,12 @@ impl StrokeContent {
         );
         cairo_cx.clip();
 
-        let mut piet_cx = piet_cairo::CairoRenderContext::new(cairo_cx);
         for stroke in self.strokes.iter() {
-            stroke.draw(&mut piet_cx, image_scale)?;
+            stroke.draw_to_cairo(cairo_cx, image_scale)?;
         }
+
         cairo_cx.restore()?;
-        cairo_cx.restore()?;
+
         Ok(())
     }
 }

--- a/crates/rnote-engine/src/pens/selector/mod.rs
+++ b/crates/rnote-engine/src/pens/selector/mod.rs
@@ -6,7 +6,7 @@ use super::penbehaviour::{PenBehaviour, PenProgress};
 use super::pensconfig::selectorconfig::SelectorStyle;
 use super::PenStyle;
 use crate::engine::{EngineView, EngineViewMut, StrokeContent};
-use crate::render::{self, Svg};
+use crate::render::Svg;
 use crate::store::StrokeKey;
 use crate::strokes::Content;
 use crate::{Camera, DrawableOnDoc, RnoteEngine, WidgetFlags};
@@ -181,8 +181,6 @@ impl PenBehaviour for Selector {
                         StrokeContent::MIME_TYPE.to_string(),
                     ));
                     if let Some(stroke_content_svg) = stroke_content_svg {
-                        let stroke_content_svg_bounds = stroke_content_svg.bounds;
-
                         // Add generated Svg
                         clipboard_content.push((
                             stroke_content_svg.svg_data.clone().into_bytes(),
@@ -190,12 +188,9 @@ impl PenBehaviour for Selector {
                         ));
 
                         // Add rendered Png
-                        let image = render::Image::gen_image_from_svg(
-                            stroke_content_svg,
-                            stroke_content_svg_bounds,
-                            RnoteEngine::STROKE_EXPORT_IMAGE_SCALE,
-                        )?
-                        .into_encoded_bytes(image::ImageOutputFormat::Png)?;
+                        let image = stroke_content_svg
+                            .gen_image(RnoteEngine::STROKE_EXPORT_IMAGE_SCALE)?
+                            .into_encoded_bytes(image::ImageOutputFormat::Png)?;
                         clipboard_content.push((image, String::from("image/png")));
                     }
                 }
@@ -244,8 +239,6 @@ impl PenBehaviour for Selector {
                         StrokeContent::MIME_TYPE.to_string(),
                     ));
                     if let Some(stroke_content_svg) = stroke_content_svg {
-                        let stroke_content_svg_bounds = stroke_content_svg.bounds;
-
                         // Add generated Svg
                         clipboard_content.push((
                             stroke_content_svg.svg_data.clone().into_bytes(),
@@ -253,12 +246,9 @@ impl PenBehaviour for Selector {
                         ));
 
                         // Add rendered Png
-                        let image = render::Image::gen_image_from_svg(
-                            stroke_content_svg,
-                            stroke_content_svg_bounds,
-                            RnoteEngine::STROKE_EXPORT_IMAGE_SCALE,
-                        )?
-                        .into_encoded_bytes(image::ImageOutputFormat::Png)?;
+                        let image = stroke_content_svg
+                            .gen_image(RnoteEngine::STROKE_EXPORT_IMAGE_SCALE)?
+                            .into_encoded_bytes(image::ImageOutputFormat::Png)?;
                         clipboard_content.push((image, String::from("image/png")));
                     }
                 }

--- a/crates/rnote-engine/src/render.rs
+++ b/crates/rnote-engine/src/render.rs
@@ -135,7 +135,7 @@ impl Drawable for Image {
     ///
     /// Expects image to be in rgba8-premultiplied format, else drawing will fail.
     ///
-    /// `image_scale` has no meaning here, as the image pixels are already provided
+    /// `image_scale` has no meaning here, because the bitamp is already provided.
     fn draw(&self, cx: &mut impl piet::RenderContext, _image_scale: f64) -> anyhow::Result<()> {
         let piet_image_format = piet::ImageFormat::try_from(self.memory_format)?;
 

--- a/crates/rnote-engine/src/render.rs
+++ b/crates/rnote-engine/src/render.rs
@@ -7,7 +7,7 @@ use image::io::Reader;
 use once_cell::sync::Lazy;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use piet::RenderContext;
-use rnote_compose::ext::{AabbExt, Vector2Ext};
+use rnote_compose::ext::AabbExt;
 use rnote_compose::shapes::{Rectangle, Shapeable};
 use rnote_compose::transform::Transformable;
 use serde::{Deserialize, Serialize};
@@ -115,7 +115,6 @@ impl From<image::DynamicImage> for Image {
         let pixel_height = dynamic_image.height();
         let memory_format = ImageMemoryFormat::R8g8b8a8Premultiplied;
         let data = glib::Bytes::from_owned(dynamic_image.into_rgba8().to_vec());
-
         let bounds = Aabb::new(
             na::point![0.0, 0.0],
             na::point![f64::from(pixel_width), f64::from(pixel_height)],
@@ -138,9 +137,9 @@ impl Drawable for Image {
     ///
     /// `image_scale` has no meaning here, as the image pixels are already provided
     fn draw(&self, cx: &mut impl piet::RenderContext, _image_scale: f64) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         let piet_image_format = piet::ImageFormat::try_from(self.memory_format)?;
 
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         let piet_image = cx
             .make_image(
                 self.pixel_width as usize,
@@ -149,9 +148,7 @@ impl Drawable for Image {
                 piet_image_format,
             )
             .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-
         cx.transform(self.rect.transform.to_kurbo());
-
         cx.draw_image(
             &piet_image,
             self.rect.cuboid.local_aabb().to_kurbo_rect(),
@@ -185,7 +182,7 @@ impl Image {
             || self.data.len() as u32 != 4 * self.pixel_width * self.pixel_height
         {
             Err(anyhow::anyhow!(
-                "assert_image() failed, invalid size or data"
+                "Asserting image validity failed, invalid size or data."
             ))
         } else {
             Ok(())
@@ -215,7 +212,9 @@ impl Image {
         })
     }
 
-    pub fn to_imgbuf(self) -> Result<image::ImageBuffer<image::Rgba<u8>, Vec<u8>>, anyhow::Error> {
+    pub fn into_imgbuf(
+        self,
+    ) -> Result<image::ImageBuffer<image::Rgba<u8>, Vec<u8>>, anyhow::Error> {
         self.assert_valid()?;
 
         match self.memory_format {
@@ -223,9 +222,9 @@ impl Image {
                 image::RgbaImage::from_vec(self.pixel_width, self.pixel_height, self.data.to_vec())
                     .ok_or_else(|| {
                         anyhow::anyhow!(
-                    "RgbaImage::from_vec() failed in Image to_imgbuf() for image with Format {:?}",
-                    self.memory_format
-                )
+                            "RgbaImage::from_vec() failed for image with memory-format {:?}.",
+                            self.memory_format
+                        )
                     })
             }
         }
@@ -239,12 +238,11 @@ impl Image {
         let mut bytes_buf: Cursor<Vec<u8>> = Cursor::new(Vec::new());
 
         let dynamic_image = image::DynamicImage::ImageRgba8(
-            self.to_imgbuf()
-                .context("image.to_imgbuf() failed in image_to_bytes()")?,
+            self.into_imgbuf().context("image.to_imgbuf() failed.")?,
         );
         dynamic_image
             .write_to(&mut bytes_buf, format)
-            .context("dynamic_image.write_to() failed in image_to_bytes()")?;
+            .context("dynamic_image.write_to() failed.")?;
 
         Ok(bytes_buf.into_inner())
     }
@@ -282,105 +280,7 @@ impl Image {
     pub fn images_to_rendernodes<'a>(
         images: impl IntoIterator<Item = &'a Self>,
     ) -> Result<Vec<gsk::RenderNode>, anyhow::Error> {
-        let mut rendernodes = Vec::new();
-
-        for image in images {
-            rendernodes.push(image.to_rendernode()?)
-        }
-
-        Ok(rendernodes)
-    }
-
-    /// Generate an image from an Svg.
-    ///
-    /// Using librsvg for rendering.
-    pub fn gen_image_from_svg(
-        svg: Svg,
-        mut bounds: Aabb,
-        image_scale: f64,
-    ) -> Result<Self, anyhow::Error> {
-        let svg_data = rnote_compose::utils::wrap_svg_root(
-            svg.svg_data.as_str(),
-            Some(bounds),
-            Some(bounds),
-            false,
-        );
-
-        bounds.ensure_positive();
-        bounds = bounds.ceil().loosened(1.0);
-        bounds.assert_valid()?;
-
-        let width_scaled = ((bounds.extents()[0]) * image_scale).round() as u32;
-        let height_scaled = ((bounds.extents()[1]) * image_scale).round() as u32;
-
-        let mut surface = cairo::ImageSurface::create(
-                cairo::Format::ARgb32,
-                width_scaled as i32,
-                height_scaled as i32,
-            )
-            .map_err(|e| {
-                anyhow::anyhow!(
-                    "create ImageSurface with dimensions ({width_scaled}, {height_scaled}) failed in gen_image_from_svg(), Err: {e:?}"
-                )
-            })?;
-
-        // Context in new scope, else accessing the surface data fails with a borrow error
-        {
-            let cx = cairo::Context::new(&surface)
-                .context("new cairo::Context failed in gen_image_from_svg()")?;
-            cx.scale(image_scale, image_scale);
-            cx.translate(-bounds.mins[0], -bounds.mins[1]);
-
-            let stream =
-                gio::MemoryInputStream::from_bytes(&glib::Bytes::from(svg_data.as_bytes()));
-
-            let handle = rsvg::Loader::new()
-                .read_stream::<gio::MemoryInputStream, gio::File, gio::Cancellable>(
-                    &stream, None, None,
-                )
-                .context("read stream to librsvg Loader failed in gen_image_from_svg()")?;
-
-            let renderer = rsvg::CairoRenderer::new(&handle);
-            renderer
-                .render_document(
-                    &cx,
-                    &cairo::Rectangle::new(
-                        bounds.mins[0],
-                        bounds.mins[1],
-                        bounds.extents()[0],
-                        bounds.extents()[1],
-                    ),
-                )
-                .map_err(|e| {
-                    anyhow::Error::msg(format!(
-                        "librsvg render_document() failed in gen_image_from_svg() with Err: {e:?}"
-                    ))
-                })?;
-        }
-        // Surface needs to be flushed before accessing its data
-        surface.flush();
-
-        let data = surface
-            .data()
-            .map_err(|e| {
-                anyhow::Error::msg(format!(
-                    "accessing imagesurface data failed in gen_image_from_svg() with Err: {e:?}"
-                ))
-            })?
-            .to_vec();
-
-        Ok(Self {
-            data: glib::Bytes::from_owned(convert_image_bgra_to_rgba(
-                width_scaled,
-                height_scaled,
-                data,
-            )),
-            rect: Rectangle::from_p2d_aabb(bounds),
-            pixel_width: width_scaled,
-            pixel_height: height_scaled,
-            // cairo renders to bgra8-premultiplied, but we convert it to rgba8-premultiplied
-            memory_format: ImageMemoryFormat::R8g8b8a8Premultiplied,
-        })
+        images.into_iter().map(|img| img.to_rendernode()).collect()
     }
 
     /// Generates an image with a provided closure that draws onto a [cairo::Context].
@@ -393,7 +293,6 @@ impl Image {
         F: FnOnce(&cairo::Context) -> anyhow::Result<()>,
     {
         bounds.ensure_positive();
-        bounds = bounds.ceil().loosened(1.0);
         bounds.assert_valid()?;
 
         let width_scaled = ((bounds.extents()[0]) * image_scale).round() as u32;
@@ -406,7 +305,7 @@ impl Image {
         )
         .map_err(|e| {
             anyhow::anyhow!(
-                "create ImageSurface with dimensions ({}, {}) failed, Err: {e:?}",
+                "creating image surface with dimensions ({}, {}) failed, Err: {e:?}",
                 width_scaled,
                 height_scaled,
             )
@@ -416,18 +315,15 @@ impl Image {
             let cairo_cx = cairo::Context::new(&image_surface)?;
             cairo_cx.scale(image_scale, image_scale);
             cairo_cx.translate(-bounds.mins[0], -bounds.mins[1]);
-
             // Apply the draw function
             draw_func(&cairo_cx)?;
         }
-        // Surface needs to be flushed before accessing its data
+        // surface needs to be flushed before accessing its data
         image_surface.flush();
 
         let data = image_surface
             .data()
-            .map_err(|e| {
-                anyhow::Error::msg(format!("accessing imagesurface data failed, Err: {e:?}"))
-            })?
+            .map_err(|e| anyhow::anyhow!("accessing image surface data failed, Err: {e:?}"))?
             .to_vec();
 
         Ok(Image {
@@ -451,10 +347,8 @@ impl Image {
     {
         let cairo_draw_fn = move |cairo_cx: &cairo::Context| -> anyhow::Result<()> {
             let mut piet_cx = piet_cairo::CairoRenderContext::new(cairo_cx);
-
             // Apply the draw function
             draw_func(&mut piet_cx)?;
-
             piet_cx
                 .finish()
                 .map_err(|e| anyhow::anyhow!("finishing piet context failed, Err: {e:?}"))?;
@@ -503,103 +397,6 @@ impl Svg {
         }
     }
 
-    /// Generate an Svg with piet, using the `piet_cairo` backend and cairo's SvgSurface.
-    ///
-    /// This might be preferable to the `piet_svg` backend, because especially text alignment and sizes can be different with it.
-    pub fn gen_with_piet_cairo_backend<F>(draw_func: F, mut bounds: Aabb) -> anyhow::Result<Self>
-    where
-        F: FnOnce(&mut piet_cairo::CairoRenderContext) -> anyhow::Result<()>,
-    {
-        bounds.ensure_positive();
-        bounds.assert_valid()?;
-
-        let width = bounds.extents()[0];
-        let height = bounds.extents()[1];
-        let svg_stream: Vec<u8> = vec![];
-        let mut svg_surface =
-            cairo::SvgSurface::for_stream(width, height, svg_stream).map_err(|e| {
-                anyhow::anyhow!(
-                    "create SvgSurface with dimensions ({width}, {height}) failed, Err: {e:?}"
-                )
-            })?;
-        svg_surface.set_document_unit(cairo::SvgUnit::Px);
-
-        {
-            let cairo_cx = cairo::Context::new(&svg_surface)?;
-            let mut piet_cx = piet_cairo::CairoRenderContext::new(&cairo_cx);
-
-            // Cairo only draws elements with positive coordinates, so we need to transform them here
-            piet_cx.transform(kurbo::Affine::translate(-bounds.mins.coords.to_kurbo_vec()));
-
-            // Apply the draw function
-            draw_func(&mut piet_cx)?;
-
-            piet_cx.finish().map_err(|e| {
-                anyhow::anyhow!(
-                    "piet_cx.finish() failed in Svg gen_with_piet_cairo_backend() with Err: {e:?}"
-                )
-            })?;
-        }
-
-        let file_content = svg_surface
-            .finish_output_stream()
-            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-
-        let svg_data = rnote_compose::utils::remove_xml_header(
-            String::from_utf8(*file_content.downcast::<Vec<u8>>().map_err(|_e| {
-                anyhow::anyhow!(
-                    "failed to downcast svg surface content in Svg gen_with_piet_cairo_backend()"
-                )
-            })?)?
-            .as_str(),
-        );
-
-        let mut group = svg::node::element::Group::new().add(svg::node::Text::new(svg_data));
-
-        group.assign(
-            "transform",
-            format!("translate({} {})", bounds.mins[0], bounds.mins[1]),
-        );
-
-        Ok(Self {
-            svg_data: rnote_compose::utils::svg_node_to_string(&group)?,
-            bounds,
-        })
-    }
-
-    pub fn draw_to_cairo(&self, cx: &cairo::Context) -> anyhow::Result<()> {
-        let svg_data = rnote_compose::utils::wrap_svg_root(
-            self.svg_data.as_str(),
-            Some(self.bounds),
-            Some(self.bounds),
-            false,
-        );
-
-        let stream = gio::MemoryInputStream::from_bytes(&glib::Bytes::from(svg_data.as_bytes()));
-
-        let handle = rsvg::Loader::new()
-            .read_stream::<gio::MemoryInputStream, gio::File, gio::Cancellable>(&stream, None, None)
-            .context("read stream to librsvg Loader failed")?;
-
-        let renderer = rsvg::CairoRenderer::new(&handle);
-        renderer
-                .render_document(
-                    cx,
-                    &cairo::Rectangle::new(
-                        self.bounds.mins[0],
-                        self.bounds.mins[1],
-                        self.bounds.extents()[0],
-                        self.bounds.extents()[1],
-                    ),
-                )
-                .map_err(|e| {
-                    anyhow::Error::msg(format!(
-                    "librsvg render_document() failed in draw_svgs_to_cairo_context() with Err: {e:?}"
-                ))
-                })?;
-        Ok(())
-    }
-
     /// Simplify the Svg by passing it through [usvg].
     pub fn simplify(&mut self) -> anyhow::Result<()> {
         let xml_options = usvg::XmlOptions {
@@ -627,13 +424,192 @@ impl Svg {
         Ok(())
     }
 
+    /// Generate an Svg through cairo's SvgSurface.
+    pub fn gen_with_cairo<F>(draw_func: F, mut bounds: Aabb) -> anyhow::Result<Self>
+    where
+        F: FnOnce(&cairo::Context) -> anyhow::Result<()>,
+    {
+        bounds.ensure_positive();
+        bounds.assert_valid()?;
+
+        let width = bounds.extents()[0];
+        let height = bounds.extents()[1];
+        let svg_stream: Vec<u8> = vec![];
+        let mut svg_surface =
+            cairo::SvgSurface::for_stream(width, height, svg_stream).map_err(|e| {
+                anyhow::anyhow!(
+                    "create svg surface with dimensions ({width}, {height}) failed, Err: {e:?}"
+                )
+            })?;
+        svg_surface.set_document_unit(cairo::SvgUnit::Px);
+
+        {
+            let cairo_cx = cairo::Context::new(&svg_surface)?;
+            // cairo only draws elements with positive coordinates, so we need to translate the content here
+            cairo_cx.translate(-bounds.mins[0], -bounds.mins[1]);
+            // apply the draw function
+            draw_func(&cairo_cx)?;
+        }
+        // surface needs to be flushed before accessing its data
+        svg_surface.flush();
+
+        let file_content = svg_surface
+            .finish_output_stream()
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
+        let svg_data = rnote_compose::utils::remove_xml_header(
+            String::from_utf8(*file_content.downcast::<Vec<u8>>().map_err(|e| {
+                anyhow::anyhow!("downcasting svg surface content failed, Err: {e:?}")
+            })?)?
+            .as_str(),
+        );
+
+        let mut group = svg::node::element::Group::new().add(svg::node::Text::new(svg_data));
+        // translate the content back to it's original position
+        group.assign(
+            "transform",
+            format!("translate({} {})", bounds.mins[0], bounds.mins[1]),
+        );
+
+        Ok(Self {
+            svg_data: rnote_compose::utils::svg_node_to_string(&group)?,
+            bounds,
+        })
+    }
+
+    /// Generate an Svg with piet, using the `piet_cairo` backend and cairo's SvgSurface.
+    ///
+    /// This might be preferable to the `piet_svg` backend, because especially text alignment and sizes can be different
+    /// with it.
+    pub fn gen_with_piet_cairo_backend<F>(draw_func: F, bounds: Aabb) -> anyhow::Result<Self>
+    where
+        F: FnOnce(&mut piet_cairo::CairoRenderContext) -> anyhow::Result<()>,
+    {
+        Self::gen_with_cairo(
+            |cairo_cx| {
+                let mut piet_cx = piet_cairo::CairoRenderContext::new(cairo_cx);
+                // Apply the draw function
+                draw_func(&mut piet_cx)?;
+                piet_cx
+                    .finish()
+                    .map_err(|e| anyhow::anyhow!("finishing piet context failed, Err: {e:?}"))
+            },
+            bounds,
+        )
+    }
+
+    pub fn draw_to_cairo(&self, cx: &cairo::Context) -> anyhow::Result<()> {
+        let svg_data = rnote_compose::utils::wrap_svg_root(
+            self.svg_data.as_str(),
+            Some(self.bounds),
+            Some(self.bounds),
+            false,
+        );
+        let stream = gio::MemoryInputStream::from_bytes(&glib::Bytes::from(svg_data.as_bytes()));
+        let handle = rsvg::Loader::new()
+            .read_stream::<gio::MemoryInputStream, gio::File, gio::Cancellable>(&stream, None, None)
+            .context("reading stream to librsvg loader failed.")?;
+        let renderer = rsvg::CairoRenderer::new(&handle);
+        renderer
+            .render_document(
+                cx,
+                &cairo::Rectangle::new(
+                    self.bounds.mins[0],
+                    self.bounds.mins[1],
+                    self.bounds.extents()[0],
+                    self.bounds.extents()[1],
+                ),
+            )
+            .map_err(|e| anyhow::anyhow!("rendering librsvg document failed, Err: {e:?}"))?;
+        Ok(())
+    }
+
     #[allow(unused)]
-    pub fn draw_as_caironode(&self) -> Result<gsk::CairoNode, anyhow::Error> {
+    pub fn gen_caironode(&self) -> Result<gsk::CairoNode, anyhow::Error> {
         self.bounds.assert_valid()?;
         let node = gsk::CairoNode::new(&graphene::Rect::from_p2d_aabb(self.bounds));
         let cx = node.draw_context();
         self.draw_to_cairo(&cx)?;
         Ok(node)
+    }
+
+    /// Generate an image from an Svg.
+    ///
+    /// Using librsvg for rendering.
+    pub fn gen_image(&self, image_scale: f64) -> Result<Image, anyhow::Error> {
+        let mut bounds = self.bounds;
+        bounds.ensure_positive();
+        bounds.assert_valid()?;
+
+        let svg_data = rnote_compose::utils::wrap_svg_root(
+            self.svg_data.as_str(),
+            Some(bounds),
+            Some(bounds),
+            false,
+        );
+        let width_scaled = ((bounds.extents()[0]) * image_scale).round() as u32;
+        let height_scaled = ((bounds.extents()[1]) * image_scale).round() as u32;
+
+        let mut surface = cairo::ImageSurface::create(
+                cairo::Format::ARgb32,
+                width_scaled as i32,
+                height_scaled as i32,
+            )
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "creating ImageSurface with dimensions ({width_scaled}, {height_scaled}) failed, Err: {e:?}"
+                )
+            })?;
+
+        // Context in new scope, else accessing the surface data fails with a borrow error
+        {
+            let cx =
+                cairo::Context::new(&surface).context("creating new cairo::Context failed.")?;
+            cx.scale(image_scale, image_scale);
+            cx.translate(-bounds.mins[0], -bounds.mins[1]);
+
+            let stream =
+                gio::MemoryInputStream::from_bytes(&glib::Bytes::from(svg_data.as_bytes()));
+
+            let handle = rsvg::Loader::new()
+                .read_stream::<gio::MemoryInputStream, gio::File, gio::Cancellable>(
+                    &stream, None, None,
+                )
+                .context("read stream to librsvg loader failed.")?;
+
+            let renderer = rsvg::CairoRenderer::new(&handle);
+            renderer
+                .render_document(
+                    &cx,
+                    &cairo::Rectangle::new(
+                        bounds.mins[0],
+                        bounds.mins[1],
+                        bounds.extents()[0],
+                        bounds.extents()[1],
+                    ),
+                )
+                .map_err(|e| anyhow::anyhow!("rendering librsvg document failed, Err: {e:?}"))?;
+        }
+        // Surface needs to be flushed before accessing its data
+        surface.flush();
+
+        let data = surface
+            .data()
+            .map_err(|e| anyhow::anyhow!("accessing imagesurface data failed, Err: {e:?}"))?
+            .to_vec();
+
+        Ok(Image {
+            data: glib::Bytes::from_owned(convert_image_bgra_to_rgba(
+                width_scaled,
+                height_scaled,
+                data,
+            )),
+            rect: Rectangle::from_p2d_aabb(bounds),
+            pixel_width: width_scaled,
+            pixel_height: height_scaled,
+            // cairo renders to bgra8-premultiplied, but we convert it to rgba8-premultiplied
+            memory_format: ImageMemoryFormat::R8g8b8a8Premultiplied,
+        })
     }
 }
 

--- a/crates/rnote-engine/src/store/render_comp.rs
+++ b/crates/rnote-engine/src/store/render_comp.rs
@@ -221,11 +221,11 @@ impl StrokeStore {
                             image_scale,
                             stroke_bounds: stroke.bounds(),
                         }).unwrap_or_else(|e| {
-                            log::error!("tasks_tx.send() UpdateStrokeWithImages failed in regenerate_rendering_for_stroke_threaded() for stroke with key {key:?}, with Err, {e:?}");
+                            log::error!("tasks_tx.send() UpdateStrokeWithImages failed in regenerate_rendering_for_stroke_threaded() for stroke with key {key:?} , Err, {e:?}");
                         });
                     }
                     Err(e) => {
-                        log::debug!("stroke.gen_image() failed in regenerate_rendering_for_stroke_threaded() for stroke with key {key:?}, with Err: {e:?}");
+                        log::debug!("stroke.gen_image() failed in regenerate_rendering_for_stroke_threaded() for stroke with key {key:?} , Err: {e:?}");
                     }
                 },
             );
@@ -317,11 +317,11 @@ impl StrokeStore {
                                 image_scale,
                                 stroke_bounds: stroke.bounds(),
                             }).unwrap_or_else(|e| {
-                                log::error!("tasks_tx.send() UpdateStrokeWithImages failed in regenerate_rendering_in_viewport_threaded(), with Err, {e}");
+                                log::error!("tasks_tx.send() UpdateStrokeWithImages failed in regenerate_rendering_in_viewport_threaded(), , Err, {e}");
                             });
                         }
                         Err(e) => {
-                            log::debug!("stroke.gen_image() failed in regenerate_rendering_in_viewport_threaded(), with Err: {e:?}");
+                            log::debug!("stroke.gen_image() failed in regenerate_rendering_in_viewport_threaded(), , Err: {e:?}");
                         }
                     },
                 );
@@ -526,7 +526,7 @@ impl StrokeStore {
             if let Some(stroke) = self.stroke_components.get(key) {
                 if let Err(e) = stroke.draw(piet_cx, image_scale) {
                     log::error!(
-                        "drawing stroke in draw_strokes_immediate_w_piet() failed with Err: {e:?}"
+                        "drawing stroke in draw_strokes_immediate_w_piet() failed , Err: {e:?}"
                     );
                 }
             }

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -224,7 +224,7 @@ impl StrokeStore {
                         render_comp.rendernodes = rendernodes;
                     }
                     Err(e) => log::error!(
-                        "images_to_rendernode() failed in translate_strokes_images() with Err: {e:?}"
+                        "images_to_rendernode() failed in translate_strokes_images() , Err: {e:?}"
                     ),
                 }
             }
@@ -349,7 +349,7 @@ impl StrokeStore {
                         render_comp.rendernodes = rendernodes;
                     }
                     Err(e) => log::error!(
-                        "images_to_rendernode() failed in rotate_strokes() with Err: {e:?}"
+                        "images_to_rendernode() failed in rotate_strokes() , Err: {e:?}"
                     ),
                 }
             }
@@ -391,7 +391,7 @@ impl StrokeStore {
                         render_comp.rendernodes = rendernodes;
                     }
                     Err(e) => log::error!(
-                        "images_to_rendernode() failed in rotate_strokes() with Err: {e:?}"
+                        "images_to_rendernode() failed in rotate_strokes() , Err: {e:?}"
                     ),
                 }
             }
@@ -503,7 +503,7 @@ impl StrokeStore {
                         render_comp.rendernodes = rendernodes;
                     }
                     Err(e) => log::error!(
-                        "images_to_rendernode() failed in resize_strokes() with Err: {e:?}"
+                        "images_to_rendernode() failed in resize_strokes() , Err: {e:?}"
                     ),
                 }
             }

--- a/crates/rnote-engine/src/strokes/bitmapimage.rs
+++ b/crates/rnote-engine/src/strokes/bitmapimage.rs
@@ -1,16 +1,15 @@
 // Imports
-use super::content::{self, GeneratedContentImages};
+use super::content::{self};
 use super::{Content, Stroke};
 use crate::document::Format;
 use crate::engine::import::{PdfImportPageSpacing, PdfImportPrefs};
 use crate::render;
 use crate::Drawable;
 use anyhow::Context;
-use p2d::bounding_volume::{Aabb, BoundingVolume};
-use piet::RenderContext;
+use p2d::bounding_volume::Aabb;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rnote_compose::color;
-use rnote_compose::ext::{AabbExt, Affine2Ext, Vector2Ext};
+use rnote_compose::ext::{AabbExt, Affine2Ext};
 use rnote_compose::shapes::Rectangle;
 use rnote_compose::shapes::Shapeable;
 use rnote_compose::transform::Transform;
@@ -41,50 +40,6 @@ impl Default for BitmapImage {
 }
 
 impl Content for BitmapImage {
-    fn gen_svg(&self) -> Result<render::Svg, anyhow::Error> {
-        let bounds = self.bounds();
-
-        render::Svg::gen_with_piet_cairo_backend(
-            |cx| {
-                cx.transform(kurbo::Affine::translate(-bounds.mins.coords.to_kurbo_vec()));
-                self.draw(cx, 1.0)
-            },
-            bounds,
-        )
-    }
-
-    fn gen_images(
-        &self,
-        viewport: Aabb,
-        image_scale: f64,
-    ) -> Result<GeneratedContentImages, anyhow::Error> {
-        let bounds = self.bounds();
-
-        if viewport.contains(&bounds) {
-            Ok(GeneratedContentImages::Full(vec![
-                render::Image::gen_with_piet(
-                    |piet_cx| self.draw(piet_cx, image_scale),
-                    bounds,
-                    image_scale,
-                )?,
-            ]))
-        } else if let Some(intersection_bounds) = viewport.intersection(&bounds) {
-            Ok(GeneratedContentImages::Partial {
-                images: vec![render::Image::gen_with_piet(
-                    |piet_cx| self.draw(piet_cx, image_scale),
-                    intersection_bounds,
-                    image_scale,
-                )?],
-                viewport,
-            })
-        } else {
-            Ok(GeneratedContentImages::Partial {
-                images: vec![],
-                viewport,
-            })
-        }
-    }
-
     fn draw_highlight(
         &self,
         cx: &mut impl piet::RenderContext,

--- a/crates/rnote-engine/src/strokes/bitmapimage.rs
+++ b/crates/rnote-engine/src/strokes/bitmapimage.rs
@@ -59,10 +59,9 @@ impl Content for BitmapImage {
 
 impl Drawable for BitmapImage {
     fn draw(&self, cx: &mut impl piet::RenderContext, _image_scale: f64) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
-
         let piet_image_format = piet::ImageFormat::try_from(self.image.memory_format)?;
 
+        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         cx.transform(self.rectangle.transform.affine.to_kurbo());
 
         let piet_image = cx
@@ -73,11 +72,10 @@ impl Drawable for BitmapImage {
                 piet_image_format,
             )
             .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-
         let dest_rect = self.rectangle.cuboid.local_aabb().to_kurbo_rect();
         cx.draw_image(&piet_image, dest_rect, piet::InterpolationMode::Bilinear);
-
         cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
         Ok(())
     }
 }
@@ -107,26 +105,23 @@ impl Transformable for BitmapImage {
 }
 
 impl BitmapImage {
-    pub fn import_from_image_bytes(
+    pub fn from_image_bytes(
         bytes: &[u8],
         pos: na::Vector2<f64>,
         size: Option<na::Vector2<f64>>,
     ) -> Result<Self, anyhow::Error> {
         let image = render::Image::try_from_encoded_bytes(bytes)?;
-
         let size = size.unwrap_or_else(|| {
             na::vector![f64::from(image.pixel_width), f64::from(image.pixel_height)]
         });
-
         let rectangle = Rectangle {
             cuboid: p2d::shape::Cuboid::new(size * 0.5),
             transform: Transform::new_w_isometry(na::Isometry2::new(pos + size * 0.5, 0.0)),
         };
-
         Ok(Self { image, rectangle })
     }
 
-    pub fn import_from_pdf_bytes(
+    pub fn from_pdf_bytes(
         to_be_read: &[u8],
         pdf_import_prefs: PdfImportPrefs,
         insert_pos: na::Vector2<f64>,
@@ -135,7 +130,6 @@ impl BitmapImage {
     ) -> Result<Vec<Self>, anyhow::Error> {
         let doc = poppler::Document::from_bytes(&glib::Bytes::from(to_be_read), None)?;
         let page_range = page_range.unwrap_or(0..doc.n_pages() as u32);
-
         let page_width = format.width * (pdf_import_prefs.page_width_perc / 100.0);
         // calculate the page zoom based on the width of the first page.
         let page_zoom = if let Some(first_page) = doc.page(0) {
@@ -147,73 +141,64 @@ impl BitmapImage {
         let mut y = insert_pos[1];
 
         let pngs = page_range
-            .filter_map(|page_i| {
-                let page = doc.page(page_i as i32)?;
+            .map(|page_i| {
+                let page = doc
+                    .page(page_i as i32)
+                    .ok_or_else(|| anyhow::anyhow!("no page at index '{page_i}"))?;
                 let intrinsic_size = page.size();
                 let width = intrinsic_size.0 * page_zoom;
                 let height = intrinsic_size.1 * page_zoom;
+                let surface_width = (width * pdf_import_prefs.bitmap_scalefactor).round() as i32;
+                let surface_height = (height * pdf_import_prefs.bitmap_scalefactor).round() as i32;
+                let surface = cairo::ImageSurface::create(
+                    cairo::Format::ARgb32,
+                    surface_width,
+                    surface_height,
+                )
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "create image surface while importing bitmapimage failed, {e:?}"
+                    )
+                })?;
 
-                let res =
-                    move || -> anyhow::Result<(Vec<u8>, na::Vector2<f64>, na::Vector2<f64>)> {
-                        let surface_width =
-                            (width * pdf_import_prefs.bitmap_scalefactor).round() as i32;
-                        let surface_height =
-                            (height * pdf_import_prefs.bitmap_scalefactor).round() as i32;
+                {
+                    let cx = cairo::Context::new(&surface).context("new cairo::Context failed")?;
 
-                        let surface = cairo::ImageSurface::create(
-                            cairo::Format::ARgb32,
-                            surface_width,
-                            surface_height,
-                        )
-                        .map_err(|e| {
-                            anyhow::anyhow!(
-                                "create image surface while importing bitmapimage failed, {e:?}"
-                            )
-                        })?;
+                    // Scale with the bitmap scalefactor pref
+                    cx.scale(
+                        page_zoom * pdf_import_prefs.bitmap_scalefactor,
+                        page_zoom * pdf_import_prefs.bitmap_scalefactor,
+                    );
 
-                        {
-                            let cx = cairo::Context::new(&surface)
-                                .context("new cairo::Context failed")?;
+                    // Set margin to white
+                    cx.set_source_rgba(1.0, 1.0, 1.0, 1.0);
+                    cx.paint()?;
 
-                            // Scale with the bitmap scalefactor pref
-                            cx.scale(
-                                page_zoom * pdf_import_prefs.bitmap_scalefactor,
-                                page_zoom * pdf_import_prefs.bitmap_scalefactor,
-                            );
+                    page.render_for_printing(&cx);
 
-                            // Set margin to white
-                            cx.set_source_rgba(1.0, 1.0, 1.0, 1.0);
-                            cx.paint()?;
+                    // Draw outline around page
+                    cx.set_source_rgba(
+                        color::GNOME_REDS[4].as_rgba().0,
+                        color::GNOME_REDS[4].as_rgba().1,
+                        color::GNOME_REDS[4].as_rgba().2,
+                        1.0,
+                    );
 
-                            page.render_for_printing(&cx);
+                    let line_width = 1.0;
+                    cx.set_line_width(line_width);
+                    cx.rectangle(
+                        line_width * 0.5,
+                        line_width * 0.5,
+                        intrinsic_size.0 - line_width,
+                        intrinsic_size.1 - line_width,
+                    );
+                    cx.stroke()?;
+                }
 
-                            // Draw outline around page
-                            cx.set_source_rgba(
-                                color::GNOME_REDS[4].as_rgba().0,
-                                color::GNOME_REDS[4].as_rgba().1,
-                                color::GNOME_REDS[4].as_rgba().2,
-                                1.0,
-                            );
-
-                            let line_width = 1.0;
-                            cx.set_line_width(line_width);
-                            cx.rectangle(
-                                line_width * 0.5,
-                                line_width * 0.5,
-                                intrinsic_size.0 - line_width,
-                                intrinsic_size.1 - line_width,
-                            );
-                            cx.stroke()?;
-                        }
-
-                        let mut png_data: Vec<u8> = Vec::new();
-                        surface.write_to_png(&mut png_data)?;
-
-                        let image_pos = na::vector![x, y];
-                        let image_size = na::vector![width, height];
-
-                        Ok((png_data, image_pos, image_size))
-                    };
+                let mut png_data: Vec<u8> = Vec::new();
+                surface.write_to_png(&mut png_data)?;
+                let image_pos = na::vector![x, y];
+                let image_size = na::vector![width, height];
 
                 y += match pdf_import_prefs.page_spacing {
                     PdfImportPageSpacing::Continuous => {
@@ -222,31 +207,12 @@ impl BitmapImage {
                     PdfImportPageSpacing::OnePerDocumentPage => format.height,
                 };
 
-                match res() {
-                    Ok(ret) => Some(ret),
-                    Err(e) => {
-                        log::error!("bitmapimage import_from_pdf_bytes() failed with Err: {e:?}");
-                        None
-                    }
-                }
+                Ok((png_data, image_pos, image_size))
             })
-            .collect::<Vec<(Vec<u8>, na::Vector2<f64>, na::Vector2<f64>)>>();
+            .collect::<anyhow::Result<Vec<(Vec<u8>, na::Vector2<f64>, na::Vector2<f64>)>>>()?;
 
-        Ok(pngs
-            .into_par_iter()
-            .filter_map(|(png_data, pos, size)| {
-                match Self::import_from_image_bytes(
-                    &png_data,
-                    pos,
-                    Some(size),
-                ) {
-                    Ok(bitmapimage) => Some(bitmapimage),
-                    Err(e) => {
-                        log::error!("import_from_image_bytes() failed in bitmapimage import_from_pdf_bytes() with Err: {e:?}");
-                        None
-                    }
-                }
-            })
-            .collect())
+        pngs.into_par_iter()
+            .map(|(png_data, pos, size)| Self::from_image_bytes(&png_data, pos, Some(size)))
+            .collect()
     }
 }

--- a/crates/rnote-engine/src/strokes/brushstroke.rs
+++ b/crates/rnote-engine/src/strokes/brushstroke.rs
@@ -7,8 +7,7 @@ use crate::{
     strokes::content,
 };
 use p2d::bounding_volume::{Aabb, BoundingVolume};
-use piet::RenderContext;
-use rnote_compose::ext::{AabbExt, Vector2Ext};
+use rnote_compose::ext::AabbExt;
 use rnote_compose::penpath::{Element, Segment};
 use rnote_compose::shapes::Shapeable;
 use rnote_compose::style::Composer;
@@ -29,18 +28,6 @@ pub struct BrushStroke {
 }
 
 impl Content for BrushStroke {
-    fn gen_svg(&self) -> Result<render::Svg, anyhow::Error> {
-        let bounds = self.bounds();
-
-        render::Svg::gen_with_piet_cairo_backend(
-            |cx| {
-                cx.transform(kurbo::Affine::translate(-bounds.mins.coords.to_kurbo_vec()));
-                self.draw(cx, 1.0)
-            },
-            bounds,
-        )
-    }
-
     fn gen_images(
         &self,
         viewport: Aabb,
@@ -63,12 +50,11 @@ impl Content for BrushStroke {
         let image_size_condition = bounds_extents[0] < IMAGES_SIZE_THRESHOLD / image_scale
             && bounds_extents[1] < IMAGES_SIZE_THRESHOLD / image_scale;
 
-        //
         let stroke_width_condition = self.style.stroke_width()
             > IMAGES_STROKE_WIDTH_BOUNDS_THRESHOLD * bounds_extents[0]
             || self.style.stroke_width() > IMAGES_STROKE_WIDTH_BOUNDS_THRESHOLD * bounds_extents[1];
 
-        // if these conditions evaluate true the stroke is rendered as a single imaeg
+        // if these conditions evaluate true the stroke is rendered as a single image
         let images = if image_size_condition || stroke_width_condition {
             // generate a single image when bounds are smaller than threshold
             match &self.style {

--- a/crates/rnote-engine/src/strokes/brushstroke.rs
+++ b/crates/rnote-engine/src/strokes/brushstroke.rs
@@ -71,7 +71,7 @@ impl Content for BrushStroke {
                     match image {
                         Ok(image) => vec![image],
                         Err(e) => {
-                            log::error!("gen_images() in brushstroke failed with Err: {e:?}");
+                            log::error!("gen_images() in brushstroke failed , Err: {e:?}");
                             vec![]
                         }
                     }
@@ -93,7 +93,7 @@ impl Content for BrushStroke {
                     match image {
                         Ok(image) => vec![image],
                         Err(e) => {
-                            log::error!("gen_images() in brushstroke failed with Err: {e:?}");
+                            log::error!("gen_images() in brushstroke failed , Err: {e:?}");
                             vec![]
                         }
                     }
@@ -118,7 +118,7 @@ impl Content for BrushStroke {
                         ) {
                             Ok(image) => images.push(image),
                             Err(e) => {
-                                log::error!("gen_images() in brushstroke failed with Err: {e:?}")
+                                log::error!("gen_images() in brushstroke failed , Err: {e:?}")
                             }
                         }
 
@@ -149,7 +149,7 @@ impl Content for BrushStroke {
                         ) {
                             Ok(image) => images.push(image),
                             Err(e) => {
-                                log::error!("gen_images() in brushstroke failed with Err: {e:?}")
+                                log::error!("gen_images() in brushstroke failed , Err: {e:?}")
                             }
                         }
 

--- a/crates/rnote-engine/src/strokes/content.rs
+++ b/crates/rnote-engine/src/strokes/content.rs
@@ -1,6 +1,5 @@
 // Imports
-use crate::render;
-use crate::Drawable;
+use crate::{render, Drawable};
 use once_cell::sync::Lazy;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use rnote_compose::{color, shapes::Shapeable};
@@ -27,13 +26,15 @@ pub trait Content: Drawable + Shapeable
 where
     Self: Sized,
 {
-    /// Generate Svg, without the xml header or the svg root. Used for export.
+    /// Generate Svg from the content, without the Xml header or the Svg root.
+    ///
+    /// Used for exporting.
     fn gen_svg(&self) -> Result<render::Svg, anyhow::Error> {
         let bounds = self.bounds();
         render::Svg::gen_with_cairo(|cx| self.draw_to_cairo(cx, 1.0), bounds)
     }
 
-    /// Generates bitmap images.
+    /// Generate bitmap images for rendering in the app.
     ///
     /// A larger `image_scale` value renders them in a higher than native resolution (usually set as the camera zoom).
     /// The bounds are not scaled by it.
@@ -70,6 +71,7 @@ where
     }
 
     /// Draw it's highlight.
+    ///
     /// The implementors are expected to save/restore the drawing context.
     ///
     /// `total_zoom` is the zoom-factor of the surface that draws the highlight.
@@ -84,7 +86,7 @@ where
     /// Must be called after the stroke has been (geometrically) modified or transformed.
     fn update_geometry(&mut self);
 
-    /// Export to encoded bitmap image (Png/Jpg/..).
+    /// Export to encoded bitmap image (Png/Jpeg/..).
     fn export_to_bitmap_image_bytes(
         &self,
         format: image::ImageOutputFormat,

--- a/crates/rnote-engine/src/strokes/shapestroke.rs
+++ b/crates/rnote-engine/src/strokes/shapestroke.rs
@@ -1,10 +1,8 @@
 // Imports
-use super::content::GeneratedContentImages;
 use super::Content;
-use crate::{render, strokes::content, Drawable};
+use crate::{strokes::content, Drawable};
 use p2d::bounding_volume::{Aabb, BoundingVolume};
-use piet::RenderContext;
-use rnote_compose::ext::{AabbExt, Vector2Ext};
+use rnote_compose::ext::AabbExt;
 use rnote_compose::shapes::Shape;
 use rnote_compose::shapes::Shapeable;
 use rnote_compose::style::Composer;
@@ -25,50 +23,6 @@ pub struct ShapeStroke {
 }
 
 impl Content for ShapeStroke {
-    fn gen_svg(&self) -> Result<crate::render::Svg, anyhow::Error> {
-        let bounds = self.bounds();
-
-        render::Svg::gen_with_piet_cairo_backend(
-            |cx| {
-                cx.transform(kurbo::Affine::translate(-bounds.mins.coords.to_kurbo_vec()));
-                self.draw(cx, 1.0)
-            },
-            bounds,
-        )
-    }
-
-    fn gen_images(
-        &self,
-        viewport: Aabb,
-        image_scale: f64,
-    ) -> Result<GeneratedContentImages, anyhow::Error> {
-        let bounds = self.bounds();
-
-        if viewport.contains(&bounds) {
-            Ok(GeneratedContentImages::Full(vec![
-                render::Image::gen_with_piet(
-                    |piet_cx| self.draw(piet_cx, image_scale),
-                    bounds,
-                    image_scale,
-                )?,
-            ]))
-        } else if let Some(intersection_bounds) = viewport.intersection(&bounds) {
-            Ok(GeneratedContentImages::Partial {
-                images: vec![render::Image::gen_with_piet(
-                    |piet_cx| self.draw(piet_cx, image_scale),
-                    intersection_bounds,
-                    image_scale,
-                )?],
-                viewport,
-            })
-        } else {
-            Ok(GeneratedContentImages::Partial {
-                images: vec![],
-                viewport,
-            })
-        }
-    }
-
     fn draw_highlight(
         &self,
         cx: &mut impl piet::RenderContext,

--- a/crates/rnote-engine/src/strokes/stroke.rs
+++ b/crates/rnote-engine/src/strokes/stroke.rs
@@ -95,6 +95,16 @@ impl Drawable for Stroke {
             Stroke::BitmapImage(bitmapimage) => bitmapimage.draw(cx, image_scale),
         }
     }
+
+    fn draw_to_cairo(&self, cx: &cairo::Context, image_scale: f64) -> anyhow::Result<()> {
+        match self {
+            Stroke::BrushStroke(brushstroke) => brushstroke.draw_to_cairo(cx, image_scale),
+            Stroke::ShapeStroke(shapestroke) => shapestroke.draw_to_cairo(cx, image_scale),
+            Stroke::TextStroke(textstroke) => textstroke.draw_to_cairo(cx, image_scale),
+            Stroke::VectorImage(vectorimage) => vectorimage.draw_to_cairo(cx, image_scale),
+            Stroke::BitmapImage(bitmapimage) => bitmapimage.draw_to_cairo(cx, image_scale),
+        }
+    }
 }
 
 impl Shapeable for Stroke {
@@ -389,7 +399,7 @@ impl Stroke {
                 ))
             }
             Stroke::ShapeStroke(shapestroke) => {
-                let png_data = match shapestroke.export_as_bitmapimage_bytes(
+                let png_data = match shapestroke.export_to_bitmap_image_bytes(
                     image::ImageOutputFormat::Png,
                     RnoteEngine::STROKE_EXPORT_IMAGE_SCALE,
                 ) {
@@ -430,7 +440,7 @@ impl Stroke {
             Stroke::TextStroke(textstroke) => {
                 // Xournal++ text strokes do not support affine transformations, so we have to convert on best effort here.
                 // The best solution for now seems to be to export them as a bitmap image.
-                let png_data = match textstroke.export_as_bitmapimage_bytes(
+                let png_data = match textstroke.export_to_bitmap_image_bytes(
                     image::ImageOutputFormat::Png,
                     RnoteEngine::STROKE_EXPORT_IMAGE_SCALE,
                 ) {
@@ -469,7 +479,7 @@ impl Stroke {
                 ))
             }
             Stroke::VectorImage(vectorimage) => {
-                let png_data = match vectorimage.export_as_bitmapimage_bytes(
+                let png_data = match vectorimage.export_to_bitmap_image_bytes(
                     image::ImageOutputFormat::Png,
                     RnoteEngine::STROKE_EXPORT_IMAGE_SCALE,
                 ) {
@@ -508,7 +518,7 @@ impl Stroke {
                 ))
             }
             Stroke::BitmapImage(bitmapimage) => {
-                let png_data = match bitmapimage.export_as_bitmapimage_bytes(
+                let png_data = match bitmapimage.export_to_bitmap_image_bytes(
                     image::ImageOutputFormat::Png,
                     RnoteEngine::STROKE_EXPORT_IMAGE_SCALE,
                 ) {

--- a/crates/rnote-engine/src/strokes/stroke.rs
+++ b/crates/rnote-engine/src/strokes/stroke.rs
@@ -405,7 +405,7 @@ impl Stroke {
                 ) {
                     Ok(image_bytes) => image_bytes,
                     Err(e) => {
-                        log::error!("export_as_bytes() failed for shapestroke in stroke to_xopp() with Err: {e:?}");
+                        log::error!("export_as_bytes() failed for shapestroke in stroke to_xopp() , Err: {e:?}");
                         return None;
                     }
                 };
@@ -446,7 +446,7 @@ impl Stroke {
                 ) {
                     Ok(image_bytes) => image_bytes,
                     Err(e) => {
-                        log::error!("export_as_bytes() failed for vectorimage in stroke to_xopp() with Err: {e:?}");
+                        log::error!("export_as_bytes() failed for vectorimage in stroke to_xopp() , Err: {e:?}");
                         return None;
                     }
                 };
@@ -485,7 +485,7 @@ impl Stroke {
                 ) {
                     Ok(image_bytes) => image_bytes,
                     Err(e) => {
-                        log::error!("export_as_bytes() failed for vectorimage in stroke to_xopp() with Err: {e:?}");
+                        log::error!("export_as_bytes() failed for vectorimage in stroke to_xopp() , Err: {e:?}");
                         return None;
                     }
                 };
@@ -524,7 +524,7 @@ impl Stroke {
                 ) {
                     Ok(image_bytes) => image_bytes,
                     Err(e) => {
-                        log::error!("export_as_bytes() failed for bitmapimage in stroke to_xopp() with Err: {e:?}");
+                        log::error!("export_as_bytes() failed for bitmapimage in stroke to_xopp() , Err: {e:?}");
                         return None;
                     }
                 };

--- a/crates/rnote-engine/src/strokes/textstroke.rs
+++ b/crates/rnote-engine/src/strokes/textstroke.rs
@@ -1,10 +1,9 @@
 // Imports
-use super::content::GeneratedContentImages;
 use super::Content;
-use crate::{render, strokes::content, Camera, Drawable};
+use crate::{strokes::content, Camera, Drawable};
 use kurbo::Shape;
 use once_cell::sync::Lazy;
-use p2d::bounding_volume::{Aabb, BoundingVolume};
+use p2d::bounding_volume::Aabb;
 use piet::{RenderContext, TextLayout, TextLayoutBuilder};
 use rnote_compose::ext::{AabbExt, Affine2Ext, Vector2Ext};
 use rnote_compose::shapes::Shapeable;
@@ -484,51 +483,6 @@ impl Shapeable for TextStroke {
 }
 
 impl Content for TextStroke {
-    fn gen_svg(&self) -> Result<render::Svg, anyhow::Error> {
-        let bounds = self.bounds();
-
-        // We need to generate the svg with the cairo backend, because text layout would differ with the svg backend
-        render::Svg::gen_with_piet_cairo_backend(
-            |cx| {
-                cx.transform(kurbo::Affine::translate(-bounds.mins.coords.to_kurbo_vec()));
-                self.draw(cx, 1.0)
-            },
-            bounds,
-        )
-    }
-
-    fn gen_images(
-        &self,
-        viewport: Aabb,
-        image_scale: f64,
-    ) -> Result<GeneratedContentImages, anyhow::Error> {
-        let bounds = self.bounds();
-
-        if viewport.contains(&bounds) {
-            Ok(GeneratedContentImages::Full(vec![
-                render::Image::gen_with_piet(
-                    |piet_cx| self.draw(piet_cx, image_scale),
-                    bounds,
-                    image_scale,
-                )?,
-            ]))
-        } else if let Some(intersection_bounds) = viewport.intersection(&bounds) {
-            Ok(GeneratedContentImages::Partial {
-                images: vec![render::Image::gen_with_piet(
-                    |piet_cx| self.draw(piet_cx, image_scale),
-                    intersection_bounds,
-                    image_scale,
-                )?],
-                viewport,
-            })
-        } else {
-            Ok(GeneratedContentImages::Partial {
-                images: vec![],
-                viewport,
-            })
-        }
-    }
-
     fn draw_highlight(
         &self,
         cx: &mut impl piet::RenderContext,

--- a/crates/rnote-engine/src/strokes/vectorimage.rs
+++ b/crates/rnote-engine/src/strokes/vectorimage.rs
@@ -112,14 +112,14 @@ impl Content for VectorImage {
 // ensure to export an actual Svg when calling gen_svg(), but are also able to draw to piet.
 impl Drawable for VectorImage {
     fn draw(&self, cx: &mut impl piet::RenderContext, image_scale: f64) -> anyhow::Result<()> {
-        cx.save().map_err(|e| anyhow::anyhow!("{e:?}"))?;
-
         let image = self.gen_svg()?.gen_image(image_scale)?;
         // image_scale does not have a meaning here
         image.draw(cx, image_scale)?;
-
-        cx.restore().map_err(|e| anyhow::anyhow!("{e:?}"))?;
         Ok(())
+    }
+
+    fn draw_to_cairo(&self, cx: &cairo::Context, _image_scale: f64) -> anyhow::Result<()> {
+        self.gen_svg()?.draw_to_cairo(cx)
     }
 }
 

--- a/crates/rnote-engine/src/strokes/vectorimage.rs
+++ b/crates/rnote-engine/src/strokes/vectorimage.rs
@@ -56,20 +56,17 @@ impl Content for VectorImage {
             )
             .set("preserveAspectRatio", "none")
             .add(svg::node::Text::new(self.svg_data.clone()));
-
         let group = svg::node::element::Group::new()
             .set(
                 "transform",
                 self.rectangle.transform.to_svg_transform_attr_str(),
             )
             .add(svg_root);
-
         let svg_data = rnote_compose::utils::svg_node_to_string(&group)?;
         let svg = render::Svg {
             bounds: self.rectangle.bounds(),
             svg_data,
         };
-
         Ok(svg)
     }
 
@@ -79,7 +76,6 @@ impl Content for VectorImage {
         image_scale: f64,
     ) -> Result<GeneratedContentImages, anyhow::Error> {
         let bounds = self.bounds();
-
         // always generate full stroke images for vectorimages, they are too expensive to be repeatedly rendered
         Ok(GeneratedContentImages::Full(vec![
             render::Image::gen_with_piet(
@@ -107,15 +103,15 @@ impl Content for VectorImage {
     fn update_geometry(&mut self) {}
 }
 
-// Because it is currently not possible to render SVGs directly with piet, we need to overwrite the gen_svg() default
-// implementation and call it in draw(). There the librsvg renderer is used to generate bitmap images. This way we
-// ensure to export an actual Svg when calling gen_svg(), but are also able to draw to piet.
+// Because it is currently not possible to render SVGs directly with piet, the default gen_svg() implementation is
+// overwritten and called in `draw()` and `draw_to_cairo()`. There the librsvg renderer is used to generate bitmap
+// images. This way it is ensured that an actual Svg is generated when calling `gen_svg()`, but it is also possible to
+// to be drawn to piet.
 impl Drawable for VectorImage {
     fn draw(&self, cx: &mut impl piet::RenderContext, image_scale: f64) -> anyhow::Result<()> {
         let image = self.gen_svg()?.gen_image(image_scale)?;
         // image_scale does not have a meaning here
-        image.draw(cx, image_scale)?;
-        Ok(())
+        image.draw(cx, image_scale)
     }
 
     fn draw_to_cairo(&self, cx: &cairo::Context, _image_scale: f64) -> anyhow::Result<()> {

--- a/crates/rnote-ui/src/appwindow/appwindowactions.rs
+++ b/crates/rnote-ui/src/appwindow/appwindowactions.rs
@@ -670,7 +670,7 @@ impl RnAppWindow {
 
             // Run the print op
             if let Err(e) = print_op.run(PrintOperationAction::PrintDialog, Some(&appwindow)){
-                log::error!("running print operation failed with Err, {e:?}");
+                log::error!("running print operation failed , Err, {e:?}");
                 appwindow.overlays().dispatch_toast_error(&gettext("Printing document failed"));
                 appwindow.overlays().progressbar_abort();
             } else {
@@ -801,7 +801,7 @@ impl RnAppWindow {
                         }
                         Ok(None) => {}
                         Err(e) => {
-                            log::error!("failed to paste clipboard from path, read_text() failed with Err: {e:?}");
+                            log::error!("failed to paste clipboard from path, read_text() failed , Err: {e:?}");
 
                         }
                     }
@@ -841,7 +841,7 @@ impl RnAppWindow {
                             }
                         }
                         Err(e) => {
-                            log::error!("failed to paste clipboard as {}, read_future() failed with Err: {e:?}", StrokeContent::MIME_TYPE);
+                            log::error!("failed to paste clipboard as {}, read_future() failed , Err: {e:?}", StrokeContent::MIME_TYPE);
                         }
                     };
                 }));
@@ -879,7 +879,7 @@ impl RnAppWindow {
                             }
                         }
                         Err(e) => {
-                            log::error!("failed to paste clipboard as vector image, read_future() failed with Err: {e:?}");
+                            log::error!("failed to paste clipboard as vector image, read_future() failed , Err: {e:?}");
                         }
                     };
                 }));
@@ -906,7 +906,7 @@ impl RnAppWindow {
                             }
                             Ok(None) => {}
                             Err(e) => {
-                                log::error!("failed to paste clipboard as {mime_type}, read_texture_future() failed with Err: {e:?}");
+                                log::error!("failed to paste clipboard as {mime_type}, read_texture_future() failed , Err: {e:?}");
                             }
                         };
                     }));
@@ -922,7 +922,7 @@ impl RnAppWindow {
                         }
                         Ok(None) => {}
                         Err(e) => {
-                            log::error!("failed to paste clipboard text, read_text() failed with Err: {e:?}");
+                            log::error!("failed to paste clipboard text, read_text() failed , Err: {e:?}");
 
                         }
                     }

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -162,7 +162,7 @@ impl RnAppWindow {
             glib::source::timeout_add_seconds_local(
                 Self::PERIODIC_CONFIGSAVE_INTERVAL, clone!(@weak self as appwindow => @default-return glib::source::Continue(false), move || {
                     if let Err(e) = appwindow.active_tab_wrapper().canvas().save_engine_config(&appwindow.app_settings()) {
-                        log::error!("saving engine config in periodic task failed with Err: {e:?}");
+                        log::error!("saving engine config in periodic task failed , Err: {e:?}");
                     }
 
                     glib::source::Continue(true)
@@ -182,7 +182,7 @@ impl RnAppWindow {
     pub(crate) fn close_force(&self) {
         // Saving all state
         if let Err(e) = self.save_to_settings() {
-            log::error!("Failed to save appwindow to settings, with Err: {e:?}");
+            log::error!("Failed to save appwindow to settings, , Err: {e:?}");
         }
 
         // Closing the state tasks channel receiver for all tabs

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -436,7 +436,7 @@ mod imp {
                 snapshot.pop();
                 Ok(())
             }() {
-                log::error!("canvas snapshot() failed with Err: {e:?}");
+                log::error!("canvas snapshot() failed , Err: {e:?}");
             }
         }
     }
@@ -788,17 +788,16 @@ impl RnCanvas {
     }
 
     pub(crate) fn create_output_file_monitor(&self, file: &gio::File, appwindow: &RnAppWindow) {
-        let new_monitor =
-            match file.monitor_file(gio::FileMonitorFlags::WATCH_MOVES, gio::Cancellable::NONE) {
-                Ok(output_file_monitor) => output_file_monitor,
-                Err(e) => {
-                    self.clear_output_file_monitor();
-                    log::error!(
-                        "creating a file monitor for the new output file failed with Err: {e:?}"
-                    );
-                    return;
-                }
-            };
+        let new_monitor = match file
+            .monitor_file(gio::FileMonitorFlags::WATCH_MOVES, gio::Cancellable::NONE)
+        {
+            Ok(output_file_monitor) => output_file_monitor,
+            Err(e) => {
+                self.clear_output_file_monitor();
+                log::error!("creating a file monitor for the new output file failed , Err: {e:?}");
+                return;
+            }
+        };
 
         let new_handler = new_monitor.connect_changed(
             glib::clone!(@weak self as canvas, @weak appwindow => move |_monitor, file, other_file, event| {

--- a/crates/rnote-ui/src/workspacebrowser/filerow/actions/rename.rs
+++ b/crates/rnote-ui/src/workspacebrowser/filerow/actions/rename.rs
@@ -88,7 +88,7 @@ fn connect_apply_button(
             log::error!("file already exists");
         } else {
             if let Err(e) = current_file.move_(&new_file, gio::FileCopyFlags::NONE, None::<&gio::Cancellable>, None) {
-                log::error!("rename file failed with Err: {e:?}");
+                log::error!("rename file failed , Err: {e:?}");
             }
 
             popover.popdown();

--- a/crates/rnote-ui/src/workspacebrowser/filerow/actions/trash.rs
+++ b/crates/rnote-ui/src/workspacebrowser/filerow/actions/trash.rs
@@ -9,7 +9,7 @@ pub(crate) fn trash(filerow: &RnFileRow) -> gio::SimpleAction {
         if let Some(current_file) = filerow.current_file() {
             current_file.trash_async(glib::PRIORITY_DEFAULT, None::<&gio::Cancellable>, clone!(@weak filerow, @weak current_file => move |res| {
                 if let Err(e) = res {
-                    log::error!("filerow trash file failed with Err: {e:?}");
+                    log::error!("filerow trash file failed , Err: {e:?}");
                 } else {
                     filerow.set_current_file(None);
                 }

--- a/crates/rnote-ui/src/workspacebrowser/workspacesbar/mod.rs
+++ b/crates/rnote-ui/src/workspacebrowser/workspacesbar/mod.rs
@@ -257,14 +257,14 @@ impl RnWorkspacesBar {
 
     pub(crate) fn save_to_settings(&self, settings: &gio::Settings) {
         if let Err(e) = settings.set("workspace-list", self.imp().workspace_list.to_variant()) {
-            log::error!("saving `workspace-list` to settings failed with Err: {e:?}");
+            log::error!("saving `workspace-list` to settings failed , Err: {e:?}");
         }
 
         if let Err(e) = settings.set(
             "selected-workspace-index",
             self.selected_workspace_index().unwrap_or(0),
         ) {
-            log::error!("saving `selected-workspace-index` to settings failed with Err: {e:?}");
+            log::error!("saving `selected-workspace-index` to settings failed , Err: {e:?}");
         }
     }
 


### PR DESCRIPTION
This PR restores the vectorized vector-image export.