### PR TITLE
Disable Qt5 and Qt6 in the poppler build configuration

### DIFF
--- a/build-aux/com.github.flxzt.rnote.Devel.json
+++ b/build-aux/com.github.flxzt.rnote.Devel.json
@@ -54,7 +54,9 @@
         "-DCMAKE_INSTALL_LIBDIR=/app/lib",
         "-DCMAKE_INSTALL_INCLUDEDIR=/app/include",
         "-DENABLE_BOOST=OFF",
-        "-DENABLE_LIBOPENJPEG=none"
+        "-DENABLE_LIBOPENJPEG=none",
+        "-DENABLE_QT5=OFF",
+        "-DENABLE_QT6=OFF"
       ],
       "sources": [
         {

--- a/build-aux/com.github.flxzt.rnote.Devel.yaml
+++ b/build-aux/com.github.flxzt.rnote.Devel.yaml
@@ -46,6 +46,8 @@ modules:
           - "-DCMAKE_INSTALL_INCLUDEDIR=/app/include"
           - "-DENABLE_BOOST=OFF"
           - "-DENABLE_LIBOPENJPEG=none"
+          - "-DENABLE_QT5=OFF"
+          - "-DENABLE_QT6=OFF"
       sources:
           - type: archive
             url: "https://poppler.freedesktop.org/poppler-23.10.0.tar.xz"


### PR DESCRIPTION
These features don't seam to be required, and can cause issues when building the project.