### PR TITLE
fix: workaround for windows ink

### DIFF
--- a/crates/rnote-ui/src/canvas/input.rs
+++ b/crates/rnote-ui/src/canvas/input.rs
@@ -119,6 +119,11 @@ pub(crate) fn handle_pointer_controller_event(
                 if gdk_button == gdk::BUTTON_PRIMARY {
                     pen_state = PenState::Up;
                 } else {
+                    // Workaround for https://github.com/flxzt/rnote/issues/785
+                    // On window only one button release event is sent when the
+                    // pen leaves the screen, and if the button is pressed this
+                    // is not a gdk::BUTTON_PRIMARY
+                    #[allow(clippy::collapsible_else_if)]
                     if cfg!(target_os = "windows") {
                         pen_state = PenState::Up;
                     } else {
@@ -172,6 +177,11 @@ pub(crate) fn handle_pointer_controller_event(
         for (element, event_time) in elements {
             tracing::trace!("handle pen event element - element: {element:?}, pen_state: {pen_state:?}, event_time_delta: {:?}, modifier_keys: {modifier_keys:?}, pen_mode: {pen_mode:?}", now.duration_since(event_time));
 
+            // Workaround for https://github.com/flxzt/rnote/issues/785
+            // only one event is sent when the pen approaches the screen
+            // on Windows whereas rnote expects 2 (switch to proximity
+            // then down). This forces the pen to be down when on the
+            // screen
             #[cfg(target_os = "windows")]
             {
                 if element.pressure > 0.0 && is_stylus {

--- a/crates/rnote-ui/src/canvas/input.rs
+++ b/crates/rnote-ui/src/canvas/input.rs
@@ -119,12 +119,9 @@ pub(crate) fn handle_pointer_controller_event(
                 if gdk_button == gdk::BUTTON_PRIMARY {
                     pen_state = PenState::Up;
                 } else {
-                    #[cfg(target_os = "windows")]
-                    {
+                    if cfg!(target_os = "windows") {
                         pen_state = PenState::Up;
-                    }
-                    #[cfg(not(target_os = "windows"))]
-                    {
+                    } else {
                         pen_state = PenState::Proximity;
                     }
                 }

--- a/crates/rnote-ui/src/canvas/input.rs
+++ b/crates/rnote-ui/src/canvas/input.rs
@@ -119,7 +119,14 @@ pub(crate) fn handle_pointer_controller_event(
                 if gdk_button == gdk::BUTTON_PRIMARY {
                     pen_state = PenState::Up;
                 } else {
-                    pen_state = PenState::Proximity;
+                    #[cfg(target_os = "windows")]
+                    {
+                        pen_state = PenState::Up;
+                    }
+                    #[cfg(not(target_os = "windows"))]
+                    {
+                        pen_state = PenState::Proximity;
+                    }
                 }
             } else {
                 #[allow(clippy::collapsible_else_if)]
@@ -167,6 +174,13 @@ pub(crate) fn handle_pointer_controller_event(
 
         for (element, event_time) in elements {
             tracing::trace!("handle pen event element - element: {element:?}, pen_state: {pen_state:?}, event_time_delta: {:?}, modifier_keys: {modifier_keys:?}, pen_mode: {pen_mode:?}", now.duration_since(event_time));
+
+            #[cfg(target_os = "windows")]
+            {
+                if element.pressure > 0.0 && is_stylus {
+                    pen_state = PenState::Down;
+                }
+            }
 
             match pen_state {
                 PenState::Up => {


### PR DESCRIPTION
This is a workaround for #785 

- force down state when the element is a stylus with a pressure value that is not zero. This way when a button is pressed before the pen is on the screen, this triggers proximity mode as rnote expects a left click when the pen touches the screen

- forces a pen state to up upon a button release as once again we have our button as a buttonrelease instead of the left click or BUTTON_PRIMARY release

Tested and working on my surface pro.
For now this is implemented using `cfg` flags only for windows builds.

From testing directly the pen input seen when using the Win32 API (what gtk is seeing) and WinRT, the original issue stems from limitations of the Win32 API. I'm reasonably confident then that the issue is a general issue on Windows, hence an os-specific workaround, so that applying it for all windows build shouldn't create issues.

Not sure this would make sense to apply elsewhere (or that this workaround may be needed outside windows).

I can add a toggle somewhere in the settings toolbar (hopefully in a way that's only shown on windows) if you want. I think it makes sense though to have the workaround enabled by default (xournal++ has a similar toggle that's disabled by default and isn't easy to find or understand that it fixes the issue when encountered).