### PR TITLE
ui: migrate `GtkDialog` to `AdwDialog`

### DIFF
--- a/crates/rnote-ui/data/ui/dialogs/dialogs.ui
+++ b/crates/rnote-ui/data/ui/dialogs/dialogs.ui
@@ -61,126 +61,131 @@ Changes which are not saved will be permanently lost.</property>
     </responses>
   </object>
 
-  <object class="GtkDialog" id="dialog_edit_selected_workspace">
-    <property name="use-header-bar">1</property>
-    <property name="modal">true</property>
+  <object class="AdwDialog" id="dialog_edit_selected_workspace">
     <property name="title" translatable="yes">Edit Workspace</property>
-    <child type="action">
-      <object class="GtkButton" id="edit_selected_workspace_button_cancel">
-        <property name="label" translatable="yes">Cancel</property>
-      </object>
-    </child>
-    <child type="action">
-      <object class="GtkButton" id="edit_selected_workspace_button_apply">
-        <property name="label" translatable="yes">Apply</property>
-        <style>
-          <class name="suggested-action" />
-        </style>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="cancel">edit_selected_workspace_button_cancel</action-widget>
-      <action-widget response="apply" default="true">edit_selected_workspace_button_apply</action-widget>
-    </action-widgets>
     <child>
-      <object class="AdwClamp">
-        <property name="maximum-size">800</property>
-        <property name="tightening-threshold">600</property>
-        <property name="hexpand">true</property>
-        <property name="vexpand">false</property>
-        <property name="valign">fill</property>
-        <property name="halign">fill</property>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox">
-            <property name="orientation">vertical</property>
-            <property name="spacing">24</property>
-            <property name="margin-start">12</property>
-            <property name="margin-end">12</property>
-            <property name="margin-top">12</property>
-            <property name="margin-bottom">12</property>
-            <style>
-              <class name="background" />
-            </style>
-            <child>
-              <object class="RnWorkspaceRow" id="edit_selected_workspace_preview_row">
-                <property name="halign">center</property>
+          <object class="AdwHeaderBar">
+            <property name="show-end-title-buttons">false</property>
+            <property name="show-start-title-buttons">false</property>
+            <child type="start">
+              <object class="GtkButton" id="edit_selected_workspace_button_cancel">
+                <property name="label" translatable="yes">Cancel</property>
+              </object>
+            </child>
+            <child type="end">
+              <object class="GtkButton" id="edit_selected_workspace_button_apply">
+                <property name="label" translatable="yes">Apply</property>
                 <style>
-                  <class name="preview" />
+                  <class name="suggested-action" />
                 </style>
               </object>
             </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwClamp">
+            <property name="maximum-size">800</property>
+            <property name="tightening-threshold">600</property>
+            <property name="hexpand">true</property>
+            <property name="vexpand">false</property>
+            <property name="valign">fill</property>
+            <property name="halign">fill</property>
             <child>
-              <object class="AdwPreferencesGroup">
-                <property name="halign">fill</property>
+              <object class="GtkBox">
+                <property name="orientation">vertical</property>
+                <property name="spacing">24</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
+                <style>
+                  <class name="background" />
+                </style>
                 <child>
-                  <object class="AdwEntryRow" id="edit_selected_workspace_name_entryrow">
-                    <property name="title" translatable="yes">Workspace Name</property>
+                  <object class="RnWorkspaceRow" id="edit_selected_workspace_preview_row">
+                    <property name="halign">center</property>
+                    <style>
+                      <class name="preview" />
+                    </style>
                   </object>
                 </child>
                 <child>
-                  <object class="AdwActionRow">
-                    <property name="title" translatable="yes">Icon</property>
-                    <property name="subtitle" translatable="yes">Change the workspace icon</property>
-                    <child type="suffix">
-                      <object class="GtkBox">
-                        <child>
-                          <object class="GtkMenuButton" id="edit_selected_workspace_icon_menubutton">
+                  <object class="AdwPreferencesGroup">
+                    <property name="halign">fill</property>
+                    <child>
+                      <object class="AdwEntryRow" id="edit_selected_workspace_name_entryrow">
+                        <property name="title" translatable="yes">Workspace Name</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwActionRow">
+                        <property name="title" translatable="yes">Icon</property>
+                        <property name="subtitle" translatable="yes">Change the workspace icon</property>
+                        <child type="suffix">
+                          <object class="GtkBox">
+                            <child>
+                              <object class="GtkMenuButton" id="edit_selected_workspace_icon_menubutton">
+                                <property name="hexpand">false</property>
+                                <property name="hexpand">false</property>
+                                <property name="valign">center</property>
+                                <property name="halign">end</property>
+                                <property name="icon-name">folder-symbolic</property>
+                                <property name="popover">edit_selected_workspace_icon_popover</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorDialog" id="edit_selected_workspace_color_dialog"></object>
+                      <object class="AdwActionRow">
+                        <property name="title" translatable="yes">Color</property>
+                        <property name="subtitle" translatable="yes">Change the workspace color</property>
+                        <child type="suffix">
+                          <object class="GtkColorDialogButton" id="edit_selected_workspace_color_button">
                             <property name="hexpand">false</property>
                             <property name="hexpand">false</property>
                             <property name="valign">center</property>
                             <property name="halign">end</property>
-                            <property name="icon-name">folder-symbolic</property>
-                            <property name="popover">edit_selected_workspace_icon_popover</property>
+                            <property name="dialog">edit_selected_workspace_color_dialog</property>
                           </object>
                         </child>
                       </object>
                     </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkColorDialog" id="edit_selected_workspace_color_dialog"></object>
-                  <object class="AdwActionRow">
-                    <property name="title" translatable="yes">Color</property>
-                    <property name="subtitle" translatable="yes">Change the workspace color</property>
-                    <child type="suffix">
-                      <object class="GtkColorDialogButton" id="edit_selected_workspace_color_button">
-                        <property name="hexpand">false</property>
-                        <property name="hexpand">false</property>
-                        <property name="valign">center</property>
-                        <property name="halign">end</property>
-                        <property name="dialog">edit_selected_workspace_color_dialog</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="AdwActionRow">
-                    <property name="title" translatable="yes">Directory</property>
-                    <property name="subtitle" translatable="yes">Change the workspace directory</property>
-                    <child type="suffix">
-                      <object class="GtkBox">
-                        <property name="valign">center</property>
-                        <property name="halign">end</property>
-                        <property name="orientation">horizontal</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkLabel" id="edit_selected_workspace_dir_label">
-                            <property name="label" translatable="yes">- no directory selected -</property>
-                            <property name="ellipsize">start</property>
-                            <property name="max-width-chars">50</property>
-                            <style>
-                              <class name="dim-label" />
-                            </style>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="edit_selected_workspace_dir_button">
-                            <layout>
-                              <property name="column">1</property>
-                              <property name="row">1</property>
-                            </layout>
-                            <property name="icon_name">folder-open-symbolic</property>
-                            <property name="tooltip_text" translatable="yes">Change the directory</property>
+                    <child>
+                      <object class="AdwActionRow">
+                        <property name="title" translatable="yes">Directory</property>
+                        <property name="subtitle" translatable="yes">Change the workspace directory</property>
+                        <child type="suffix">
+                          <object class="GtkBox">
+                            <property name="valign">center</property>
+                            <property name="halign">end</property>
+                            <property name="orientation">horizontal</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkLabel" id="edit_selected_workspace_dir_label">
+                                <property name="label" translatable="yes">- no directory selected -</property>
+                                <property name="ellipsize">start</property>
+                                <property name="max-width-chars">50</property>
+                                <style>
+                                  <class name="dim-label" />
+                                </style>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="edit_selected_workspace_dir_button">
+                                <layout>
+                                  <property name="column">1</property>
+                                  <property name="row">1</property>
+                                </layout>
+                                <property name="icon_name">folder-open-symbolic</property>
+                                <property name="tooltip_text" translatable="yes">Change the directory</property>
+                              </object>
+                            </child>
                           </object>
                         </child>
                       </object>

--- a/crates/rnote-ui/data/ui/dialogs/dialogs.ui
+++ b/crates/rnote-ui/data/ui/dialogs/dialogs.ui
@@ -64,9 +64,8 @@ Changes which are not saved will be permanently lost.</property>
   <object class="AdwDialog" id="dialog_edit_selected_workspace">
     <property name="title" translatable="yes">Edit Workspace</property>
     <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <child>
+      <object class="AdwToolbarView">
+        <child type="top">
           <object class="AdwHeaderBar">
             <property name="show-end-title-buttons">false</property>
             <property name="show-start-title-buttons">false</property>
@@ -85,7 +84,7 @@ Changes which are not saved will be permanently lost.</property>
             </child>
           </object>
         </child>
-        <child>
+        <property name="content">
           <object class="AdwClamp">
             <property name="maximum-size">800</property>
             <property name="tightening-threshold">600</property>
@@ -195,7 +194,7 @@ Changes which are not saved will be permanently lost.</property>
               </object>
             </child>
           </object>
-        </child>
+        </property>
       </object>
     </child>
   </object>

--- a/crates/rnote-ui/data/ui/dialogs/export.ui
+++ b/crates/rnote-ui/data/ui/dialogs/export.ui
@@ -1,157 +1,162 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Export dialogs -->
 <interface>
-  <object class="GtkDialog" id="dialog_export_doc_w_prefs">
-    <property name="use-header-bar">1</property>
-    <property name="modal">true</property>
+  <object class="AdwDialog" id="dialog_export_doc_w_prefs">
     <property name="title" translatable="yes">Export Document</property>
-    <child type="action">
-      <object class="GtkButton" id="export_doc_button_cancel">
-        <property name="label" translatable="yes">Cancel</property>
-      </object>
-    </child>
-    <child type="action">
-      <object class="GtkButton" id="export_doc_button_confirm">
-        <property name="label" translatable="yes">Export</property>
-        <property name="sensitive">false</property>
-        <style>
-          <class name="suggested-action" />
-        </style>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="cancel">export_doc_button_cancel</action-widget>
-      <action-widget response="apply" default="true">export_doc_button_confirm</action-widget>
-    </action-widgets>
     <child>
-      <object class="AdwClamp">
-        <property name="maximum-size">1000</property>
-        <property name="tightening-threshold">900</property>
-        <property name="hexpand">true</property>
-        <property name="vexpand">false</property>
-        <property name="halign">fill</property>
-        <property name="valign">start</property>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox">
-            <property name="orientation">horizontal</property>
-            <property name="spacing">12</property>
-            <property name="margin-start">12</property>
-            <property name="margin-end">0</property>
-            <property name="margin-top">12</property>
-            <property name="margin-bottom">12</property>
-            <style>
-              <class name="background" />
-            </style>
-            <child>
-              <object class="RnStrokeContentPreview" id="export_doc_preview">
-                <property name="halign">fill</property>
-                <property name="valign">fill</property>
-                <property name="hexpand">true</property>
-                <property name="vexpand">true</property>
+          <object class="AdwHeaderBar">
+            <property name="show-end-title-buttons">false</property>
+            <property name="show-start-title-buttons">false</property>
+            <child type="start">
+              <object class="GtkButton" id="export_doc_button_cancel">
+                <property name="label" translatable="yes">Cancel</property>
               </object>
             </child>
+            <child type="end">
+              <object class="GtkButton" id="export_doc_button_confirm">
+                <property name="label" translatable="yes">Export</property>
+                <property name="sensitive">false</property>
+                <style>
+                  <class name="suggested-action" />
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwClamp">
+            <property name="maximum-size">1000</property>
+            <property name="tightening-threshold">900</property>
+            <property name="hexpand">true</property>
+            <property name="vexpand">false</property>
+            <property name="halign">fill</property>
+            <property name="valign">start</property>
             <child>
-              <object class="GtkScrolledWindow">
-                <property name="hscrollbar-policy">never</property>
-                <property name="hexpand">true</property>
-                <property name="vexpand">true</property>
-                <property name="halign">fill</property>
-                <property name="valign">fill</property>
-                <property name="propagate-natural-width">true</property>
-                <property name="propagate-natural-height">true</property>
-                <property name="window-placement">top-left</property>
+              <object class="GtkBox">
+                <property name="orientation">horizontal</property>
+                <property name="spacing">12</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">0</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
+                <style>
+                  <class name="background" />
+                </style>
                 <child>
