### PR TITLE
Move shape builders button & constraints button to top and shaper style buttons to bottom

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Felix Zwettler
 Óscar Fernández Díaz
 Seio Inoue
 Moritz Mechelk
+PhilProg

--- a/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
@@ -47,6 +47,15 @@
       </object>
     </child>
     <child>
+      <object class="RnStrokeWidthPicker" id="stroke_width_picker">
+      </object>
+    </child>
+    <child>
+      <object class="GtkSeparator">
+        <property name="orientation">vertical</property>
+      </object>
+    </child>
+    <child>
       <object class="GtkBox">
         <property name="orientation">vertical</property>
         <child>
@@ -72,15 +81,6 @@
             </style>
           </object>
         </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkSeparator">
-        <property name="orientation">vertical</property>
-      </object>
-    </child>
-    <child>
-      <object class="RnStrokeWidthPicker" id="stroke_width_picker">
       </object>
     </child>
 

--- a/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
@@ -12,6 +12,43 @@
     <child>
       <object class="GtkBox">
         <property name="orientation">vertical</property>
+        <property name="vexpand">false</property>
+        <child>
+          <object class="GtkMenuButton" id="shapebuildertype_menubutton">
+            <property name="direction">left</property>
+            <property name="tooltip_text" translatable="yes">Shape Builders</property>
+            <property name="popover">shapebuildertype_popover</property>
+            <property name="icon-name">shapebuilder-line-symbolic</property>
+            <style>
+              <class name="flat" />
+              <class name="sidebar_action_button" />
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkMenuButton" id="constraint_menubutton">
+            <property name="icon-name">settings-symbolic</property>
+            <property name="hexpand">true</property>
+            <property name="sensitive">true</property>
+            <property name="halign">fill</property>
+            <property name="direction">left</property>
+            <property name="tooltip_text" translatable="yes">Constraints</property>
+            <property name="popover">constraint_popover</property>
+            <style>
+              <class name="flat" />
+            </style>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkSeparator">
+        <property name="orientation">vertical</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
         <child>
           <object class="GtkMenuButton" id="shaperstyle_menubutton">
             <property name="direction">left</property>
@@ -44,43 +81,6 @@
     </child>
     <child>
       <object class="RnStrokeWidthPicker" id="stroke_width_picker">
-      </object>
-    </child>
-    <child>
-      <object class="GtkSeparator">
-        <property name="orientation">vertical</property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <property name="vexpand">false</property>
-        <child>
-          <object class="GtkMenuButton" id="shapebuildertype_menubutton">
-            <property name="direction">left</property>
-            <property name="tooltip_text" translatable="yes">Shape Builders</property>
-            <property name="popover">shapebuildertype_popover</property>
-            <property name="icon-name">shapebuilder-line-symbolic</property>
-            <style>
-              <class name="flat" />
-              <class name="sidebar_action_button" />
-            </style>
-          </object>
-        </child>
-        <child>
-          <object class="GtkMenuButton" id="constraint_menubutton">
-            <property name="icon-name">settings-symbolic</property>
-            <property name="hexpand">true</property>
-            <property name="sensitive">true</property>
-            <property name="halign">fill</property>
-            <property name="direction">left</property>
-            <property name="tooltip_text" translatable="yes">Constraints</property>
-            <property name="popover">constraint_popover</property>
-            <style>
-              <class name="flat" />
-            </style>
-          </object>
-        </child>
       </object>
     </child>
 


### PR DESCRIPTION
This Pull request moves the shape builders button and the constraints button to the top and the shaper style buttons to the bottom of the shaper sidebar.

Fixes #230

![Bildschirmfoto vom 2023-09-14 13-08-14](https://github.com/flxzt/rnote/assets/91820316/1f4eebba-4a84-4cf7-9165-c6db83b9c7be)

