### PR TITLE
refactor: improve canvas file watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6584280525fb2059cba3db2c04abf947a1a29a45ddae89f3870f8281704fafc9"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2658,6 +2667,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-debouncer-full"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f5dab59c348b9b50cf7f261960a20e389feb2713636399cd9082cd4b536154"
+dependencies = [
+ "crossbeam-channel",
+ "file-id",
+ "log",
+ "notify",
+ "parking_lot",
+ "walkdir",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,6 +3017,24 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "path-slash"
@@ -3486,13 +3527,14 @@ dependencies = [
  "kurbo 0.10.4",
  "libadwaita",
  "nalgebra",
- "notify",
+ "notify-debouncer-full",
  "num-derive 0.4.2",
  "num-traits",
  "numeric-sort",
  "once_cell",
  "open",
  "parry2d-f64",
+ "path-absolutize",
  "piet",
  "piet-cairo",
  "poppler-rs",
@@ -3505,7 +3547,6 @@ dependencies = [
  "rnote-engine",
  "rough_piet",
  "roughr",
- "same-file",
  "serde",
  "serde_json",
  "svg",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1224,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,6 +1312,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futf"
@@ -1998,6 +2028,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,6 +2193,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -2458,6 +2528,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "moveit"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2554,6 +2636,25 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.4.2",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3371,6 +3472,7 @@ name = "rnote"
 version = "0.9.4"
 dependencies = [
  "anyhow",
+ "async-fs",
  "base64",
  "cairo-rs",
  "fs_extra",
@@ -3384,6 +3486,7 @@ dependencies = [
  "kurbo 0.10.4",
  "libadwaita",
  "nalgebra",
+ "notify",
  "num-derive 0.4.2",
  "num-traits",
  "numeric-sort",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,10 @@ version = "0.9.4"
 rnote-compose = { version = "0.9.4", path = "crates/rnote-compose" }
 rnote-engine = { version = "0.9.4", path = "crates/rnote-engine" }
 
+adw = { version = "0.6.0", package = "libadwaita", features = ["v1_4"] }
 anyhow = "1"
 approx = "0.5.1"
+async-fs = "2"
 atty = "0.2"
 base64 = "0.21"
 cairo-rs = { version = "0.19.1", features = ["v1_18", "png", "svg", "pdf"] }
@@ -36,12 +38,14 @@ gettext-rs = { version = "0.7", features = ["gettext-system"] }
 gio = "0.19.0"
 glib = "0.19.0"
 glib-build-tools = "0.19.0"
+gtk4 = { version = "0.8.0", features = ["v4_12"] }
 ijson = "0.1"
 image = "0.24"
 indicatif = "0.17"
 itertools = "0.12"
 kurbo = "0.10"
 nalgebra = { version = "0.32", features = ["serde-serialize"] }
+notify = "6"
 num-derive = "0.4"
 num-traits = "0.2"
 once_cell = "1"
@@ -77,8 +81,6 @@ url = "2"
 usvg = "0.40"
 winresource = "0.1"
 xmlwriter = "0.1"
-adw = { version = "0.6.0", package = "libadwaita", features = ["v1_4"] }
-gtk4 = { version = "0.8.0", features = ["v4_12"] }
 # once a new librsvg (current v2.57.1) is released that includes updated cairo,
 # this can be replaced by the version on crates-io.
 librsvg = { git = "https://gitlab.gnome.org/GNOME/librsvg", rev = "3a497b56fe581ab4fda1a80ac19352bfb91676b6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ indicatif = "0.17"
 itertools = "0.12"
 kurbo = "0.10"
 nalgebra = { version = "0.32", features = ["serde-serialize"] }
-notify = "6"
+notify-debouncer-full = "0.3.1"
 num-derive = "0.4"
 num-traits = "0.2"
 once_cell = "1"
@@ -66,7 +66,7 @@ rough_piet = "0.6"
 roughr = "0.6"
 roxmltree = "0.19"
 rstar = "0.12"
-same-file = "1"
+path-absolutize = "3.1"
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"

--- a/crates/rnote-ui/Cargo.toml
+++ b/crates/rnote-ui/Cargo.toml
@@ -15,6 +15,7 @@ rnote-engine = { workspace = true, features = ["ui"] }
 
 adw = { workspace = true }
 anyhow = { workspace = true }
+async-fs = "2"
 base64 = { workspace = true }
 cairo-rs = { workspace = true }
 fs_extra = { workspace = true }
@@ -26,6 +27,7 @@ image = { workspace = true }
 itertools = { workspace = true }
 kurbo = { workspace = true }
 nalgebra = { workspace = true }
+notify = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 numeric-sort = { workspace = true }

--- a/crates/rnote-ui/Cargo.toml
+++ b/crates/rnote-ui/Cargo.toml
@@ -15,7 +15,7 @@ rnote-engine = { workspace = true, features = ["ui"] }
 
 adw = { workspace = true }
 anyhow = { workspace = true }
-async-fs = "2"
+async-fs = { workspace = true }
 base64 = { workspace = true }
 cairo-rs = { workspace = true }
 fs_extra = { workspace = true }

--- a/crates/rnote-ui/Cargo.toml
+++ b/crates/rnote-ui/Cargo.toml
@@ -27,7 +27,7 @@ image = { workspace = true }
 itertools = { workspace = true }
 kurbo = { workspace = true }
 nalgebra = { workspace = true }
-notify = { workspace = true }
+notify-debouncer-full = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 numeric-sort = { workspace = true }
@@ -44,7 +44,7 @@ rayon = { workspace = true }
 regex = { workspace = true }
 rough_piet = { workspace = true }
 roughr = { workspace = true }
-same-file = { workspace = true }
+path-absolutize = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 svg = { workspace = true }

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -382,7 +382,8 @@ impl RnAppWindow {
                 ))
             })
             .find(|(_, output_file_path)| {
-                same_file::is_same_file(output_file_path, input_file_path.as_ref()).unwrap_or(false)
+                crate::utils::paths_abs_eq(output_file_path, input_file_path.as_ref())
+                    .unwrap_or(false)
             })
             .map(|(found, _)| found)
     }

--- a/crates/rnote-ui/src/canvas/imexport.rs
+++ b/crates/rnote-ui/src/canvas/imexport.rs
@@ -1,6 +1,8 @@
 // Imports
 use super::RnCanvas;
+use anyhow::Context;
 use futures::channel::oneshot;
+use futures::AsyncWriteExt;
 use gtk4::{gio, prelude::*};
 use rnote_compose::ext::Vector2Ext;
 use rnote_engine::engine::export::{DocExportPrefs, DocPagesExportPrefs, SelectionExportPrefs};
@@ -191,47 +193,56 @@ impl RnCanvas {
             tracing::debug!("Saving file already in progress.");
             return Ok(false);
         }
+        self.set_save_in_progress(true);
+
         let file_path = file
             .path()
             .ok_or_else(|| anyhow::anyhow!("Could not get a path for file: `{file:?}`."))?;
         let basename = file
             .basename()
             .ok_or_else(|| anyhow::anyhow!("Could not retrieve basename for file: `{file:?}`."))?;
-
-        self.set_save_in_progress(true);
         let rnote_bytes_receiver = self
             .engine_ref()
             .save_as_rnote_bytes(basename.to_string_lossy().to_string());
-
         let mut skip_set_output_file = false;
         if let Some(current_file_path) = self.output_file().and_then(|f| f.path()) {
-            if same_file::is_same_file(current_file_path, file_path).unwrap_or(false) {
+            if same_file::is_same_file(current_file_path, &file_path).unwrap_or(false) {
                 skip_set_output_file = true;
             }
         }
 
         self.dismiss_output_file_modified_toast();
-        self.set_output_file_expect_write(true);
 
-        let res = async move {
-            crate::utils::create_replace_file_future(rnote_bytes_receiver.await??, file).await
-        }
-        .await;
+        let file_write_operation = async move {
+            let bytes = rnote_bytes_receiver.await??;
+            let mut write_file = async_fs::File::create(&file_path).await.context(format!(
+                "Failed to create file for path '{}'",
+                file_path.display()
+            ))?;
+            self.set_output_file_expect_write(true);
+            if !skip_set_output_file {
+                // this installs the file watcher.
+                self.set_output_file(Some(file.to_owned()));
+            }
+            write_file.write_all(&bytes).await.context(format!(
+                "Failed to write bytes to file with path '{}'",
+                file_path.display()
+            ))?;
+            write_file.flush().await.context(format!(
+                "Failed to flush file with path '{}'",
+                file_path.display()
+            ))?;
+            Ok(())
+        };
 
-        if let Err(e) = res {
+        if let Err(e) = file_write_operation.await {
             self.set_save_in_progress(false);
-
             // If the file operations failed in any way, we make sure to clear the expect_write flag
-            // because we can't know for sure if the output_file monitor will be able to.
+            // because we can't know for sure if the output-file watcher will be able to.
             self.set_output_file_expect_write(false);
             return Err(e);
         }
 
-        // this **must** come after saving the file to disk,
-        // else it is not possible to watch the file.
-        if !skip_set_output_file {
-            self.set_output_file(Some(file.to_owned()));
-        }
         self.set_unsaved_changes(false);
         self.set_save_in_progress(false);
 

--- a/crates/rnote-ui/src/canvas/imexport.rs
+++ b/crates/rnote-ui/src/canvas/imexport.rs
@@ -215,11 +215,11 @@ impl RnCanvas {
 
         let file_write_operation = async move {
             let bytes = rnote_bytes_receiver.await??;
+            self.set_output_file_expect_write(true);
             let mut write_file = async_fs::File::create(&file_path).await.context(format!(
                 "Failed to create file for path '{}'",
                 file_path.display()
             ))?;
-            self.set_output_file_expect_write(true);
             if !skip_set_output_file {
                 // this installs the file watcher.
                 self.set_output_file(Some(file.to_owned()));

--- a/crates/rnote-ui/src/canvas/imexport.rs
+++ b/crates/rnote-ui/src/canvas/imexport.rs
@@ -210,12 +210,6 @@ impl RnCanvas {
             }
         }
 
-        // this **must** come before actually saving the file to disk,
-        // else the event might not be caught by the monitor for new or changed files
-        if !skip_set_output_file {
-            self.set_output_file(Some(file.to_owned()));
-        }
-
         self.dismiss_output_file_modified_toast();
         self.set_output_file_expect_write(true);
 
@@ -233,6 +227,11 @@ impl RnCanvas {
             return Err(e);
         }
 
+        // this **must** come after saving the file to disk,
+        // else it is not possible to watch the file.
+        if !skip_set_output_file {
+            self.set_output_file(Some(file.to_owned()));
+        }
         self.set_unsaved_changes(false);
         self.set_save_in_progress(false);
 

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -899,7 +899,7 @@ impl RnCanvas {
 
         let event_handler =
             move |appwindow: &RnAppWindow, canvas: &RnCanvas, event: notify::Event| {
-                tracing::info!("file watcher - handling event: {event:?}");
+                tracing::info!("file watcher - received event: {event:?}");
 
                 match event.kind {
                     notify::EventKind::Create(_create_kind) => {}

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -950,6 +950,7 @@ impl RnCanvas {
                     _ => {}
                 }
             };
+
         let new_watcher_task = glib::spawn_future_local(
             glib::clone!(@strong file, @weak self as canvas, @weak appwindow => async move {
                 let (tx, mut rx) = futures::channel::mpsc::unbounded();

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -899,7 +899,7 @@ impl RnCanvas {
 
         let event_handler =
             move |appwindow: &RnAppWindow, canvas: &RnCanvas, event: notify::Event| {
-                tracing::info!("file watcher - received event: {event:?}");
+                tracing::debug!("file watcher - received event: {event:?}");
 
                 match event.kind {
                     notify::EventKind::Create(_create_kind) => {}


### PR DESCRIPTION
using the `notify` and `async-fs` crates. They do not have the particularities of the glib file monitor and goutputstream files.

addresses #894, #990, #815