### PR TITLE
improv: reduce repaints

### DIFF
--- a/crates/rnote-engine/Cargo.toml
+++ b/crates/rnote-engine/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 rnote-compose = { workspace = true }
 
 anyhow = { workspace = true }
+approx = { workspace = true }
 base64 = { workspace = true }
 cairo-rs = { workspace = true }
 chrono = { workspace = true }

--- a/crates/rnote-engine/src/camera.rs
+++ b/crates/rnote-engine/src/camera.rs
@@ -232,6 +232,13 @@ impl Camera {
         self.zoom * self.scale_factor
     }
 
+    /// The scale factor that gets set according to the toolkit hi-dpi settings.
+    ///
+    /// For Gtk it currently is 1.0 for scaling < 150%, 2.0 for >= 150% and < 250%, ..
+    pub fn scale_factor(&self) -> f64 {
+        self.scale_factor
+    }
+
     pub fn set_scale_factor(&mut self, scale_factor: f64) -> WidgetFlags {
         self.scale_factor = scale_factor;
         let mut widget_flags = WidgetFlags::default();

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -689,7 +689,7 @@ impl Engine {
     ///
     /// Background and content rendering then needs to be updated.
     pub fn doc_expand_autoexpand(&mut self) -> WidgetFlags {
-        self.document.expand_autoexpand(&self.camera)
+        self.document.expand_autoexpand(&self.camera, &self.store)
     }
 
     /// Add a page to the document when in fixed size layout.

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -185,6 +185,12 @@ pub struct Engine {
     #[cfg(feature = "ui")]
     #[serde(skip)]
     background_rendernodes: Vec<gtk4::gsk::RenderNode>,
+    // Origin indicator rendering
+    #[serde(skip)]
+    origin_indicator_image: Option<render::Image>,
+    #[cfg(feature = "ui")]
+    #[serde(skip)]
+    origin_indicator_rendernode: Option<gtk4::gsk::RenderNode>,
 }
 
 impl Default for Engine {
@@ -208,6 +214,9 @@ impl Default for Engine {
             background_tile_image: None,
             #[cfg(feature = "ui")]
             background_rendernodes: Vec::default(),
+            origin_indicator_image: None,
+            #[cfg(feature = "ui")]
+            origin_indicator_rendernode: None,
         }
     }
 }
@@ -318,7 +327,7 @@ impl Engine {
         let mut widget_flags = self.store.import_from_snapshot(&snapshot)
             | self.doc_resize_autoexpand()
             | self.current_pen_update_state()
-            | self.background_regenerate_pattern()
+            | self.background_rendering_regenerate()
             | self.update_content_rendering_current_viewport();
         widget_flags.refresh_ui = true;
         widget_flags.view_modified = true;
@@ -444,7 +453,7 @@ impl Engine {
                 let all_strokes = self.store.stroke_keys_unordered();
                 self.store.set_rendering_dirty_for_strokes(&all_strokes);
                 widget_flags |= self.doc_resize_autoexpand()
-                    | self.background_regenerate_pattern()
+                    | self.background_rendering_regenerate()
                     | self.update_rendering_current_viewport();
             }
             EngineTask::Quit => {
@@ -564,7 +573,7 @@ impl Engine {
         let mut widget_flags = WidgetFlags::default();
         if active {
             widget_flags |= self.reinstall_pen_current_style()
-                | self.background_regenerate_pattern()
+                | self.background_rendering_regenerate()
                 | self.update_content_rendering_current_viewport();
             widget_flags.view_modified = true;
         } else {
@@ -631,7 +640,7 @@ impl Engine {
         self.store
             .set_rendering_dirty_for_strokes(&self.store.stroke_keys_as_rendered());
         self.camera.set_scale_factor(scale_factor)
-            | self.background_regenerate_pattern()
+            | self.background_rendering_regenerate()
             | self.update_content_rendering_current_viewport()
     }
 

--- a/crates/rnote-engine/src/engine/rendering.rs
+++ b/crates/rnote-engine/src/engine/rendering.rs
@@ -1,5 +1,9 @@
 // Imports
+use crate::render::Image;
 use crate::{Engine, WidgetFlags};
+use p2d::bounding_volume::Aabb;
+use piet::RenderContext;
+use rnote_compose::color;
 
 impl Engine {
     /// Update the background rendering for the current viewport.
@@ -47,6 +51,38 @@ impl Engine {
             self.background_rendernodes = rendernodes;
         }
 
+        #[cfg(feature = "ui")]
+        {
+            use crate::ext::GrapheneRectExt;
+            use gtk4::{graphene, gsk, prelude::*};
+
+            let image_scale = self.camera.image_scale();
+
+            if let Some(image) = &self.origin_indicator_image {
+                // Only create the texture once, it is expensive
+                let new_texture = match image.to_memtexture() {
+                    Ok(t) => t,
+                    Err(e) => {
+                        tracing::error!(
+                            "failed to generate memory-texture of origin indicator image, {e:?}"
+                        );
+                        return widget_flags;
+                    }
+                };
+
+                self.origin_indicator_rendernode = Some(
+                    gsk::TextureNode::new(
+                        &new_texture,
+                        &graphene::Rect::from_p2d_aabb(
+                            origin_indicator_bounds()
+                                .scaled(&na::Vector2::repeat(1.0 / image_scale)),
+                        ),
+                    )
+                    .upcast(),
+                );
+            }
+        }
+
         widget_flags.redraw = true;
         widget_flags
     }
@@ -77,25 +113,44 @@ impl Engine {
         let mut widget_flags = WidgetFlags::default();
         self.store.clear_rendering();
         self.background_tile_image.take();
+        self.origin_indicator_image.take();
         #[cfg(feature = "ui")]
         {
             self.background_rendernodes.clear();
+            self.origin_indicator_rendernode.take();
         }
         widget_flags.redraw = true;
         widget_flags
     }
 
-    /// Regenerate the background tile image and updates the background rendering.
-    pub fn background_regenerate_pattern(&mut self) -> WidgetFlags {
+    /// Regenerate the background tile image, origin indicator and updates the background rendering.
+    pub fn background_rendering_regenerate(&mut self) -> WidgetFlags {
         let mut widget_flags = WidgetFlags::default();
         let image_scale = self.camera.image_scale();
+        let scale_factor = self.camera.scale_factor();
+
         match self.document.background.gen_tile_image(image_scale) {
             Ok(image) => {
                 self.background_tile_image = Some(image);
-                widget_flags |= self.update_background_rendering_current_viewport();
             }
-            Err(e) => tracing::error!("Regenerating background tile image failed, Err: {e:?}"),
+            Err(e) => {
+                tracing::error!("Regenerating background tile image failed, Err: {e:?}");
+                return widget_flags;
+            }
         }
+
+        match gen_origin_indicator_image(scale_factor) {
+            Ok(image) => {
+                self.origin_indicator_image = Some(image);
+            }
+            Err(e) => {
+                tracing::error!("Regenerating origin indicator image failed, Err: {e:?}");
+                widget_flags.redraw = true;
+                return widget_flags;
+            }
+        }
+
+        widget_flags |= self.update_background_rendering_current_viewport();
         widget_flags.redraw = true;
         widget_flags
     }
@@ -121,10 +176,7 @@ impl Engine {
         self.draw_document_shadow_to_gtk_snapshot(snapshot);
         self.draw_background_to_gtk_snapshot(snapshot)?;
         self.draw_format_borders_to_gtk_snapshot(snapshot)?;
-        snapshot.restore();
         self.draw_origin_indicator_to_gtk_snapshot(snapshot)?;
-        snapshot.save();
-        snapshot.transform(Some(&camera_transform));
         self.store
             .draw_strokes_to_gtk_snapshot(snapshot, doc_bounds, viewport);
         snapshot.restore();
@@ -276,52 +328,63 @@ impl Engine {
     }
 
     /// Draw the document origin indicator cross.
-    ///
-    /// Expects that the snapshot is untransformed in surface coordinate space.
     #[cfg(feature = "ui")]
     fn draw_origin_indicator_to_gtk_snapshot(
         &self,
         snapshot: &gtk4::Snapshot,
     ) -> anyhow::Result<()> {
-        use crate::ext::GrapheneRectExt;
-        use gtk4::{graphene, prelude::*};
-        use p2d::bounding_volume::Aabb;
-        use piet::RenderContext;
-        use rnote_compose::color;
-        use rnote_compose::ext::{AabbExt, Affine2Ext};
+        use gtk4::prelude::*;
 
         if self.document.format.show_origin_indicator {
-            const PATH_COLOR: piet::Color = color::GNOME_GREENS[4];
-            const PATH_WIDTH: f64 = 1.5;
-            let total_zoom = self.camera.total_zoom();
-
-            let bounds = Aabb::from_half_extents(
-                na::point![0.0, 0.0],
-                na::Vector2::repeat(5.0 / total_zoom),
-            );
-            let bounds_on_surface = bounds
-                .extend_by(na::Vector2::repeat(PATH_WIDTH / total_zoom))
-                .scale(total_zoom)
-                .translate(-self.camera.offset());
-
-            let cairo_cx =
-                snapshot.append_cairo(&graphene::Rect::from_p2d_aabb(bounds_on_surface.ceil()));
-            let mut piet_cx = piet_cairo::CairoRenderContext::new(&cairo_cx);
-            let path = kurbo::BezPath::from_iter([
-                kurbo::PathEl::MoveTo(kurbo::Point::new(bounds.mins[0], bounds.mins[1])),
-                kurbo::PathEl::LineTo(kurbo::Point::new(bounds.maxs[0], bounds.maxs[1])),
-                kurbo::PathEl::MoveTo(kurbo::Point::new(bounds.mins[0], bounds.maxs[1])),
-                kurbo::PathEl::LineTo(kurbo::Point::new(bounds.maxs[0], bounds.mins[1])),
-            ]);
-            piet_cx.transform(self.camera.transform().to_kurbo());
-            piet_cx.stroke_styled(
-                path,
-                &PATH_COLOR,
-                PATH_WIDTH / total_zoom,
-                &piet::StrokeStyle::default().line_cap(piet::LineCap::Round),
-            );
+            if let Some(r) = &self.origin_indicator_rendernode {
+                snapshot.append_node(r);
+            }
         }
 
         Ok(())
     }
+}
+
+/// Origin indicator bounds in document coordinate space.
+fn origin_indicator_bounds() -> Aabb {
+    const SIZE: na::Vector2<f64> = na::vector![17., 17.];
+    Aabb::from_half_extents(na::Vector2::zeros().into(), SIZE * 0.5)
+}
+
+fn gen_origin_indicator_image(scale_factor: f64) -> anyhow::Result<Image> {
+    const PATH_COLOR: piet::Color = color::GNOME_GREENS[4];
+    const PATH_WIDTH: f64 = 1.5;
+    let bounds = origin_indicator_bounds();
+
+    Image::gen_with_piet(
+        |piet_cx| {
+            let path = kurbo::BezPath::from_iter([
+                kurbo::PathEl::MoveTo(kurbo::Point::new(
+                    bounds.mins[0] + PATH_WIDTH * 0.5,
+                    bounds.mins[1] + PATH_WIDTH * 0.5,
+                )),
+                kurbo::PathEl::LineTo(kurbo::Point::new(
+                    bounds.maxs[0] - PATH_WIDTH * 0.5,
+                    bounds.maxs[1] - PATH_WIDTH * 0.5,
+                )),
+                kurbo::PathEl::MoveTo(kurbo::Point::new(
+                    bounds.mins[0] + PATH_WIDTH * 0.5,
+                    bounds.maxs[1] - PATH_WIDTH * 0.5,
+                )),
+                kurbo::PathEl::LineTo(kurbo::Point::new(
+                    bounds.maxs[0] - PATH_WIDTH * 0.5,
+                    bounds.mins[1] + PATH_WIDTH * 0.5,
+                )),
+            ]);
+            piet_cx.stroke_styled(
+                path,
+                &PATH_COLOR,
+                PATH_WIDTH,
+                &piet::StrokeStyle::default().line_cap(piet::LineCap::Round),
+            );
+            Ok(())
+        },
+        bounds,
+        scale_factor,
+    )
 }

--- a/crates/rnote-engine/src/pens/selector/penevents.rs
+++ b/crates/rnote-engine/src/pens/selector/penevents.rs
@@ -51,7 +51,9 @@ impl Selector {
                 widget_flags |= engine_view
                     .camera
                     .nudge_w_pos(element.pos, engine_view.document);
-                widget_flags |= engine_view.document.expand_autoexpand(engine_view.camera);
+                widget_flags |= engine_view
+                    .document
+                    .expand_autoexpand(engine_view.camera, engine_view.store);
                 engine_view.store.regenerate_rendering_in_viewport_threaded(
                     engine_view.tasks_tx.clone(),
                     false,
@@ -216,7 +218,9 @@ impl Selector {
                         widget_flags |= engine_view
                             .camera
                             .nudge_w_pos(element.pos, engine_view.document);
-                        widget_flags |= engine_view.document.expand_autoexpand(engine_view.camera);
+                        widget_flags |= engine_view
+                            .document
+                            .expand_autoexpand(engine_view.camera, engine_view.store);
                         engine_view.store.regenerate_rendering_in_viewport_threaded(
                             engine_view.tasks_tx.clone(),
                             false,
@@ -335,7 +339,9 @@ impl Selector {
                         widget_flags |= engine_view
                             .camera
                             .nudge_w_pos(element.pos, engine_view.document);
-                        widget_flags |= engine_view.document.expand_autoexpand(engine_view.camera);
+                        widget_flags |= engine_view
+                            .document
+                            .expand_autoexpand(engine_view.camera, engine_view.store);
                         engine_view.store.regenerate_rendering_in_viewport_threaded(
                             engine_view.tasks_tx.clone(),
                             false,

--- a/crates/rnote-engine/src/pens/tools.rs
+++ b/crates/rnote-engine/src/pens/tools.rs
@@ -369,7 +369,9 @@ impl PenBehaviour for Tools {
                         widget_flags |= engine_view
                             .camera
                             .nudge_w_pos(element.pos, engine_view.document);
-                        widget_flags |= engine_view.document.expand_autoexpand(engine_view.camera);
+                        widget_flags |= engine_view
+                            .document
+                            .expand_autoexpand(engine_view.camera, engine_view.store);
                         engine_view.store.regenerate_rendering_in_viewport_threaded(
                             engine_view.tasks_tx.clone(),
                             false,
@@ -415,7 +417,9 @@ impl PenBehaviour for Tools {
                                 .camera
                                 .zoom_w_timeout(new_zoom, engine_view.tasks_tx.clone());
                             widget_flags |= engine_view.camera.set_viewport_center(viewport_center)
-                                | engine_view.document.expand_autoexpand(engine_view.camera);
+                                | engine_view
+                                    .document
+                                    .expand_autoexpand(engine_view.camera, engine_view.store);
                         }
                         self.zoom_tool.current_surface_coord = new_surface_coord;
                     }

--- a/crates/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/crates/rnote-engine/src/pens/typewriter/penevents.rs
@@ -74,7 +74,9 @@ impl Typewriter {
                 widget_flags |= engine_view
                     .camera
                     .nudge_w_pos(element.pos, engine_view.document);
-                widget_flags |= engine_view.document.expand_autoexpand(engine_view.camera);
+                widget_flags |= engine_view
+                    .document
+                    .expand_autoexpand(engine_view.camera, engine_view.store);
                 engine_view.store.regenerate_rendering_in_viewport_threaded(
                     engine_view.tasks_tx.clone(),
                     false,
@@ -258,8 +260,9 @@ impl Typewriter {
                             widget_flags |= engine_view
                                 .camera
                                 .nudge_w_pos(element.pos, engine_view.document);
-                            widget_flags |=
-                                engine_view.document.expand_autoexpand(engine_view.camera);
+                            widget_flags |= engine_view
+                                .document
+                                .expand_autoexpand(engine_view.camera, engine_view.store);
                             engine_view.store.regenerate_rendering_in_viewport_threaded(
                                 engine_view.tasks_tx.clone(),
                                 false,

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -185,7 +185,7 @@ impl RnAppWindow {
 
     // Returns true if the flags indicate that any loop that handles the flags should be quit. (usually an async event loop)
     pub(crate) fn handle_widget_flags(&self, widget_flags: WidgetFlags, canvas: &RnCanvas) {
-        //tracing::info!("handling widget flags: '{widget_flags:?}'");
+        //tracing::debug!("handling widget flags: '{widget_flags:?}'");
 
         if widget_flags.redraw {
             canvas.queue_draw();

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -185,6 +185,8 @@ impl RnAppWindow {
 
     // Returns true if the flags indicate that any loop that handles the flags should be quit. (usually an async event loop)
     pub(crate) fn handle_widget_flags(&self, widget_flags: WidgetFlags, canvas: &RnCanvas) {
+        //tracing::info!("handling widget flags: '{widget_flags:?}'");
+
         if widget_flags.redraw {
             canvas.queue_draw();
         }

--- a/crates/rnote-ui/src/settingspanel/mod.rs
+++ b/crates/rnote-ui/src/settingspanel/mod.rs
@@ -602,7 +602,7 @@ impl RnSettingsPanel {
 
                 if !canvas.engine_ref().document.background.color.approx_eq_f32(background_color) {
                     canvas.engine_mut().document.background.color = background_color;
-                    let mut widget_flags = canvas.engine_mut().background_regenerate_pattern();
+                    let mut widget_flags = canvas.engine_mut().background_rendering_regenerate();
                     widget_flags.store_modified = true;
                     appwindow.handle_widget_flags(widget_flags, &canvas);
                 }
@@ -663,7 +663,7 @@ impl RnSettingsPanel {
 
             if canvas.engine_ref().document.background.pattern != pattern {
                 canvas.engine_mut().document.background.pattern = pattern;
-                let mut widget_flags = canvas.engine_mut().background_regenerate_pattern();
+                let mut widget_flags = canvas.engine_mut().background_rendering_regenerate();
                 widget_flags.store_modified = true;
                 appwindow.handle_widget_flags(widget_flags, &canvas);
             }
@@ -676,7 +676,7 @@ impl RnSettingsPanel {
 
                 if !canvas.engine_ref().document.background.pattern_color.approx_eq_f32(pattern_color) {
                     canvas.engine_mut().document.background.pattern_color = pattern_color;
-                    let mut widget_flags = canvas.engine_mut().background_regenerate_pattern();
+                    let mut widget_flags = canvas.engine_mut().background_rendering_regenerate();
                     widget_flags.store_modified = true;
                     appwindow.handle_widget_flags(widget_flags, &canvas);
                 }
@@ -694,7 +694,7 @@ impl RnSettingsPanel {
 
                         if !canvas.engine_ref().document.background.pattern_size.approx_eq(&pattern_size) {
                             canvas.engine_mut().document.background.pattern_size = pattern_size;
-                            let mut widget_flags = canvas.engine_mut().background_regenerate_pattern();
+                            let mut widget_flags = canvas.engine_mut().background_rendering_regenerate();
                             widget_flags.store_modified = true;
                             appwindow.handle_widget_flags(widget_flags, &canvas);
                         }
@@ -712,7 +712,7 @@ impl RnSettingsPanel {
 
                         if !canvas.engine_ref().document.background.pattern_size.approx_eq(&pattern_size) {
                             canvas.engine_mut().document.background.pattern_size = pattern_size;
-                            let mut widget_flags = canvas.engine_mut().background_regenerate_pattern();
+                            let mut widget_flags = canvas.engine_mut().background_rendering_regenerate();
                             widget_flags.store_modified = true;
                             appwindow.handle_widget_flags(widget_flags, &canvas);
                         }
@@ -728,7 +728,7 @@ impl RnSettingsPanel {
                         engine.document.background.color = engine.document.background.color.to_inverted_brightness_color();
                         engine.document.background.pattern_color = engine.document.background.pattern_color.to_inverted_brightness_color();
                         engine.document.format.border_color = engine.document.format.border_color.to_inverted_brightness_color();
-                        engine.background_regenerate_pattern()
+                        engine.background_rendering_regenerate()
                     };
 
                     widget_flags.refresh_ui = true;


### PR DESCRIPTION
improves the experience on EPD. addresses #658

-  the origin indicator rendering is now cached
- the `resize` flag is only set when the dimensions actually change while performing a resize