-                  <object class="GtkBox">
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">12</property>
-                    <property name="margin-end">18</property>
+                  <object class="RnStrokeContentPreview" id="export_doc_preview">
+                    <property name="halign">fill</property>
+                    <property name="valign">fill</property>
+                    <property name="hexpand">true</property>
+                    <property name="vexpand">true</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="hscrollbar-policy">never</property>
+                    <property name="hexpand">true</property>
+                    <property name="vexpand">true</property>
+                    <property name="halign">fill</property>
+                    <property name="valign">fill</property>
+                    <property name="propagate-natural-width">true</property>
+                    <property name="propagate-natural-height">true</property>
+                    <property name="window-placement">top-left</property>
                     <child>
-                      <object class="AdwPreferencesGroup">
+                      <object class="GtkBox">
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">12</property>
+                        <property name="margin-end">18</property>
                         <child>
-                          <object class="AdwActionRow">
-                            <property name="title" translatable="yes">Export File</property>
-                            <property name="subtitle" translatable="yes">Select the export file</property>
-                            <child type="suffix">
-                              <object class="GtkBox">
-                                <property name="valign">center</property>
-                                <property name="halign">end</property>
-                                <property name="orientation">horizontal</property>
-                                <property name="spacing">6</property>
-                                <child>
-                                  <object class="GtkLabel" id="export_doc_export_file_label">
-                                    <property name="label" translatable="yes">- no file selected -</property>
-                                    <property name="ellipsize">start</property>
-                                    <style>
-                                      <class name="dim-label" />
-                                    </style>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkButton" id="export_doc_export_file_button">
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">1</property>
-                                    </layout>
-                                    <property name="icon_name">folder-open-symbolic</property>
+                          <object class="AdwPreferencesGroup">
+                            <child>
+                              <object class="AdwActionRow">
+                                <property name="title" translatable="yes">Export File</property>
+                                <property name="subtitle" translatable="yes">Select the export file</property>
+                                <child type="suffix">
+                                  <object class="GtkBox">
+                                    <property name="valign">center</property>
+                                    <property name="halign">end</property>
+                                    <property name="orientation">horizontal</property>
+                                    <property name="spacing">6</property>
+                                    <child>
+                                      <object class="GtkLabel" id="export_doc_export_file_label">
+                                        <property name="label" translatable="yes">- no file selected -</property>
+                                        <property name="ellipsize">start</property>
+                                        <style>
+                                          <class name="dim-label" />
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="export_doc_export_file_button">
+                                        <layout>
+                                          <property name="column">1</property>
+                                          <property name="row">1</property>
+                                        </layout>
+                                        <property name="icon_name">folder-open-symbolic</property>
+                                      </object>
+                                    </child>
                                   </object>
                                 </child>
                               </object>
                             </child>
                           </object>
                         </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="AdwPreferencesGroup">
-                        <property name="title" translatable="yes">Export Preferences</property>
-                        <property name="halign">fill</property>
                         <child>
-                          <object class="AdwSwitchRow" id="export_doc_with_background_row">
-                            <property name="title" translatable="yes">With Background</property>
-                            <property name="subtitle" translatable="yes">Set whether the background should be exported</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwSwitchRow" id="export_doc_with_pattern_row">
-                            <property name="title" translatable="yes">With Pattern</property>
-                            <property name="subtitle" translatable="yes">Set whether the background pattern should be exported</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwSwitchRow" id="export_doc_optimize_printing_row">
-                            <property name="title" translatable="yes">Optimize for Printing</property>
-                            <property name="subtitle" translatable="yes">Set whether the content should be optimized for printing</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwComboRow" id="export_doc_export_format_row">
-                            <property name="title" translatable="yes">Export Format</property>
-                            <property name="subtitle" translatable="yes">The export format</property>
-                            <property name="model">
-                              <object class="GtkStringList">
-                                <items>
-                                  <item translatable="yes">Svg</item>
-                                  <item translatable="yes">Pdf</item>
-                                  <item translatable="yes">Xopp</item>
-                                </items>
+                          <object class="AdwPreferencesGroup">
+                            <property name="title" translatable="yes">Export Preferences</property>
+                            <property name="halign">fill</property>
+                            <child>
+                              <object class="AdwSwitchRow" id="export_doc_with_background_row">
+                                <property name="title" translatable="yes">With Background</property>
+                                <property name="subtitle" translatable="yes">Set whether the background should be exported</property>
                               </object>
-                            </property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwComboRow" id="export_doc_page_order_row">
-                            <property name="title" translatable="yes">Page Order</property>
-                            <property name="subtitle" translatable="yes">The page order when documents with layouts
-that expand in horizontal and vertical directions
-are cut into pages</property>
-                            <property name="model">
-                              <object class="GtkStringList">
-                                <items>
-                                  <item translatable="yes">Horizontal First</item>
-                                  <item translatable="yes">Vertical First</item>
-                                </items>
+                            </child>
+                            <child>
+                              <object class="AdwSwitchRow" id="export_doc_with_pattern_row">
+                                <property name="title" translatable="yes">With Pattern</property>
+                                <property name="subtitle" translatable="yes">Set whether the background pattern should be exported</property>
                               </object>
-                            </property>
+                            </child>
+                            <child>
+                              <object class="AdwSwitchRow" id="export_doc_optimize_printing_row">
+                                <property name="title" translatable="yes">Optimize for Printing</property>
+                                <property name="subtitle" translatable="yes">Set whether the content should be optimized for printing</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwComboRow" id="export_doc_export_format_row">
+                                <property name="title" translatable="yes">Export Format</property>
+                                <property name="subtitle" translatable="yes">The export format</property>
+                                <property name="model">
+                                  <object class="GtkStringList">
+                                    <items>
+                                      <item translatable="yes">Svg</item>
+                                      <item translatable="yes">Pdf</item>
+                                      <item translatable="yes">Xopp</item>
+                                    </items>
+                                  </object>
+                                </property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwComboRow" id="export_doc_page_order_row">
+                                <property name="title" translatable="yes">Page Order</property>
+                                <property name="subtitle" translatable="yes">The page order when documents with layouts
+    that expand in horizontal and vertical directions
+    are cut into pages</property>
+                                <property name="model">
+                                  <object class="GtkStringList">
+                                    <items>
+                                      <item translatable="yes">Horizontal First</item>
+                                      <item translatable="yes">Vertical First</item>
+                                    </items>
+                                  </object>
+                                </property>
+                              </object>
+                            </child>
                           </object>
                         </child>
                       </object>
@@ -166,135 +171,104 @@ are cut into pages</property>
     </child>
   </object>
 
-  <object class="GtkDialog" id="dialog_export_doc_pages_w_prefs">
-    <property name="use-header-bar">1</property>
-    <property name="modal">true</property>
+  <object class="AdwDialog" id="dialog_export_doc_pages_w_prefs">
     <property name="title" translatable="yes">Export Document Pages</property>
-    <child type="action">
-      <object class="GtkButton" id="export_doc_pages_button_cancel">
-        <property name="label" translatable="yes">Cancel</property>
-      </object>
-    </child>
-    <child type="action">
-      <object class="GtkButton" id="export_doc_pages_button_confirm">
-        <property name="label" translatable="yes">Export</property>
-        <property name="sensitive">false</property>
-        <style>
-          <class name="suggested-action" />
-        </style>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="cancel">export_doc_pages_button_cancel</action-widget>
-      <action-widget response="apply" default="true">export_doc_pages_button_confirm</action-widget>
-    </action-widgets>
     <child>
-      <object class="AdwClamp">
-        <property name="maximum-size">1000</property>
-        <property name="tightening-threshold">900</property>
-        <property name="hexpand">true</property>
-        <property name="vexpand">false</property>
-        <property name="halign">fill</property>
-        <property name="valign">start</property>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox">
-            <property name="orientation">horizontal</property>
-            <property name="spacing">12</property>
-            <property name="margin-start">12</property>
-            <property name="margin-end">0</property>
-            <property name="margin-top">12</property>
-            <property name="margin-bottom">12</property>
-            <style>
-              <class name="background" />
-            </style>
-            <child>
-              <object class="RnStrokeContentPreview" id="export_doc_pages_preview">
-                <property name="halign">fill</property>
-                <property name="valign">fill</property>
-                <property name="hexpand">true</property>
-                <property name="vexpand">true</property>
+          <object class="AdwHeaderBar">
+            <property name="show-end-title-buttons">false</property>
+            <property name="show-start-title-buttons">false</property>
+            <child type="start">
+              <object class="GtkButton" id="export_doc_pages_button_cancel">
+                <property name="label" translatable="yes">Cancel</property>
               </object>
             </child>
+            <child type="end">
+              <object class="GtkButton" id="export_doc_pages_button_confirm">
+                <property name="label" translatable="yes">Export</property>
+                <property name="sensitive">false</property>
+                <style>
+                  <class name="suggested-action" />
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwClamp">
+            <property name="maximum-size">1000</property>
+            <property name="tightening-threshold">900</property>
+            <property name="hexpand">true</property>
+            <property name="vexpand">false</property>
+            <property name="halign">fill</property>
+            <property name="valign">start</property>
             <child>
-              <object class="GtkScrolledWindow">
-                <property name="hscrollbar-policy">never</property>
-                <property name="hexpand">true</property>
-                <property name="vexpand">true</property>
-                <property name="halign">fill</property>
-                <property name="valign">fill</property>
-                <property name="propagate-natural-width">true</property>
-                <property name="propagate-natural-height">true</property>
-                <property name="window-placement">top-left</property>
+              <object class="GtkBox">
+                <property name="orientation">horizontal</property>
+                <property name="spacing">12</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">0</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
+                <style>
+                  <class name="background" />
+                </style>
                 <child>
-                  <object class="GtkBox">
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">12</property>
-                    <property name="margin-end">18</property>
+                  <object class="RnStrokeContentPreview" id="export_doc_pages_preview">
+                    <property name="halign">fill</property>
+                    <property name="valign">fill</property>
+                    <property name="hexpand">true</property>
+                    <property name="vexpand">true</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="hscrollbar-policy">never</property>
+                    <property name="hexpand">true</property>
+                    <property name="vexpand">true</property>
+                    <property name="halign">fill</property>
+                    <property name="valign">fill</property>
+                    <property name="propagate-natural-width">true</property>
+                    <property name="propagate-natural-height">true</property>
+                    <property name="window-placement">top-left</property>
                     <child>
                       <object class="GtkBox">
                         <property name="orientation">vertical</property>
                         <property name="spacing">12</property>
-                        <style>
-                          <class name="card" />
-                          <class name="view" />
-                        </style>
+                        <property name="margin-end">18</property>
                         <child>
                           <object class="GtkBox">
-                            <property name="orientation">horizontal</property>
-                            <property name="halign">fill</property>
-                            <property name="valign">center</property>
+                            <property name="orientation">vertical</property>
                             <property name="spacing">12</property>
-                            <property name="margin-start">12</property>
-                            <property name="margin-end">12</property>
-                            <property name="margin-top">12</property>
-                            <property name="margin-bottom">12</property>
+                            <style>
+                              <class name="card" />
+                              <class name="view" />
+                            </style>
                             <child>
-                              <object class="GtkLabel">
-                                <property name="margin-end">12</property>
-                                <property name="label" translatable="yes">Page Files Naming:</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="export_doc_pages_page_files_naming_info_label">
-                                <property name="sensitive">false</property>
-                                <property name="hexpand">true</property>
-                                <property name="halign">end</property>
-                                <property name="use-markup">true</property>
-                                <property name="ellipsize">end</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="AdwPreferencesGroup">
-                        <child>
-                          <object class="AdwActionRow">
-                            <property name="title" translatable="yes">Export Directory</property>
-                            <property name="subtitle" translatable="yes">Select the export directory</property>
-                            <child type="suffix">
                               <object class="GtkBox">
-                                <property name="valign">center</property>
-                                <property name="halign">end</property>
                                 <property name="orientation">horizontal</property>
