### PR TITLE
implement nudging camera while performing certain pen actions

### DIFF
--- a/crates/rnote-engine/src/camera.rs
+++ b/crates/rnote-engine/src/camera.rs
@@ -313,7 +313,7 @@ impl Camera {
             (_, _, true, true) => Some(NudgeDirection::SouthWest),
             (false, _, false, true) => Some(NudgeDirection::West),
             (true, _, _, true) => Some(NudgeDirection::NorthWest),
-            _ => None,
+            (false, false, false, false) => None,
         }
     }
 

--- a/crates/rnote-engine/src/camera.rs
+++ b/crates/rnote-engine/src/camera.rs
@@ -336,10 +336,8 @@ impl Camera {
 
     pub fn nudge_w_pos(&mut self, pos: na::Vector2<f64>, doc: &Document) -> WidgetFlags {
         let mut widget_flags = WidgetFlags::default();
-        for nudge in self.detect_nudges_needed(pos) {
-            if let Some(nudge_direction) = nudge {
-                widget_flags |= self.nudge(nudge_direction, doc);
-            }
+        for nudge_direction in self.detect_nudges_needed(pos).into_iter().flatten() {
+            widget_flags |= self.nudge(nudge_direction, doc);
         }
         widget_flags
     }

--- a/crates/rnote-engine/src/camera.rs
+++ b/crates/rnote-engine/src/camera.rs
@@ -295,10 +295,8 @@ impl Camera {
             .scale(total_zoom as f32, total_zoom as f32)
     }
 
-    /// Detects needed horizontal and/or vertical nudges.
-    ///
-    /// Horizontal are the first element, vertical are the second.
-    pub fn detect_nudges_needed(&self, pos: na::Vector2<f64>) -> Option<NudgeDirection> {
+    /// Detects if a nudge is needed, meaning: the position is close to an edge of the current viewport.
+    pub fn detect_nudge_needed(&self, pos: na::Vector2<f64>) -> Option<NudgeDirection> {
         const NUDGE_VIEWPORT_DIST: f64 = 10.0;
         let viewport = self.viewport();
         let nudge_north = pos[1] <= viewport.mins[1] + NUDGE_VIEWPORT_DIST;
@@ -345,7 +343,7 @@ impl Camera {
 
     pub fn nudge_w_pos(&mut self, pos: na::Vector2<f64>, doc: &Document) -> WidgetFlags {
         let mut widget_flags = WidgetFlags::default();
-        if let Some(nudge_direction) = self.detect_nudges_needed(pos) {
+        if let Some(nudge_direction) = self.detect_nudge_needed(pos) {
             widget_flags |= self.nudge(nudge_direction, doc);
         }
         widget_flags

--- a/crates/rnote-engine/src/camera.rs
+++ b/crates/rnote-engine/src/camera.rs
@@ -330,7 +330,7 @@ impl Camera {
     }
 
     pub fn nudge(&mut self, direction: NudgeDirection, doc: &Document) -> WidgetFlags {
-        const NUDGE_AMOUNT: f64 = 10.0;
+        const NUDGE_AMOUNT: f64 = 20.0;
         self.nudge_by(NUDGE_AMOUNT, direction, doc)
     }
 

--- a/crates/rnote-engine/src/pens/penholder.rs
+++ b/crates/rnote-engine/src/pens/penholder.rs
@@ -5,6 +5,7 @@ use super::{
     Brush, Eraser, Pen, PenBehaviour, PenMode, PenStyle, Selector, Shaper, Shortcuts, Tools,
     Typewriter,
 };
+use crate::camera::NudgeDirection;
 use crate::engine::{EngineView, EngineViewMut};
 use crate::pens::shortcuts::ShortcutAction;
 use crate::widgetflags::WidgetFlags;
@@ -297,52 +298,56 @@ impl PenHolder {
                 modifier_keys,
             } => match keyboard_key {
                 KeyboardKey::NavUp => {
-                    let y_offset = if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
-                        -engine_view.camera.size()[1]
+                    let nudge_amount = if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
+                        engine_view.camera.size()[1]
                     } else {
-                        -engine_view.camera.size()[1] * MOVE_VIEW_FACTOR
+                        engine_view.camera.size()[1] * MOVE_VIEW_FACTOR
                     };
-                    widget_flags |= engine_view.camera.set_offset(
-                        engine_view.camera.offset() + na::vector![0.0, y_offset],
+                    widget_flags |= engine_view.camera.nudge_by(
+                        nudge_amount,
+                        NudgeDirection::Up,
                         engine_view.doc,
                     );
 
                     EventPropagation::Stop
                 }
                 KeyboardKey::NavDown => {
-                    let y_offset = if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
+                    let nudge_amount = if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
                         engine_view.camera.size()[1]
                     } else {
                         engine_view.camera.size()[1] * MOVE_VIEW_FACTOR
                     };
-                    widget_flags |= engine_view.camera.set_offset(
-                        engine_view.camera.offset() + na::vector![0.0, y_offset],
+                    widget_flags |= engine_view.camera.nudge_by(
+                        nudge_amount,
+                        NudgeDirection::Down,
                         engine_view.doc,
                     );
 
                     EventPropagation::Stop
                 }
                 KeyboardKey::NavLeft => {
-                    let x_offset = if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
-                        -engine_view.camera.size()[0]
+                    let nudge_amount = if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
+                        engine_view.camera.size()[0]
                     } else {
-                        -engine_view.camera.size()[0] * MOVE_VIEW_FACTOR
+                        engine_view.camera.size()[0] * MOVE_VIEW_FACTOR
                     };
-                    widget_flags |= engine_view.camera.set_offset(
-                        engine_view.camera.offset() + na::vector![x_offset, 0.0],
+                    widget_flags |= engine_view.camera.nudge_by(
+                        nudge_amount,
+                        NudgeDirection::Left,
                         engine_view.doc,
                     );
 
                     EventPropagation::Stop
                 }
                 KeyboardKey::NavRight => {
-                    let x_offset = if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
+                    let nudge_amount = if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
                         engine_view.camera.size()[0]
                     } else {
                         engine_view.camera.size()[0] * MOVE_VIEW_FACTOR
                     };
-                    widget_flags |= engine_view.camera.set_offset(
-                        engine_view.camera.offset() + na::vector![x_offset, 0.0],
+                    widget_flags |= engine_view.camera.nudge_by(
+                        nudge_amount,
+                        NudgeDirection::Right,
                         engine_view.doc,
                     );
 

--- a/crates/rnote-engine/src/pens/penholder.rs
+++ b/crates/rnote-engine/src/pens/penholder.rs
@@ -305,7 +305,7 @@ impl PenHolder {
                     };
                     widget_flags |= engine_view.camera.nudge_by(
                         nudge_amount,
-                        NudgeDirection::Up,
+                        NudgeDirection::North,
                         engine_view.doc,
                     );
 
@@ -319,7 +319,7 @@ impl PenHolder {
                     };
                     widget_flags |= engine_view.camera.nudge_by(
                         nudge_amount,
-                        NudgeDirection::Down,
+                        NudgeDirection::East,
                         engine_view.doc,
                     );
 
@@ -333,7 +333,7 @@ impl PenHolder {
                     };
                     widget_flags |= engine_view.camera.nudge_by(
                         nudge_amount,
-                        NudgeDirection::Left,
+                        NudgeDirection::West,
                         engine_view.doc,
                     );
 
@@ -347,7 +347,7 @@ impl PenHolder {
                     };
                     widget_flags |= engine_view.camera.nudge_by(
                         nudge_amount,
-                        NudgeDirection::Right,
+                        NudgeDirection::South,
                         engine_view.doc,
                     );
 

--- a/crates/rnote-engine/src/pens/selector/penevents.rs
+++ b/crates/rnote-engine/src/pens/selector/penevents.rs
@@ -46,6 +46,8 @@ impl Selector {
                     path,
                     element,
                 );
+                // possibly nudge camera
+                widget_flags |= engine_view.camera.nudge_w_pos(element.pos, engine_view.doc);
 
                 EventResult {
                     handled: true,
@@ -172,11 +174,15 @@ impl Selector {
                         if offset.magnitude()
                             > Self::TRANSLATE_MAGNITUDE_THRESHOLD / engine_view.camera.total_zoom()
                         {
+                            // move selection
                             engine_view.store.translate_strokes(selection, offset);
                             engine_view
                                 .store
                                 .translate_strokes_images(selection, offset);
                             *selection_bounds = selection_bounds.translate(offset);
+                            // possibly nudge camera
+                            widget_flags |=
+                                engine_view.camera.nudge_w_pos(element.pos, engine_view.doc);
 
                             // strokes that were not visible previously might come into view
                             engine_view.store.regenerate_rendering_in_viewport_threaded(
@@ -269,17 +275,20 @@ impl Selector {
                         );
                         let scale = new_extents.component_div(&selection_bounds.extents());
 
+                        // resize strokes
                         engine_view
                             .store
                             .scale_strokes_with_pivot(selection, scale, pivot);
                         engine_view
                             .store
                             .scale_strokes_images_with_pivot(selection, scale, pivot);
-
                         *selection_bounds = selection_bounds
                             .translate(-pivot)
                             .scale_non_uniform(scale)
                             .translate(pivot);
+                        // possibly nudge camera
+                        widget_flags |=
+                            engine_view.camera.nudge_w_pos(element.pos, engine_view.doc);
                     }
                 }
 

--- a/crates/rnote-engine/src/pens/tools.rs
+++ b/crates/rnote-engine/src/pens/tools.rs
@@ -350,6 +350,10 @@ impl PenBehaviour for Tools {
                                 &self.verticalspace_tool.strokes_below,
                                 na::vector![0.0, y_offset],
                             );
+                            // possibly nudge camera
+                            widget_flags |=
+                                engine_view.camera.nudge_w_pos(element.pos, engine_view.doc);
+                            // new strokes might come into view
                             engine_view.store.regenerate_rendering_in_viewport_threaded(
                                 engine_view.tasks_tx.clone(),
                                 false,

--- a/crates/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/crates/rnote-engine/src/pens/typewriter/penevents.rs
@@ -220,10 +220,14 @@ impl Typewriter {
                         if offset.magnitude()
                             > Self::TRANSLATE_MAGNITUDE_THRESHOLD / engine_view.camera.total_zoom()
                         {
+                            // move text
                             engine_view.store.translate_strokes(&[*stroke_key], offset);
                             engine_view
                                 .store
                                 .translate_strokes_images(&[*stroke_key], offset);
+                            // possibly nudge camera
+                            widget_flags |=
+                                engine_view.camera.nudge_w_pos(element.pos, engine_view.doc);
 
                             *current_pos = element.pos;
 


### PR DESCRIPTION
This PR implements nudging the camera when the pen reaches the edge of the current viewport while certain pen actions are performed:
- selecting with a rectangle
- translating the current selection
- resizing the current selection
- translating the typewriter text
- using the vertical-space tool