### PR TITLE
fallback to defaults when settings schema is not installed

### DIFF
--- a/crates/rnote-ui/data/meson.build
+++ b/crates/rnote-ui/data/meson.build
@@ -356,6 +356,7 @@ rnote_ui_gresources_ui_files = files(
     'ui/sidebar.ui',
     'ui/strokecontentpreview.ui',
     'ui/strokewidthpicker.ui',
+    'ui/style.css',
     'ui/unitentry.ui',
     'ui/workspacebrowser.ui',
 )

--- a/crates/rnote-ui/data/ui/style.css
+++ b/crates/rnote-ui/data/ui/style.css
@@ -240,4 +240,6 @@ from https://gitlab.com/posidon_software/paper/-/blob/main/src/css/style.css
 
 toast {
     margin-bottom: 72px;
+    margin-left: 72px;
+    margin-right: 72px;
 }

--- a/crates/rnote-ui/po/rnote.pot
+++ b/crates/rnote-ui/po/rnote.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rnote\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-26 16:14+0100\n"
+"POT-Creation-Date: 2023-11-26 16:17+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1636,8 +1636,8 @@ msgstr ""
 
 #: crates/rnote-ui/src/appwindow/mod.rs:126
 msgid ""
-"Settings schema is not installed. App settings are not loaded and won't be "
-"saved."
+"Settings schema is not installed. App settings could not be loaded and won't "
+"be saved."
 msgstr ""
 
 #: crates/rnote-ui/src/appwindow/mod.rs:564

--- a/crates/rnote-ui/po/rnote.pot
+++ b/crates/rnote-ui/po/rnote.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rnote\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-25 12:58+0100\n"
+"POT-Creation-Date: 2023-11-26 16:14+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1325,7 +1325,7 @@ msgstr ""
 
 #: crates/rnote-ui/data/ui/settingspanel.ui:247
 #: crates/rnote-ui/data/ui/shortcuts.ui:146
-#: crates/rnote-ui/src/dialogs/mod.rs:632
+#: crates/rnote-ui/src/dialogs/mod.rs:626
 msgid "Document"
 msgstr ""
 
@@ -1634,11 +1634,17 @@ msgstr ""
 msgid "Create new Folder"
 msgstr ""
 
-#: crates/rnote-ui/src/appwindow/mod.rs:555
+#: crates/rnote-ui/src/appwindow/mod.rs:126
+msgid ""
+"Settings schema is not installed. App settings are not loaded and won't be "
+"saved."
+msgstr ""
+
+#: crates/rnote-ui/src/appwindow/mod.rs:564
 msgid "Opening file failed"
 msgstr ""
 
-#: crates/rnote-ui/src/appwindow/imp.rs:250
+#: crates/rnote-ui/src/appwindow/imp.rs:248
 #: crates/rnote-ui/src/appwindow/appwindowactions.rs:582
 #: crates/rnote-ui/src/dialogs/export.rs:68
 #: crates/rnote-ui/src/dialogs/mod.rs:126
@@ -1647,19 +1653,19 @@ msgstr ""
 msgid "Saving document failed"
 msgstr ""
 
-#: crates/rnote-ui/src/appwindow/imp.rs:270
+#: crates/rnote-ui/src/appwindow/imp.rs:268
 msgid "Button 1"
 msgstr ""
 
-#: crates/rnote-ui/src/appwindow/imp.rs:277
+#: crates/rnote-ui/src/appwindow/imp.rs:275
 msgid "Button 2"
 msgstr ""
 
-#: crates/rnote-ui/src/appwindow/imp.rs:284
+#: crates/rnote-ui/src/appwindow/imp.rs:282
 msgid "Button 3"
 msgstr ""
 
-#: crates/rnote-ui/src/appwindow/imp.rs:291
+#: crates/rnote-ui/src/appwindow/imp.rs:289
 msgid "Button 4"
 msgstr ""
 
@@ -1877,206 +1883,206 @@ msgstr ""
 msgid "Change Workspace Directory"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:619
+#: crates/rnote-ui/src/dialogs/mod.rs:613
 msgid "Band-Aid"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:620
+#: crates/rnote-ui/src/dialogs/mod.rs:614
 msgid "Bank"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:621
+#: crates/rnote-ui/src/dialogs/mod.rs:615
 msgid "Bookmark"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:622
+#: crates/rnote-ui/src/dialogs/mod.rs:616
 msgid "Book"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:623
+#: crates/rnote-ui/src/dialogs/mod.rs:617
 msgid "Bread"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:624
+#: crates/rnote-ui/src/dialogs/mod.rs:618
 msgid "Calendar"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:625
+#: crates/rnote-ui/src/dialogs/mod.rs:619
 msgid "Camera"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:626
+#: crates/rnote-ui/src/dialogs/mod.rs:620
 msgctxt "as in computer chip"
 msgid "Chip"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:627
+#: crates/rnote-ui/src/dialogs/mod.rs:621
 msgid "Clock"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:628
+#: crates/rnote-ui/src/dialogs/mod.rs:622
 msgid "Code"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:629
