### PR TITLE
#812 - Typewriter formatting improvments

### DIFF
--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -910,6 +910,27 @@ impl Engine {
         widget_flags
     }
 
+    pub fn text_selection_toggle_attribute(
+        &mut self,
+        text_attribute: TextAttribute,
+    ) -> WidgetFlags {
+        let mut widget_flags = WidgetFlags::default();
+        if let Pen::Typewriter(typewriter) = self.penholder.current_pen_mut() {
+            widget_flags |= typewriter.toggle_text_attribute_current_selection(
+                text_attribute,
+                &mut EngineViewMut {
+                    tasks_tx: self.tasks_tx.clone(),
+                    pens_config: &mut self.pens_config,
+                    doc: &mut self.document,
+                    store: &mut self.store,
+                    camera: &mut self.camera,
+                    audioplayer: &mut self.audioplayer,
+                },
+            )
+        }
+        widget_flags
+    }
+
     pub fn text_selection_add_attribute(&mut self, text_attribute: TextAttribute) -> WidgetFlags {
         let mut widget_flags = WidgetFlags::default();
         if let Pen::Typewriter(typewriter) = self.penholder.current_pen_mut() {

--- a/crates/rnote-engine/src/pens/typewriter/mod.rs
+++ b/crates/rnote-engine/src/pens/typewriter/mod.rs
@@ -784,6 +784,34 @@ impl Typewriter {
         widget_flags
     }
 
+    pub(crate) fn toggle_text_attribute_current_selection(
+        &mut self,
+        text_attribute: TextAttribute,
+        engine_view: &mut EngineViewMut,
+    ) -> WidgetFlags {
+        let mut widget_flags = WidgetFlags::default();
+
+        if let Some((selection_range, stroke_key)) = self.selection_range() {
+            if let Some(Stroke::TextStroke(textstroke)) =
+                engine_view.store.get_stroke_mut(stroke_key)
+            {
+                textstroke.toggle_attrs_for_range(selection_range.clone(), text_attribute.clone());
+                engine_view.store.update_geometry_for_stroke(stroke_key);
+                engine_view.store.regenerate_rendering_for_stroke(
+                    stroke_key,
+                    engine_view.camera.viewport(),
+                    engine_view.camera.image_scale(),
+                );
+
+                widget_flags |= engine_view.store.record(Instant::now());
+                widget_flags.redraw = true;
+                widget_flags.store_modified = true;
+            }
+        }
+
+        widget_flags
+    }
+
     pub(crate) fn remove_text_attributes_current_selection(
         &mut self,
         engine_view: &mut EngineViewMut,

--- a/crates/rnote-engine/src/strokes/textstroke.rs
+++ b/crates/rnote-engine/src/strokes/textstroke.rs
@@ -707,18 +707,80 @@ impl TextStroke {
     /// Remove all attributes in the given range.
     pub fn remove_attrs_for_range(&mut self, range: Range<usize>) {
         // partition into attrs that intersect the range, and those who don't and will be retained
-        let (intersecting_attrs, mut retained_attrs): (
-            Vec<RangedTextAttribute>,
-            Vec<RangedTextAttribute>,
-        ) = self
+        let (intersecting_attrs, mut retained_attrs) = Self::get_intersecting_attrs_for_range(
+            &range,
+            self.text_style.ranged_text_attributes.clone(),
+        );
+
+        // Truncate and filter the ranges of intersecting attrs
+        let truncated_attrs = Self::remove_intersecting_attrs_in_range(&range, intersecting_attrs);
+
+        // Set the updated attributes
+        self.text_style.ranged_text_attributes = {
+            retained_attrs.extend(truncated_attrs);
+            retained_attrs
+        };
+    }
+
+    pub fn toggle_attrs_for_range(&mut self, range: Range<usize>, text_attribute: TextAttribute) {
+        let (matching_attributes, mut non_matching_attrs) = self
             .text_style
             .ranged_text_attributes
             .clone()
             .into_iter()
-            .partition(|attr| attr.range.end > range.start && attr.range.start < range.end);
+            .partition(|attr| Self::is_same_attribute(&attr.attribute, &text_attribute));
 
-        // Truncate and filter the ranges of intersecting attrs
-        let truncated_attrs = intersecting_attrs
+        let (intersecting_attrs, mut retained_attrs) =
+            Self::get_intersecting_attrs_for_range(&range, matching_attributes);
+
+        let _bold_weight = piet::FontWeight::BOLD.to_raw();
+        let toggled_attribute = intersecting_attrs
+            .clone()
+            .into_iter()
+            .sorted_by(|a, b| (a.range.end - a.range.start).cmp(&(b.range.end - b.range.start)))
+            // Filter out any that became empty or are contained in the given range
+            .collect::<Vec<RangedTextAttribute>>()
+            .first()
+            .map(|attr| match &attr.attribute {
+                TextAttribute::Strikethrough(strike) => Some(TextAttribute::Strikethrough(!strike)),
+                TextAttribute::Underline(underline) => Some(TextAttribute::Underline(!underline)),
+                TextAttribute::Style(FontStyle::Regular) => {
+                    Some(TextAttribute::Style(FontStyle::Italic))
+                }
+                TextAttribute::Style(FontStyle::Italic) => {
+                    Some(TextAttribute::Style(FontStyle::Regular))
+                }
+                TextAttribute::FontWeight(_bold_weight) => None,
+                _ => Some(text_attribute.clone()),
+            })
+            .unwrap_or_else(|| Some(text_attribute.clone()));
+
+        let truncated_attrs = Self::remove_intersecting_attrs_in_range(&range, intersecting_attrs);
+
+        non_matching_attrs.extend(retained_attrs);
+        non_matching_attrs.extend(truncated_attrs);
+        if let Some(attribute) = toggled_attribute {
+            non_matching_attrs.extend([RangedTextAttribute { attribute, range }]);
+        }
+
+        // Set the updated attributes
+        self.text_style.ranged_text_attributes = non_matching_attrs;
+    }
+
+    fn get_intersecting_attrs_for_range(
+        range: &Range<usize>,
+        ranged_text_attributes: Vec<RangedTextAttribute>,
+    ) -> (Vec<RangedTextAttribute>, Vec<RangedTextAttribute>) {
+        return ranged_text_attributes
+            .into_iter()
+            .partition(|attr| attr.range.end > range.start && attr.range.start < range.end);
+    }
+
+    fn remove_intersecting_attrs_in_range(
+        range: &Range<usize>,
+        intersecting_attrs: Vec<RangedTextAttribute>,
+    ) -> Vec<RangedTextAttribute> {
+        intersecting_attrs
             .into_iter()
             .flat_map(|mut attr| {
                 if attr.range.start <= range.start && attr.range.end >= range.end {
@@ -744,12 +806,19 @@ impl TextStroke {
             })
             // Filter out any that became empty or are contained in the given range
             .filter(|attr| !attr.range.is_empty())
-            .collect::<Vec<RangedTextAttribute>>();
+            .collect::<Vec<RangedTextAttribute>>()
+    }
 
-        // Set the updated attributes
-        self.text_style.ranged_text_attributes = {
-            retained_attrs.extend(truncated_attrs);
-            retained_attrs
+    fn is_same_attribute(attr1: &TextAttribute, attr2: &TextAttribute) -> bool {
+        return match (attr1, attr2) {
+            (TextAttribute::FontFamily(_), TextAttribute::FontFamily(_)) => true,
+            (TextAttribute::FontSize(_), TextAttribute::FontSize(_)) => true,
+            (TextAttribute::FontWeight(_), TextAttribute::FontWeight(_)) => true,
+            (TextAttribute::Strikethrough(_), TextAttribute::Strikethrough(_)) => true,
+            (TextAttribute::Underline(_), TextAttribute::Underline(_)) => true,
+            (TextAttribute::Style(_), TextAttribute::Style(_)) => true,
+            (TextAttribute::TextColor(_), TextAttribute::TextColor(_)) => true,
+            (_, _) => false,
         };
     }
 

--- a/crates/rnote-engine/src/strokes/textstroke.rs
+++ b/crates/rnote-engine/src/strokes/textstroke.rs
@@ -140,6 +140,19 @@ impl TextAttribute {
             TextAttribute::Strikethrough(strikethrough) => Ok(piet::TextAttribute::Strikethrough(strikethrough)),
         }
     }
+
+    fn is_same_attribute(&self, other: &TextAttribute) -> bool {
+        match (self, other) {
+            (TextAttribute::FontFamily(_), TextAttribute::FontFamily(_)) => true,
+            (TextAttribute::FontSize(_), TextAttribute::FontSize(_)) => true,
+            (TextAttribute::FontWeight(_), TextAttribute::FontWeight(_)) => true,
+            (TextAttribute::Strikethrough(_), TextAttribute::Strikethrough(_)) => true,
+            (TextAttribute::Underline(_), TextAttribute::Underline(_)) => true,
+            (TextAttribute::Style(_), TextAttribute::Style(_)) => true,
+            (TextAttribute::TextColor(_), TextAttribute::TextColor(_)) => true,
+            (_, _) => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -729,7 +742,7 @@ impl TextStroke {
             .ranged_text_attributes
             .clone()
             .into_iter()
-            .partition(|attr| Self::is_same_attribute(&attr.attribute, &text_attribute));
+            .partition(|attr| attr.attribute.is_same_attribute(&text_attribute));
 
         let (intersecting_attrs, retained_attrs) =
             Self::get_intersecting_attrs_for_range(&range, matching_attributes);
@@ -772,9 +785,9 @@ impl TextStroke {
         range: &Range<usize>,
         ranged_text_attributes: Vec<RangedTextAttribute>,
     ) -> (Vec<RangedTextAttribute>, Vec<RangedTextAttribute>) {
-        return ranged_text_attributes
+        ranged_text_attributes
             .into_iter()
-            .partition(|attr| attr.range.end > range.start && attr.range.start < range.end);
+            .partition(|attr| attr.range.end > range.start && attr.range.start < range.end)
     }
 
     fn remove_intersecting_attrs_in_range(
@@ -808,19 +821,6 @@ impl TextStroke {
             // Filter out any that became empty or are contained in the given range
             .filter(|attr| !attr.range.is_empty())
             .collect::<Vec<RangedTextAttribute>>()
-    }
-
-    fn is_same_attribute(attr1: &TextAttribute, attr2: &TextAttribute) -> bool {
-        return match (attr1, attr2) {
-            (TextAttribute::FontFamily(_), TextAttribute::FontFamily(_)) => true,
-            (TextAttribute::FontSize(_), TextAttribute::FontSize(_)) => true,
-            (TextAttribute::FontWeight(_), TextAttribute::FontWeight(_)) => true,
-            (TextAttribute::Strikethrough(_), TextAttribute::Strikethrough(_)) => true,
-            (TextAttribute::Underline(_), TextAttribute::Underline(_)) => true,
-            (TextAttribute::Style(_), TextAttribute::Style(_)) => true,
-            (TextAttribute::TextColor(_), TextAttribute::TextColor(_)) => true,
-            (_, _) => false,
-        };
     }
 
     pub fn update_selection_entire_text(

--- a/crates/rnote-engine/src/strokes/textstroke.rs
+++ b/crates/rnote-engine/src/strokes/textstroke.rs
@@ -1,6 +1,7 @@
 // Imports
 use super::Content;
 use crate::{Camera, Drawable};
+use itertools::Itertools;
 use kurbo::Shape;
 use p2d::bounding_volume::Aabb;
 use piet::{RenderContext, TextLayout, TextLayoutBuilder};
@@ -730,7 +731,7 @@ impl TextStroke {
             .into_iter()
             .partition(|attr| Self::is_same_attribute(&attr.attribute, &text_attribute));
 
-        let (intersecting_attrs, mut retained_attrs) =
+        let (intersecting_attrs, retained_attrs) =
             Self::get_intersecting_attrs_for_range(&range, matching_attributes);
 
         let _bold_weight = piet::FontWeight::BOLD.to_raw();

--- a/crates/rnote-ui/src/penssidebar/typewriterpage.rs
+++ b/crates/rnote-ui/src/penssidebar/typewriterpage.rs
@@ -179,7 +179,7 @@ impl RnTypewriterPage {
         imp.text_bold_button
             .connect_clicked(clone!(@weak appwindow => move |_| {
                 let canvas = appwindow.active_tab_wrapper().canvas();
-                let widget_flags = canvas.engine_mut().text_selection_add_attribute(
+                let widget_flags = canvas.engine_mut().text_selection_toggle_attribute(
                     TextAttribute::FontWeight(piet::FontWeight::BOLD.to_raw())
                 );
                 appwindow.handle_widget_flags(widget_flags, &canvas);
@@ -189,7 +189,7 @@ impl RnTypewriterPage {
         imp.text_italic_button
             .connect_clicked(clone!(@weak appwindow => move |_| {
                 let canvas = appwindow.active_tab_wrapper().canvas();
-                let widget_flags = canvas.engine_mut().text_selection_add_attribute(
+                let widget_flags = canvas.engine_mut().text_selection_toggle_attribute(
                     TextAttribute::Style(FontStyle::Italic)
                 );
                 appwindow.handle_widget_flags(widget_flags, &canvas);
@@ -199,7 +199,7 @@ impl RnTypewriterPage {
         imp.text_underline_button
             .connect_clicked(clone!(@weak appwindow => move |_| {
                 let canvas = appwindow.active_tab_wrapper().canvas();
-                let widget_flags = canvas.engine_mut().text_selection_add_attribute(
+                let widget_flags = canvas.engine_mut().text_selection_toggle_attribute(
                     TextAttribute::Underline(true)
                 );
                 appwindow.handle_widget_flags(widget_flags, &canvas);
@@ -209,7 +209,7 @@ impl RnTypewriterPage {
         imp.text_strikethrough_button
             .connect_clicked(clone!(@weak appwindow => move |_| {
                 let canvas = appwindow.active_tab_wrapper().canvas();
-                let widget_flags = canvas.engine_mut().text_selection_add_attribute(
+                let widget_flags = canvas.engine_mut().text_selection_toggle_attribute(
                     TextAttribute::Strikethrough(true)
                 );
                 appwindow.handle_widget_flags(widget_flags, &canvas);


### PR DESCRIPTION
- Updates bold, italic, strikethrough, and underline buttons to act as a toggle for selected text 
- If the selected text is half toggled, then toggle that value for the entire selection
