### PR TITLE
feat: 'adjust document' pdf import option

### DIFF
--- a/crates/rnote-engine/src/engine/import.rs
+++ b/crates/rnote-engine/src/engine/import.rs
@@ -1,5 +1,6 @@
 // Imports
 use super::{EngineConfig, EngineViewMut, StrokeContent};
+use crate::document::Layout;
 use crate::pens::Pen;
 use crate::pens::PenStyle;
 use crate::store::chrono_comp::StrokeLayer;
@@ -7,6 +8,8 @@ use crate::store::StrokeKey;
 use crate::strokes::{BitmapImage, Stroke, VectorImage};
 use crate::{CloneConfig, Engine, WidgetFlags};
 use futures::channel::oneshot;
+use rnote_compose::ext::Vector2Ext;
+use rnote_compose::shapes::Shapeable;
 use serde::{Deserialize, Serialize};
 use std::ops::Range;
 use std::path::PathBuf;
@@ -91,6 +94,9 @@ pub struct PdfImportPrefs {
     /// Whether the imported Pdf pages have drawn borders
     #[serde(rename = "page_borders")]
     pub page_borders: bool,
+    /// Whether the document layout should be adjusted to the Pdf
+    #[serde(rename = "adjust_document")]
+    pub adjust_document: bool,
 }
 
 impl Default for PdfImportPrefs {
@@ -101,6 +107,7 @@ impl Default for PdfImportPrefs {
             page_spacing: PdfImportPageSpacing::default(),
             bitmap_scalefactor: 1.8,
             page_borders: true,
+            adjust_document: false,
         }
     }
 }
