### PR TITLE
add plaintext file import

### DIFF
--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -519,6 +519,12 @@ impl RnAppWindow {
                     )
                     .await?
                 }
+                FileType::PlaintextFile => {
+                    let canvas = appwindow.active_tab_wrapper().canvas();
+                    let (bytes, _) = input_file.load_bytes_future().await?;
+                    canvas.load_in_text(String::from_utf8(bytes.to_vec())?, target_pos)?;
+                    true
+                }
                 FileType::Folder => {
                     if let Some(dir) = input_file.path() {
                         appwindow

--- a/crates/rnote-ui/src/dialogs/import.rs
+++ b/crates/rnote-ui/src/dialogs/import.rs
@@ -50,13 +50,15 @@ pub(crate) async fn filedialog_import_file(appwindow: &RnAppWindow) {
     filter.add_mime_type("image/svg+xml");
     filter.add_mime_type("image/png");
     filter.add_mime_type("image/jpeg");
+    filter.add_mime_type("text/plain");
     filter.add_suffix("xopp");
     filter.add_suffix("pdf");
     filter.add_suffix("svg");
     filter.add_suffix("png");
     filter.add_suffix("jpg");
     filter.add_suffix("jpeg");
-    filter.set_name(Some(&gettext("Jpg, Pdf, Png, Svg, Xopp")));
+    filter.add_suffix("txt");
+    filter.set_name(Some(&gettext("Jpg, Pdf, Png, Svg, Xopp, Txt")));
 
     let dialog = FileDialog::builder()
         .title(gettext("Import File"))

--- a/crates/rnote-ui/src/filetype.rs
+++ b/crates/rnote-ui/src/filetype.rs
@@ -10,6 +10,7 @@ pub(crate) enum FileType {
     BitmapImageFile,
     XoppFile,
     PdfFile,
+    PlaintextFile,
     Unsupported,
 }
 
@@ -38,6 +39,9 @@ impl FileType {
                             }
                             "application/pdf" => {
                                 return Self::PdfFile;
+                            }
+                            "text/plain" => {
+                                return Self::PlaintextFile;
                             }
                             _ => {}
                         }
@@ -73,6 +77,9 @@ impl FileType {
                     }
                     "pdf" => {
                         return Self::PdfFile;
+                    }
+                    "txt" => {
+                        return Self::PlaintextFile;
                     }
                     _ => {}
                 }


### PR DESCRIPTION
This adds the ability to import plain text files (files with MIME-type `text/plain`).

The already existing `import_text()` functionality simply is reused here, I only had to expose it in the UI by adding plain text as allowed file type.

I tested the functionality with the UTF8-demo text file found here: https://www.w3.org/2001/06/utf-8-test/UTF-8-demo.html

fixes #798 when merged.