-                                <property name="spacing">6</property>
+                                <property name="halign">fill</property>
+                                <property name="valign">center</property>
+                                <property name="spacing">12</property>
+                                <property name="margin-start">12</property>
+                                <property name="margin-end">12</property>
+                                <property name="margin-top">12</property>
+                                <property name="margin-bottom">12</property>
                                 <child>
-                                  <object class="GtkLabel" id="export_doc_pages_export_dir_label">
-                                    <property name="label" translatable="yes">- no directory selected -</property>
-                                    <property name="ellipsize">start</property>
-                                    <style>
-                                      <class name="dim-label" />
-                                    </style>
+                                  <object class="GtkLabel">
+                                    <property name="margin-end">12</property>
+                                    <property name="label" translatable="yes">Page Files Naming:</property>
                                   </object>
                                 </child>
                                 <child>
-                                  <object class="GtkButton" id="export_doc_pages_export_dir_button">
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">1</property>
-                                    </layout>
-                                    <property name="icon_name">folder-open-symbolic</property>
+                                  <object class="GtkLabel" id="export_doc_pages_page_files_naming_info_label">
+                                    <property name="sensitive">false</property>
+                                    <property name="hexpand">true</property>
+                                    <property name="halign">end</property>
+                                    <property name="use-markup">true</property>
+                                    <property name="ellipsize">end</property>
                                   </object>
                                 </child>
                               </object>
@@ -302,80 +276,116 @@ are cut into pages</property>
                           </object>
                         </child>
                         <child>
-                          <object class="AdwEntryRow" id="export_doc_pages_export_files_stemname_entryrow">
-                            <property name="title" translatable="yes" context="When pages are exported this is the base name, followed by: - Page 0,1,..">Export Files Stem Name</property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="AdwPreferencesGroup">
-                        <property name="title" translatable="yes">Export Preferences</property>
-                        <property name="halign">fill</property>
-                        <child>
-                          <object class="AdwSwitchRow" id="export_doc_pages_with_background_row">
-                            <property name="title" translatable="yes">With Background</property>
-                            <property name="subtitle" translatable="yes">Set whether the background should be exported</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwSwitchRow" id="export_doc_pages_with_pattern_row">
-                            <property name="title" translatable="yes">With Pattern</property>
-                            <property name="subtitle" translatable="yes">Set whether the background pattern should be exported</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwSwitchRow" id="export_doc_pages_optimize_printing_row">
-                            <property name="title" translatable="yes">Optimize for Printing</property>
-                            <property name="subtitle" translatable="yes">Set whether the content should be optimized for printing</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwComboRow" id="export_doc_pages_export_format_row">
-                            <property name="title" translatable="yes">Export Format</property>
-                            <property name="subtitle" translatable="yes">The export format</property>
-                            <property name="model">
-                              <object class="GtkStringList">
-                                <items>
-                                  <item translatable="yes">Svg</item>
-                                  <item translatable="yes">Png</item>
-                                  <item translatable="yes">Jpeg</item>
-                                </items>
+                          <object class="AdwPreferencesGroup">
+                            <child>
+                              <object class="AdwActionRow">
+                                <property name="title" translatable="yes">Export Directory</property>
+                                <property name="subtitle" translatable="yes">Select the export directory</property>
+                                <child type="suffix">
+                                  <object class="GtkBox">
+                                    <property name="valign">center</property>
+                                    <property name="halign">end</property>
+                                    <property name="orientation">horizontal</property>
+                                    <property name="spacing">6</property>
+                                    <child>
+                                      <object class="GtkLabel" id="export_doc_pages_export_dir_label">
+                                        <property name="label" translatable="yes">- no directory selected -</property>
+                                        <property name="ellipsize">start</property>
+                                        <style>
+                                          <class name="dim-label" />
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="export_doc_pages_export_dir_button">
+                                        <layout>
+                                          <property name="column">1</property>
+                                          <property name="row">1</property>
+                                        </layout>
+                                        <property name="icon_name">folder-open-symbolic</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
                               </object>
-                            </property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwComboRow" id="export_doc_pages_page_order_row">
-                            <property name="title" translatable="yes">Page Order</property>
-                            <property name="subtitle" translatable="yes">The page order when documents with layouts
-that expand in horizontal and vertical directions
-are cut into pages</property>
-                            <property name="model">
-                              <object class="GtkStringList">
-                                <items>
-                                  <item translatable="yes">Horizontal First</item>
-                                  <item translatable="yes">Vertical First</item>
-                                </items>
+                            </child>
+                            <child>
+                              <object class="AdwEntryRow" id="export_doc_pages_export_files_stemname_entryrow">
+                                <property name="title" translatable="yes" context="When pages are exported this is the base name, followed by: - Page 0,1,..">Export Files Stem Name</property>
                               </object>
-                            </property>
+                            </child>
                           </object>
                         </child>
                         <child>
-                          <object class="AdwSpinRow" id="export_doc_pages_bitmap_scalefactor_row">
-                            <property name="title" translatable="yes">Bitmap Scale-Factor</property>
-                            <property name="subtitle" translatable="yes">Set the bitmap scale factor in relation
-to the actual size on the document</property>
-                            <property name="adjustment">export_doc_pages_bitmap_scalefactor_adj</property>
-                            <property name="digits">1</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwSpinRow" id="export_doc_pages_jpeg_quality_row">
-                            <property name="title" translatable="yes">Jpeg Quality</property>
-                            <property name="subtitle" translatable="yes">Set the quality of the Jpeg image (1 - 100)</property>
-                            <property name="adjustment">export_doc_pages_jpeg_quality_adj</property>
-                            <property name="digits">0</property>
+                          <object class="AdwPreferencesGroup">
+                            <property name="title" translatable="yes">Export Preferences</property>
+                            <property name="halign">fill</property>
+                            <child>
+                              <object class="AdwSwitchRow" id="export_doc_pages_with_background_row">
+                                <property name="title" translatable="yes">With Background</property>
+                                <property name="subtitle" translatable="yes">Set whether the background should be exported</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwSwitchRow" id="export_doc_pages_with_pattern_row">
+                                <property name="title" translatable="yes">With Pattern</property>
+                                <property name="subtitle" translatable="yes">Set whether the background pattern should be exported</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwSwitchRow" id="export_doc_pages_optimize_printing_row">
+                                <property name="title" translatable="yes">Optimize for Printing</property>
+                                <property name="subtitle" translatable="yes">Set whether the content should be optimized for printing</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwComboRow" id="export_doc_pages_export_format_row">
+                                <property name="title" translatable="yes">Export Format</property>
+                                <property name="subtitle" translatable="yes">The export format</property>
+                                <property name="model">
+                                  <object class="GtkStringList">
+                                    <items>
+                                      <item translatable="yes">Svg</item>
+                                      <item translatable="yes">Png</item>
+                                      <item translatable="yes">Jpeg</item>
+                                    </items>
+                                  </object>
+                                </property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwComboRow" id="export_doc_pages_page_order_row">
+                                <property name="title" translatable="yes">Page Order</property>
+                                <property name="subtitle" translatable="yes">The page order when documents with layouts
+    that expand in horizontal and vertical directions
+    are cut into pages</property>
+                                <property name="model">
+                                  <object class="GtkStringList">
+                                    <items>
+                                      <item translatable="yes">Horizontal First</item>
+                                      <item translatable="yes">Vertical First</item>
+                                    </items>
+                                  </object>
+                                </property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwSpinRow" id="export_doc_pages_bitmap_scalefactor_row">
+                                <property name="title" translatable="yes">Bitmap Scale-Factor</property>
+                                <property name="subtitle" translatable="yes">Set the bitmap scale factor in relation
+    to the actual size on the document</property>
+                                <property name="adjustment">export_doc_pages_bitmap_scalefactor_adj</property>
+                                <property name="digits">1</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwSpinRow" id="export_doc_pages_jpeg_quality_row">
+                                <property name="title" translatable="yes">Jpeg Quality</property>
+                                <property name="subtitle" translatable="yes">Set the quality of the Jpeg image (1 - 100)</property>
+                                <property name="adjustment">export_doc_pages_jpeg_quality_adj</property>
+                                <property name="digits">0</property>
+                              </object>
+                            </child>
                           </object>
                         </child>
                       </object>
@@ -402,166 +412,171 @@ to the actual size on the document</property>
     <property name="value">85</property>
   </object>
 
-  <object class="GtkDialog" id="dialog_export_selection_w_prefs">
-    <property name="use-header-bar">1</property>
-    <property name="modal">true</property>
+  <object class="AdwDialog" id="dialog_export_selection_w_prefs">
     <property name="title" translatable="yes">Export Selection</property>
-    <child type="action">
-      <object class="GtkButton" id="export_selection_button_cancel">
-        <property name="label" translatable="yes">Cancel</property>
-      </object>
-    </child>
-    <child type="action">
-      <object class="GtkButton" id="export_selection_button_confirm">
-        <property name="label" translatable="yes">Export</property>
-        <property name="sensitive">false</property>
-        <style>
-          <class name="suggested-action" />
-        </style>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="cancel">export_selection_button_cancel</action-widget>
-      <action-widget response="apply" default="true">export_selection_button_confirm</action-widget>
-    </action-widgets>
     <child>
-      <object class="AdwClamp">
-        <property name="maximum-size">1000</property>
-        <property name="tightening-threshold">900</property>
-        <property name="hexpand">true</property>
-        <property name="vexpand">false</property>
-        <property name="halign">fill</property>
-        <property name="valign">start</property>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox">
-            <property name="orientation">horizontal</property>
-            <property name="spacing">12</property>
-            <property name="margin-start">12</property>
-            <property name="margin-end">0</property>
-            <property name="margin-top">12</property>
-            <property name="margin-bottom">12</property>
-            <style>
-              <class name="background" />
-            </style>
-            <child>
-              <object class="RnStrokeContentPreview" id="export_selection_preview">
-                <property name="halign">fill</property>
-                <property name="valign">fill</property>
-                <property name="hexpand">true</property>
-                <property name="vexpand">true</property>
+          <object class="AdwHeaderBar">
+            <property name="show-end-title-buttons">false</property>
+            <property name="show-start-title-buttons">false</property>
+            <child type="start">
+              <object class="GtkButton" id="export_selection_button_cancel">
+                <property name="label" translatable="yes">Cancel</property>
               </object>
             </child>
+            <child type="end">
+              <object class="GtkButton" id="export_selection_button_confirm">
+                <property name="label" translatable="yes">Export</property>
+                <property name="sensitive">false</property>
+                <style>
+                  <class name="suggested-action" />
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwClamp">
+            <property name="maximum-size">1000</property>
+            <property name="tightening-threshold">900</property>
+            <property name="hexpand">true</property>
+            <property name="vexpand">false</property>
+            <property name="halign">fill</property>
+            <property name="valign">start</property>
             <child>
-              <object class="GtkScrolledWindow">
-                <property name="hscrollbar-policy">never</property>
-                <property name="hexpand">true</property>
-                <property name="vexpand">true</property>
-                <property name="halign">fill</property>
-                <property name="valign">fill</property>
-                <property name="propagate-natural-width">true</property>
-                <property name="propagate-natural-height">true</property>
-                <property name="window-placement">top-left</property>
+              <object class="GtkBox">
+                <property name="orientation">horizontal</property>
+                <property name="spacing">12</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">0</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
+                <style>
+                  <class name="background" />
+                </style>
                 <child>
-                  <object class="GtkBox">
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">12</property>
-                    <property name="margin-end">18</property>
+                  <object class="RnStrokeContentPreview" id="export_selection_preview">
+                    <property name="halign">fill</property>
+                    <property name="valign">fill</property>
+                    <property name="hexpand">true</property>
+                    <property name="vexpand">true</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="hscrollbar-policy">never</property>
+                    <property name="hexpand">true</property>
+                    <property name="vexpand">true</property>
+                    <property name="halign">fill</property>
+                    <property name="valign">fill</property>
+                    <property name="propagate-natural-width">true</property>
+                    <property name="propagate-natural-height">true</property>
+                    <property name="window-placement">top-left</property>
                     <child>
-                      <object class="AdwPreferencesGroup">
+                      <object class="GtkBox">
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">12</property>
+                        <property name="margin-end">18</property>
                         <child>
