### PR TITLE
ui: migrate to libadwaita-1.5 and its adaptive dialogs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   check:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-22.04
-    container: fedora:39
+    container: fedora:40
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -8,7 +8,7 @@ name: Generate Dist Archive
 jobs:
   dist:
     runs-on: ubuntu-22.04
-    container: fedora:39
+    container: fedora:40
     permissions:
       contents: write # needed for uploading release artifact
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.10.2"
 rnote-compose = { version = "0.10.2", path = "crates/rnote-compose" }
 rnote-engine = { version = "0.10.2", path = "crates/rnote-engine" }
 
-adw = { version = "0.6.0", package = "libadwaita", features = ["v1_4"] }
+adw = { version = "0.6.0", package = "libadwaita", features = ["v1_5"] }
 anyhow = "1.0"
 approx = "0.5.1"
 async-fs = "2.1"

--- a/crates/rnote-ui/data/ui/dialogs/dialogs.ui
+++ b/crates/rnote-ui/data/ui/dialogs/dialogs.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- misc dialogs -->
 <interface>
-  <object class="AdwMessageDialog" id="dialog_clear_doc">
+  <object class="AdwAlertDialog" id="dialog_clear_doc">
     <property name="heading" translatable="yes">Clear Document</property>
     <property name="body" translatable="yes">This clears the entire document. Please confirm.</property>
     <property name="default-response">clear</property>
@@ -12,7 +12,7 @@
     </responses>
   </object>
 
-  <object class="AdwMessageDialog" id="dialog_new_doc">
+  <object class="AdwAlertDialog" id="dialog_new_doc">
     <property name="heading" translatable="yes">New Document</property>
     <property name="body" translatable="yes">Creating a new document will discard any unsaved changes.
 Do you want to save the current document?</property>
@@ -25,7 +25,7 @@ Do you want to save the current document?</property>
     </responses>
   </object>
 
-  <object class="AdwMessageDialog" id="dialog_close_tab">
+  <object class="AdwAlertDialog" id="dialog_close_tab">
     <property name="heading" translatable="yes">Close Tab</property>
     <property name="body" translatable="yes">This tab contains unsaved changes.
 Changes which are not saved will be permanently lost.</property>
@@ -43,7 +43,7 @@ Changes which are not saved will be permanently lost.</property>
     </responses>
   </object>
 
-  <object class="AdwMessageDialog" id="dialog_close_window">
+  <object class="AdwAlertDialog" id="dialog_close_window">
     <property name="heading" translatable="yes">Close Window</property>
     <property name="body" translatable="yes">Some opened files contain unsaved changes.
 Changes which are not saved will be permanently lost.</property>

--- a/crates/rnote-ui/src/dialogs/mod.rs
+++ b/crates/rnote-ui/src/dialogs/mod.rs
@@ -27,9 +27,7 @@ pub(crate) fn dialog_about(appwindow: &RnAppWindow) {
         config::APP_NAME.to_string()
     };
 
-    let aboutdialog = adw::AboutWindow::builder()
-        .modal(true)
-        .transient_for(appwindow)
+    let aboutdialog = adw::AboutDialog::builder()
         .application_name(config::APP_NAME_CAPITALIZED)
         .application_icon(app_icon_name)
         .comments(gettext("Sketch and take handwritten notes"))
@@ -48,7 +46,7 @@ pub(crate) fn dialog_about(appwindow: &RnAppWindow) {
         aboutdialog.add_css_class("devel");
     }
 
