### PR TITLE
only open a `layer` if the content to write is not empty

### DIFF
--- a/crates/rnote-engine/src/fileformats/xoppformat.rs
+++ b/crates/rnote-engine/src/fileformats/xoppformat.rs
@@ -475,8 +475,7 @@ impl XmlWritable for XoppLayer {
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter) {
         // only do something if we are sure the layer is not empty
         // Fix for #985
-        let is_empty = self.name.as_ref().is_none()
-            && (self.strokes.is_empty())
+        let is_empty = (self.strokes.is_empty())
             && (self.texts.is_empty())
             && (self.images.is_empty());
         if is_empty {

--- a/crates/rnote-engine/src/fileformats/xoppformat.rs
+++ b/crates/rnote-engine/src/fileformats/xoppformat.rs
@@ -475,10 +475,10 @@ impl XmlWritable for XoppLayer {
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter) {
         // only do something if we are sure the layer is not empty
         // Fix for #985
-        let is_empty = (self.name.as_ref().is_some()
-            || (self.strokes.len() > 0)
-            || (self.texts.len() > 0)
-            || (self.images.len() > 0));
+        let is_empty = self.name.as_ref().is_some()
+            || (!self.strokes.is_empty())
+            || (!self.texts.is_empty())
+            || (!self.images.is_empty());
         match is_empty {
             false => {
                 tracing::trace!("empty layer, skipped")

--- a/crates/rnote-engine/src/fileformats/xoppformat.rs
+++ b/crates/rnote-engine/src/fileformats/xoppformat.rs
@@ -475,9 +475,7 @@ impl XmlWritable for XoppLayer {
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter) {
         // only do something if we are sure the layer is not empty
         // Fix for #985
-        let is_empty = (self.strokes.is_empty())
-            && (self.texts.is_empty())
-            && (self.images.is_empty());
+        let is_empty = self.strokes.is_empty() && self.texts.is_empty() && self.images.is_empty();
         if is_empty {
             tracing::trace!("empty layer, skipped")
         } else {

--- a/crates/rnote-engine/src/fileformats/xoppformat.rs
+++ b/crates/rnote-engine/src/fileformats/xoppformat.rs
@@ -475,16 +475,15 @@ impl XmlWritable for XoppLayer {
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter) {
         // only do something if we are sure the layer is not empty
         // Fix for #985
-        tracing::debug!("name {:?}", self.name.as_ref());
         let is_empty = self.name.as_ref().is_none()
             && (self.strokes.is_empty())
             && (self.texts.is_empty())
             && (self.images.is_empty());
         if is_empty {
-            tracing::debug!("empty layer, skipped")
+            tracing::trace!("empty layer, skipped")
         } else {
             w.start_element("layer");
-            tracing::debug!("layer element opened");
+            tracing::trace!("layer element opened");
 
             if let Some(name) = self.name.as_ref() {
                 w.write_attribute("name", name.as_str());

--- a/crates/rnote-engine/src/fileformats/xoppformat.rs
+++ b/crates/rnote-engine/src/fileformats/xoppformat.rs
@@ -473,22 +473,36 @@ impl XmlLoadable for XoppLayer {
 
 impl XmlWritable for XoppLayer {
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter) {
-        w.start_element("layer");
+        // only do something if we are sure the layer is not empty
+        // Fix for #985
+        let is_empty = (self.name.as_ref().is_some()
+            || (self.strokes.len() > 0)
+            || (self.texts.len() > 0)
+            || (self.images.len() > 0));
+        match is_empty {
+            false => {
+                tracing::trace!("empty layer, skipped")
+            }
+            true => {
+                w.start_element("layer");
+                tracing::trace!("layer element opened");
 
-        if let Some(name) = self.name.as_ref() {
-            w.write_attribute("name", name.as_str());
-        }
+                if let Some(name) = self.name.as_ref() {
+                    w.write_attribute("name", name.as_str());
+                }
 
-        for stroke in self.strokes.iter() {
-            stroke.write_to_xml(w);
-        }
-        for text in self.texts.iter() {
-            text.write_to_xml(w);
-        }
-        for image in self.images.iter() {
-            image.write_to_xml(w);
-        }
-        w.end_element();
+                for stroke in self.strokes.iter() {
+                    stroke.write_to_xml(w);
+                }
+                for text in self.texts.iter() {
+                    text.write_to_xml(w);
+                }
+                for image in self.images.iter() {
+                    image.write_to_xml(w);
+                }
+                w.end_element();
+            }
+        };
     }
 }
 

--- a/crates/rnote-engine/src/fileformats/xoppformat.rs
+++ b/crates/rnote-engine/src/fileformats/xoppformat.rs
@@ -475,34 +475,32 @@ impl XmlWritable for XoppLayer {
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter) {
         // only do something if we are sure the layer is not empty
         // Fix for #985
-        let is_empty = self.name.as_ref().is_some()
-            || (!self.strokes.is_empty())
-            || (!self.texts.is_empty())
-            || (!self.images.is_empty());
-        match is_empty {
-            false => {
-                tracing::trace!("empty layer, skipped")
-            }
-            true => {
-                w.start_element("layer");
-                tracing::trace!("layer element opened");
+        tracing::debug!("name {:?}", self.name.as_ref());
+        let is_empty = self.name.as_ref().is_none()
+            && (self.strokes.is_empty())
+            && (self.texts.is_empty())
+            && (self.images.is_empty());
+        if is_empty {
+            tracing::debug!("empty layer, skipped")
+        } else {
+            w.start_element("layer");
+            tracing::debug!("layer element opened");
 
-                if let Some(name) = self.name.as_ref() {
-                    w.write_attribute("name", name.as_str());
-                }
-
-                for stroke in self.strokes.iter() {
-                    stroke.write_to_xml(w);
-                }
-                for text in self.texts.iter() {
-                    text.write_to_xml(w);
-                }
-                for image in self.images.iter() {
-                    image.write_to_xml(w);
-                }
-                w.end_element();
+            if let Some(name) = self.name.as_ref() {
+                w.write_attribute("name", name.as_str());
             }
-        };
+
+            for stroke in self.strokes.iter() {
+                stroke.write_to_xml(w);
+            }
+            for text in self.texts.iter() {
+                text.write_to_xml(w);
+            }
+            for image in self.images.iter() {
+                image.write_to_xml(w);
+            }
+            w.end_element();
+        }
     }
 }
 


### PR DESCRIPTION
For #985

Changing how `layer` elements are created to circumvent bugs that pushed all images down into the background instead of being editable in xournal.

I wonder if I should add to this PR some other modifications to export more shapes to their xournal equivalent.

I've glanced over the xournal code for line and rectangle as well as how these things are exported in the xournal file and it seems feasible to convert them to their xournal equivalent (in their non rough version).