-                          <object class="AdwActionRow">
-                            <property name="title" translatable="yes">Export File</property>
-                            <property name="subtitle" translatable="yes">Select the export file</property>
-                            <child type="suffix">
-                              <object class="GtkBox">
-                                <property name="valign">center</property>
-                                <property name="halign">end</property>
-                                <property name="orientation">horizontal</property>
-                                <property name="spacing">6</property>
-                                <child>
-                                  <object class="GtkLabel" id="export_selection_export_file_label">
-                                    <property name="label" translatable="yes">- no file selected -</property>
-                                    <property name="ellipsize">start</property>
-                                    <style>
-                                      <class name="dim-label" />
-                                    </style>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkButton" id="export_selection_export_file_button">
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">1</property>
-                                    </layout>
-                                    <property name="icon_name">folder-open-symbolic</property>
+                          <object class="AdwPreferencesGroup">
+                            <child>
+                              <object class="AdwActionRow">
+                                <property name="title" translatable="yes">Export File</property>
+                                <property name="subtitle" translatable="yes">Select the export file</property>
+                                <child type="suffix">
+                                  <object class="GtkBox">
+                                    <property name="valign">center</property>
+                                    <property name="halign">end</property>
+                                    <property name="orientation">horizontal</property>
+                                    <property name="spacing">6</property>
+                                    <child>
+                                      <object class="GtkLabel" id="export_selection_export_file_label">
+                                        <property name="label" translatable="yes">- no file selected -</property>
+                                        <property name="ellipsize">start</property>
+                                        <style>
+                                          <class name="dim-label" />
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="export_selection_export_file_button">
+                                        <layout>
+                                          <property name="column">1</property>
+                                          <property name="row">1</property>
+                                        </layout>
+                                        <property name="icon_name">folder-open-symbolic</property>
+                                      </object>
+                                    </child>
                                   </object>
                                 </child>
                               </object>
                             </child>
                           </object>
                         </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="AdwPreferencesGroup">
-                        <property name="title" translatable="yes">Export Preferences</property>
-                        <property name="halign">fill</property>
                         <child>
-                          <object class="AdwSwitchRow" id="export_selection_with_background_row">
-                            <property name="title" translatable="yes">With Background</property>
-                            <property name="subtitle" translatable="yes">Set whether the background should be exported</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwSwitchRow" id="export_selection_with_pattern_row">
-                            <property name="title" translatable="yes">With Pattern</property>
-                            <property name="subtitle" translatable="yes">Set whether the background pattern should be exported</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwSwitchRow" id="export_selection_optimize_printing_row">
-                            <property name="title" translatable="yes">Optimize for Printing</property>
-                            <property name="subtitle" translatable="yes">Set whether the content should be optimized for printing</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwComboRow" id="export_selection_export_format_row">
-                            <property name="title" translatable="yes">Export Format</property>
-                            <property name="subtitle" translatable="yes">The export image format</property>
-                            <property name="model">
-                              <object class="GtkStringList">
-                                <items>
-                                  <item translatable="yes">Svg</item>
-                                  <item translatable="yes">Png</item>
-                                  <item translatable="yes">Jpeg</item>
-                                </items>
+                          <object class="AdwPreferencesGroup">
+                            <property name="title" translatable="yes">Export Preferences</property>
+                            <property name="halign">fill</property>
+                            <child>
+                              <object class="AdwSwitchRow" id="export_selection_with_background_row">
+                                <property name="title" translatable="yes">With Background</property>
+                                <property name="subtitle" translatable="yes">Set whether the background should be exported</property>
                               </object>
-                            </property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwSpinRow" id="export_selection_bitmap_scalefactor_row">
-                            <property name="title" translatable="yes">Bitmap Scale-Factor</property>
-                            <property name="subtitle" translatable="yes">Set the bitmap scale factor in relation
-to the actual size on the document</property>
-                            <property name="adjustment">export_selection_bitmap_scalefactor_adj</property>
-                            <property name="digits">1</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwSpinRow" id="export_selection_jpeg_quality_row">
-                            <property name="title" translatable="yes">Jpeg Quality</property>
-                            <property name="subtitle" translatable="yes">Set the quality of the Jpeg image (1 - 100)</property>
-                            <property name="adjustment">export_selection_jpeg_quality_adj</property>
-                            <property name="digits">0</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwSpinRow" id="export_selection_margin_row">
-                            <property name="title" translatable="yes">Margin</property>
-                            <property name="subtitle" translatable="yes">Set the margin around the selected area</property>
-                            <property name="adjustment">export_selection_margin_adj</property>
-                            <property name="digits">0</property>
+                            </child>
+                            <child>
+                              <object class="AdwSwitchRow" id="export_selection_with_pattern_row">
+                                <property name="title" translatable="yes">With Pattern</property>
+                                <property name="subtitle" translatable="yes">Set whether the background pattern should be exported</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwSwitchRow" id="export_selection_optimize_printing_row">
+                                <property name="title" translatable="yes">Optimize for Printing</property>
+                                <property name="subtitle" translatable="yes">Set whether the content should be optimized for printing</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwComboRow" id="export_selection_export_format_row">
+                                <property name="title" translatable="yes">Export Format</property>
+                                <property name="subtitle" translatable="yes">The export image format</property>
+                                <property name="model">
+                                  <object class="GtkStringList">
+                                    <items>
+                                      <item translatable="yes">Svg</item>
+                                      <item translatable="yes">Png</item>
+                                      <item translatable="yes">Jpeg</item>
+                                    </items>
+                                  </object>
+                                </property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwSpinRow" id="export_selection_bitmap_scalefactor_row">
+                                <property name="title" translatable="yes">Bitmap Scale-Factor</property>
+                                <property name="subtitle" translatable="yes">Set the bitmap scale factor in relation
+    to the actual size on the document</property>
+                                <property name="adjustment">export_selection_bitmap_scalefactor_adj</property>
+                                <property name="digits">1</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwSpinRow" id="export_selection_jpeg_quality_row">
+                                <property name="title" translatable="yes">Jpeg Quality</property>
+                                <property name="subtitle" translatable="yes">Set the quality of the Jpeg image (1 - 100)</property>
+                                <property name="adjustment">export_selection_jpeg_quality_adj</property>
+                                <property name="digits">0</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwSpinRow" id="export_selection_margin_row">
+                                <property name="title" translatable="yes">Margin</property>
+                                <property name="subtitle" translatable="yes">Set the margin around the selected area</property>
+                                <property name="adjustment">export_selection_margin_adj</property>
+                                <property name="digits">0</property>
+                              </object>
+                            </child>
                           </object>
                         </child>
                       </object>

--- a/crates/rnote-ui/data/ui/dialogs/export.ui
+++ b/crates/rnote-ui/data/ui/dialogs/export.ui
@@ -4,9 +4,8 @@
   <object class="AdwDialog" id="dialog_export_doc_w_prefs">
     <property name="title" translatable="yes">Export Document</property>
     <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <child>
+      <object class="AdwToolbarView">
+        <child type="top">
           <object class="AdwHeaderBar">
             <property name="show-end-title-buttons">false</property>
             <property name="show-start-title-buttons">false</property>
@@ -26,7 +25,7 @@
             </child>
           </object>
         </child>
-        <child>
+        <property name="content">
           <object class="AdwClamp">
             <property name="maximum-size">1000</property>
             <property name="tightening-threshold">900</property>
@@ -166,7 +165,7 @@
               </object>
             </child>
           </object>
-        </child>
+        </property>
       </object>
     </child>
   </object>
@@ -174,9 +173,8 @@
   <object class="AdwDialog" id="dialog_export_doc_pages_w_prefs">
     <property name="title" translatable="yes">Export Document Pages</property>
     <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <child>
+      <object class="AdwToolbarView">
+        <child type="top">
           <object class="AdwHeaderBar">
             <property name="show-end-title-buttons">false</property>
             <property name="show-start-title-buttons">false</property>
@@ -196,7 +194,7 @@
             </child>
           </object>
         </child>
-        <child>
+        <property name="content">
           <object class="AdwClamp">
             <property name="maximum-size">1000</property>
             <property name="tightening-threshold">900</property>
@@ -395,7 +393,7 @@
               </object>
             </child>
           </object>
-        </child>
+        </property>
       </object>
     </child>
   </object>
@@ -415,9 +413,8 @@
   <object class="AdwDialog" id="dialog_export_selection_w_prefs">
     <property name="title" translatable="yes">Export Selection</property>
     <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <child>
+      <object class="AdwToolbarView">
+        <child type="top">
           <object class="AdwHeaderBar">
             <property name="show-end-title-buttons">false</property>
             <property name="show-start-title-buttons">false</property>
@@ -437,7 +434,7 @@
             </child>
           </object>
         </child>
-        <child>
+        <property name="content">
           <object class="AdwClamp">
             <property name="maximum-size">1000</property>
             <property name="tightening-threshold">900</property>
@@ -586,7 +583,7 @@
               </object>
             </child>
           </object>
-        </child>
+        </property>
       </object>
     </child>
   </object>

--- a/crates/rnote-ui/data/ui/dialogs/import.ui
+++ b/crates/rnote-ui/data/ui/dialogs/import.ui
@@ -1,171 +1,176 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Import dialogs -->
 <interface>
-  <object class="GtkDialog" id="dialog_import_pdf_w_prefs">
-    <property name="use-header-bar">1</property>
-    <property name="modal">true</property>
+  <object class="AdwDialog" id="dialog_import_pdf_w_prefs">
     <property name="title" translatable="yes">Import Pdf</property>
-    <child type="action">
-      <object class="GtkButton" id="import_pdf_button_cancel">
-        <property name="label" translatable="yes">Cancel</property>
-      </object>
-    </child>
-    <child type="action">
-      <object class="GtkButton" id="import_pdf_button_confirm">
-        <property name="label" translatable="yes">Import</property>
-        <style>
-          <class name="suggested-action" />
-        </style>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="cancel">import_pdf_button_cancel</action-widget>
-      <action-widget response="apply" default="true">import_pdf_button_confirm</action-widget>
-    </action-widgets>
     <child>
-      <object class="AdwClamp">
-        <property name="maximum-size">800</property>
-        <property name="tightening-threshold">600</property>
-        <property name="hexpand">true</property>
-        <property name="vexpand">false</property>
-        <property name="valign">fill</property>
-        <property name="halign">fill</property>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox">
-            <property name="orientation">vertical</property>
-            <property name="spacing">24</property>
-            <property name="margin-start">12</property>
-            <property name="margin-end">12</property>
-            <property name="margin-top">12</property>
-            <property name="margin-bottom">12</property>
-            <style>
-              <class name="background" />
-            </style>
+          <object class="AdwHeaderBar">
+            <property name="show-end-title-buttons">false</property>
+            <property name="show-start-title-buttons">false</property>
+            <child type="start">
+              <object class="GtkButton" id="import_pdf_button_cancel">
+                <property name="label" translatable="yes">Cancel</property>
+              </object>
+            </child>
+            <child type="end">
+              <object class="GtkButton" id="import_pdf_button_confirm">
+                <property name="label" translatable="yes">Import</property>
+                <style>
+                  <class name="suggested-action" />
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwClamp">
+            <property name="maximum-size">800</property>
+            <property name="tightening-threshold">600</property>
+            <property name="hexpand">true</property>
+            <property name="vexpand">false</property>
+            <property name="valign">fill</property>
+            <property name="halign">fill</property>
             <child>
               <object class="GtkBox">
                 <property name="orientation">vertical</property>
-                <property name="halign">fill</property>
-                <property name="spacing">12</property>
+                <property name="spacing">24</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
                 <style>
-                  <class name="card" />
-                  <class name="view" />
+                  <class name="background" />
                 </style>
                 <child>
-                  <object class="GtkLabel">
-                    <property name="margin-start">24</property>
-                    <property name="margin-end">24</property>
-                    <property name="margin-top">12</property>
+                  <object class="GtkBox">
+                    <property name="orientation">vertical</property>
+                    <property name="halign">fill</property>
+                    <property name="spacing">12</property>
                     <style>