-    aboutdialog.present();
+    aboutdialog.present(appwindow);
 }
 
 pub(crate) fn dialog_keyboard_shortcuts(appwindow: &RnAppWindow) {
@@ -63,10 +61,9 @@ pub(crate) async fn dialog_clear_doc(appwindow: &RnAppWindow, canvas: &RnCanvas)
     let builder = Builder::from_resource(
         (String::from(config::APP_IDPATH) + "ui/dialogs/dialogs.ui").as_str(),
     );
-    let dialog: adw::MessageDialog = builder.object("dialog_clear_doc").unwrap();
-    dialog.set_transient_for(Some(appwindow));
+    let dialog: adw::AlertDialog = builder.object("dialog_clear_doc").unwrap();
 
-    match dialog.choose_future().await.as_str() {
+    match dialog.choose_future(appwindow).await.as_str() {
         "clear" => {
             let prev_empty = canvas.empty();
 
@@ -89,8 +86,7 @@ pub(crate) async fn dialog_new_doc(appwindow: &RnAppWindow, canvas: &RnCanvas) {
     let builder = Builder::from_resource(
         (String::from(config::APP_IDPATH) + "ui/dialogs/dialogs.ui").as_str(),
     );
-    let dialog: adw::MessageDialog = builder.object("dialog_new_doc").unwrap();
-    dialog.set_transient_for(Some(appwindow));
+    let dialog: adw::AlertDialog = builder.object("dialog_new_doc").unwrap();
 
     let new_doc = |appwindow: &RnAppWindow, canvas: &RnCanvas| {
         let widget_flags = canvas.engine_mut().clear();
@@ -106,7 +102,7 @@ pub(crate) async fn dialog_new_doc(appwindow: &RnAppWindow, canvas: &RnCanvas) {
         return;
     }
 
-    match dialog.choose_future().await.as_str() {
+    match dialog.choose_future(appwindow).await.as_str() {
         "discard" => {
             new_doc(appwindow, canvas);
         }
@@ -151,9 +147,8 @@ pub(crate) async fn dialog_close_tab(appwindow: &RnAppWindow, tab_page: &adw::Ta
     let builder = Builder::from_resource(
         (String::from(config::APP_IDPATH) + "ui/dialogs/dialogs.ui").as_str(),
     );
-    let dialog: adw::MessageDialog = builder.object("dialog_close_tab").unwrap();
+    let dialog: adw::AlertDialog = builder.object("dialog_close_tab").unwrap();
     let file_group: adw::PreferencesGroup = builder.object("close_tab_file_group").unwrap();
-    dialog.set_transient_for(Some(appwindow));
     let canvas = tab_page
         .child()
         .downcast::<RnCanvasWrapper>()
@@ -238,7 +233,7 @@ pub(crate) async fn dialog_close_tab(appwindow: &RnAppWindow, tab_page: &adw::Ta
 
     // Returns close_finish_confirm, a boolean that indicates if the tab should actually be closed or closing
     // should be aborted.
-    match dialog.choose_future().await.as_str() {
+    match dialog.choose_future(appwindow).await.as_str() {
         "discard" => true,
         "save" => {
             if let Some(save_file) = save_file {
@@ -274,9 +269,8 @@ pub(crate) async fn dialog_close_window(appwindow: &RnAppWindow) {
     let builder = Builder::from_resource(
         (String::from(config::APP_IDPATH) + "ui/dialogs/dialogs.ui").as_str(),
     );
-    let dialog: adw::MessageDialog = builder.object("dialog_close_window").unwrap();
+    let dialog: adw::AlertDialog = builder.object("dialog_close_window").unwrap();
     let files_group: adw::PreferencesGroup = builder.object("close_window_files_group").unwrap();
-    dialog.set_transient_for(Some(appwindow));
 
     let tabs = appwindow.tabs_snapshot();
     let mut rows = Vec::new();
@@ -375,7 +369,7 @@ pub(crate) async fn dialog_close_window(appwindow: &RnAppWindow) {
         rows.push((i, check, save_file));
     }
 
-    let close = match dialog.choose_future().await.as_str() {
+    let close = match dialog.choose_future(appwindow).await.as_str() {
         "discard" => {
             // do nothing and close
             true


### PR DESCRIPTION
I've used [`AdwAboutDialog`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.AboutDialog.html) and [`AdwAlertDialog`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.AlertDialog.html) in place of [`AdwAboutWindow`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.AboutWindow.html) and [`AdwMessageDialog`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.MessageDialog.html) respectively.

Old dialogs using [`GtkDialog`](https://docs.gtk.org/gtk4/class.Dialog.html) are still displayed in separate windows. We might look at the possibility of using [`AdwDialog`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Dialog.html) as an alternative.