### PR TITLE
fix linux chinese locale

### DIFF
--- a/crates/rnote-ui/po/LINGUAS
+++ b/crates/rnote-ui/po/LINGUAS
@@ -9,7 +9,11 @@ pt_BR
 fr
 nb_NO
 zh_Hans
+zh_CN
+zh_SG
 zh_Hant
+zh_HK
+zh_TW
 pl
 tr
 hu

--- a/crates/rnote-ui/po/zh_CN.po
+++ b/crates/rnote-ui/po/zh_CN.po
@@ -1,0 +1,1 @@
+zh_Hans.po

--- a/crates/rnote-ui/po/zh_HK.po
+++ b/crates/rnote-ui/po/zh_HK.po
@@ -1,0 +1,1 @@
+zh_Hant.po

--- a/crates/rnote-ui/po/zh_SG.po
+++ b/crates/rnote-ui/po/zh_SG.po
@@ -1,0 +1,1 @@
+zh_Hans.po

--- a/crates/rnote-ui/po/zh_TW.po
+++ b/crates/rnote-ui/po/zh_TW.po
@@ -1,0 +1,1 @@
+zh_Hant.po


### PR DESCRIPTION
On Linux, there are no `zh_Hans` nor `zh_Hant` supported:
```shell
$ cat /usr/share/i18n/SUPPORTED | grep zh
lzh_TW UTF-8
zh_CN.GB18030 GB18030
zh_CN.GBK GBK
zh_CN.UTF-8 UTF-8
zh_CN GB2312
zh_HK.UTF-8 UTF-8
zh_HK BIG5-HKSCS
zh_SG.UTF-8 UTF-8
zh_SG.GBK GBK
zh_SG GB2312
zh_TW.EUC-TW EUC-TW
zh_TW.UTF-8 UTF-8
zh_TW BIG5
```
So the current Chinese translate actually not been applied and used under Linux.
The working way right now is to use `zh_CN`, `zh_SG` for Simplified Chinese and `zh_HK`, `zh_TW` for Traditional Chinese, like this pr will do, or this change can be done from Weblate side?