### PR TITLE
fix: remove window maximized macOS workaround, improve logic

### DIFF
--- a/crates/rnote-ui/src/appwindow/appsettings.rs
+++ b/crates/rnote-ui/src/appwindow/appsettings.rs
@@ -412,9 +412,6 @@ impl RnAppWindow {
             let is_maximized = app_settings.boolean("is-maximized");
 
             if is_maximized {
-                // don't restore maximized window state on macos, avoids issues discussed in
-                // issue 823 - https://github.com/flxzt/rnote/issues/823
-                #[cfg(not(target_os = "macos"))]
                 self.maximize();
             } else {
                 self.set_default_size(window_width, window_height);
@@ -446,9 +443,17 @@ impl RnAppWindow {
 
         {
             // Appwindow
-            app_settings.set_int("window-width", self.width())?;
-            app_settings.set_int("window-height", self.height())?;
-            app_settings.set_boolean("is-maximized", self.is_maximized())?;
+            match self.is_maximized() {
+                false => {
+                    app_settings.set_int("window-width", self.width())?;
+                    app_settings.set_int("window-height", self.height())?;
+                    app_settings.set_boolean("is-maximized", self.is_maximized())?;
+                }
+                true => {
+                    // this way we don't force the window to be the same size as the last maximized window
+                    app_settings.set_boolean("is-maximized", self.is_maximized())?;
+                }
+            }
         }
 
         {

--- a/crates/rnote-ui/src/appwindow/appsettings.rs
+++ b/crates/rnote-ui/src/appwindow/appsettings.rs
@@ -443,13 +443,10 @@ impl RnAppWindow {
 
         {
             // Appwindow
-            if self.is_maximized() {
-                // this way we don't force the window to be the same size as the last maximized window
-                app_settings.set_boolean("is-maximized", self.is_maximized())?;
-            } else {
+            app_settings.set_boolean("is-maximized", self.is_maximized())?;
+            if !self.is_maximized() {
                 app_settings.set_int("window-width", self.width())?;
                 app_settings.set_int("window-height", self.height())?;
-                app_settings.set_boolean("is-maximized", self.is_maximized())?;
             }
         }
 

--- a/crates/rnote-ui/src/appwindow/appsettings.rs
+++ b/crates/rnote-ui/src/appwindow/appsettings.rs
@@ -443,16 +443,13 @@ impl RnAppWindow {
 
         {
             // Appwindow
-            match self.is_maximized() {
-                false => {
-                    app_settings.set_int("window-width", self.width())?;
-                    app_settings.set_int("window-height", self.height())?;
-                    app_settings.set_boolean("is-maximized", self.is_maximized())?;
-                }
-                true => {
-                    // this way we don't force the window to be the same size as the last maximized window
-                    app_settings.set_boolean("is-maximized", self.is_maximized())?;
-                }
+            if self.is_maximized() {
+                // this way we don't force the window to be the same size as the last maximized window
+                app_settings.set_boolean("is-maximized", self.is_maximized())?;
+            } else {
+                app_settings.set_int("window-width", self.width())?;
+                app_settings.set_int("window-height", self.height())?;
+                app_settings.set_boolean("is-maximized", self.is_maximized())?;
             }
         }
 


### PR DESCRIPTION
- chore : remove the mac-specific workaround for fullscreen (okay if the mac version is compiled with gtk > 4.14 and the mac os version is already using gtk 4.14 anyway)
- improv : Do not save the size of the window if the window is maximized. This makes closing a rnote application in maximized form remember the last window size when dragging it down rather than have the same size between maximized and non maximized state on the next launch.