### PR TITLE
Add `Ctrl+A` to select all strokes and re enable `Ctrl+T`

### DIFF
--- a/crates/rnote-ui/data/ui/shortcuts.ui
+++ b/crates/rnote-ui/data/ui/shortcuts.ui
@@ -233,6 +233,12 @@
                 </child>
                 <child>
                   <object class="GtkShortcutsShortcut">
+                    <property name="title" translatable="yes">Select All Strokes</property>
+                    <property name="accelerator">&lt;ctrl&gt;a</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkShortcutsShortcut">
                     <property name="title" translatable="yes">Duplicate Selection</property>
                     <property name="accelerator">&lt;ctrl&gt;d</property>
                   </object>

--- a/crates/rnote-ui/data/ui/shortcuts.ui
+++ b/crates/rnote-ui/data/ui/shortcuts.ui
@@ -176,6 +176,12 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">Open New Tab</property>
+                <property name="accelerator">&lt;ctrl&gt;t</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Snap Positions</property>
                 <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;p</property>
               </object>

--- a/crates/rnote-ui/src/appwindow/actions.rs
+++ b/crates/rnote-ui/src/appwindow/actions.rs
@@ -956,6 +956,7 @@ impl RnAppWindow {
         app.set_accels_for_action("win.clipboard-copy", &["<Ctrl>c"]);
         app.set_accels_for_action("win.clipboard-cut", &["<Ctrl>x"]);
         app.set_accels_for_action("win.clipboard-paste", &["<Ctrl>v"]);
+        app.set_accels_for_action("win.selection-select-all", &["<Ctrl>a"]);
         app.set_accels_for_action("win.pen-style::brush", &["<Ctrl>1"]);
         app.set_accels_for_action("win.pen-style::shaper", &["<Ctrl>2"]);
         app.set_accels_for_action("win.pen-style::typewriter", &["<Ctrl>3"]);


### PR DESCRIPTION
- `Ctrl+A` to select all strokes
- `Ctrl+T` re enabled (added back to the `shortcuts.ui`, wouldn't work otherwise)