### PR TITLE
include angle libegl.dll

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -27,7 +27,7 @@ jobs:
             git mingw-w64-x86_64-xz mingw-w64-x86_64-pkgconf mingw-w64-x86_64-gcc mingw-w64-x86_64-clang mingw-w64-x86_64-toolchain
             mingw-w64-x86_64-autotools mingw-w64-x86_64-make mingw-w64-x86_64-cmake mingw-w64-x86_64-meson mingw-w64-x86_64-diffutils
             mingw-w64-x86_64-desktop-file-utils mingw-w64-x86_64-appstream-glib mingw-w64-x86_64-gtk4 mingw-w64-x86_64-libadwaita
-            mingw-w64-x86_64-poppler mingw-w64-x86_64-poppler-data
+            mingw-w64-x86_64-poppler mingw-w64-x86_64-poppler-data mingw-w64-x86_64-angleproject
       - name: Remove libpthread.dll.a
         run: rm /mingw64/lib/libpthread.dll.a
         continue-on-error: true

--- a/build-aux/inno_build.py
+++ b/build-aux/inno_build.py
@@ -4,6 +4,7 @@ import sys
 import os
 import shutil
 import glob
+import itertools
 
 source_root = sys.argv[1]
 build_root = sys.argv[2]
@@ -53,6 +54,15 @@ for loader in glob.glob(f"{msys_path}/mingw64/lib/gdk-pixbuf-2.0/2.10.0/loaders/
     run_command(
         f"ldd {loader} | grep '\\/mingw.*\.dll' -o | xargs -i cp {{}} {dlls_dir}",
         f"Collecting pixbuf-loader ({loader}) DLLs failed"
+    )
+
+for angle_dll in itertools.chain(
+    glob.glob(f"{msys_path}/mingw64/bin/libEGL*.dll"),
+    glob.glob(f"{msys_path}/mingw64/bin/libGLES*.dll"),
+):
+    run_command(
+        f"ldd {angle_dll} | grep '\\/mingw.*\.dll' -o | xargs -i cp {{}} {dlls_dir}",
+        f"Collecting angle ({angle_dll}) DLLs failed",
     )
 
 # Collect necessary GSchema Xml's and compile them into a `gschemas.compiled`

--- a/misc/building/rnote-windows-build.md
+++ b/misc/building/rnote-windows-build.md
@@ -15,7 +15,7 @@ The MSYS2 binary directories, namely `C:\msys64\mingw64\bin` and `C:\msys64\usr\
 In order to install the necessary dependencies, run the following command in a MSYS2 terminal.
 
 ```bash
-pacman -S git mingw-w64-x86_64-xz mingw-w64-x86_64-pkgconf mingw-w64-x86_64-gcc mingw-w64-x86_64-clang mingw-w64-x86_64-toolchain mingw-w64-x86_64-autotools mingw-w64-x86_64-make mingw-w64-x86_64-cmake mingw-w64-x86_64-meson mingw-w64-x86_64-diffutils mingw-w64-x86_64-desktop-file-utils mingw-w64-x86_64-appstream-glib mingw-w64-x86_64-gtk4 mingw-w64-x86_64-libadwaita mingw-w64-x86_64-poppler mingw-w64-x86_64-poppler-data
+pacman -S git mingw-w64-x86_64-xz mingw-w64-x86_64-pkgconf mingw-w64-x86_64-gcc mingw-w64-x86_64-clang mingw-w64-x86_64-toolchain mingw-w64-x86_64-autotools mingw-w64-x86_64-make mingw-w64-x86_64-cmake mingw-w64-x86_64-meson mingw-w64-x86_64-diffutils mingw-w64-x86_64-desktop-file-utils mingw-w64-x86_64-appstream-glib mingw-w64-x86_64-gtk4 mingw-w64-x86_64-libadwaita mingw-w64-x86_64-poppler mingw-w64-x86_64-poppler-data mingw-w64-x86_64-angleproject
 ```
 
 ### Configuration


### PR DESCRIPTION
I haven't run a full build with these changes but copying these DLLs into my Rnote installation stops it from trying to find other libEGL.dll files on my system.

Fixes #839 