### PR TITLE
ui(AboutWindow): fix developers credits list

### DIFF
--- a/crates/rnote-ui/src/config.rs.in
+++ b/crates/rnote-ui/src/config.rs.in
@@ -13,7 +13,7 @@ pub(crate) const APP_VERSION_SUFFIX: &str = @APP_VERSION_SUFFIX@;
 #[allow(unused)]
 pub(crate) const APP_AUTHOR_NAME: &str = @APP_AUTHOR_NAME@;
 #[allow(unused)]
-pub(crate) const APP_AUTHORS: &[&str] = &[@APP_AUTHORS@];
+pub(crate) const APP_AUTHORS: &str = @APP_AUTHORS@;
 #[allow(unused)]
 pub(crate) const APP_WEBSITE: &str = @APP_WEBSITE@;
 #[allow(unused)]

--- a/crates/rnote-ui/src/dialogs/mod.rs
+++ b/crates/rnote-ui/src/dialogs/mod.rs
@@ -37,12 +37,7 @@ pub(crate) fn dialog_about(appwindow: &RnAppWindow) {
         .issue_url(config::APP_ISSUES_URL)
         .support_url(config::APP_SUPPORT_URL)
         .developer_name(config::APP_AUTHOR_NAME)
-        .developers(glib::StrV::from(
-            config::APP_AUTHORS
-                .iter()
-                .map(|&s| String::from(s))
-                .collect::<Vec<String>>(),
-        ))
+        .developers(config::APP_AUTHORS.lines().collect::<Vec<&str>>())
         // TRANSLATORS: 'Name <email@domain.com>' or 'Name https://website.example'
         .translator_credits(gettext("translator-credits"))
         .license_type(globals::APP_LICENSE)


### PR DESCRIPTION
### Before
![screenshot_2024_05_13_02_25_21](https://github.com/flxzt/rnote/assets/65136727/f043dd39-74db-41a6-a6f9-596caa0c6f4d)
### After
![screenshot_2024_05_13_02_25_13](https://github.com/flxzt/rnote/assets/65136727/a92f7ad9-799b-4fef-9777-d65130605821)


---

IIRC there is no way to format `@APP_AUTHORS@` as a comma separated strings using meson, but if there was it would be more efficient.