### PR TITLE
fix: `filters` not working for the save dialog

### DIFF
--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -300,6 +300,10 @@ fn create_filedialog_export_doc(
         Some(&(String::from(".") + &file_ext)),
     );
 
+    let filter_list = gio::ListStore::new::<FileFilter>();
+    filter_list.append(&filter);
+    filedialog.set_filters(Some(&filter_list));
+
     filedialog.set_default_filter(Some(&filter));
     filedialog.set_initial_name(Some(&file_name));
     filedialog.set_initial_folder(get_initial_folder_for_export(appwindow, canvas).as_ref());
@@ -596,6 +600,10 @@ fn create_filedialog_export_doc_pages(
         }
     }
 
+    let filter_list = gio::ListStore::new::<FileFilter>();
+    filter_list.append(&filter);
+    filedialog.set_filters(Some(&filter_list));
+
     filedialog.set_default_filter(Some(&filter));
 
     filedialog
@@ -889,6 +897,10 @@ fn create_filedialog_export_selection(
         Some(&(String::from(" - Selection") + "." + &file_ext)),
     );
 
+    let filter_list = gio::ListStore::new::<FileFilter>();
+    filter_list.append(&filter);
+    filedialog.set_filters(Some(&filter_list));
+
     filedialog.set_default_filter(Some(&filter));
     filedialog.set_initial_name(Some(&file_name));
 