-                      <class name="title-4" />
+                      <class name="card" />
+                      <class name="view" />
                     </style>
-                    <property name="label" translatable="yes">Info</property>
-                    <property name="halign">center</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="pdf_info_label">
-                    <property name="halign">start</property>
-                    <property name="margin-start">24</property>
-                    <property name="margin-end">24</property>
-                    <property name="margin-bottom">12</property>
-                    <property name="use-markup">true</property>
-                    <property name="ellipsize">end</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="AdwPreferencesGroup">
-                <property name="title" translatable="yes">Pdf Import Preferences</property>
-                <property name="halign">fill</property>
-                <child>
-                  <object class="AdwSpinRow" id="pdf_page_start_row">
-                    <property name="title" translatable="yes">Start Page</property>
-                    <property name="adjustment">pdf_page_start_adj</property>
-                    <property name="numeric">true</property>
-                    <property name="digits">0</property>
-                    <property name="climb-rate">1</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="AdwSpinRow" id="pdf_page_end_row">
-                    <property name="title" translatable="yes">End Page</property>
-                    <property name="adjustment">pdf_page_end_adj</property>
-                    <property name="numeric">true</property>
-                    <property name="digits">0</property>
-                    <property name="climb-rate">1</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="AdwSwitchRow" id="pdf_import_adjust_document_row">
-                    <property name="title" translatable="yes">Adjust Document</property>
-                    <property name="subtitle" translatable="yes">Whether the document layout should be adjusted to the Pdf</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="AdwSpinRow" id="pdf_import_width_row">
-                    <property name="title" translatable="yes">Page Width (%)</property>
-                    <property name="subtitle" translatable="yes">Set the width of imported Pdf's in percentage to the format width</property>
-                    <property name="adjustment">pdf_import_width_perc_adj</property>
-                    <property name="digits">0</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="AdwComboRow" id="pdf_import_page_spacing_row">
-                    <property name="title" translatable="yes">Page Spacing</property>
-                    <property name="subtitle" translatable="yes">How Pdf pages are spaced</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">Continuous</item>
-                          <item translatable="yes">One per Document Page</item>
-                        </items>
-                      </object>
-                    </property>
-                  </object>
-                </child>
-                <child>
-                  <object class="AdwActionRow" id="pdf_import_pages_type_row">
-                    <property name="title" translatable="yes">Pages Type</property>
-                    <property name="subtitle" translatable="yes">Set whether Pdf's should be imported as vector or bitmap images</property>
-                    <child type="suffix">
-                      <object class="GtkBox">
-                        <property name="orientation">horizontal</property>
-                        <property name="homogeneous">true</property>
-                        <property name="vexpand">false</property>
-                        <property name="valign">center</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="margin-start">24</property>
+                        <property name="margin-end">24</property>
+                        <property name="margin-top">12</property>
                         <style>
-                          <class name="linked" />
+                          <class name="title-4" />
                         </style>
-                        <child>
-                          <object class="GtkToggleButton" id="pdf_import_as_vector_toggle">
-                            <property name="label" translatable="yes">Vector</property>
-                            <property name="active">true</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkToggleButton" id="pdf_import_as_bitmap_toggle">
-                            <property name="group">pdf_import_as_vector_toggle</property>
-                            <property name="label" translatable="yes">Bitmap</property>
-                          </object>
-                        </child>
+                        <property name="label" translatable="yes">Info</property>
+                        <property name="halign">center</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="pdf_info_label">
+                        <property name="halign">start</property>
+                        <property name="margin-start">24</property>
+                        <property name="margin-end">24</property>
+                        <property name="margin-bottom">12</property>
+                        <property name="use-markup">true</property>
+                        <property name="ellipsize">end</property>
                       </object>
                     </child>
                   </object>
                 </child>
                 <child>
-                  <object class="AdwSpinRow" id="pdf_import_bitmap_scalefactor_row">
-                    <property name="title" translatable="yes">Bitmap Scale-Factor</property>
-                    <property name="subtitle" translatable="yes">Set the bitmap scale factor in relation
-to the actual size on the document</property>
-                    <property name="adjustment">pdf_import_bitmap_scalefactor_adj</property>
-                    <property name="digits">1</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="AdwSwitchRow" id="pdf_import_page_borders_row">
-                    <property name="title" translatable="yes">Page Borders</property>
-                    <property name="subtitle" translatable="yes">Whether the pages have drawn borders</property>
+                  <object class="AdwPreferencesGroup">
+                    <property name="title" translatable="yes">Pdf Import Preferences</property>
+                    <property name="halign">fill</property>
+                    <child>
+                      <object class="AdwSpinRow" id="pdf_page_start_row">
+                        <property name="title" translatable="yes">Start Page</property>
+                        <property name="adjustment">pdf_page_start_adj</property>
+                        <property name="numeric">true</property>
+                        <property name="digits">0</property>
+                        <property name="climb-rate">1</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwSpinRow" id="pdf_page_end_row">
+                        <property name="title" translatable="yes">End Page</property>
+                        <property name="adjustment">pdf_page_end_adj</property>
+                        <property name="numeric">true</property>
+                        <property name="digits">0</property>
+                        <property name="climb-rate">1</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwSwitchRow" id="pdf_import_adjust_document_row">
+                        <property name="title" translatable="yes">Adjust Document</property>
+                        <property name="subtitle" translatable="yes">Whether the document layout should be adjusted to the Pdf</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwSpinRow" id="pdf_import_width_row">
+                        <property name="title" translatable="yes">Page Width (%)</property>
+                        <property name="subtitle" translatable="yes">Set the width of imported Pdf's in percentage to the format width</property>
+                        <property name="adjustment">pdf_import_width_perc_adj</property>
+                        <property name="digits">0</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwComboRow" id="pdf_import_page_spacing_row">
+                        <property name="title" translatable="yes">Page Spacing</property>
+                        <property name="subtitle" translatable="yes">How Pdf pages are spaced</property>
+                        <property name="model">
+                          <object class="GtkStringList">
+                            <items>
+                              <item translatable="yes">Continuous</item>
+                              <item translatable="yes">One per Document Page</item>
+                            </items>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwActionRow" id="pdf_import_pages_type_row">
+                        <property name="title" translatable="yes">Pages Type</property>
+                        <property name="subtitle" translatable="yes">Set whether Pdf's should be imported as vector or bitmap images</property>
+                        <child type="suffix">
+                          <object class="GtkBox">
+                            <property name="orientation">horizontal</property>
+                            <property name="homogeneous">true</property>
+                            <property name="vexpand">false</property>
+                            <property name="valign">center</property>
+                            <style>
+                              <class name="linked" />
+                            </style>
+                            <child>
+                              <object class="GtkToggleButton" id="pdf_import_as_vector_toggle">
+                                <property name="label" translatable="yes">Vector</property>
+                                <property name="active">true</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkToggleButton" id="pdf_import_as_bitmap_toggle">
+                                <property name="group">pdf_import_as_vector_toggle</property>
+                                <property name="label" translatable="yes">Bitmap</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwSpinRow" id="pdf_import_bitmap_scalefactor_row">
+                        <property name="title" translatable="yes">Bitmap Scale-Factor</property>
+                        <property name="subtitle" translatable="yes">Set the bitmap scale factor in relation
+    to the actual size on the document</property>
+                        <property name="adjustment">pdf_import_bitmap_scalefactor_adj</property>
+                        <property name="digits">1</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwSwitchRow" id="pdf_import_page_borders_row">
+                        <property name="title" translatable="yes">Page Borders</property>
+                        <property name="subtitle" translatable="yes">Whether the pages have drawn borders</property>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>
@@ -196,56 +201,61 @@ to the actual size on the document</property>
     <property name="value">1.0</property>
   </object>
 
-  <object class="GtkDialog" id="dialog_import_xopp_w_prefs">
-    <property name="use-header-bar">1</property>
-    <property name="modal">true</property>
+  <object class="AdwDialog" id="dialog_import_xopp_w_prefs">
     <property name="title" translatable="yes">Import Xournal++ File</property>
-    <child type="action">
-      <object class="GtkButton" id="import_xopp_button_cancel">
-        <property name="label" translatable="yes">Cancel</property>
-      </object>
-    </child>
-    <child type="action">
-      <object class="GtkButton" id="import_xopp_button_confirm">
-        <property name="label" translatable="yes">Import</property>
-        <style>
-          <class name="suggested-action" />
-        </style>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="cancel">import_xopp_button_cancel</action-widget>
-      <action-widget response="apply" default="true">import_xopp_button_confirm</action-widget>
-    </action-widgets>
     <child>
-      <object class="AdwClamp">
-        <property name="maximum-size">800</property>
-        <property name="tightening-threshold">600</property>
-        <property name="hexpand">true</property>
-        <property name="vexpand">false</property>
-        <property name="valign">fill</property>
-        <property name="halign">fill</property>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox">
-            <property name="orientation">vertical</property>
-            <property name="spacing">24</property>
-            <property name="margin-start">12</property>
-            <property name="margin-end">12</property>
-            <property name="margin-top">12</property>
-            <property name="margin-bottom">12</property>
-            <style>
-              <class name="background" />
-            </style>
+          <object class="AdwHeaderBar">
+            <property name="show-end-title-buttons">false</property>
+            <property name="show-start-title-buttons">false</property>
+            <child type="start">
+              <object class="GtkButton" id="import_xopp_button_cancel">
+                <property name="label" translatable="yes">Cancel</property>
+              </object>
+            </child>
+            <child type="end">
+              <object class="GtkButton" id="import_xopp_button_confirm">
+                <property name="label" translatable="yes">Import</property>
+                <style>
+                  <class name="suggested-action" />
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwClamp">
+            <property name="maximum-size">800</property>
+            <property name="tightening-threshold">600</property>
+            <property name="hexpand">true</property>
+            <property name="vexpand">false</property>
+            <property name="valign">fill</property>
+            <property name="halign">fill</property>
             <child>
-              <object class="AdwPreferencesGroup">
-                <property name="title" translatable="yes">Xournal++ File Import Preferences</property>
-                <property name="halign">fill</property>
+              <object class="GtkBox">
+                <property name="orientation">vertical</property>
+                <property name="spacing">24</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
+                <style>
+                  <class name="background" />
+                </style>
                 <child>
-                  <object class="AdwSpinRow" id="xopp_import_dpi_row">
-                    <property name="title" translatable="yes">DPI</property>
-                    <property name="subtitle" translatable="yes">Set the preferred DPI for the Xournal++ file</property>
-                    <property name="adjustment">xopp_import_dpi_adj</property>
-                    <property name="digits">0</property>
+                  <object class="AdwPreferencesGroup">
+                    <property name="title" translatable="yes">Xournal++ File Import Preferences</property>
+                    <property name="halign">fill</property>
+                    <child>
+                      <object class="AdwSpinRow" id="xopp_import_dpi_row">
+                        <property name="title" translatable="yes">DPI</property>
+                        <property name="subtitle" translatable="yes">Set the preferred DPI for the Xournal++ file</property>
+                        <property name="adjustment">xopp_import_dpi_adj</property>
+                        <property name="digits">0</property>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/crates/rnote-ui/data/ui/dialogs/import.ui
+++ b/crates/rnote-ui/data/ui/dialogs/import.ui
@@ -4,9 +4,8 @@
   <object class="AdwDialog" id="dialog_import_pdf_w_prefs">
     <property name="title" translatable="yes">Import Pdf</property>
     <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <child>
+      <object class="AdwToolbarView">
+        <child type="top">
           <object class="AdwHeaderBar">
             <property name="show-end-title-buttons">false</property>
             <property name="show-start-title-buttons">false</property>
@@ -25,7 +24,7 @@
             </child>
           </object>
         </child>
-        <child>
+        <property name="content">
           <object class="AdwClamp">
             <property name="maximum-size">800</property>
             <property name="tightening-threshold">600</property>
@@ -176,7 +175,7 @@
               </object>
             </child>
           </object>
-        </child>
+        </property>
       </object>
     </child>
   </object>
@@ -204,9 +203,8 @@
   <object class="AdwDialog" id="dialog_import_xopp_w_prefs">
     <property name="title" translatable="yes">Import Xournal++ File</property>
     <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <child>
