### PR TITLE
Don't open a new tab when the default "New Document" hasn't been modified

### DIFF
--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -451,12 +451,18 @@ impl RnAppWindow {
                         appwindow.overlays().tabview().set_selected_page(&page);
                         false
                     } else {
-                        let wrapper = if !rnote_file_new_tab
-                            || appwindow.active_tab_wrapper().canvas().empty() {
-                                appwindow.active_tab_wrapper()
+                        let rnote_file_new_tab = if appwindow.active_tab_wrapper().canvas().empty() {
+                            false
                         } else {
+                            rnote_file_new_tab
+                        };
+
+                        let wrapper = if rnote_file_new_tab {
                             // a new tab for rnote files
                             appwindow.new_canvas_wrapper()
+                        } else {
+                            appwindow.active_tab_wrapper()
+
                         };
                         let (bytes, _) = input_file.load_bytes_future().await?;
                         let widget_flags = wrapper

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -451,7 +451,13 @@ impl RnAppWindow {
                         appwindow.overlays().tabview().set_selected_page(&page);
                         false
                     } else {
-                        let rnote_file_new_tab = if appwindow.active_tab_wrapper().canvas().empty() {
+                        let rnote_file_new_tab = if appwindow.active_tab_wrapper().canvas().empty()
+                            && appwindow
+                                .active_tab_wrapper()
+                                .canvas()
+                                .output_file()
+                                .is_none()
+                        {
                             false
                         } else {
                             rnote_file_new_tab
@@ -462,7 +468,6 @@ impl RnAppWindow {
                             appwindow.new_canvas_wrapper()
                         } else {
                             appwindow.active_tab_wrapper()
-
                         };
                         let (bytes, _) = input_file.load_bytes_future().await?;
                         let widget_flags = wrapper

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -451,7 +451,8 @@ impl RnAppWindow {
                         appwindow.overlays().tabview().set_selected_page(&page);
                         false
                     } else {
-                        let rnote_file_new_tab = if appwindow.active_tab_wrapper().canvas().empty() {
+                        let rnote_file_new_tab = if appwindow.active_tab_wrapper().canvas().empty()
+                        {
                             false
                         } else {
                             rnote_file_new_tab
@@ -462,7 +463,6 @@ impl RnAppWindow {
                             appwindow.new_canvas_wrapper()
                         } else {
                             appwindow.active_tab_wrapper()
-
                         };
                         let (bytes, _) = input_file.load_bytes_future().await?;
                         let widget_flags = wrapper

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -451,8 +451,7 @@ impl RnAppWindow {
                         appwindow.overlays().tabview().set_selected_page(&page);
                         false
                     } else {
-                        let rnote_file_new_tab = if appwindow.active_tab_wrapper().canvas().empty()
-                        {
+                        let rnote_file_new_tab = if appwindow.active_tab_wrapper().canvas().empty() {
                             false
                         } else {
                             rnote_file_new_tab
@@ -463,6 +462,7 @@ impl RnAppWindow {
                             appwindow.new_canvas_wrapper()
                         } else {
                             appwindow.active_tab_wrapper()
+
                         };
                         let (bytes, _) = input_file.load_bytes_future().await?;
                         let widget_flags = wrapper

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -451,11 +451,12 @@ impl RnAppWindow {
                         appwindow.overlays().tabview().set_selected_page(&page);
                         false
                     } else {
-                        let wrapper = if rnote_file_new_tab {
+                        let wrapper = if !rnote_file_new_tab
+                            || appwindow.active_tab_wrapper().canvas().empty() {
+                                appwindow.active_tab_wrapper()
+                        } else {
                             // a new tab for rnote files
                             appwindow.new_canvas_wrapper()
-                        } else {
-                            appwindow.active_tab_wrapper()
                         };
                         let (bytes, _) = input_file.load_bytes_future().await?;
                         let widget_flags = wrapper


### PR DESCRIPTION
Previously, when opening rnote and loading a document  by opening a file the "default" (empty) canvas would remain open and the opened file would appear in a new tab. This PR changes this so that the default document gets replaced by the opened document when no changes to the default canvas were made, which I think is better.