### PR TITLE
build: refactor win-installer build

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup
-        run: meson setup --prefix=C:/msys64/mingw64 -Dinstaller-name='${{ steps.set_installer_name.outputs.name }}' _mesonbuild
+        run: meson setup --prefix=C:/msys64/mingw64 -Dwin-installer-name='${{ steps.set_installer_name.outputs.name }}' _mesonbuild
       - name: Generate locale files
         run: meson compile rnote-gmo -C _mesonbuild
       - name: Compile

--- a/build-aux/inno_build.py
+++ b/build-aux/inno_build.py
@@ -8,7 +8,8 @@ import itertools
 
 source_root = sys.argv[1]
 build_root = sys.argv[2]
-msys_path = sys.argv[3]
+# The build environment (from an msys installation - choose from https://www.msys2.org/docs/environments/)
+build_environment_path = sys.argv[3]
 app_name = sys.argv[4]
 app_name_capitalized = sys.argv[5]
 app_id = sys.argv[6]
@@ -19,7 +20,7 @@ print(f"""
 ### executing Inno-Setup installer build script with arguments: ###
     source_root: {source_root}
     build_root: {build_root}
-    msys_path: {msys_path}
+    build_environment_path: {build_environment_path}
     app_name: {app_name}
     app_name_capitalized: {app_name_capitalized}
     app_id: {app_id}
@@ -50,15 +51,15 @@ run_command(
     "Collecting app DLLs failed"
 )
 
-for loader in glob.glob(f"{msys_path}/mingw64/lib/gdk-pixbuf-2.0/2.10.0/loaders/*.dll"):
+for loader in glob.glob(f"{build_environment_path}/lib/gdk-pixbuf-2.0/2.10.0/loaders/*.dll"):
     run_command(
         f"ldd {loader} | grep '\\/mingw.*\.dll' -o | xargs -i cp {{}} {dlls_dir}",
         f"Collecting pixbuf-loader ({loader}) DLLs failed"
     )
 
 for angle_dll in itertools.chain(
-    glob.glob(f"{msys_path}/mingw64/bin/libEGL*.dll"),
-    glob.glob(f"{msys_path}/mingw64/bin/libGLES*.dll"),
+    glob.glob(f"{build_environment_path}/bin/libEGL*.dll"),
+    glob.glob(f"{build_environment_path}/bin/libGLES*.dll"),
 ):
     run_command(
         f"ldd {angle_dll} | grep '\\/mingw.*\.dll' -o | xargs -i cp {{}} {dlls_dir}",
@@ -74,7 +75,7 @@ if os.path.exists(gschemas_dir):
 
 os.mkdir(gschemas_dir)
 
-for src in glob.glob(f"{msys_path}/mingw64/share/glib-2.0/schemas/org.gtk.*"):
+for src in glob.glob(f"{build_environment_path}/share/glib-2.0/schemas/org.gtk.*"):
     shutil.copy(src, gschemas_dir)
 
 shutil.copy(f"{build_root}/crates/rnote-ui/data/{app_id}.gschema.xml", gschemas_dir)
@@ -100,7 +101,7 @@ shutil.copytree(app_mo_dir, locale_dir)
 for file in os.listdir(app_mo_dir):
     current_lang = os.fsdecode(file)
     current_locale_out_dir = os.path.join(locale_dir, current_lang, "LC_MESSAGES")
-    current_system_locale_dir = os.path.join(msys_path, "mingw64/share/locale", current_lang, "LC_MESSAGES")
+    current_system_locale_dir = os.path.join(build_environment_path, "share/locale", current_lang, "LC_MESSAGES")
 
     if not os.path.exists(current_locale_out_dir):
         os.mkdir(current_locale_out_dir)
@@ -123,7 +124,7 @@ for file in os.listdir(app_mo_dir):
 print("Running ISCC...", file=sys.stderr)
 
 run_command(
-    f"{msys_path}/usr/bin/bash -lc \"iscc {inno_script}\"",
+    f"{build_environment_path}/../usr/bin/bash -lc \"iscc {inno_script}\"",
     "Running ISCC failed"
 )
 

--- a/build-aux/inno_build.py
+++ b/build-aux/inno_build.py
@@ -8,7 +8,7 @@ import itertools
 
 source_root = sys.argv[1]
 build_root = sys.argv[2]
-# The build environment (from an msys installation - choose from https://www.msys2.org/docs/environments/)
+# The build environment (from a msys installation - choose from https://www.msys2.org/docs/environments/)
 build_environment_path = sys.argv[3]
 app_name = sys.argv[4]
 app_name_capitalized = sys.argv[5]

--- a/build-aux/inno_build.py
+++ b/build-aux/inno_build.py
@@ -124,7 +124,7 @@ for file in os.listdir(app_mo_dir):
 print("Running ISCC...", file=sys.stderr)
 
 run_command(
-    f"{build_environment_path}/../usr/bin/bash -lc \"iscc {inno_script}\"",
+    f"bash -lc \"iscc {inno_script}\"",
     "Running ISCC failed"
 )
 

--- a/build-aux/rnote_inno.iss.in
+++ b/build-aux/rnote_inno.iss.in
@@ -14,7 +14,7 @@
 #define app_id = @APP_ID@
 #define meson_source_root = @MESON_SOURCE_ROOT@
 #define meson_build_root = @MESON_BUILD_ROOT@
-#define msys_path @MSYS_PATH@
+#define build_environment_path = @BUILD_ENVIRONMENT_PATH@
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
@@ -56,16 +56,16 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Source: "{#meson_build_root}\dlls\*.dll"; DestDir: "{app}\bin"; Flags: ignoreversion
 
 ; gdk-pixbuf loaders
-Source: "{#msys_path}\mingw64\lib\gdk-pixbuf-2.0\*"; DestDir: "{app}\lib\gdk-pixbuf-2.0"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#build_environment_path}\lib\gdk-pixbuf-2.0\*"; DestDir: "{app}\lib\gdk-pixbuf-2.0"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; poppler-data
-Source: "{#msys_path}\mingw64\share\poppler\*"; DestDir: "{app}\share\poppler"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#build_environment_path}\share\poppler\*"; DestDir: "{app}\share\poppler"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; Settings GSchema
 Source: "{#meson_build_root}\gschemas\gschemas.compiled"; DestDir: "{app}\share\glib-2.0\schemas"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; win32 session dbus
-Source: "{#msys_path}\mingw64\bin\gdbus.exe"; DestDir: "{app}\bin\"; Flags: ignoreversion
+Source: "{#build_environment_path}\bin\gdbus.exe"; DestDir: "{app}\bin\"; Flags: ignoreversion
 ; Icons
-Source: "{#msys_path}\mingw64\share\icons\hicolor\*"; DestDir: "{app}\share\icons\hicolor"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "{#msys_path}\mingw64\share\icons\Adwaita\*"; DestDir: "{app}\share\icons\Adwaita"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#build_environment_path}\share\icons\hicolor\*"; DestDir: "{app}\share\icons\hicolor"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#build_environment_path}\share\icons\Adwaita\*"; DestDir: "{app}\share\icons\Adwaita"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#meson_source_root}\crates\rnote-ui\data\icons\rnote.ico"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#meson_source_root}\crates\rnote-ui\data\icons\rnote-symbolic.ico"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#meson_source_root}\crates\rnote-ui\data\icons\application-rnote.ico"; DestDir: "{app}"; Flags: ignoreversion

--- a/meson.build
+++ b/meson.build
@@ -21,8 +21,8 @@ localedir = prefix / get_option('localedir')
 sysconfdir = prefix / get_option('sysconfdir')
 profile = get_option('profile')
 build_cli = get_option('cli')
-msys_path = get_option('msys-path')
-installer_name = get_option('installer-name')
+win_build_environment_path = get_option('win-build-environment-path')
+win_installer_name = get_option('win-installer-name')
 
 app_name = 'rnote'
 app_name_capitalized = 'Rnote'
@@ -332,14 +332,14 @@ gnome.post_install(
 
 # Windows installer
 
-installer_output= installer_name + '.exe'
+installer_output= win_installer_name + '.exe'
 
 message('Configuring Inno-Setup installer script file')
 
 inno_script_conf = configuration_data()
 inno_script_conf.set_quoted('MESON_SOURCE_ROOT', meson.project_source_root())
 inno_script_conf.set_quoted('MESON_BUILD_ROOT', meson.project_build_root())
-inno_script_conf.set_quoted('MSYS_PATH', msys_path)
+inno_script_conf.set_quoted('BUILD_ENVIRONMENT_PATH', win_build_environment_path)
 inno_script_conf.set_quoted('APP_NAME', app_name)
 inno_script_conf.set_quoted('APP_NAME_CAPITALIZED', app_name_capitalized)
 inno_script_conf.set_quoted('APP_ID', app_id)
@@ -352,7 +352,7 @@ inno_script_conf.set_quoted('APP_ISSUES_URL', app_issues_url)
 inno_script_conf.set_quoted('APP_SUPPORT_URL', app_support_url)
 inno_script_conf.set_quoted('APP_DONATE_URL', app_donate_url)
 inno_script_conf.set_quoted('APP_OUTPUT', app_output)
-inno_script_conf.set_quoted('INSTALLER_NAME', installer_name)
+inno_script_conf.set_quoted('INSTALLER_NAME', win_installer_name)
 
 inno_script = configure_file(
     input: 'build-aux/rnote_inno.iss.in',
@@ -369,7 +369,7 @@ if host_machine.system() == 'windows'
             inno_build_script,
             meson.project_source_root(),
             meson.project_build_root(),
-            msys_path,
+            win_build_environment_path,
             app_name,
             app_name_capitalized,
             app_id,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,15 +17,15 @@ option(
 )
 
 option(
-  'installer-name',
+  'win-installer-name',
   type: 'string',
   value: 'rnote-win-installer',
   description: 'Only relevant for builds on Windows: the name of the generated installer after executing the "build-installer" target.',
 )
 
 option(
-  'msys-path',
+  'win-build-environment-path',
   type: 'string',
-  value: 'C:\\msys64',
-  description: 'Only relevant for builds on Windows: the path of the installed msys / mingw64 distribution.',
+  value: 'C:\\msys64\\mingw64',
+  description: 'Only relevant for builds on Windows: the path of the installed msys/mingw64 environment.',
 )

--- a/misc/building/rnote-windows-build.md
+++ b/misc/building/rnote-windows-build.md
@@ -99,5 +99,5 @@ called `msys-path` prior to building.
 meson configure -Dmsys-path='C:\path\to\msys64' _mesonbuild
 ```
 
-Likewise, you can adjust the output name of the installer using the `installer-name` option
+Likewise, you can adjust the output name of the installer using the `win-installer-name` option
 (which defaults to `rnote_installer`).


### PR DESCRIPTION
This refactors the win installer build steps in order in anticipation to be able to use different msys environment in the future (like urcvt or clangarm64 - for a list of available environments see [here](https://www.msys2.org/docs/environments/) ). For example for Windows ARM builds - issue #837