+      <object class="AdwToolbarView">
+        <child type="top">
           <object class="AdwHeaderBar">
             <property name="show-end-title-buttons">false</property>
             <property name="show-start-title-buttons">false</property>
@@ -225,7 +223,7 @@
             </child>
           </object>
         </child>
-        <child>
+        <property name="content">
           <object class="AdwClamp">
             <property name="maximum-size">800</property>
             <property name="tightening-threshold">600</property>
@@ -261,7 +259,7 @@
               </object>
             </child>
           </object>
-        </child>
+        </property>
       </object>
     </child>
   </object>

--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -1,5 +1,4 @@
-// gtk4::Dialog is deprecated, but the replacement adw::ToolbarView is not suitable for a async flow
-#![allow(deprecated)]
+//adw::ToolbarView is a replacement for adw::Dialog but not suitable for an async flow
 
 // Imports
 use crate::canvas::{self, RnCanvas};
@@ -7,9 +6,7 @@ use crate::RnStrokeContentPreview;
 use crate::{config, RnAppWindow};
 use adw::prelude::*;
 use gettextrs::gettext;
-use gtk4::{
-    gio, glib, glib::clone, Builder, Button, Dialog, FileDialog, FileFilter, Label, ResponseType,
-};
+use gtk4::{gio, glib, glib::clone, Builder, Button, FileDialog, FileFilter, Label};
 use num_traits::ToPrimitive;
 use rnote_compose::SplitOrder;
 use rnote_engine::document::Layout;
@@ -89,7 +86,7 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
     let builder = Builder::from_resource(
         (String::from(config::APP_IDPATH) + "ui/dialogs/export.ui").as_str(),
     );
-    let dialog: Dialog = builder.object("dialog_export_doc_w_prefs").unwrap();
+    let dialog: adw::Dialog = builder.object("dialog_export_doc_w_prefs").unwrap();
     let button_confirm: Button = builder.object("export_doc_button_confirm").unwrap();
     let with_background_row: adw::SwitchRow =
         builder.object("export_doc_with_background_row").unwrap();
@@ -101,10 +98,12 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
     let export_file_label: Label = builder.object("export_doc_export_file_label").unwrap();
     let export_file_button: Button = builder.object("export_doc_export_file_button").unwrap();
     let preview: RnStrokeContentPreview = builder.object("export_doc_preview").unwrap();
+    let export_doc_button_cancel: Button = builder.object("export_doc_button_cancel").unwrap();
+    let export_doc_button_confirm: Button = builder.object("export_doc_button_confirm").unwrap();
 
     let initial_doc_export_prefs = canvas.engine_ref().export_prefs.doc_export_prefs;
     let doc_layout = canvas.engine_ref().document.layout;
-    dialog.set_transient_for(Some(appwindow));
+    dialog.present(appwindow);
 
     // initial widget state with the preferences
     let selected_file: Rc<RefCell<Option<gio::File>>> = Rc::new(RefCell::new(None));
@@ -131,7 +130,7 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
     export_file_button.connect_clicked(
         clone!(@strong selected_file, @weak export_file_label, @weak button_confirm, @weak dialog, @weak canvas, @weak appwindow => move |_| {
             glib::spawn_future_local(clone!(@strong selected_file, @weak export_file_label, @weak button_confirm, @weak dialog, @weak canvas, @weak appwindow => async move {
-                dialog.hide();
+                dialog.set_sensitive(false);
 
                 let doc_export_prefs = canvas.engine_mut().export_prefs.doc_export_prefs;
                 let filedialog =
@@ -156,7 +155,7 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
                     }
                 }
 
-                dialog.present();
+                dialog.set_sensitive(true);
             }));
         }),
     );
@@ -212,56 +211,59 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
         }),
     );
 
-    let response = dialog.run_future().await;
-    dialog.close();
-    match response {
-        ResponseType::Apply => {
-            if let Some(file) = selected_file.take() {
-                glib::spawn_future_local(clone!(@weak canvas, @weak appwindow => async move {
-                    appwindow.overlays().progressbar_start_pulsing();
+    // Listen to responses
 
-                    let file_title = crate::utils::default_file_title_for_export(
-                        Some(file.clone()),
-                        Some(&canvas::OUTPUT_FILE_NEW_TITLE),
-                        None,
-                    );
-                    if let Err(e) = canvas.export_doc(&file, file_title, None).await {
-                        tracing::error!("Exporting document failed, Err: `{e:?}`");
+    export_doc_button_cancel.connect_clicked(clone!(@weak dialog => move |_| {
+        dialog.close();
+    }));
 
-                        appwindow.overlays().dispatch_toast_error(&gettext("Exporting document failed"));
-                        appwindow.overlays().progressbar_abort();
-                    } else {
-                        appwindow.overlays().dispatch_toast_w_button_singleton(
-                            &gettext("Exported document successfully"),
-                            &gettext("View in file manager"),
-                            clone!(@weak canvas, @weak appwindow => move |_reload_toast| {
-                                let Some(folder_path_string) = file
-                                    .parent()
-                                    .and_then(|p|
-                                        p.path())
-                                    .and_then(|p| p.into_os_string().into_string().ok()) else {
-                                        tracing::error!("Failed to get the parent folder of the output file `{file:?}.");
-                                        appwindow.overlays().dispatch_toast_error(&gettext("Exporting document failed"));
-                                        return;
-                                };
+    export_doc_button_confirm.connect_clicked(clone!(@weak dialog, @weak canvas, @weak appwindow => move |_| {
+        dialog.close();
 
-                                if let Err(e) = open::that(&folder_path_string) {
-                                    tracing::error!("Opening the parent folder '{folder_path_string}' in the file manager failed, Err: {e:?}");
-                                    appwindow.overlays().dispatch_toast_error(&gettext("Failed to open the file in the file manager"));
-                                }
+        if let Some(file) = selected_file.take() {
+            glib::spawn_future_local(clone!(@weak canvas, @weak appwindow => async move {
+                appwindow.overlays().progressbar_start_pulsing();
+
+                let file_title = crate::utils::default_file_title_for_export(
+                    Some(file.clone()),
+                    Some(&canvas::OUTPUT_FILE_NEW_TITLE),
+                    None,
+                );
+                if let Err(e) = canvas.export_doc(&file, file_title, None).await {
+                    tracing::error!("Exporting document failed, Err: `{e:?}`");
+
+                    appwindow.overlays().dispatch_toast_error(&gettext("Exporting document failed"));
+                    appwindow.overlays().progressbar_abort();
+                } else {
+                    appwindow.overlays().dispatch_toast_w_button_singleton(
+                        &gettext("Exported document successfully"),
+                        &gettext("View in file manager"),
+                        clone!(@weak canvas, @weak appwindow => move |_reload_toast| {
+                            let Some(folder_path_string) = file
+                                .parent()
+                                .and_then(|p|
+                                    p.path())
+                                .and_then(|p| p.into_os_string().into_string().ok()) else {
+                                    tracing::error!("Failed to get the parent folder of the output file `{file:?}.");
+                                    appwindow.overlays().dispatch_toast_error(&gettext("Exporting document failed"));
+                                    return;
+                            };
+
+                            if let Err(e) = open::that(&folder_path_string) {
+                                tracing::error!("Opening the parent folder '{folder_path_string}' in the file manager failed, Err: {e:?}");
+                                appwindow.overlays().dispatch_toast_error(&gettext("Failed to open the file in the file manager"));
                             }
-                        ), crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT, &mut None);
-                        appwindow.overlays().progressbar_finish();
-                    }
-                }));
-            } else {
-                appwindow
-                    .overlays()
-                    .dispatch_toast_error(&gettext("Exporting document failed, no file selected"));
-            }
+                        }
+                    ), crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT, &mut None);
+                    appwindow.overlays().progressbar_finish();
+                }
+            }));
+        } else {
+            appwindow
+                .overlays()
+                .dispatch_toast_error(&gettext("Exporting document failed, no file selected"));
         }
-        _ => {}
-    }
+    }));
 }
 
 fn create_filedialog_export_doc(
@@ -315,7 +317,7 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
     let builder = Builder::from_resource(
         (String::from(config::APP_IDPATH) + "ui/dialogs/export.ui").as_str(),
     );
-    let dialog: Dialog = builder.object("dialog_export_doc_pages_w_prefs").unwrap();
+    let dialog: adw::Dialog = builder.object("dialog_export_doc_pages_w_prefs").unwrap();
     let button_confirm: Button = builder.object("export_doc_pages_button_confirm").unwrap();
     let with_background_row: adw::SwitchRow = builder
         .object("export_doc_pages_with_background_row")
@@ -345,10 +347,14 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
         .object("export_doc_pages_page_files_naming_info_label")
         .unwrap();
     let preview: RnStrokeContentPreview = builder.object("export_doc_pages_preview").unwrap();
+    let export_doc_pages_button_cancel: Button =
+        builder.object("export_doc_pages_button_cancel").unwrap();
+    let export_doc_pages_button_confirm: Button =
+        builder.object("export_doc_pages_button_confirm").unwrap();
 
     let initial_doc_pages_export_prefs = canvas.engine_ref().export_prefs.doc_pages_export_prefs;
     let doc_layout = canvas.engine_ref().document.layout;
-    dialog.set_transient_for(Some(appwindow));
+    dialog.present(appwindow);
 
     // initial widget state with the preferences
     let selected_file: Rc<RefCell<Option<gio::File>>> = Rc::new(RefCell::new(None));
@@ -400,7 +406,7 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
     export_dir_button.connect_clicked(
         clone!(@strong selected_file, @weak export_dir_label, @weak button_confirm, @weak dialog, @weak canvas, @weak appwindow => move |_| {
             glib::spawn_future_local(clone!(@strong selected_file, @weak export_dir_label, @weak button_confirm, @weak dialog, @weak canvas, @weak appwindow => async move {
-                dialog.hide();
+                dialog.set_sensitive(false);
 
                 let doc_pages_export_prefs = canvas.engine_mut().export_prefs.doc_pages_export_prefs;
                 let filedialog = create_filedialog_export_doc_pages(
@@ -429,7 +435,7 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
                     }
                 }
 
-                dialog.present();
+                dialog.set_sensitive(true);
             }));
         }),
     );
@@ -521,48 +527,51 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
         }),
     );
 
