### PR TITLE
engine `ui`, `cli` features, making `gtk4` dep optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3391,6 +3391,7 @@ dependencies = [
  "flate2",
  "futures",
  "geo",
+ "gio",
  "glib",
  "gtk4",
  "ijson",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,7 +3339,6 @@ dependencies = [
  "atty",
  "clap",
  "dialoguer",
- "gtk4",
  "indicatif",
  "log",
  "nalgebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/flxzt/rnote"
 
 [workspace.dependencies]
 rnote-compose = { version="0.7.1", path = "crates/rnote-compose" }
-rnote-engine = { version="0.7.1", path = "crates/rnote-engine", default-features = false }
+rnote-engine = { version="0.7.1", path = "crates/rnote-engine" }
 
 log = "0.4"
 pretty_env_logger = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/flxzt/rnote"
 
 [workspace.dependencies]
 rnote-compose = { version="0.7.1", path = "crates/rnote-compose" }
-rnote-engine = { version="0.7.1", path = "crates/rnote-engine" }
+rnote-engine = { version="0.7.1", path = "crates/rnote-engine", default-features = false }
 
 log = "0.4"
 pretty_env_logger = "0.5"
@@ -62,13 +62,14 @@ piet-cairo = "0.6"
 roughr = "0.6"
 rough_piet = "0.6"
 palette = "0.7.2"
-rodio = { version = "0.17", default-features=false, features = ["symphonia-wav"] }
+rodio = { version = "0.17", default-features = false, features = ["symphonia-wav"] }
 winresource = "0.1"
 smol = "1"
 clap = { version = "4", features = ["derive"] }
 indicatif = "0.17"
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
 glib = "0.18.1"
+gio = "0.18.1"
 cairo-rs = { version = "0.18", features = ["png", "svg", "pdf"] }
 librsvg = { git = "https://gitlab.gnome.org/GNOME/librsvg", rev = "58c52b742d7623b9a4e94975fb65cbf4a9ff13f1" }
 # newest poppler feature ("v21_12") is causing linking errors when building in mingw for some reason.

--- a/crates/rnote-cli/Cargo.toml
+++ b/crates/rnote-cli/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 
 [dependencies]
 rnote-compose = { workspace = true, features = ["clap-derive"] }
-rnote-engine = { workspace = true, features = ["clap-derive"] }
+rnote-engine = { workspace = true, features = ["cli"] }
 
 log = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/rnote-cli/Cargo.toml
+++ b/crates/rnote-cli/Cargo.toml
@@ -21,5 +21,4 @@ dialoguer = { workspace = true }
 open = { workspace = true }
 nalgebra = { workspace = true }
 parry2d-f64 = { workspace = true }
-gtk4 = { workspace = true }
 atty = { workspace = true }

--- a/crates/rnote-cli/src/export.rs
+++ b/crates/rnote-cli/src/export.rs
@@ -22,7 +22,6 @@ pub(crate) async fn run_export(
     open: bool,
     export_command: cli::ExportCommand,
 ) -> anyhow::Result<()> {
-    gtk4::init()?;
     if rnote_files.is_empty() {
         return Err(anyhow::anyhow!(
             "There must be at least one rnote file specified for exporting."

--- a/crates/rnote-cli/src/import.rs
+++ b/crates/rnote-cli/src/import.rs
@@ -9,7 +9,6 @@ pub(crate) async fn run_import(
     input_file: &Path,
     xopp_dpi: f64,
 ) -> anyhow::Result<()> {
-    gtk4::init()?;
     validators::file_has_ext(rnote_file, "rnote")?;
     // Xopp files don't require file extensions
     validators::path_is_file(input_file)?;

--- a/crates/rnote-engine/Cargo.toml
+++ b/crates/rnote-engine/Cargo.toml
@@ -61,6 +61,6 @@ clap = { workspace = true, optional = true }
 approx = { workspace = true }
 
 [features]
-default = ["cli"]
+default = []
 cli = ["dep:clap"]
 ui = ["dep:gtk4"]

--- a/crates/rnote-engine/Cargo.toml
+++ b/crates/rnote-engine/Cargo.toml
@@ -49,15 +49,18 @@ roughr = { workspace = true }
 rough_piet = { workspace = true }
 rodio = { workspace = true }
 glib = { workspace = true }
+gio = { workspace = true }
 cairo-rs = { workspace = true }
 librsvg = { workspace = true }
 poppler-rs = { workspace = true }
 # the long-term plan is to remove the gtk4 dependency entirely after switching to another renderer.
-gtk4 = { workspace = true }
+gtk4 = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 
 [dev-dependencies]
 approx = { workspace = true }
 
 [features]
-clap-derive = [ "dep:clap" ]
+default = ["cli"]
+cli = ["dep:clap"]
+ui = ["dep:gtk4"]

--- a/crates/rnote-engine/src/camera.rs
+++ b/crates/rnote-engine/src/camera.rs
@@ -3,7 +3,6 @@ use crate::document::Layout;
 use crate::engine::{EngineTask, EngineTaskSender};
 use crate::tasks::{OneOffTaskError, OneOffTaskHandle};
 use crate::{Document, WidgetFlags};
-use gtk4::{graphene, gsk};
 use p2d::bounding_volume::Aabb;
 use rnote_compose::ext::AabbExt;
 use serde::{Deserialize, Serialize};
@@ -272,11 +271,12 @@ impl Camera {
     /// GTKs transformations are applied on its coordinate system,
     /// so we need to reverse the transformation order (translate, then scale).
     /// To get the inverse, call .invert().
-    pub fn transform_for_gtk_snapshot(&self) -> gsk::Transform {
+    #[cfg(feature = "ui")]
+    pub fn transform_for_gtk_snapshot(&self) -> gtk4::gsk::Transform {
         let total_zoom = self.total_zoom();
 
-        gsk::Transform::new()
-            .translate(&graphene::Point::new(
+        gtk4::gsk::Transform::new()
+            .translate(&gtk4::graphene::Point::new(
                 -self.offset[0] as f32,
                 -self.offset[1] as f32,
             ))

--- a/crates/rnote-engine/src/drawable.rs
+++ b/crates/rnote-engine/src/drawable.rs
@@ -1,10 +1,7 @@
 // Imports
 use crate::engine::EngineView;
-use crate::ext::GrapheneRectExt;
-use gtk4::{graphene, prelude::*};
 use p2d::bounding_volume::Aabb;
 use piet::RenderContext;
-use rnote_compose::ext::{AabbExt, Affine2Ext};
 
 /// Trait for types that can draw themselves on a [piet::RenderContext].
 pub trait Drawable {
@@ -54,11 +51,16 @@ pub trait DrawableOnDoc {
     /// Draw itself on the snapshot.
     ///
     /// The snapshot is expected to be untransformed in surface coordinate space.
+    #[cfg(feature = "ui")]
     fn draw_on_doc_to_gtk_snapshot(
         &self,
         snapshot: &gtk4::Snapshot,
         engine_view: &EngineView,
     ) -> anyhow::Result<()> {
+        use crate::ext::GrapheneRectExt;
+        use gtk4::{graphene, prelude::*};
+        use rnote_compose::ext::{AabbExt, Affine2Ext};
+
         if let Some(bounds) = self.bounds_on_doc(engine_view) {
             let viewport = engine_view.camera.viewport();
             // Restrict to viewport as maximum bounds, else cairo is very unperformant

--- a/crates/rnote-engine/src/engine/export.rs
+++ b/crates/rnote-engine/src/engine/export.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
     num_derive::FromPrimitive,
     num_derive::ToPrimitive,
 )]
-#[cfg_attr(feature = "clap-derive", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[serde(rename = "doc_export_format")]
 pub enum DocExportFormat {
     #[serde(rename = "svg")]
@@ -116,7 +116,7 @@ impl DocExportPrefs {
     num_derive::FromPrimitive,
     num_derive::ToPrimitive,
 )]
-#[cfg_attr(feature = "clap-derive", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[serde(rename = "doc_pages_export_format")]
 pub enum DocPagesExportFormat {
     #[serde(rename = "svg")]
@@ -215,7 +215,7 @@ impl Default for DocPagesExportPrefs {
     num_derive::FromPrimitive,
     num_derive::ToPrimitive,
 )]
-#[cfg_attr(feature = "clap-derive", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[serde(rename = "selection_export_format")]
 pub enum SelectionExportFormat {
     #[serde(rename = "svg")]

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -25,7 +25,6 @@ use crate::strokes::textstroke::{TextAttribute, TextStyle};
 use crate::{render, AudioPlayer, SelectionCollision, WidgetFlags};
 use crate::{Camera, Document, PenHolder, StrokeStore};
 use futures::channel::{mpsc, oneshot};
-use gtk4::gsk;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use rnote_compose::eventresult::EventPropagation;
 use rnote_compose::ext::AabbExt;
@@ -183,8 +182,9 @@ pub struct Engine {
     // Background rendering
     #[serde(skip)]
     background_tile_image: Option<render::Image>,
+    #[cfg(feature = "ui")]
     #[serde(skip)]
-    background_rendernodes: Vec<gsk::RenderNode>,
+    background_rendernodes: Vec<gtk4::gsk::RenderNode>,
 }
 
 impl Default for Engine {
@@ -206,6 +206,7 @@ impl Default for Engine {
             tasks_tx: EngineTaskSender(tasks_tx),
             tasks_rx: Some(EngineTaskReceiver(tasks_rx)),
             background_tile_image: None,
+            #[cfg(feature = "ui")]
             background_rendernodes: Vec::default(),
         }
     }

--- a/crates/rnote-engine/src/engine/visual_debug.rs
+++ b/crates/rnote-engine/src/engine/visual_debug.rs
@@ -1,22 +1,9 @@
 // Imports
-use super::EngineView;
-use crate::ext::{GdkRGBAExt, GrapheneRectExt};
-use crate::{DrawableOnDoc, Engine};
-use gtk4::{gdk, graphene, gsk, prelude::*, Snapshot};
-use p2d::bounding_volume::{Aabb, BoundingVolume};
-use piet::{RenderContext, Text, TextLayoutBuilder};
-use rnote_compose::ext::{AabbExt, Vector2Ext};
 use rnote_compose::Color;
 
 pub const COLOR_POS: Color = Color {
     r: 1.0,
     g: 0.0,
-    b: 0.0,
-    a: 1.0,
-};
-pub const COLOR_POS_ALT: Color = Color {
-    r: 1.0,
-    g: 1.0,
     b: 0.0,
     a: 1.0,
 };
@@ -63,12 +50,16 @@ pub const COLOR_DOC_BOUNDS: Color = Color {
     a: 1.0,
 };
 
+#[cfg(feature = "ui")]
 pub(crate) fn draw_bounds_to_gtk_snapshot(
-    bounds: Aabb,
+    bounds: p2d::bounding_volume::Aabb,
     color: Color,
-    snapshot: &Snapshot,
+    snapshot: &gtk4::Snapshot,
     width: f64,
 ) {
+    use crate::ext::GdkRGBAExt;
+    use gtk4::{gdk, graphene, gsk, prelude::*};
+
     let bounds = graphene::Rect::new(
         bounds.mins[0] as f32,
         bounds.mins[1] as f32,
@@ -96,12 +87,16 @@ pub(crate) fn draw_bounds_to_gtk_snapshot(
     )
 }
 
+#[cfg(feature = "ui")]
 pub(crate) fn draw_pos_to_gtk_snapshot(
-    snapshot: &Snapshot,
+    snapshot: &gtk4::Snapshot,
     pos: na::Vector2<f64>,
     color: Color,
     width: f64,
 ) {
+    use crate::ext::GdkRGBAExt;
+    use gtk4::{gdk, graphene, prelude::*};
+
     snapshot.append_color(
         &gdk::RGBA::from_compose_color(color),
         &graphene::Rect::new(
@@ -113,7 +108,15 @@ pub(crate) fn draw_pos_to_gtk_snapshot(
     );
 }
 
-pub(crate) fn draw_fill_to_gtk_snapshot(snapshot: &Snapshot, rect: Aabb, color: Color) {
+#[cfg(feature = "ui")]
+pub(crate) fn draw_fill_to_gtk_snapshot(
+    snapshot: &gtk4::Snapshot,
+    rect: p2d::bounding_volume::Aabb,
+    color: Color,
+) {
+    use crate::ext::{GdkRGBAExt, GrapheneRectExt};
+    use gtk4::{gdk, graphene, prelude::*};
+
     snapshot.append_color(
         &gdk::RGBA::from_compose_color(color),
         &graphene::Rect::from_p2d_aabb(rect),
@@ -123,11 +126,18 @@ pub(crate) fn draw_fill_to_gtk_snapshot(snapshot: &Snapshot, rect: Aabb, color: 
 /// Draw some engine statistics for debugging purposes.
 ///
 /// Expects that the snapshot is untransformed in surface coordinate space.
+#[cfg(feature = "ui")]
 pub(crate) fn draw_statistics_to_gtk_snapshot(
-    snapshot: &Snapshot,
-    engine: &Engine,
-    surface_bounds: Aabb,
+    snapshot: &gtk4::Snapshot,
+    engine: &crate::Engine,
+    surface_bounds: p2d::bounding_volume::Aabb,
 ) -> anyhow::Result<()> {
+    use crate::ext::GrapheneRectExt;
+    use gtk4::{graphene, prelude::*};
+    use p2d::bounding_volume::Aabb;
+    use piet::{RenderContext, Text, TextLayoutBuilder};
+    use rnote_compose::ext::{AabbExt, Vector2Ext};
+
     // A statistics overlay
     {
         let text_bounds = Aabb::new(
@@ -187,11 +197,16 @@ pub(crate) fn draw_statistics_to_gtk_snapshot(
 }
 
 /// Draw stroke bounds, positions, etc. for visual debugging purposes.
+#[cfg(feature = "ui")]
 pub(crate) fn draw_stroke_debug_to_gtk_snapshot(
-    snapshot: &Snapshot,
-    engine: &Engine,
-    surface_bounds: Aabb,
+    snapshot: &gtk4::Snapshot,
+    engine: &crate::Engine,
+    surface_bounds: p2d::bounding_volume::Aabb,
 ) -> anyhow::Result<()> {
+    use crate::drawable::DrawableOnDoc;
+    use crate::engine::EngineView;
+    use p2d::bounding_volume::BoundingVolume;
+
     let viewport = engine.camera.viewport();
     let total_zoom = engine.camera.total_zoom();
     let doc_bounds = engine.document.bounds();

--- a/crates/rnote-engine/src/ext.rs
+++ b/crates/rnote-engine/src/ext.rs
@@ -1,9 +1,8 @@
 // Imports
-use gtk4::{gdk, graphene};
-use p2d::bounding_volume::Aabb;
 use rnote_compose::eventresult::EventPropagation;
 
 /// Extension trait for [gdk::RGBA].
+#[cfg(feature = "ui")]
 pub trait GdkRGBAExt
 where
     Self: Sized,
@@ -14,9 +13,10 @@ where
     fn into_piet_color(self) -> piet::Color;
 }
 
-impl GdkRGBAExt for gdk::RGBA {
+#[cfg(feature = "ui")]
+impl GdkRGBAExt for gtk4::gdk::RGBA {
     fn from_compose_color(color: rnote_compose::Color) -> Self {
-        gdk::RGBA::new(
+        gtk4::gdk::RGBA::new(
             color.r as f32,
             color.g as f32,
             color.b as f32,
@@ -34,7 +34,7 @@ impl GdkRGBAExt for gdk::RGBA {
 
     fn from_piet_color(color: piet::Color) -> Self {
         let (r, g, b, a) = color.as_rgba();
-        gdk::RGBA::new(r as f32, g as f32, b as f32, a as f32)
+        gtk4::gdk::RGBA::new(r as f32, g as f32, b as f32, a as f32)
     }
 
     fn into_piet_color(self) -> piet::Color {
@@ -48,16 +48,18 @@ impl GdkRGBAExt for gdk::RGBA {
 }
 
 /// Extension trait for [graphene::Rect].
+#[cfg(feature = "ui")]
 pub trait GrapheneRectExt
 where
     Self: Sized,
 {
-    fn from_p2d_aabb(aabb: Aabb) -> Self;
+    fn from_p2d_aabb(aabb: p2d::bounding_volume::Aabb) -> Self;
 }
 
-impl GrapheneRectExt for graphene::Rect {
-    fn from_p2d_aabb(aabb: Aabb) -> Self {
-        graphene::Rect::new(
+#[cfg(feature = "ui")]
+impl GrapheneRectExt for gtk4::graphene::Rect {
+    fn from_p2d_aabb(aabb: p2d::bounding_volume::Aabb) -> Self {
+        gtk4::graphene::Rect::new(
             aabb.mins[0] as f32,
             aabb.mins[1] as f32,
             (aabb.extents()[0]) as f32,

--- a/crates/rnote-engine/src/render.rs
+++ b/crates/rnote-engine/src/render.rs
@@ -2,7 +2,7 @@
 use crate::ext::GrapheneRectExt;
 use crate::Drawable;
 use anyhow::Context;
-use gtk4::{gdk, gio, graphene, gsk, prelude::*};
+use gtk4::{gdk, graphene, gsk, prelude::*};
 use image::io::Reader;
 use once_cell::sync::Lazy;
 use p2d::bounding_volume::{Aabb, BoundingVolume};

--- a/crates/rnote-engine/src/render.rs
+++ b/crates/rnote-engine/src/render.rs
@@ -1,8 +1,6 @@
 // Imports
-use crate::ext::GrapheneRectExt;
 use crate::Drawable;
 use anyhow::Context;
-use gtk4::{gdk, graphene, gsk, prelude::*};
 use image::io::Reader;
 use once_cell::sync::Lazy;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
@@ -45,11 +43,12 @@ impl Default for ImageMemoryFormat {
     }
 }
 
-impl TryFrom<gdk::MemoryFormat> for ImageMemoryFormat {
+#[cfg(feature = "ui")]
+impl TryFrom<gtk4::gdk::MemoryFormat> for ImageMemoryFormat {
     type Error = anyhow::Error;
-    fn try_from(value: gdk::MemoryFormat) -> Result<Self, Self::Error> {
+    fn try_from(value: gtk4::gdk::MemoryFormat) -> Result<Self, Self::Error> {
         match value {
-            gdk::MemoryFormat::R8g8b8a8Premultiplied => Ok(Self::R8g8b8a8Premultiplied),
+            gtk4::gdk::MemoryFormat::R8g8b8a8Premultiplied => Ok(Self::R8g8b8a8Premultiplied),
             _ => Err(anyhow::anyhow!(
                 "ImageMemoryFormat try_from() gdk::MemoryFormat failed, unsupported MemoryFormat `{:?}`",
                 value
@@ -58,10 +57,13 @@ impl TryFrom<gdk::MemoryFormat> for ImageMemoryFormat {
     }
 }
 
-impl From<ImageMemoryFormat> for gdk::MemoryFormat {
+#[cfg(feature = "ui")]
+impl From<ImageMemoryFormat> for gtk4::gdk::MemoryFormat {
     fn from(value: ImageMemoryFormat) -> Self {
         match value {
-            ImageMemoryFormat::R8g8b8a8Premultiplied => gdk::MemoryFormat::R8g8b8a8Premultiplied,
+            ImageMemoryFormat::R8g8b8a8Premultiplied => {
+                gtk4::gdk::MemoryFormat::R8g8b8a8Premultiplied
+            }
         }
     }
 }
@@ -247,10 +249,11 @@ impl Image {
         Ok(bytes_buf.into_inner())
     }
 
-    pub fn to_memtexture(&self) -> Result<gdk::MemoryTexture, anyhow::Error> {
+    #[cfg(feature = "ui")]
+    pub fn to_memtexture(&self) -> Result<gtk4::gdk::MemoryTexture, anyhow::Error> {
         self.assert_valid()?;
 
-        Ok(gdk::MemoryTexture::new(
+        Ok(gtk4::gdk::MemoryTexture::new(
             self.pixel_width as i32,
             self.pixel_height as i32,
             self.memory_format.into(),
@@ -259,7 +262,11 @@ impl Image {
         ))
     }
 
-    pub fn to_rendernode(&self) -> Result<gsk::RenderNode, anyhow::Error> {
+    #[cfg(feature = "ui")]
+    pub fn to_rendernode(&self) -> Result<gtk4::gsk::RenderNode, anyhow::Error> {
+        use crate::ext::GrapheneRectExt;
+        use gtk4::{graphene, gsk, prelude::*};
+
         self.assert_valid()?;
 
         let memtexture = self.to_memtexture()?;
@@ -277,9 +284,10 @@ impl Image {
         Ok(transform_node)
     }
 
+    #[cfg(feature = "ui")]
     pub fn images_to_rendernodes<'a>(
         images: impl IntoIterator<Item = &'a Self>,
-    ) -> Result<Vec<gsk::RenderNode>, anyhow::Error> {
+    ) -> Result<Vec<gtk4::gsk::RenderNode>, anyhow::Error> {
         images.into_iter().map(|img| img.to_rendernode()).collect()
     }
 
@@ -523,15 +531,6 @@ impl Svg {
             )
             .map_err(|e| anyhow::anyhow!("rendering rsvg document failed, Err: {e:?}"))?;
         Ok(())
-    }
-
-    #[allow(unused)]
-    pub fn gen_caironode(&self) -> Result<gsk::CairoNode, anyhow::Error> {
-        self.bounds.assert_valid()?;
-        let node = gsk::CairoNode::new(&graphene::Rect::from_p2d_aabb(self.bounds));
-        let cx = node.draw_context();
-        self.draw_to_cairo(&cx)?;
-        Ok(node)
     }
 
     /// Generate an image from an Svg.

--- a/crates/rnote-engine/src/selectioncollision.rs
+++ b/crates/rnote-engine/src/selectioncollision.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "clap-derive", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum SelectionCollision {
     #[default]
     /// All strokes completely inside the area

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -3,7 +3,7 @@ use super::render_comp::RenderCompState;
 use super::StrokeKey;
 use crate::engine::StrokeContent;
 use crate::strokes::{Content, Stroke};
-use crate::{render, StrokeStore, WidgetFlags};
+use crate::{StrokeStore, WidgetFlags};
 use geo::intersects::Intersects;
 use geo::prelude::Contains;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
@@ -52,6 +52,7 @@ impl StrokeStore {
         self.stroke_components.keys().collect()
     }
 
+    #[allow(unused)]
     pub(crate) fn keys_unordered_intersecting_bounds(&self, bounds: Aabb) -> Vec<StrokeKey> {
         self.key_tree.keys_intersecting_bounds(bounds)
     }
@@ -218,7 +219,8 @@ impl StrokeStore {
                     image.translate(offset);
                 }
 
-                match render::Image::images_to_rendernodes(&render_comp.images) {
+                #[cfg(feature = "ui")]
+                match crate::render::Image::images_to_rendernodes(&render_comp.images) {
                     Ok(rendernodes) => {
                         render_comp.rendernodes = rendernodes;
                     }
@@ -377,7 +379,8 @@ impl StrokeStore {
                     image.rotate(angle, center);
                 }
 
-                match render::Image::images_to_rendernodes(&render_comp.images) {
+                #[cfg(feature = "ui")]
+                match crate::render::Image::images_to_rendernodes(&render_comp.images) {
                     Ok(rendernodes) => {
                         render_comp.rendernodes = rendernodes;
                     }
@@ -419,7 +422,8 @@ impl StrokeStore {
                     image.scale(scale);
                 }
 
-                match render::Image::images_to_rendernodes(&render_comp.images) {
+                #[cfg(feature = "ui")]
+                match crate::render::Image::images_to_rendernodes(&render_comp.images) {
                     Ok(rendernodes) => {
                         render_comp.rendernodes = rendernodes;
                     }

--- a/crates/rnote-engine/src/utils.rs
+++ b/crates/rnote-engine/src/utils.rs
@@ -1,10 +1,8 @@
 // Imports
 use crate::fileformats::xoppformat;
 use geo::line_string;
-use gtk4::{graphene, gsk};
 use p2d::bounding_volume::Aabb;
 use rnote_compose::Color;
-use rnote_compose::Transform;
 use std::ops::Range;
 
 pub fn color_from_xopp(xopp_color: xoppformat::XoppColor) -> Color {
@@ -45,8 +43,9 @@ pub fn convert_coord_dpi(
     (coord / current_dpi) * target_dpi
 }
 
-pub fn transform_to_gsk(transform: &Transform) -> gsk::Transform {
-    gsk::Transform::new().matrix(&graphene::Matrix::from_2d(
+#[cfg(feature = "ui")]
+pub fn transform_to_gsk(transform: &rnote_compose::Transform) -> gtk4::gsk::Transform {
+    gtk4::gsk::Transform::new().matrix(&gtk4::graphene::Matrix::from_2d(
         transform.affine[(0, 0)],
         transform.affine[(1, 0)],
         transform.affine[(0, 1)],

--- a/crates/rnote-ui/Cargo.toml
+++ b/crates/rnote-ui/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 rnote-compose = { workspace = true }
-rnote-engine = { workspace = true, default-features = false, features = ["ui"] }
+rnote-engine = { workspace = true, features = ["ui"] }
 
 log = { workspace = true }
 pretty_env_logger = { workspace = true }

--- a/crates/rnote-ui/Cargo.toml
+++ b/crates/rnote-ui/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 rnote-compose = { workspace = true }
-rnote-engine = { workspace = true }
+rnote-engine = { workspace = true, default-features = false, features = ["ui"] }
 
 log = { workspace = true }
 pretty_env_logger = { workspace = true }


### PR DESCRIPTION
This PR adds features "ui" and "cli" to the engine and makes the gtk4 dependency optional. The code in the engine that needs `gtk4` (mainly related to the rendering) is now gated behind the "ui" feature and only conditionally compiled.

It removes `gtk4` as dependency for the cli entirely.