@@ -271,6 +278,8 @@ impl Engine {
     /// Generate image strokes for each page for the bytes.
     ///
     /// The bytes are expected to be from a valid Pdf.
+    ///
+    /// Note: `insert_pos` does not have an effect when the `adjust_document` import pref is set true.
     #[allow(clippy::type_complexity)]
     pub fn generate_pdf_pages_from_bytes(
         &self,
@@ -282,6 +291,11 @@ impl Engine {
             oneshot::channel::<anyhow::Result<Vec<(Stroke, Option<StrokeLayer>)>>>();
         let pdf_import_prefs = self.import_prefs.pdf_import_prefs;
         let format = self.document.format;
+        let insert_pos = if self.import_prefs.pdf_import_prefs.adjust_document {
+            na::Vector2::<f64>::zeros()
+        } else {
+            insert_pos
+        };
 
         rayon::spawn(move || {
             let result = || -> anyhow::Result<Vec<(Stroke, Option<StrokeLayer>)>> {
@@ -329,13 +343,30 @@ impl Engine {
         strokes: Vec<(Stroke, Option<StrokeLayer>)>,
     ) -> WidgetFlags {
         let mut widget_flags = WidgetFlags::default();
+        if strokes.is_empty() {
+            return widget_flags;
+        }
+        let adjust_document = self.import_prefs.pdf_import_prefs.adjust_document;
+        let select = !self.import_prefs.pdf_import_prefs.adjust_document;
 
-        // we need to always deselect all strokes -
-        // even tough changing the pen style deselects too, it does only when the pen is actually different.
+        // we need to always deselect all strokes. Even tough changing the pen style deselects too, it does only when
+        // the pen is actually different.
         let all_strokes = self.store.stroke_keys_as_rendered();
         self.store.set_selected_keys(&all_strokes, false);
 
-        widget_flags |= self.change_pen_style(PenStyle::Selector);
+        if select {
+            widget_flags |= self.change_pen_style(PenStyle::Selector);
+        }
+
+        if adjust_document {
+            let max_size = strokes
+                .iter()
+                .map(|(stroke, _)| stroke.bounds().extents())
+                .fold(na::Vector2::<f64>::zeros(), |acc, x| acc.maxs(&x));
+            self.document.width = max_size[0];
+            self.document.height = max_size[1];
+            widget_flags |= self.set_doc_layout(Layout::FixedSize) | self.doc_resize_autoexpand()
+        }
 
         let inserted = strokes
             .into_iter()
@@ -344,7 +375,9 @@ impl Engine {
 
         // resize after the strokes are inserted, but before they are set selected
         widget_flags |= self.doc_resize_to_fit_content();
-        self.store.set_selected_keys(&inserted, true);
+        if select {
+            self.store.set_selected_keys(&inserted, true);
+        }
         widget_flags |= self.current_pen_update_state();
         widget_flags |= self.store.record(Instant::now());
         widget_flags.resize = true;

--- a/crates/rnote-engine/src/engine/import.rs
+++ b/crates/rnote-engine/src/engine/import.rs
@@ -363,8 +363,8 @@ impl Engine {
                 .iter()
                 .map(|(stroke, _)| stroke.bounds().extents())
                 .fold(na::Vector2::<f64>::zeros(), |acc, x| acc.maxs(&x));
-            self.document.width = max_size[0];
-            self.document.height = max_size[1];
+            self.document.format.set_width(max_size[0]);
+            self.document.format.set_height(max_size[1]);
             widget_flags |= self.set_doc_layout(Layout::FixedSize) | self.doc_resize_autoexpand()
         }
 

--- a/crates/rnote-engine/src/strokes/bitmapimage.rs
+++ b/crates/rnote-engine/src/strokes/bitmapimage.rs
@@ -122,7 +122,11 @@ impl BitmapImage {
     ) -> Result<Vec<Self>, anyhow::Error> {
         let doc = poppler::Document::from_bytes(&glib::Bytes::from(to_be_read), None)?;
         let page_range = page_range.unwrap_or(0..doc.n_pages() as u32);
-        let page_width = format.width() * (pdf_import_prefs.page_width_perc / 100.0);
+        let page_width = if pdf_import_prefs.adjust_document {
+            format.width()
+        } else {
+            format.width() * (pdf_import_prefs.page_width_perc / 100.0)
+        };
         // calculate the page zoom based on the width of the first page.
         let page_zoom = if let Some(first_page) = doc.page(0) {
             page_width / first_page.size().0
@@ -195,12 +199,16 @@ impl BitmapImage {
                 let image_pos = na::vector![x, y];
                 let image_size = na::vector![width, height];
 
-                y += match pdf_import_prefs.page_spacing {
-                    PdfImportPageSpacing::Continuous => {
-                        height + Stroke::IMPORT_OFFSET_DEFAULT[1] * 0.5
-                    }
-                    PdfImportPageSpacing::OnePerDocumentPage => format.height(),
-                };
+                if pdf_import_prefs.adjust_document {
+                    y += height
+                } else {
+                    y += match pdf_import_prefs.page_spacing {
+                        PdfImportPageSpacing::Continuous => {
+                            height + Stroke::IMPORT_OFFSET_DEFAULT[1] * 0.5
+                        }
+                        PdfImportPageSpacing::OnePerDocumentPage => format.height(),
+                    };
+                }
 
                 Ok((png_data, image_pos, image_size))
             })

--- a/crates/rnote-engine/src/strokes/vectorimage.rs
+++ b/crates/rnote-engine/src/strokes/vectorimage.rs
@@ -191,7 +191,11 @@ impl VectorImage {
         let doc = poppler::Document::from_bytes(&glib::Bytes::from(bytes), None)?;
         let page_range = page_range.unwrap_or(0..doc.n_pages() as u32);
 
-        let page_width = format.width() * (pdf_import_prefs.page_width_perc / 100.0);
+        let page_width = if pdf_import_prefs.adjust_document {
+            format.width()
+        } else {
+            format.width() * (pdf_import_prefs.page_width_perc / 100.0)
+        };
         // calculate the page zoom based on the width of the first page.
         let page_zoom = if let Some(first_page) = doc.page(0) {
             page_width / first_page.size().0
@@ -281,12 +285,16 @@ impl VectorImage {
 
                 let bounds = Aabb::new(na::point![x, y], na::point![x + width, y + height]);
 
-                y += match pdf_import_prefs.page_spacing {
-                    PdfImportPageSpacing::Continuous => {
-                        height + Stroke::IMPORT_OFFSET_DEFAULT[1] * 0.5
-                    }
-                    PdfImportPageSpacing::OnePerDocumentPage => format.height(),
-                };
+                if pdf_import_prefs.adjust_document {
+                    y += height
+                } else {
+                    y += match pdf_import_prefs.page_spacing {
+                        PdfImportPageSpacing::Continuous => {
+                            height + Stroke::IMPORT_OFFSET_DEFAULT[1] * 0.5
+                        }
+                        PdfImportPageSpacing::OnePerDocumentPage => format.height(),
+                    };
+                }
 
                 match res() {
                     Ok(svg_data) => Some(render::Svg { svg_data, bounds }),

--- a/crates/rnote-ui/data/ui/dialogs/import.ui
+++ b/crates/rnote-ui/data/ui/dialogs/import.ui
@@ -97,6 +97,12 @@
                   </object>
                 </child>
                 <child>
+                  <object class="AdwSwitchRow" id="pdf_import_adjust_document_row">
+                    <property name="title" translatable="yes">Adjust Document</property>
+                    <property name="subtitle" translatable="yes">Whether the document layout should be adjusted to the Pdf</property>
+                  </object>
+                </child>
+                <child>
                   <object class="AdwSpinRow" id="pdf_import_width_row">
                     <property name="title" translatable="yes">Page Width (%)</property>
                     <property name="subtitle" translatable="yes">Set the width of imported Pdf's in percentage to the format width</property>

--- a/crates/rnote-ui/src/dialogs/import.rs
+++ b/crates/rnote-ui/src/dialogs/import.rs
@@ -112,8 +112,21 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
         builder.object("pdf_import_bitmap_scalefactor_row").unwrap();
     let pdf_import_page_borders_row: adw::SwitchRow =
         builder.object("pdf_import_page_borders_row").unwrap();
+    let pdf_import_adjust_document_row: adw::SwitchRow =
+        builder.object("pdf_import_adjust_document_row").unwrap();
 
     dialog.set_transient_for(Some(appwindow));
+
+    pdf_import_adjust_document_row
+        .bind_property("active", &pdf_import_width_row, "sensitive")
+        .invert_boolean()
+        .sync_create()
+        .build();
+    pdf_import_adjust_document_row
+        .bind_property("active", &pdf_import_page_spacing_row, "sensitive")
+        .invert_boolean()
+        .sync_create()
+        .build();
 
     let pdf_import_prefs = canvas.engine_ref().import_prefs.pdf_import_prefs;
 
@@ -132,6 +145,7 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
     pdf_import_page_spacing_row.set_selected(pdf_import_prefs.page_spacing.to_u32().unwrap());
     pdf_import_bitmap_scalefactor_row.set_value(pdf_import_prefs.bitmap_scalefactor);
     pdf_import_page_borders_row.set_active(pdf_import_prefs.page_borders);
+    pdf_import_adjust_document_row.set_active(pdf_import_prefs.adjust_document);
 
     pdf_page_start_row
         .bind_property("value", &pdf_page_end_row.adjustment(), "lower")
@@ -182,6 +196,12 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
     pdf_import_page_borders_row.connect_active_notify(
         clone!(@weak canvas, @weak appwindow => move |row| {
             canvas.engine_mut().import_prefs.pdf_import_prefs.page_borders = row.is_active();
+        }),
+    );
+
+    pdf_import_adjust_document_row.connect_active_notify(
+        clone!(@weak canvas, @weak appwindow => move |row| {
+            canvas.engine_mut().import_prefs.pdf_import_prefs.adjust_document = row.is_active();
         }),
     );
 


### PR DESCRIPTION
Implements an option that, when enabled, adjusts the document page size to the import pdf maximum page size, positions the pdf at the origin and sets the layout to 'fixed-size'.

fixes #1027