### PR TITLE
fix: filters with native file pickers and forcing file extensions

### DIFF
--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -30,6 +30,9 @@ pub(crate) async fn dialog_save_doc_as(appwindow: &RnAppWindow, canvas: &RnCanva
     } else {
         filter.add_mime_type("application/rnote");
     }
+    if cfg!(target_os = "macos") {
+        filter.add_suffix("rnote");
+    }
     filter.set_name(Some(&gettext(".rnote")));
 
     // create the list of filters
@@ -292,6 +295,9 @@ fn create_filedialog_export_doc(
             } else {
                 filter.add_mime_type("image/svg+xml");
             }
+            if cfg!(target_os = "macos") {
+                filter.add_suffix("svg");
+            }
             filter.set_name(Some(&gettext("Svg")));
         }
         DocExportFormat::Pdf => {
@@ -300,6 +306,9 @@ fn create_filedialog_export_doc(
             } else {
                 filter.add_mime_type("application/pdf");
             }
+            if cfg!(target_os = "macos") {
+                filter.add_suffix("pdf");
+            }
             filter.set_name(Some(&gettext("Pdf")));
         }
         DocExportFormat::Xopp => {
@@ -307,6 +316,9 @@ fn create_filedialog_export_doc(
                 filter.add_pattern("*.xopp");
             } else {
                 filter.add_mime_type("application/x-xopp");
+            }
+            if cfg!(target_os = "macos") {
+                filter.add_suffix("xopp");
             }
             filter.set_name(Some(&gettext("Xopp")));
         }
@@ -596,8 +608,6 @@ fn create_filedialog_export_doc_pages(
 
     filedialog.set_initial_folder(get_initial_folder_for_export(appwindow, canvas).as_ref());
 
-    // does it work with mimetype but not the previous thing ?
-
     let filter = FileFilter::new();
     // We always need to be able to select folders
     filter.add_mime_type("inode/directory");
@@ -608,6 +618,9 @@ fn create_filedialog_export_doc_pages(
             } else {
                 filter.add_mime_type("image/svg+xml");
             }
+            if cfg!(target_os = "macos") {
+                filter.add_suffix("svg");
+            }
             filter.set_name(Some(&gettext("Svg")));
         }
         DocPagesExportFormat::Png => {
@@ -615,6 +628,9 @@ fn create_filedialog_export_doc_pages(
                 filter.add_pattern("*.png");
             } else {
                 filter.add_mime_type("image/png");
+            }
+            if cfg!(target_os = "macos") {
+                filter.add_suffix("png");
             }
             filter.set_name(Some(&gettext("Png")));
         }
@@ -624,7 +640,9 @@ fn create_filedialog_export_doc_pages(
             } else {
                 filter.add_mime_type("image/jpeg");
             }
-            filter.add_suffix("jpeg");
+            if cfg!(target_os = "macos") {
+                filter.add_suffix("jpg");
+            }
             filter.set_name(Some(&gettext("Jpeg")));
         }
     }
@@ -907,6 +925,9 @@ fn create_filedialog_export_selection(
             } else {
                 filter.add_mime_type("image/svg+xml");
             }
+            if cfg!(target_os = "macos") {
+                filter.add_suffix("svg");
+            }
             filter.set_name(Some(&gettext("Svg")));
         }
         SelectionExportFormat::Png => {
@@ -914,6 +935,9 @@ fn create_filedialog_export_selection(
                 filter.add_pattern("*.png");
             } else {
                 filter.add_mime_type("image/png");
+            }
+            if cfg!(target_os = "macos") {
+                filter.add_suffix("png");
             }
             filter.set_name(Some(&gettext("Png")));
         }
@@ -923,6 +947,9 @@ fn create_filedialog_export_selection(
                 filter.add_pattern("*.jpeg");
             } else {
                 filter.add_mime_type("image/jpeg");
+            }
+            if cfg!(target_os = "macos") {
+                filter.add_suffix("jpg");
             }
             filter.set_name(Some(&gettext("Jpeg")));
         }