@@ -900,6 +912,10 @@ pub(crate) async fn filechooser_export_engine_state(appwindow: &RnAppWindow, can
     filter.add_mime_type("application/json");
     filter.add_suffix("json");
     filter.set_name(Some(&gettext("Json")));
+
+    let filter_list = gio::ListStore::new::<FileFilter>();
+    filter_list.append(&filter);
+
     let initial_name = crate::utils::default_file_title_for_export(
         canvas.output_file(),
         Some(&canvas::OUTPUT_FILE_NEW_TITLE),
@@ -910,6 +926,7 @@ pub(crate) async fn filechooser_export_engine_state(appwindow: &RnAppWindow, can
         .title(gettext("Export Engine State"))
         .modal(true)
         .accept_label(gettext("Export"))
+        .filters(&filter_list)
         .default_filter(&filter)
         .initial_name(&initial_name)
         .build();
@@ -948,6 +965,10 @@ pub(crate) async fn filechooser_export_engine_config(appwindow: &RnAppWindow, ca
     filter.add_mime_type("application/json");
     filter.add_suffix("json");
     filter.set_name(Some(&gettext("Json")));
+
+    let filter_list = gio::ListStore::new::<FileFilter>();
+    filter_list.append(&filter);
+
     let initial_name = crate::utils::default_file_title_for_export(
         canvas.output_file(),
         Some(&canvas::OUTPUT_FILE_NEW_TITLE),
@@ -958,6 +979,7 @@ pub(crate) async fn filechooser_export_engine_config(appwindow: &RnAppWindow, ca
         .title(gettext("Export Engine Config"))
         .modal(true)
         .accept_label(gettext("Export"))
+        .filters(&filter_list)
         .default_filter(&filter)
         .initial_name(&initial_name)
         .build();

--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -26,10 +26,15 @@ pub(crate) async fn dialog_save_doc_as(appwindow: &RnAppWindow, canvas: &RnCanva
     filter.add_suffix("rnote");
     filter.set_name(Some(&gettext(".rnote")));
 
+    // create the list of filters
+    let filter_list = gio::ListStore::new::<FileFilter>();
+    filter_list.append(&filter);
+
     let filedialog = FileDialog::builder()
         .title(gettext("Save Document As"))
         .modal(true)
         .accept_label(gettext("Save"))
+        .filters(&filter_list)
         .default_filter(&filter)
         .build();
 

--- a/crates/rnote-ui/src/dialogs/import.rs
+++ b/crates/rnote-ui/src/dialogs/import.rs
@@ -50,43 +50,31 @@ pub(crate) async fn filedialog_open_doc(appwindow: &RnAppWindow) {
 }
 
 pub(crate) async fn filedialog_import_file(appwindow: &RnAppWindow) {
-    // use a list of filters
-    let filters = gio::ListStore::new::<FileFilter>();
+    let filter = FileFilter::new();
+    filter.add_mime_type("application/x-xopp");
+    filter.add_mime_type("application/pdf");
+    filter.add_mime_type("image/svg+xml");
+    filter.add_mime_type("image/png");
+    filter.add_mime_type("image/jpeg");
+    filter.add_mime_type("text/plain");
+    filter.add_suffix("xopp");
+    filter.add_suffix("pdf");
+    filter.add_suffix("svg");
+    filter.add_suffix("png");
+    filter.add_suffix("jpg");
+    filter.add_suffix("jpeg");
+    filter.add_suffix("txt");
+    filter.set_name(Some(&gettext("Jpg, Pdf, Png, Svg, Xopp, Txt")));
 
-    let filters_vec = vec![FileFilter::new(); 6];
-    filters_vec[0].add_mime_type("application/x-xopp");
-    filters_vec[0].add_suffix("xopp");
-    filters_vec[0].set_name(Some(&gettext("Xopp")));
-
-    filters_vec[1].add_mime_type("application/pdf");
-    filters_vec[1].add_suffix("pdf");
-    filters_vec[1].set_name(Some(&gettext("Pdf")));
-
-    filters_vec[2].add_mime_type("image/svg+xml");
-    filters_vec[2].add_suffix("svg");
-    filters_vec[2].set_name(Some(&gettext("Svg")));
-
-    filters_vec[3].add_mime_type("image/png");
-    filters_vec[3].add_suffix("png");
-    filters_vec[3].set_name(Some(&gettext("Png")));
-
-    filters_vec[4].add_mime_type("image/jpeg");
-    filters_vec[4].add_suffix("jpg");
-    filters_vec[4].add_suffix("jpeg");
-    filters_vec[4].set_name(Some(&gettext("Jpg")));
-
-    filters_vec[5].add_mime_type("text/plain");
-    filters_vec[5].add_suffix("txt");
-    filters_vec[5].set_name(Some(&gettext("Txt")));
-
-    // append all these filters to the gio::ListStore
-    filters_vec.iter().for_each(|filter| filters.append(filter));
+    let filter_list = gio::ListStore::new::<FileFilter>();
+    filter_list.append(&filter);
 
     let dialog = FileDialog::builder()
         .title(gettext("Import File"))
         .modal(true)
         .accept_label(gettext("Import"))
-        .filters(&filters)
+        .filters(&filter_list)
+        .default_filter(&filter)
         .build();
 
     if let Some(current_workspace_dir) = appwindow.sidebar().workspacebrowser().dir_list_dir() {

--- a/crates/rnote-ui/src/dialogs/import.rs
+++ b/crates/rnote-ui/src/dialogs/import.rs
@@ -20,10 +20,14 @@ pub(crate) async fn filedialog_open_doc(appwindow: &RnAppWindow) {
     filter.add_suffix("rnote");
     filter.set_name(Some(&gettext(".rnote")));
 
+    let filter_list = gio::ListStore::new::<FileFilter>();
+    filter_list.append(&filter);
+
     let filedialog = FileDialog::builder()
         .title(gettext("Open File"))
         .modal(true)
         .accept_label(gettext("Open"))
+        .filters(&filter_list)
         .default_filter(&filter)
         .build();
 
@@ -46,27 +50,43 @@ pub(crate) async fn filedialog_open_doc(appwindow: &RnAppWindow) {
 }
 
 pub(crate) async fn filedialog_import_file(appwindow: &RnAppWindow) {
-    let filter = FileFilter::new();
-    filter.add_mime_type("application/x-xopp");
-    filter.add_mime_type("application/pdf");
-    filter.add_mime_type("image/svg+xml");
-    filter.add_mime_type("image/png");
-    filter.add_mime_type("image/jpeg");
-    filter.add_mime_type("text/plain");
-    filter.add_suffix("xopp");
-    filter.add_suffix("pdf");
-    filter.add_suffix("svg");
-    filter.add_suffix("png");
-    filter.add_suffix("jpg");
-    filter.add_suffix("jpeg");
-    filter.add_suffix("txt");
-    filter.set_name(Some(&gettext("Jpg, Pdf, Png, Svg, Xopp, Txt")));
+    // use a list of filters
+    let filters = gio::ListStore::new::<FileFilter>();
+
+    let filters_vec = vec![FileFilter::new(); 6];
+    filters_vec[0].add_mime_type("application/x-xopp");
+    filters_vec[0].add_suffix("xopp");
+    filters_vec[0].set_name(Some(&gettext("Xopp")));
+
+    filters_vec[1].add_mime_type("application/pdf");
+    filters_vec[1].add_suffix("pdf");
+    filters_vec[1].set_name(Some(&gettext("Pdf")));
+
+    filters_vec[2].add_mime_type("image/svg+xml");
+    filters_vec[2].add_suffix("svg");
+    filters_vec[2].set_name(Some(&gettext("Svg")));
+
+    filters_vec[3].add_mime_type("image/png");
+    filters_vec[3].add_suffix("png");
+    filters_vec[3].set_name(Some(&gettext("Png")));
+
+    filters_vec[4].add_mime_type("image/jpeg");
+    filters_vec[4].add_suffix("jpg");
+    filters_vec[4].add_suffix("jpeg");
+    filters_vec[4].set_name(Some(&gettext("Jpg")));
+
+    filters_vec[5].add_mime_type("text/plain");
+    filters_vec[5].add_suffix("txt");
+    filters_vec[5].set_name(Some(&gettext("Txt")));
+
+    // append all these filters to the gio::ListStore
+    filters_vec.iter().for_each(|filter| filters.append(filter));
 
     let dialog = FileDialog::builder()
         .title(gettext("Import File"))
         .modal(true)
         .accept_label(gettext("Import"))
-        .default_filter(&filter)
+        .filters(&filters)
         .build();
 
     if let Some(current_workspace_dir) = appwindow.sidebar().workspacebrowser().dir_list_dir() {


### PR DESCRIPTION
To fix #1073 .

Makes the filter on the save dialog work. 

![image](https://github.com/flxzt/rnote/assets/115779707/6ecaba35-33ed-42ef-b98d-ef9068163393)

Before this the `file type` part was empty (filter not applied) leading to various potential errors, including the possibility to create files that have no extension.