### PR TITLE
scale widths of brushstrokes and shapes when resizing

### DIFF
--- a/crates/rnote-compose/src/style/mod.rs
+++ b/crates/rnote-compose/src/style/mod.rs
@@ -53,6 +53,15 @@ impl Style {
         }
     }
 
+    /// Set the stroke width. Available on all styles.
+    pub fn set_stroke_width(&mut self, stroke_width: f64) {
+        match self {
+            Style::Smooth(options) => options.stroke_width = stroke_width,
+            Style::Rough(options) => options.stroke_width = stroke_width,
+            Style::Textured(options) => options.stroke_width = stroke_width,
+        }
+    }
+
     /// The margins for bounds which contain the shape.
     pub fn bounds_margin(&self) -> f64 {
         match self {
@@ -62,7 +71,7 @@ impl Style {
         }
     }
 
-    /// Advances the seed for styles that have one.
+    /// Advance the seed for styles that have one.
     pub fn advance_seed(&mut self) {
         match self {
             Style::Smooth(_) => {}

--- a/crates/rnote-engine/src/strokes/brushstroke.rs
+++ b/crates/rnote-engine/src/strokes/brushstroke.rs
@@ -249,6 +249,9 @@ impl Transformable for BrushStroke {
     }
     fn scale(&mut self, scale: na::Vector2<f64>) {
         self.path.scale(scale);
+        let scale_uniform = (scale[0] + scale[1]) / 2.;
+        self.style
+            .set_stroke_width(self.style.stroke_width() * scale_uniform);
     }
 }
 

--- a/crates/rnote-engine/src/strokes/shapestroke.rs
+++ b/crates/rnote-engine/src/strokes/shapestroke.rs
@@ -93,6 +93,9 @@ impl Transformable for ShapeStroke {
     }
     fn scale(&mut self, scale: na::Vector2<f64>) {
         self.shape.scale(scale);
+        let scale_uniform = (scale[0] + scale[1]) / 2.;
+        self.style
+            .set_stroke_width(self.style.stroke_width() * scale_uniform);
     }
 }
 


### PR DESCRIPTION
This changes the resize behaviour of the brushstroke and shape content types so that their stroke widths are scaled when a resize happens.

Because it is possible to resize non-uniformly, the scale-factor of the average `(x+y)/2` is used as the scalar value for scaling the stroke width.

addresses #793