@@ -953,6 +980,9 @@ pub(crate) async fn filechooser_export_engine_state(appwindow: &RnAppWindow, can
         filter.add_pattern("*.json");
     } else {
         filter.add_mime_type("application/json");
+    }
+    if cfg!(target_os = "macos") {
+        filter.add_suffix("json");
     }
     filter.set_name(Some(&gettext("Json")));
 
@@ -1013,6 +1043,9 @@ pub(crate) async fn filechooser_export_engine_config(appwindow: &RnAppWindow, ca
         filter.add_pattern("*.json");
     } else {
         filter.add_mime_type("application/json");
+    }
+    if cfg!(target_os = "macos") {
+        filter.add_suffix("json");
     }
     filter.set_name(Some(&gettext("Json")));
 

--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -637,6 +637,7 @@ fn create_filedialog_export_doc_pages(
         DocPagesExportFormat::Jpeg => {
             if cfg!(target_os = "windows") {
                 filter.add_pattern("*.jpg");
+                filter.add_pattern("*.jpeg");
             } else {
                 filter.add_mime_type("image/jpeg");
             }

--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -608,7 +608,6 @@ fn create_filedialog_export_doc_pages(
             } else {
                 filter.add_mime_type("image/svg+xml");
             }
-            filter.add_suffix("svg");
             filter.set_name(Some(&gettext("Svg")));
         }
         DocPagesExportFormat::Png => {
@@ -617,7 +616,6 @@ fn create_filedialog_export_doc_pages(
             } else {
                 filter.add_mime_type("image/png");
             }
-            filter.add_suffix("png");
             filter.set_name(Some(&gettext("Png")));
         }
         DocPagesExportFormat::Jpeg => {
@@ -626,7 +624,6 @@ fn create_filedialog_export_doc_pages(
             } else {
                 filter.add_mime_type("image/jpeg");
             }
-            filter.add_suffix("jpg");
             filter.add_suffix("jpeg");
             filter.set_name(Some(&gettext("Jpeg")));
         }

--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -21,8 +21,15 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 pub(crate) async fn dialog_save_doc_as(appwindow: &RnAppWindow, canvas: &RnCanvas) {
+    // note : mimetypes are not supported with the native file picker on windows
+    // See the limitations on FileChooserNative
+    // https://gtk-rs.org/gtk3-rs/stable/latest/docs/gtk/struct.FileChooserNative.html#win32-details--gtkfilechooserdialognative-win32
     let filter = FileFilter::new();
-    filter.add_pattern("*.rnote");
+    if !cfg!(target_os = "windows") {
+        filter.add_pattern("*.rnote");
+    } else {
+        filter.add_mime_type("application/rnote");
+    }
     filter.add_suffix("rnote");
     filter.set_name(Some(&gettext(".rnote")));
 
@@ -276,19 +283,34 @@ fn create_filedialog_export_doc(
         .build();
 
     let filter = FileFilter::new();
+    // note : mimetypes are not supported with the native file picker on windows
+    // See the limitations on FileChooserNative
+    // https://gtk-rs.org/gtk3-rs/stable/latest/docs/gtk/struct.FileChooserNative.html#win32-details--gtkfilechooserdialognative-win32
     match doc_export_prefs.export_format {
         DocExportFormat::Svg => {
-            filter.add_pattern("*.svg");
+            if cfg!(target_os = "windows") {
+                filter.add_pattern("*.svg");
+            } else {
+                filter.add_mime_type("image/svg+xml");
+            }
             filter.add_suffix("svg");
             filter.set_name(Some(&gettext("Svg")));
         }
         DocExportFormat::Pdf => {
-            filter.add_pattern("*.pdf");
+            if cfg!(target_os = "windows") {
+                filter.add_pattern("*.pdf");
+            } else {
+                filter.add_mime_type("application/pdf");
+            }
             filter.add_suffix("pdf");
             filter.set_name(Some(&gettext("Pdf")));
         }
         DocExportFormat::Xopp => {
-            filter.add_pattern("*.xopp");
+            if cfg!(target_os = "windows") {
+                filter.add_pattern("*.xopp");
+            } else {
+                filter.add_mime_type("application/x-xopp");
+            }
             filter.add_suffix("xopp");
             filter.set_name(Some(&gettext("Xopp")));
         }
@@ -578,28 +600,15 @@ fn create_filedialog_export_doc_pages(
 
     filedialog.set_initial_folder(get_initial_folder_for_export(appwindow, canvas).as_ref());
 
+    // does it work with mimetype but not the previous thing ?
+
     let filter = FileFilter::new();
     // We always need to be able to select folders
     filter.add_mime_type("inode/directory");
-    match doc_pages_export_prefs.export_format {
-        DocPagesExportFormat::Svg => {
-            filter.add_pattern("*.svg");
-            filter.add_suffix("svg");
-            filter.set_name(Some(&gettext("Svg")));
-        }
-        DocPagesExportFormat::Png => {
-            filter.add_pattern("*.png");
-            filter.add_suffix("png");
-            filter.set_name(Some(&gettext("Png")));
-        }
-        DocPagesExportFormat::Jpeg => {
-            filter.add_pattern("*.jpg");
-            filter.add_pattern("*.jpeg");
-            filter.add_suffix("jpg");
-            filter.add_suffix("jpeg");
-            filter.set_name(Some(&gettext("Jpeg")));
-        }
-    }
+    // note : we revert https://github.com/flxzt/rnote/pull/1075
+    // as applying the filter correctly makes it not work on all platforms with
+    // the native folder picker
+    // Here we need the mimetype as well, including on windows
     filedialog.set_default_filter(Some(&filter));
 
     filedialog
@@ -868,20 +877,35 @@ fn create_filedialog_export_selection(
     filedialog.set_initial_folder(get_initial_folder_for_export(appwindow, canvas).as_ref());
 
     let filter = FileFilter::new();
+    // note : mimetypes are not supported with the native file picker on windows
+    // See the limitations on FileChooserNative
+    // https://gtk-rs.org/gtk3-rs/stable/latest/docs/gtk/struct.FileChooserNative.html#win32-details--gtkfilechooserdialognative-win32
     match selection_export_prefs.export_format {
         SelectionExportFormat::Svg => {
-            filter.add_pattern("*.svg");
+            if cfg!(target_os = "windows") {
+                filter.add_pattern("*.svg");
+            } else {
+                filter.add_mime_type("image/svg+xml");
+            }
             filter.add_suffix("svg");
             filter.set_name(Some(&gettext("Svg")));
         }
         SelectionExportFormat::Png => {
-            filter.add_pattern("*.png");
+            if cfg!(target_os = "windows") {
+                filter.add_pattern("*.png");
+            } else {
+                filter.add_mime_type("image/png");
+            }
             filter.add_suffix("png");
             filter.set_name(Some(&gettext("Png")));
         }
         SelectionExportFormat::Jpeg => {
-            filter.add_pattern("*.jpg");
-            filter.add_pattern("*.jpeg");
+            if cfg!(target_os = "windows") {
+                filter.add_pattern("*.jpg");
+                filter.add_pattern("*.jpeg");
+            } else {
+                filter.add_mime_type("image/jpeg");
+            }
             filter.add_suffix("jpg");
             filter.add_suffix("jpeg");
             filter.set_name(Some(&gettext("Jpeg")));
@@ -906,7 +930,14 @@ fn create_filedialog_export_selection(
 
 pub(crate) async fn filechooser_export_engine_state(appwindow: &RnAppWindow, canvas: &RnCanvas) {
     let filter = FileFilter::new();
-    filter.add_pattern("*.json");
+    // note : mimetypes are not supported with the native file picker on windows
+    // See the limitations on FileChooserNative
+    // https://gtk-rs.org/gtk3-rs/stable/latest/docs/gtk/struct.FileChooserNative.html#win32-details--gtkfilechooserdialognative-win32
+    if cfg!(target_os = "windows") {
+        filter.add_pattern("*.json");
+    } else {
+        filter.add_mime_type("application/json");
+    }
     filter.add_suffix("json");
     filter.set_name(Some(&gettext("Json")));
 
@@ -959,7 +990,15 @@ pub(crate) async fn filechooser_export_engine_state(appwindow: &RnAppWindow, can
 
 pub(crate) async fn filechooser_export_engine_config(appwindow: &RnAppWindow, canvas: &RnCanvas) {
     let filter = FileFilter::new();
-    filter.add_pattern("*.json");
+
+    // note : mimetypes are not supported with the native file picker on windows
+    // See the limitations on FileChooserNative
+    // https://gtk-rs.org/gtk3-rs/stable/latest/docs/gtk/struct.FileChooserNative.html#win32-details--gtkfilechooserdialognative-win32
+    if cfg!(target_os = "windows") {
+        filter.add_pattern("*.json");
+    } else {
+        filter.add_mime_type("application/json");
+    }
     filter.add_suffix("json");
     filter.set_name(Some(&gettext("Json")));
 

--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -22,7 +22,7 @@ use std::rc::Rc;
 
 pub(crate) async fn dialog_save_doc_as(appwindow: &RnAppWindow, canvas: &RnCanvas) {
     let filter = FileFilter::new();
-    filter.add_mime_type("application/rnote");
+    filter.add_pattern("*.rnote");
     filter.add_suffix("rnote");
     filter.set_name(Some(&gettext(".rnote")));
 
@@ -278,17 +278,17 @@ fn create_filedialog_export_doc(
     let filter = FileFilter::new();
     match doc_export_prefs.export_format {
         DocExportFormat::Svg => {
-            filter.add_mime_type("image/svg+xml");
+            filter.add_pattern("*.svg");
             filter.add_suffix("svg");
             filter.set_name(Some(&gettext("Svg")));
         }
         DocExportFormat::Pdf => {
-            filter.add_mime_type("application/pdf");
+            filter.add_pattern("*.pdf");
             filter.add_suffix("pdf");
             filter.set_name(Some(&gettext("Pdf")));
         }
         DocExportFormat::Xopp => {
-            filter.add_mime_type("application/x-xopp");
+            filter.add_pattern("*.xopp");
             filter.add_suffix("xopp");
             filter.set_name(Some(&gettext("Xopp")));
         }
@@ -583,27 +583,23 @@ fn create_filedialog_export_doc_pages(
     filter.add_mime_type("inode/directory");
     match doc_pages_export_prefs.export_format {
         DocPagesExportFormat::Svg => {
-            filter.add_mime_type("image/svg+xml");
+            filter.add_pattern("*.svg");
             filter.add_suffix("svg");
             filter.set_name(Some(&gettext("Svg")));
         }
         DocPagesExportFormat::Png => {
-            filter.add_mime_type("image/png");
+            filter.add_pattern("*.png");
             filter.add_suffix("png");
             filter.set_name(Some(&gettext("Png")));
         }
         DocPagesExportFormat::Jpeg => {
-            filter.add_mime_type("image/jpeg");
+            filter.add_pattern("*.jpg");
+            filter.add_pattern("*.jpeg");
             filter.add_suffix("jpg");
             filter.add_suffix("jpeg");
             filter.set_name(Some(&gettext("Jpeg")));
         }
     }
-
-    let filter_list = gio::ListStore::new::<FileFilter>();
-    filter_list.append(&filter);
-    filedialog.set_filters(Some(&filter_list));
-
     filedialog.set_default_filter(Some(&filter));
 
     filedialog
@@ -874,17 +870,18 @@ fn create_filedialog_export_selection(
     let filter = FileFilter::new();
     match selection_export_prefs.export_format {
         SelectionExportFormat::Svg => {
-            filter.add_mime_type("image/svg+xml");
+            filter.add_pattern("*.svg");
             filter.add_suffix("svg");
             filter.set_name(Some(&gettext("Svg")));
         }
         SelectionExportFormat::Png => {
-            filter.add_mime_type("image/png");
+            filter.add_pattern("*.png");
             filter.add_suffix("png");
             filter.set_name(Some(&gettext("Png")));
         }
         SelectionExportFormat::Jpeg => {
-            filter.add_mime_type("image/jpeg");
+            filter.add_pattern("*.jpg");
+            filter.add_pattern("*.jpeg");
             filter.add_suffix("jpg");
             filter.add_suffix("jpeg");
             filter.set_name(Some(&gettext("Jpeg")));
@@ -909,7 +906,7 @@ fn create_filedialog_export_selection(
 
 pub(crate) async fn filechooser_export_engine_state(appwindow: &RnAppWindow, canvas: &RnCanvas) {
     let filter = FileFilter::new();
-    filter.add_mime_type("application/json");
+    filter.add_pattern("*.json");
     filter.add_suffix("json");
     filter.set_name(Some(&gettext("Json")));
 
@@ -962,7 +959,7 @@ pub(crate) async fn filechooser_export_engine_state(appwindow: &RnAppWindow, can
 
 pub(crate) async fn filechooser_export_engine_config(appwindow: &RnAppWindow, canvas: &RnCanvas) {
     let filter = FileFilter::new();
-    filter.add_mime_type("application/json");
+    filter.add_pattern("*.json");
     filter.add_suffix("json");
     filter.set_name(Some(&gettext("Json")));
 

--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -25,7 +25,7 @@ pub(crate) async fn dialog_save_doc_as(appwindow: &RnAppWindow, canvas: &RnCanva
     // See the limitations on FileChooserNative
     // https://gtk-rs.org/gtk3-rs/stable/latest/docs/gtk/struct.FileChooserNative.html#win32-details--gtkfilechooserdialognative-win32
     let filter = FileFilter::new();
-    if !cfg!(target_os = "windows") {
+    if cfg!(target_os = "windows") {
         filter.add_pattern("*.rnote");
     } else {
         filter.add_mime_type("application/rnote");

--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -642,6 +642,7 @@ fn create_filedialog_export_doc_pages(
             }
             if cfg!(target_os = "macos") {
                 filter.add_suffix("jpg");
+                filter.add_suffix("jpeg");
             }
             filter.set_name(Some(&gettext("Jpeg")));
         }
@@ -950,6 +951,7 @@ fn create_filedialog_export_selection(
             }
             if cfg!(target_os = "macos") {
                 filter.add_suffix("jpg");
+                filter.add_suffix("jpeg");
             }
             filter.set_name(Some(&gettext("Jpeg")));
         }

--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -30,7 +30,6 @@ pub(crate) async fn dialog_save_doc_as(appwindow: &RnAppWindow, canvas: &RnCanva
     } else {
         filter.add_mime_type("application/rnote");
     }
-    filter.add_suffix("rnote");
     filter.set_name(Some(&gettext(".rnote")));
 
     // create the list of filters
@@ -293,7 +292,6 @@ fn create_filedialog_export_doc(
             } else {
                 filter.add_mime_type("image/svg+xml");
             }
-            filter.add_suffix("svg");
             filter.set_name(Some(&gettext("Svg")));
         }
         DocExportFormat::Pdf => {
@@ -302,7 +300,6 @@ fn create_filedialog_export_doc(
             } else {
                 filter.add_mime_type("application/pdf");
             }
-            filter.add_suffix("pdf");
             filter.set_name(Some(&gettext("Pdf")));
         }
         DocExportFormat::Xopp => {
@@ -311,7 +308,6 @@ fn create_filedialog_export_doc(
             } else {
                 filter.add_mime_type("application/x-xopp");
             }
-            filter.add_suffix("xopp");
             filter.set_name(Some(&gettext("Xopp")));
         }
     }
@@ -605,10 +601,37 @@ fn create_filedialog_export_doc_pages(
     let filter = FileFilter::new();
     // We always need to be able to select folders
     filter.add_mime_type("inode/directory");
-    // note : we revert https://github.com/flxzt/rnote/pull/1075
-    // as applying the filter correctly makes it not work on all platforms with
-    // the native folder picker
-    // Here we need the mimetype as well, including on windows
+    match doc_pages_export_prefs.export_format {
+        DocPagesExportFormat::Svg => {
+            if cfg!(target_os = "windows") {
+                filter.add_pattern("*.svg");
+            } else {
+                filter.add_mime_type("image/svg+xml");
+            }
+            filter.add_suffix("svg");
+            filter.set_name(Some(&gettext("Svg")));
+        }
+        DocPagesExportFormat::Png => {
+            if cfg!(target_os = "windows") {
+                filter.add_pattern("*.png");
+            } else {
+                filter.add_mime_type("image/png");
+            }
+            filter.add_suffix("png");
+            filter.set_name(Some(&gettext("Png")));
+        }
+        DocPagesExportFormat::Jpeg => {
+            if cfg!(target_os = "windows") {
+                filter.add_pattern("*.jpg");
+            } else {
+                filter.add_mime_type("image/jpeg");
+            }
+            filter.add_suffix("jpg");
+            filter.add_suffix("jpeg");
+            filter.set_name(Some(&gettext("Jpeg")));
+        }
+    }
+
     filedialog.set_default_filter(Some(&filter));
 
     filedialog
@@ -887,7 +910,6 @@ fn create_filedialog_export_selection(
             } else {
                 filter.add_mime_type("image/svg+xml");
             }
-            filter.add_suffix("svg");
             filter.set_name(Some(&gettext("Svg")));
         }
         SelectionExportFormat::Png => {
@@ -896,7 +918,6 @@ fn create_filedialog_export_selection(
             } else {
                 filter.add_mime_type("image/png");
             }
-            filter.add_suffix("png");
             filter.set_name(Some(&gettext("Png")));
         }
         SelectionExportFormat::Jpeg => {
@@ -906,8 +927,6 @@ fn create_filedialog_export_selection(
             } else {
                 filter.add_mime_type("image/jpeg");
             }
-            filter.add_suffix("jpg");
-            filter.add_suffix("jpeg");
             filter.set_name(Some(&gettext("Jpeg")));
         }
     }
@@ -938,7 +957,6 @@ pub(crate) async fn filechooser_export_engine_state(appwindow: &RnAppWindow, can
     } else {
         filter.add_mime_type("application/json");
     }
-    filter.add_suffix("json");
     filter.set_name(Some(&gettext("Json")));
 
     let filter_list = gio::ListStore::new::<FileFilter>();
@@ -999,7 +1017,6 @@ pub(crate) async fn filechooser_export_engine_config(appwindow: &RnAppWindow, ca
     } else {
         filter.add_mime_type("application/json");
     }
-    filter.add_suffix("json");
     filter.set_name(Some(&gettext("Json")));
 
     let filter_list = gio::ListStore::new::<FileFilter>();

--- a/crates/rnote-ui/src/dialogs/import.rs
+++ b/crates/rnote-ui/src/dialogs/import.rs
@@ -16,8 +16,8 @@ use rnote_engine::engine::import::{PdfImportPageSpacing, PdfImportPagesType};
 /// Opens a new rnote save file in a new tab
 pub(crate) async fn filedialog_open_doc(appwindow: &RnAppWindow) {
     let filter = FileFilter::new();
-    filter.add_mime_type("application/rnote");
     filter.add_suffix("rnote");
+    filter.add_pattern("*.rnote");
     filter.set_name(Some(&gettext(".rnote")));
 
     let filter_list = gio::ListStore::new::<FileFilter>();
@@ -51,12 +51,12 @@ pub(crate) async fn filedialog_open_doc(appwindow: &RnAppWindow) {
 
 pub(crate) async fn filedialog_import_file(appwindow: &RnAppWindow) {
     let filter = FileFilter::new();
-    filter.add_mime_type("application/x-xopp");
-    filter.add_mime_type("application/pdf");
-    filter.add_mime_type("image/svg+xml");
-    filter.add_mime_type("image/png");
-    filter.add_mime_type("image/jpeg");
-    filter.add_mime_type("text/plain");
+    filter.add_pattern("*.xopp");
+    filter.add_pattern("*.pdf");
+    filter.add_pattern("*.svg");
+    filter.add_pattern("*.png");
+    filter.add_pattern("*.jpeg");
+    filter.add_pattern("*.txt");
     filter.add_suffix("xopp");
     filter.add_suffix("pdf");
     filter.add_suffix("svg");

--- a/crates/rnote-ui/src/dialogs/import.rs
+++ b/crates/rnote-ui/src/dialogs/import.rs
@@ -61,7 +61,7 @@ pub(crate) async fn filedialog_import_file(appwindow: &RnAppWindow) {
     // note : mimetypes are not supported with the native file picker on windows
     // See the limitations on FileChooserNative
     // https://gtk-rs.org/gtk3-rs/stable/latest/docs/gtk/struct.FileChooserNative.html#win32-details--gtkfilechooserdialognative-win32
-    if !cfg(target_os = "windows") {
+    if cfg!(target_os = "windows") {
         filter.add_pattern("*.xopp");
         filter.add_pattern("*.pdf");
         filter.add_pattern("*.svg");

--- a/crates/rnote-ui/src/dialogs/import.rs
+++ b/crates/rnote-ui/src/dialogs/import.rs
@@ -16,8 +16,15 @@ use rnote_engine::engine::import::{PdfImportPageSpacing, PdfImportPagesType};
 /// Opens a new rnote save file in a new tab
 pub(crate) async fn filedialog_open_doc(appwindow: &RnAppWindow) {
     let filter = FileFilter::new();
+    // note : mimetypes are not supported with the native file picker on windows
+    // See the limitations on FileChooserNative
+    // https://gtk-rs.org/gtk3-rs/stable/latest/docs/gtk/struct.FileChooserNative.html#win32-details--gtkfilechooserdialognative-win32
+    if cfg!(target_os = "windows") {
+        filter.add_pattern("*.rnote");
+    } else {
+        filter.add_mime_type("application/rnote");
+    }
     filter.add_suffix("rnote");
-    filter.add_pattern("*.rnote");
     filter.set_name(Some(&gettext(".rnote")));
 
     let filter_list = gio::ListStore::new::<FileFilter>();
@@ -51,12 +58,24 @@ pub(crate) async fn filedialog_open_doc(appwindow: &RnAppWindow) {
 
 pub(crate) async fn filedialog_import_file(appwindow: &RnAppWindow) {
     let filter = FileFilter::new();
-    filter.add_pattern("*.xopp");
-    filter.add_pattern("*.pdf");
-    filter.add_pattern("*.svg");
-    filter.add_pattern("*.png");
-    filter.add_pattern("*.jpeg");
-    filter.add_pattern("*.txt");
+    // note : mimetypes are not supported with the native file picker on windows
+    // See the limitations on FileChooserNative
+    // https://gtk-rs.org/gtk3-rs/stable/latest/docs/gtk/struct.FileChooserNative.html#win32-details--gtkfilechooserdialognative-win32
+    if !cfg(target_os = "windows") {
+        filter.add_pattern("*.xopp");
+        filter.add_pattern("*.pdf");
+        filter.add_pattern("*.svg");
+        filter.add_pattern("*.png");
+        filter.add_pattern("*.jpeg");
+        filter.add_pattern("*.txt");
+    } else {
+        filter.add_mime_type("application/x-xopp");
+        filter.add_mime_type("application/pdf");
+        filter.add_mime_type("image/svg+xml");
+        filter.add_mime_type("image/png");
+        filter.add_mime_type("image/jpeg");
+        filter.add_mime_type("text/plain");
+    }
     filter.add_suffix("xopp");
     filter.add_suffix("pdf");
     filter.add_suffix("svg");

--- a/crates/rnote-ui/src/workspacebrowser/mod.rs
+++ b/crates/rnote-ui/src/workspacebrowser/mod.rs
@@ -460,7 +460,7 @@ fn create_folders_sorter() -> MultiSorter {
 
 fn create_notes_filter() -> EveryFilter {
     let file_filter = FileFilter::new();
-    file_filter.add_mime_type("application/rnote");
+    file_filter.add_pattern("*.rnote");
     file_filter.add_suffix("rnote");
     let hidden_filter = create_hidden_filter();
 
@@ -478,12 +478,12 @@ fn create_notes_sorter() -> MultiSorter {
 
 fn create_files_filter() -> EveryFilter {
     let file_filter = FileFilter::new();
-    file_filter.add_mime_type("application/pdf");
-    file_filter.add_mime_type("application/x-xopp");
-    file_filter.add_mime_type("image/svg+xml");
-    file_filter.add_mime_type("image/png");
-    file_filter.add_mime_type("image/jpeg");
-    file_filter.add_mime_type("text/plain");
+    file_filter.add_pattern("*.pdf");
+    file_filter.add_pattern("*.xopp");
+    file_filter.add_pattern("*.svg");
+    file_filter.add_pattern("*.png");
+    file_filter.add_pattern("*.jpeg");
+    file_filter.add_pattern("*.plain");
     file_filter.add_suffix("pdf");
     file_filter.add_suffix("xopp");
     file_filter.add_suffix("svg");

--- a/crates/rnote-ui/src/workspacebrowser/mod.rs
+++ b/crates/rnote-ui/src/workspacebrowser/mod.rs
@@ -460,7 +460,7 @@ fn create_folders_sorter() -> MultiSorter {
 
 fn create_notes_filter() -> EveryFilter {
     let file_filter = FileFilter::new();
-    file_filter.add_pattern("*.rnote");
+    file_filter.add_mime_type("application/rnote");
     file_filter.add_suffix("rnote");
     let hidden_filter = create_hidden_filter();
 
@@ -478,12 +478,12 @@ fn create_notes_sorter() -> MultiSorter {
 
 fn create_files_filter() -> EveryFilter {
     let file_filter = FileFilter::new();
-    file_filter.add_pattern("*.pdf");
-    file_filter.add_pattern("*.xopp");
-    file_filter.add_pattern("*.svg");
-    file_filter.add_pattern("*.png");
-    file_filter.add_pattern("*.jpeg");
-    file_filter.add_pattern("*.plain");
+    file_filter.add_mime_type("application/pdf");
+    file_filter.add_mime_type("application/x-xopp");
+    file_filter.add_mime_type("image/svg+xml");
+    file_filter.add_mime_type("image/png");
+    file_filter.add_mime_type("image/jpeg");
+    file_filter.add_mime_type("text/plain");
     file_filter.add_suffix("pdf");
     file_filter.add_suffix("xopp");
     file_filter.add_suffix("svg");


### PR DESCRIPTION
this allows for the filepicker to stay as the native one on windows and, this makes the extension automatically apply on both windows and linux even if the file name doesn't include the extension.

To fix #1114

Some notes 
- I think only having one of `filter.add_pattern` and `filter.add_suffix` is enough for it to work
- for import, we have to remove the mimetype for the filter to apply with the native file picker on windows but it's a little more restrictive on imports when used on linux. If you want I can set a conditional compilation flag to keep the mimetypes on linux (or at least on non windows targets)
- for the export of doc pages I actually removed the previous fix, but in this case adding a mimetype worked on windows. Also, as it is fundamentally a choice of folders, I don't understand why jpg/pdf/svg filters are added there, seems like an error.
- Tested on windows and linux but not yet on mac os.