### PR TITLE
Made the zoom tool zoom towards the initially selected location

### DIFF
--- a/crates/rnote-engine/src/pens/tools.rs
+++ b/crates/rnote-engine/src/pens/tools.rs
@@ -428,7 +428,7 @@ impl PenBehaviour for Tools {
                                 - self.zoom_tool.start_surface_coord;
                             widget_flags |= engine_view
                                 .camera
-                                .set_offset(new_camera_offset, &engine_view.document);
+                                .set_offset(new_camera_offset, engine_view.document);
 
                             widget_flags |= engine_view
                                 .document

--- a/crates/rnote-engine/src/pens/tools.rs
+++ b/crates/rnote-engine/src/pens/tools.rs
@@ -399,27 +399,40 @@ impl PenBehaviour for Tools {
                             .resize_autoexpand(engine_view.store, engine_view.camera);
                     }
                     ToolStyle::Zoom => {
-                        let total_zoom = engine_view.camera.total_zoom();
-                        let viewport_center = engine_view.camera.viewport_center();
+                        let total_zoom_old = engine_view.camera.total_zoom();
+                        let camera_offset = engine_view.camera.offset();
+
                         let new_surface_coord = engine_view
                             .camera
                             .transform()
                             .transform_point(&element.pos.into())
                             .coords;
+
                         let offset = new_surface_coord - self.zoom_tool.current_surface_coord;
 
                         // Drag down zooms out, drag up zooms in
                         let new_zoom =
-                            total_zoom * (1.0 - offset[1] * Camera::DRAG_ZOOM_MAGN_ZOOM_FACTOR);
+                            total_zoom_old * (1.0 - offset[1] * Camera::DRAG_ZOOM_MAGN_ZOOM_FACTOR);
 
                         if (Camera::ZOOM_MIN..=Camera::ZOOM_MAX).contains(&new_zoom) {
                             widget_flags |= engine_view
                                 .camera
                                 .zoom_w_timeout(new_zoom, engine_view.tasks_tx.clone());
-                            widget_flags |= engine_view.camera.set_viewport_center(viewport_center)
-                                | engine_view
-                                    .document
-                                    .expand_autoexpand(engine_view.camera, engine_view.store);
+
+                            // Translate the camera view so that the start_surface_coord has the same surface position
+                            // as before the zoom occured
+                            let new_camera_offset = (((camera_offset
+                                + self.zoom_tool.start_surface_coord)
+                                / total_zoom_old)
+                                * new_zoom)
+                                - self.zoom_tool.start_surface_coord;
+                            widget_flags |= engine_view
+                                .camera
+                                .set_offset(new_camera_offset, &engine_view.document);
+
+                            widget_flags |= engine_view
+                                .document
+                                .expand_autoexpand(engine_view.camera, engine_view.store);
                         }
                         self.zoom_tool.current_surface_coord = new_surface_coord;
                     }


### PR DESCRIPTION
As mentioned in #914 the zoom tool zooms towards the center of the screen. This PR makes the zoom tool zoom towards the selected start location. As mentioned in previous issues this makes navigating with a drawing tablet easier.

### Area of improvement
The "zoom formula" is copied from [this file](https://github.com/flxzt/rnote/blob/ba0c40ef25a8bf88d1f09bd46858017baf4fa88f/crates/rnote-ui/src/canvaswrapper.rs#L348). I think that there may be a need for a function in the camera to have a `zoom_towards` function. However I don't feel quite comfortable enough yet with the codebase to make that happen.