### PR TITLE
chore: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           components: rustfmt, clippy
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache
         uses: actions/cache@v3
         env:

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -20,7 +20,7 @@ jobs:
         id: toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Add workspace as git safe directory

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Configure PATH
         run: echo "export PATH=$PATH:/c/Users/$USER/.cargo/bin:/c/Program\ Files\ \(x86\)/Inno\ Setup\ 6" > ~/.bashrc
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup
         run: meson setup --prefix=C:/msys64/mingw64 -Dinstaller-name='${{ steps.set_installer_name.outputs.name }}' _mesonbuild
       - name: Generate locale files


### PR DESCRIPTION
Bump `actions/checkout` version from `v3` (Node 16) to `v4` (Node 20).