+#: crates/rnote-ui/src/dialogs/mod.rs:623
 msgid "Compose"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:630
+#: crates/rnote-ui/src/dialogs/mod.rs:624
 msgctxt "as in plant"
 msgid "Crop"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:631
+#: crates/rnote-ui/src/dialogs/mod.rs:625
 msgid "Dictionary"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:633
+#: crates/rnote-ui/src/dialogs/mod.rs:627
 msgid "Drinks"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:634
+#: crates/rnote-ui/src/dialogs/mod.rs:628
 msgid "Flag"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:635
+#: crates/rnote-ui/src/dialogs/mod.rs:629
 msgid "Folder"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:636
+#: crates/rnote-ui/src/dialogs/mod.rs:630
 msgid "Footprints"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:637
+#: crates/rnote-ui/src/dialogs/mod.rs:631
 msgid "Gamepad"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:638
+#: crates/rnote-ui/src/dialogs/mod.rs:632
 msgid "Gear"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:639
+#: crates/rnote-ui/src/dialogs/mod.rs:633
 msgid "Globe"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:640
+#: crates/rnote-ui/src/dialogs/mod.rs:634
 msgid "Hammer"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:641
+#: crates/rnote-ui/src/dialogs/mod.rs:635
 msgid "Heart"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:642
+#: crates/rnote-ui/src/dialogs/mod.rs:636
 msgid "Hourglass"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:643
+#: crates/rnote-ui/src/dialogs/mod.rs:637
 msgid "Key"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:644
+#: crates/rnote-ui/src/dialogs/mod.rs:638
 msgid "Language"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:645
+#: crates/rnote-ui/src/dialogs/mod.rs:639
 msgid "Library"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:646
+#: crates/rnote-ui/src/dialogs/mod.rs:640
 msgid "Lightbulb"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:647
+#: crates/rnote-ui/src/dialogs/mod.rs:641
 msgid "Mathematics"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:648
+#: crates/rnote-ui/src/dialogs/mod.rs:642
 msgid "Meeting"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:649
+#: crates/rnote-ui/src/dialogs/mod.rs:643
 msgid "Money"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:650
+#: crates/rnote-ui/src/dialogs/mod.rs:644
 msgid "Musical Note"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:651
+#: crates/rnote-ui/src/dialogs/mod.rs:645
 msgid "Nature"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:652
+#: crates/rnote-ui/src/dialogs/mod.rs:646
 msgid "Open Book"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:653
+#: crates/rnote-ui/src/dialogs/mod.rs:647
 msgid "Paintbrush"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:654
+#: crates/rnote-ui/src/dialogs/mod.rs:648
 msgid "Pencil and Paper"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:655
+#: crates/rnote-ui/src/dialogs/mod.rs:649
 msgid "People"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:656
+#: crates/rnote-ui/src/dialogs/mod.rs:650
 msgid "Person"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:657
+#: crates/rnote-ui/src/dialogs/mod.rs:651
 msgid "Projector"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:658
+#: crates/rnote-ui/src/dialogs/mod.rs:652
 msgid "Science"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:659
+#: crates/rnote-ui/src/dialogs/mod.rs:653
 msgid "Scratchpad"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:660
+#: crates/rnote-ui/src/dialogs/mod.rs:654
 msgid "Shapes"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:661
+#: crates/rnote-ui/src/dialogs/mod.rs:655
 msgid "Shopping"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:662
+#: crates/rnote-ui/src/dialogs/mod.rs:656
 msgid "Speech Bubble"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:663
+#: crates/rnote-ui/src/dialogs/mod.rs:657
 msgid "Speedometer"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:664
+#: crates/rnote-ui/src/dialogs/mod.rs:658
 msgid "Star"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:666
+#: crates/rnote-ui/src/dialogs/mod.rs:660
 msgctxt "as in terminal software"
 msgid "Terminal"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:668
+#: crates/rnote-ui/src/dialogs/mod.rs:662
 msgid "Text"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:669
+#: crates/rnote-ui/src/dialogs/mod.rs:663
 msgid "Travel"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:670
+#: crates/rnote-ui/src/dialogs/mod.rs:664
 msgid "Weather"
 msgstr ""
 
