### PR TITLE
Remove duplicate filefilter

### DIFF
--- a/crates/rnote-ui/src/workspacebrowser/mod.rs
+++ b/crates/rnote-ui/src/workspacebrowser/mod.rs
@@ -323,7 +323,6 @@ impl RnWorkspaceBrowser {
         filefilter.add_mime_type("image/svg+xml");
         filefilter.add_mime_type("image/png");
         filefilter.add_mime_type("image/jpeg");
-        filefilter.add_mime_type("application/x-xopp");
         filefilter.add_mime_type("inode/directory");
         filefilter.add_suffix("rnote");
         filefilter.add_suffix("pdf");


### PR DESCRIPTION
I found a duplicate line in the codebase that I don't think does anything:

```rust
filefilter.add_mime_type("application/rnote");
filefilter.add_mime_type("application/pdf");
filefilter.add_mime_type("application/x-xopp"); // <--
filefilter.add_mime_type("image/svg+xml");
filefilter.add_mime_type("image/png");
filefilter.add_mime_type("image/jpeg");
filefilter.add_mime_type("application/x-xopp"); // <--
filefilter.add_mime_type("inode/directory");
```