-    let response = dialog.run_future().await;
-    dialog.close();
-    match response {
-        ResponseType::Apply => {
-            if let Some(dir) = selected_file.take() {
-                glib::spawn_future_local(clone!(@weak canvas, @weak appwindow => async move {
-                    appwindow.overlays().progressbar_start_pulsing();
+    // Listen to responses
 
-                    let file_stem_name = export_files_stemname_entryrow.text().to_string();
-                    if let Err(e) = canvas.export_doc_pages(&dir, file_stem_name, None).await {
-                        tracing::error!("Exporting document pages failed, Err: {e:?}");
+    export_doc_pages_button_cancel.connect_clicked(clone!(@weak dialog => move |_| {
+        dialog.close();
+    }));
 
-                        appwindow.overlays().dispatch_toast_error(&gettext("Exporting document pages failed"));
-                        appwindow.overlays().progressbar_abort();
-                    } else {
-                        appwindow.overlays().dispatch_toast_w_button_singleton(
-                            &gettext("Exported document pages successfully"),
-                            &gettext("View in file manager"),
-                            clone!(@weak canvas, @weak appwindow => move |_reload_toast| {
-                                let Some(folder_path_string) = dir.path().and_then(|p| p.into_os_string().into_string().ok()) else {
-                                    tracing::error!("Failed to get the path of the parent folder");
-                                    appwindow.overlays().dispatch_toast_error(&gettext("Exporting document failed"));
-                                    return;
-                                };
+    export_doc_pages_button_confirm.connect_clicked(clone!(@weak export_files_stemname_entryrow, @weak dialog, @weak canvas, @weak appwindow => move |_| {
+        dialog.close();
 
-                                if let Err(e) = open::that(&folder_path_string) {
-                                    tracing::error!("Opening the parent folder '{folder_path_string}' in the file manager failed, Err: {e:?}");
-                                    appwindow.overlays().dispatch_toast_error(&gettext("Failed to open the file in the file manager"));
-                                }
+        if let Some(dir) = selected_file.take() {
+            glib::spawn_future_local(clone!(@weak export_files_stemname_entryrow, @weak canvas, @weak appwindow => async move {
+                appwindow.overlays().progressbar_start_pulsing();
+
+                let file_stem_name = export_files_stemname_entryrow.text().to_string();
+                if let Err(e) = canvas.export_doc_pages(&dir, file_stem_name, None).await {
+                    tracing::error!("Exporting document pages failed, Err: {e:?}");
+
+                    appwindow.overlays().dispatch_toast_error(&gettext("Exporting document pages failed"));
+                    appwindow.overlays().progressbar_abort();
+                } else {
+                    appwindow.overlays().dispatch_toast_w_button_singleton(
+                        &gettext("Exported document pages successfully"),
+                        &gettext("View in file manager"),
+                        clone!(@weak canvas, @weak appwindow => move |_reload_toast| {
+                            let Some(folder_path_string) = dir.path().and_then(|p| p.into_os_string().into_string().ok()) else {
+                                tracing::error!("Failed to get the path of the parent folder");
+                                appwindow.overlays().dispatch_toast_error(&gettext("Exporting document failed"));
+                                return;
+                            };
+
+                            if let Err(e) = open::that(&folder_path_string) {
+                                tracing::error!("Opening the parent folder '{folder_path_string}' in the file manager failed, Err: {e:?}");
+                                appwindow.overlays().dispatch_toast_error(&gettext("Failed to open the file in the file manager"));
                             }
-                        ), crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT, &mut None);
-                        appwindow.overlays().progressbar_finish();
-                    }
-                }));
-            } else {
-                appwindow.overlays().dispatch_toast_error(&gettext(
-                    "Exporting document pages failed, no directory selected",
-                ));
-            }
+                        }
+                    ), crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT, &mut None);
+                    appwindow.overlays().progressbar_finish();
+                }
+            }));
+        } else {
+            appwindow.overlays().dispatch_toast_error(&gettext(
+                "Exporting document pages failed, no directory selected",
+            ));
         }
-        _ => {}
-    }
+    }));
 }
 
 fn create_filedialog_export_doc_pages(
@@ -613,7 +622,7 @@ pub(crate) async fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, can
     let builder = Builder::from_resource(
         (String::from(config::APP_IDPATH) + "ui/dialogs/export.ui").as_str(),
     );
-    let dialog: Dialog = builder.object("dialog_export_selection_w_prefs").unwrap();
+    let dialog: adw::Dialog = builder.object("dialog_export_selection_w_prefs").unwrap();
     let button_confirm: Button = builder.object("export_selection_button_confirm").unwrap();
     let with_background_row: adw::SwitchRow = builder
         .object("export_selection_with_background_row")
@@ -639,9 +648,13 @@ pub(crate) async fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, can
         builder.object("export_selection_jpeg_quality_row").unwrap();
     let margin_row: adw::SpinRow = builder.object("export_selection_margin_row").unwrap();
     let preview: RnStrokeContentPreview = builder.object("export_selection_preview").unwrap();
+    let export_selection_button_cancel: Button =
+        builder.object("export_selection_button_cancel").unwrap();
+    let export_selection_button_confirm: Button =
+        builder.object("export_selection_button_confirm").unwrap();
 
     let initial_selection_export_prefs = canvas.engine_ref().export_prefs.selection_export_prefs;
-    dialog.set_transient_for(Some(appwindow));
+    dialog.present(appwindow);
 
     // initial widget state with the preferences
     let selected_file: Rc<RefCell<Option<gio::File>>> = Rc::new(RefCell::new(None));
@@ -682,7 +695,7 @@ pub(crate) async fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, can
     export_file_button.connect_clicked(
         clone!(@strong selected_file, @weak export_file_label, @weak button_confirm, @weak dialog, @weak canvas, @weak appwindow => move |_| {
             glib::spawn_future_local(clone!(@strong selected_file, @weak export_file_label, @weak button_confirm, @weak dialog, @weak canvas, @weak appwindow => async move {
-                dialog.hide();
+                dialog.set_sensitive(false);
 
                 let selection_export_prefs = canvas
                     .engine_ref()
@@ -713,7 +726,7 @@ pub(crate) async fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, can
                     }
                 }
 
-                dialog.present();
+                dialog.set_sensitive(true);
             }));
         }),
     );
@@ -784,10 +797,16 @@ pub(crate) async fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, can
         }),
     );
 
-    let response = dialog.run_future().await;
-    dialog.close();
-    match response {
-        ResponseType::Apply => {
+    // Listen to responses
+
+    export_selection_button_cancel.connect_clicked(clone!(@weak dialog => move |_| {
+        dialog.close();
+    }));
+
+    export_selection_button_confirm.connect_clicked(clone!(@weak selected_file, @weak dialog, @weak canvas, @weak appwindow => move |_| {
+        dialog.close();
+
+        glib::spawn_future_local(clone!(@weak selected_file, @weak canvas, @weak appwindow => async move {
             let Some(file) = selected_file.take() else {
                 appwindow
                     .overlays()
@@ -828,9 +847,8 @@ pub(crate) async fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, can
                 );
                 appwindow.overlays().progressbar_finish();
             }
-        }
-        _ => {}
-    }
+            }));
+    }));
 }
 
 /// Returns (if possible) a "reasonable" folder for export operations

--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -103,7 +103,6 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
 
     let initial_doc_export_prefs = canvas.engine_ref().export_prefs.doc_export_prefs;
     let doc_layout = canvas.engine_ref().document.layout;
-    dialog.present(appwindow);
 
     // initial widget state with the preferences
     let selected_file: Rc<RefCell<Option<gio::File>>> = Rc::new(RefCell::new(None));
@@ -264,6 +263,8 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
                 .dispatch_toast_error(&gettext("Exporting document failed, no file selected"));
         }
     }));
+
+    dialog.present(appwindow);
 }
 
 fn create_filedialog_export_doc(
@@ -354,7 +355,6 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
 
     let initial_doc_pages_export_prefs = canvas.engine_ref().export_prefs.doc_pages_export_prefs;
     let doc_layout = canvas.engine_ref().document.layout;
-    dialog.present(appwindow);
 
     // initial widget state with the preferences
     let selected_file: Rc<RefCell<Option<gio::File>>> = Rc::new(RefCell::new(None));
@@ -572,6 +572,8 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
             ));
         }
     }));
+
+    dialog.present(appwindow);
 }
 
 fn create_filedialog_export_doc_pages(
@@ -654,7 +656,6 @@ pub(crate) async fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, can
         builder.object("export_selection_button_confirm").unwrap();
 
     let initial_selection_export_prefs = canvas.engine_ref().export_prefs.selection_export_prefs;
-    dialog.present(appwindow);
 
     // initial widget state with the preferences
     let selected_file: Rc<RefCell<Option<gio::File>>> = Rc::new(RefCell::new(None));
@@ -849,6 +850,8 @@ pub(crate) async fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, can
             }
             }));
     }));
+
+    dialog.present(appwindow);
 }
 
 /// Returns (if possible) a "reasonable" folder for export operations

--- a/crates/rnote-ui/src/dialogs/import.rs
+++ b/crates/rnote-ui/src/dialogs/import.rs
@@ -328,10 +328,11 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
     dialog.add_controller(controller);
 
     // Wait for a response from the dialog
-    loop {
-        if let Some(res) = rx.next().await {
-            return res;
-        }
+    match rx.next().await {
+        Some(res) => res,
+        None => Err(anyhow::anyhow!(
+            "Channel closed before receiving a response from dialog."
+        )),
     }
 }
 
@@ -419,9 +420,10 @@ pub(crate) async fn dialog_import_xopp_w_prefs(
     dialog.add_controller(controller);
 
     // Wait for a response from the dialog
-    loop {
-        if let Some(res) = rx.next().await {
-            return res;
-        }
+    match rx.next().await {
+        Some(res) => res,
+        None => Err(anyhow::anyhow!(
+            "Channel closed before receiving a response from dialog."
+        )),
     }
 }

--- a/crates/rnote-ui/src/dialogs/import.rs
+++ b/crates/rnote-ui/src/dialogs/import.rs
@@ -1,14 +1,14 @@
-// gtk4::Dialog is deprecated, but the replacement adw::ToolbarView is not suitable for a async flow
-#![allow(deprecated)]
+//adw::ToolbarView is a replacement for adw::Dialog but not suitable for an async flow
 
 // Imports
 use crate::canvas::RnCanvas;
 use crate::{config, RnAppWindow};
 use adw::prelude::*;
+use futures::StreamExt;
 use gettextrs::gettext;
 use gtk4::{
-    gio, glib, glib::clone, Builder, Dialog, FileDialog, FileFilter, Label, ResponseType,
-    ToggleButton,
+    gio, glib, glib::clone, Builder, Button, CallbackAction, FileDialog, FileFilter, Label,
+    Shortcut, ShortcutController, ShortcutTrigger, ToggleButton,
 };
 use num_traits::ToPrimitive;
 use rnote_engine::engine::import::{PdfImportPageSpacing, PdfImportPagesType};
@@ -105,7 +105,7 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
     let builder = Builder::from_resource(
         (String::from(config::APP_IDPATH) + "ui/dialogs/import.ui").as_str(),
     );
-    let dialog: Dialog = builder.object("dialog_import_pdf_w_prefs").unwrap();
+    let dialog: adw::Dialog = builder.object("dialog_import_pdf_w_prefs").unwrap();
     let pdf_page_start_row: adw::SpinRow = builder.object("pdf_page_start_row").unwrap();
     let pdf_page_end_row: adw::SpinRow = builder.object("pdf_page_end_row").unwrap();
     let pdf_info_label: Label = builder.object("pdf_info_label").unwrap();
@@ -122,8 +122,10 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
         builder.object("pdf_import_page_borders_row").unwrap();
     let pdf_import_adjust_document_row: adw::SwitchRow =
         builder.object("pdf_import_adjust_document_row").unwrap();
+    let import_pdf_button_cancel: Button = builder.object("import_pdf_button_cancel").unwrap();
+    let import_pdf_button_confirm: Button = builder.object("import_pdf_button_confirm").unwrap();
 
-    dialog.set_transient_for(Some(appwindow));
+    dialog.present(appwindow);
 
     pdf_import_adjust_document_row
         .bind_property("active", &pdf_import_width_row, "sensitive")
@@ -266,21 +268,69 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
         pdf_page_end_row.set_value(n_pages.into());
     }
 