-#: crates/rnote-ui/src/dialogs/mod.rs:671
+#: crates/rnote-ui/src/dialogs/mod.rs:665
 msgid "Weight"
 msgstr ""
 

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -123,7 +123,7 @@ impl RnAppWindow {
         if !self.app().settings_schema_found() {
             // Display an error toast if settings schema could not be found
             self.overlays().dispatch_toast_error(&gettext(
-                "Settings schema not installed. Using app defaults.",
+                "Settings schema is not installed. App settings are not loaded and won't be saved.",
             ));
         } else {
             if let Err(e) = self.setup_settings_binds() {

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -123,7 +123,7 @@ impl RnAppWindow {
         if !self.app().settings_schema_found() {
             // Display an error toast if settings schema could not be found
             self.overlays().dispatch_toast_error(&gettext(
-                "Settings schema is not installed. App settings are not loaded and won't be saved.",
+                "Settings schema is not installed. App settings could not be loaded and won't be saved.",
             ));
         } else {
             if let Err(e) = self.setup_settings_binds() {

--- a/crates/rnote-ui/src/dialogs/mod.rs
+++ b/crates/rnote-ui/src/dialogs/mod.rs
@@ -547,12 +547,6 @@ pub(crate) async fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
                 .sidebar()
                 .workspacebrowser()
                 .refresh_dirlist_selected_workspace();
-            // And save the state
-            appwindow
-                .sidebar()
-                .workspacebrowser()
-                .workspacesbar()
-                .save_to_settings(&appwindow.app().app_settings());
         }
         _ => {
             // Cancel

--- a/crates/rnote-ui/src/workspacebrowser/workspacesbar/mod.rs
+++ b/crates/rnote-ui/src/workspacebrowser/workspacesbar/mod.rs
@@ -77,10 +77,10 @@ mod imp {
 
     impl ObjectImpl for RnWorkspacesBar {
         fn constructed(&self) {
+            let obj = self.obj();
             self.parent_constructed();
 
-            self.obj()
-                .insert_action_group("workspacesbar", Some(&self.action_group));
+            obj.insert_action_group("workspacesbar", Some(&self.action_group));
         }
 
         fn dispose(&self) {
@@ -125,9 +125,8 @@ impl RnWorkspacesBar {
         self.select_workspace_by_index(n_items.saturating_sub(1));
     }
 
-    pub(crate) fn insert_workspace(&self, i: u32, entry: RnWorkspaceListEntry) {
+    pub(crate) fn insert_workspace_entry(&self, i: u32, entry: RnWorkspaceListEntry) {
         self.imp().workspace_list.insert(i as usize, entry);
-
         self.select_workspace_by_index(i);
     }
 
@@ -153,11 +152,8 @@ impl RnWorkspacesBar {
             let i = self
                 .selected_workspace_index()
                 .unwrap_or_else(|| n_items.saturating_sub(1));
-
             let entry = self.imp().workspace_list.remove(i as usize);
-
-            self.insert_workspace(i.saturating_sub(1), entry);
-            self.select_workspace_by_index(i.saturating_sub(1));
+            self.insert_workspace_entry(i.saturating_sub(1), entry);
         }
     }
 
@@ -167,12 +163,9 @@ impl RnWorkspacesBar {
 
         if n_items > 1 {
             let i = self.selected_workspace_index().unwrap_or(i_max);
-
             let entry = self.imp().workspace_list.remove(i as usize);
-
             let insert_i = (i + 1).min(i_max);
-            self.insert_workspace(insert_i, entry);
-            self.select_workspace_by_index(insert_i);
+            self.insert_workspace_entry(insert_i, entry);
         }
     }
 
@@ -285,8 +278,8 @@ impl RnWorkspacesBar {
                 }
             }
         }
-        self.imp().workspace_list.replace_self(workspace_list);
 
+        self.imp().workspace_list.replace_self(workspace_list);
         self.select_workspace_by_index(selected_workspace_index);
     }
 
@@ -352,6 +345,9 @@ impl RnWorkspacesBar {
             clone!(@weak self as workspacesbar, @weak appwindow => move |_| {
                 adw::prelude::ActionGroupExt::activate_action(&workspacesbar.action_group(), "edit-selected-workspace", None);
             }));
+
+        // Add initial entry
+        self.insert_workspace_entry(0, RnWorkspaceListEntry::default());
     }
 
     fn setup_actions(&self, appwindow: &RnAppWindow) {

--- a/crates/rnote-ui/src/workspacebrowser/workspacesbar/mod.rs
+++ b/crates/rnote-ui/src/workspacebrowser/workspacesbar/mod.rs
@@ -297,8 +297,6 @@ impl RnWorkspacesBar {
             clone!(@weak self as workspacesbar, @weak appwindow => move |list, _, _, _| {
                 workspacesbar.imp().remove_selected_workspace_button.get().set_sensitive(list.n_items() > 1);
                 workspacesbar.imp().edit_selected_workspace_button.get().set_sensitive(list.n_items() > 0);
-
-                workspacesbar.save_to_settings(&appwindow.app().app_settings());
             }),
         );
 
@@ -311,8 +309,6 @@ impl RnWorkspacesBar {
                     appwindow.sidebar().workspacebrowser().active_workspace_name_label().set_label(&name);
                     appwindow.sidebar().workspacebrowser().active_workspace_dir_label().set_label(&dir);
                     appwindow.sidebar().workspacebrowser().set_dirlist_file(Some(&gio::File::for_path(dir)));
-
-                    workspacesbar.save_to_settings(&appwindow.app().app_settings());
                 }
 
             }),


### PR DESCRIPTION
This changes that the app uses the preconfigured app defaults when it can't load the settings because the schema is not found/installed to the system.

An error toast is displayed so that the user is aware that the settings for the current session could not be loaded and won't be saved.

This is the last step to make local builds without an installation and non-default build installation locations runnable.