### PR TITLE
RFC: consistent initial folder for export file chooser dialogs

### DIFF
--- a/crates/rnote-ui/src/canvas/imexport.rs
+++ b/crates/rnote-ui/src/canvas/imexport.rs
@@ -306,6 +306,8 @@ impl RnCanvas {
 
         crate::utils::create_replace_file_future(export_bytes.await??, file).await?;
 
+        self.set_last_export_dir(file.parent());
+
         Ok(())
     }
 
@@ -347,6 +349,8 @@ impl RnCanvas {
             .await?;
         }
 
+        self.set_last_export_dir(Some(dir.clone()));
+
         Ok(())
     }
 
@@ -361,6 +365,8 @@ impl RnCanvas {
             crate::utils::create_replace_file_future(export_bytes, file).await?;
         }
 
+        self.set_last_export_dir(file.parent());
+
         Ok(())
     }
 
@@ -371,6 +377,8 @@ impl RnCanvas {
 
         crate::utils::create_replace_file_future(exported_engine_state.into_bytes(), file).await?;
 
+        self.set_last_export_dir(file.parent());
+
         Ok(())
     }
 
@@ -380,6 +388,8 @@ impl RnCanvas {
         let exported_engine_config = self.engine_ref().export_engine_config_as_json()?;
 
         crate::utils::create_replace_file_future(exported_engine_config.into_bytes(), file).await?;
+
+        self.set_last_export_dir(file.parent());
 
         Ok(())
     }

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -78,6 +78,8 @@ mod imp {
         pub(crate) empty: Cell<bool>,
         pub(crate) touch_drawing: Cell<bool>,
         pub(crate) show_drawing_cursor: Cell<bool>,
+
+        pub(crate) last_export_dir: RefCell<Option<gio::File>>,
     }
 
     impl Default for RnCanvas {
@@ -172,6 +174,8 @@ mod imp {
                 empty: Cell::new(true),
                 touch_drawing: Cell::new(false),
                 show_drawing_cursor: Cell::new(false),
+
+                last_export_dir: RefCell::new(None),
             }
         }
     }
@@ -703,6 +707,10 @@ impl RnCanvas {
             "handle-widget-flags",
             &[&WidgetFlagsBoxed::from(widget_flags)],
         );
+    }
+
+    pub(crate) fn set_last_export_dir(&self, dir: Option<gio::File>) {
+        self.imp().last_export_dir.replace(dir);
     }
 
     /// Returns the saved date time for the modification time of the output file when it was set by the app.

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -709,6 +709,10 @@ impl RnCanvas {
         );
     }
 
+    pub(crate) fn last_export_dir(&self) -> Option<gio::File> {
+        self.imp().last_export_dir.borrow().clone()
+    }
+
     pub(crate) fn set_last_export_dir(&self, dir: Option<gio::File>) {
         self.imp().last_export_dir.replace(dir);
     }


### PR DESCRIPTION
The main change is the second commit:

```
This commit sets the initial folder of the file chooser
for all three types of export options. The following
locations are tried:

  1. last export path of the current canvas
  2. parent directory of the current canvas' output file
  3. current directory of the file browser in the sidebar

The first available will be used.
```

I have found myself wanting to see better defaults especially when I'm exporting a selection multiple times, or multiple selections in succession. So here is my attempt at implementing something.