-    let response = dialog.run_future().await;
-    dialog.close();
-    match response {
-        ResponseType::Apply => {
+    // Listen to responses
+
+    let (tx, mut rx) = futures::channel::mpsc::unbounded::<anyhow::Result<bool>>();
+    let tx_cancel = tx.clone();
+    let tx_confirm = tx.clone();
+
+    import_pdf_button_cancel.connect_clicked(clone!(@weak dialog => move |_| {
+        dialog.close();
+
+        if let Err(e) = tx_cancel.unbounded_send(Ok(false)) {
+            tracing::error!(
+                "PDF import dialog closed, but failed to send signal through channel. Err: {e:?}"
+            );
+        }
+    }));
+
+    import_pdf_button_confirm.connect_clicked(clone!(@weak pdf_page_start_row, @weak pdf_page_end_row, @weak input_file, @weak dialog, @weak canvas => move |_| {
+        dialog.close();
+
+        let inner_tx_confirm = tx_confirm.clone();
+
+        glib::spawn_future_local(clone!(@weak pdf_page_start_row, @weak pdf_page_end_row, @weak input_file, @weak canvas => async move {
             let page_range =
                 (pdf_page_start_row.value() as u32 - 1)..pdf_page_end_row.value() as u32;
-            let (bytes, _) = input_file.load_bytes_future().await?;
-            canvas
-                .load_in_pdf_bytes(bytes.to_vec(), target_pos, Some(page_range))
-                .await?;
-            Ok(true)
-        }
-        _ => {
-            // Cancel
-            Ok(false)
+
+            let (bytes, _) = match input_file.load_bytes_future().await {
+                Ok(res) => {res}
+                Err(err) => {
+                    if let Err(e) = inner_tx_confirm.unbounded_send(Err(err.into())) {
+                        tracing::error!("Failed to load file, but failed to send signal through channel. Err: {e:?}");
+                    }
+                    return;
+                }
+            };
+            if let Err(e) = canvas.load_in_pdf_bytes(bytes.to_vec(), target_pos, Some(page_range)).await {
+                if let Err(e) = inner_tx_confirm.unbounded_send(Err(e)) {
+                    tracing::error!("Failed to load PDF, but failed to send signal through channel. Err: {e:?}");
+                }
+                return;
+            }
+
+            if let Err(e) = inner_tx_confirm.unbounded_send(Ok(true)) {
+                tracing::error!("PDF file imported, but failed to send signal through channel. Err: {e:?}");
+            }
+        }));
+    }));
+
+    // Overwrite builtin close shortcut
+    let controller = ShortcutController::new();
+    controller.add_shortcut(Shortcut::new(
+        Some(ShortcutTrigger:: parse_string("Escape").unwrap()),
+        Some(CallbackAction::new(clone!(@weak import_pdf_button_cancel => @default-return glib::Propagation::Stop, move |_, _| {
+            import_pdf_button_cancel.emit_clicked();
+
+            glib::Propagation::Stop
+        }))),
+    ));
+    dialog.add_controller(controller);
+
+    // Wait for a response from the dialog
+    loop {
+        if let Some(res) = rx.next().await {
+            return res;
         }
     }
 }
@@ -296,11 +346,13 @@ pub(crate) async fn dialog_import_xopp_w_prefs(
     let builder = Builder::from_resource(
         (String::from(config::APP_IDPATH) + "ui/dialogs/import.ui").as_str(),
     );
-    let dialog: Dialog = builder.object("dialog_import_xopp_w_prefs").unwrap();
+    let dialog: adw::Dialog = builder.object("dialog_import_xopp_w_prefs").unwrap();
     let dpi_row: adw::SpinRow = builder.object("xopp_import_dpi_row").unwrap();
     let xopp_import_prefs = canvas.engine_ref().import_prefs.xopp_import_prefs;
+    let import_xopp_button_cancel: Button = builder.object("import_xopp_button_cancel").unwrap();
+    let import_xopp_button_confirm: Button = builder.object("import_xopp_button_confirm").unwrap();
 
-    dialog.set_transient_for(Some(appwindow));
+    dialog.present(appwindow);
 
     // Set initial widget state for preference
     dpi_row.set_value(xopp_import_prefs.dpi);
@@ -310,17 +362,66 @@ pub(crate) async fn dialog_import_xopp_w_prefs(
         canvas.engine_mut().import_prefs.xopp_import_prefs.dpi = row.value();
     }));
 
-    let response = dialog.run_future().await;
-    dialog.close();
-    match response {
-        ResponseType::Apply => {
-            let (bytes, _) = input_file.load_bytes_future().await?;
-            canvas.load_in_xopp_bytes(bytes.to_vec()).await?;
-            Ok(true)
+    // Listen to responses
+
+    let (tx, mut rx) = futures::channel::mpsc::unbounded::<anyhow::Result<bool>>();
+    let tx_cancel = tx.clone();
+    let tx_confirm = tx.clone();
+
+    import_xopp_button_cancel.connect_clicked(clone!(@weak dialog => move |_| {
+        dialog.close();
+
+        if let Err(e) = tx_cancel.unbounded_send(Ok(false)) {
+            tracing::error!(
+                "XOPP import dialog closed, but failed to send signal through channel. Err: {e:?}"
+            );
         }
-        _ => {
-            // Cancel
-            Ok(false)
+    }));
+
+    import_xopp_button_confirm.connect_clicked(clone!(@weak input_file, @weak dialog, @weak canvas => move |_| {
+        dialog.close();
+
+        let inner_tx_confirm = tx_confirm.clone();
+
+        glib::spawn_future_local(clone!(@weak input_file, @weak canvas => async move {
+            let (bytes, _) = match input_file.load_bytes_future().await {
+                Ok(res) => {res}
+                Err(err) => {
+                    if let Err(e) = inner_tx_confirm.unbounded_send(Err(err.into())) {
+                        tracing::error!("Failed to load file, but failed to send signal through channel. Err: {e:?}");
+                    }
+                    return;
+                }
+            };
+            if let Err(e) = canvas.load_in_xopp_bytes(bytes.to_vec()).await {
+                if let Err(e) = inner_tx_confirm.unbounded_send(Err(e)) {
+                    tracing::error!("Failed to load XOPP, but failed to send signal through channel. Err: {e:?}");
+                }
+                return;
+            };
+
+            if let Err(e) = inner_tx_confirm.unbounded_send(Ok(true)) {
+                tracing::error!("XOPP file imported, but failed to send signal through channel. Err: {e:?}");
+            }
+        }));
+    }));
+
+    // Overwrite builtin close shortcut
+    let controller = ShortcutController::new();
+    controller.add_shortcut(Shortcut::new(
+        Some(ShortcutTrigger::parse_string("Escape").unwrap()),
+        Some(CallbackAction::new(clone!(@weak import_xopp_button_cancel => @default-return glib::Propagation::Stop, move |_, _| {
+            import_xopp_button_cancel.emit_clicked();
+
+            glib::Propagation::Stop
+        }))),
+    ));
+    dialog.add_controller(controller);
+
+    // Wait for a response from the dialog
+    loop {
+        if let Some(res) = rx.next().await {
+            return res;
         }
     }
 }

--- a/crates/rnote-ui/src/dialogs/import.rs
+++ b/crates/rnote-ui/src/dialogs/import.rs
@@ -125,8 +125,6 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
     let import_pdf_button_cancel: Button = builder.object("import_pdf_button_cancel").unwrap();
     let import_pdf_button_confirm: Button = builder.object("import_pdf_button_confirm").unwrap();
 
-    dialog.present(appwindow);
-
     pdf_import_adjust_document_row
         .bind_property("active", &pdf_import_width_row, "sensitive")
         .invert_boolean()
@@ -327,7 +325,9 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
     ));
     dialog.add_controller(controller);
 
-    // Wait for a response from the dialog
+    // Present than wait for a response from the dialog
+    dialog.present(appwindow);
+
     match rx.next().await {
         Some(res) => res,
         None => Err(anyhow::anyhow!(
@@ -352,8 +352,6 @@ pub(crate) async fn dialog_import_xopp_w_prefs(
     let xopp_import_prefs = canvas.engine_ref().import_prefs.xopp_import_prefs;
     let import_xopp_button_cancel: Button = builder.object("import_xopp_button_cancel").unwrap();
     let import_xopp_button_confirm: Button = builder.object("import_xopp_button_confirm").unwrap();
-
-    dialog.present(appwindow);
 
     // Set initial widget state for preference
     dpi_row.set_value(xopp_import_prefs.dpi);
@@ -419,7 +417,9 @@ pub(crate) async fn dialog_import_xopp_w_prefs(
     ));
     dialog.add_controller(controller);
 
-    // Wait for a response from the dialog
+    // Present than wait for a response from the dialog
+    dialog.present(appwindow);
+
     match rx.next().await {
         Some(res) => res,
         None => Err(anyhow::anyhow!(

--- a/crates/rnote-ui/src/dialogs/mod.rs
+++ b/crates/rnote-ui/src/dialogs/mod.rs
@@ -448,7 +448,6 @@ pub(crate) async fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
         .unwrap();
 
     preview_row.init(appwindow);
-    dialog.present(appwindow);
 
     // Sets the icons
     icon_picker.set_list(
@@ -556,6 +555,8 @@ pub(crate) async fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
                 .refresh_dir_list_selected_workspace();
         }),
     );
+
+    dialog.present(appwindow);
 }
 
 const WORKSPACELISTENTRY_ICONS_LIST: &[&str] = &[

--- a/crates/rnote-ui/src/dialogs/mod.rs
+++ b/crates/rnote-ui/src/dialogs/mod.rs
@@ -15,8 +15,8 @@ use crate::{globals, RnIconPicker};
 use adw::prelude::*;
 use gettextrs::{gettext, pgettext};
 use gtk4::{
-    gio, glib, glib::clone, Builder, Button, CheckButton, ColorDialogButton, Dialog, FileDialog,
-    Label, MenuButton, ResponseType, ShortcutsWindow, StringList,
+    gio, glib, glib::clone, Builder, Button, CheckButton, ColorDialogButton, FileDialog, Label,
+    MenuButton, ShortcutsWindow, StringList,
 };
 
 // About Dialog
@@ -420,7 +420,7 @@ pub(crate) async fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
     let builder = Builder::from_resource(
         (String::from(config::APP_IDPATH) + "ui/dialogs/dialogs.ui").as_str(),
     );
-    let dialog: Dialog = builder.object("dialog_edit_selected_workspace").unwrap();
+    let dialog: adw::Dialog = builder.object("dialog_edit_selected_workspace").unwrap();
     let preview_row: RnWorkspaceRow = builder
         .object("edit_selected_workspace_preview_row")
         .unwrap();
@@ -440,9 +440,15 @@ pub(crate) async fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
     let icon_picker: RnIconPicker = builder
         .object("edit_selected_workspace_icon_picker")
         .unwrap();
+    let edit_selected_workspace_button_cancel: Button = builder
+        .object("edit_selected_workspace_button_cancel")
+        .unwrap();
+    let edit_selected_workspace_button_apply: Button = builder
+        .object("edit_selected_workspace_button_apply")
+        .unwrap();
 
     preview_row.init(appwindow);
-    dialog.set_transient_for(Some(appwindow));
+    dialog.present(appwindow);
 
     // Sets the icons
     icon_picker.set_list(
@@ -491,7 +497,7 @@ pub(crate) async fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
     dir_button.connect_clicked(
         clone!(@weak preview_row, @weak dir_label, @weak name_entryrow, @weak dialog, @weak appwindow => move |_| {
             glib::spawn_future_local(clone!(@weak preview_row, @weak dir_label, @weak name_entryrow, @weak dialog, @weak appwindow => async move {
-                dialog.hide();
+                dialog.set_sensitive(false);
 
                 let filedialog = FileDialog::builder()
                     .title(gettext("Change Workspace Directory"))
@@ -521,15 +527,22 @@ pub(crate) async fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
                         tracing::debug!("Did not select new folder for workspacerow (Error or dialog dismissed by user), Err: {e:?}");
                     }
                 }
-                dialog.present();
+
+                dialog.set_sensitive(true);
             }));
         }),
     );
 
-    let response = dialog.run_future().await;
-    dialog.close();
-    match response {
-        ResponseType::Apply => {
+    // Listen to responses
+
+    edit_selected_workspace_button_cancel.connect_clicked(clone!(@weak dialog => move |_| {
+        dialog.close();
+    }));
+
+    edit_selected_workspace_button_apply.connect_clicked(
+        clone!(@weak preview_row, @weak dialog, @weak appwindow => move |_| {
+            dialog.close();
+
             // update the actual selected entry
             appwindow
                 .sidebar()
@@ -541,11 +554,8 @@ pub(crate) async fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
                 .sidebar()
                 .workspacebrowser()
                 .refresh_dir_list_selected_workspace();
-        }
-        _ => {
-            // Cancel
-        }
-    }
+        }),
+    );
 }
 
 const WORKSPACELISTENTRY_ICONS_LIST: &[&str] = &[


### PR DESCRIPTION
Closes: #1120
Related: #1110

- In the UI i used ~`GtkBox`~ [`AdwToolbarView`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ToolbarView.html) and `AdwHeaderBar` to replace the actions functionality that was in `GtkDialog`. (its a minor change, but Github's diff algorithm doesn't handle .xml files properly because of the change in the indentation)

- Rather than hiding the dialog when the file selection window is opened, the `sensitive` property of the dialog will be switched to `false`. It will be returned to `true` when the file selection window is closed.

- The import related dialogs are more complicated since we need to return a value.

For now just file-selection, print, and keyboard-shortcut dialogs opens in a separate window. I think we don't have a choice for the first two, but the last one is possible (if there was `AdwShortcutsDialog`).

---

P.S. I'm not confident with my async skills so I might've done some thing wrong :)