### PR TITLE
detect multiple touch inputs

### DIFF
--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -15,7 +15,7 @@ use gettextrs::gettext;
 use gtk4::{
     gdk, gio, glib, glib::clone, graphene, prelude::*, subclass::prelude::*, Adjustment,
     DropTarget, EventControllerKey, EventControllerLegacy, IMMulticontext, PropagationPhase,
-    Scrollable, ScrollablePolicy, Widget,
+    Scrollable, ScrollablePolicy, Widget
 };
 use notify_debouncer_full::notify::{self, Watcher};
 use once_cell::sync::Lazy;
@@ -80,6 +80,7 @@ mod imp {
         pub(crate) unsaved_changes: Cell<bool>,
         pub(crate) empty: Cell<bool>,
         pub(crate) touch_drawing: Cell<bool>,
+        pub(crate) touch_id: Cell<Option<usize>>, // we need to extract the memory value ...
         pub(crate) show_drawing_cursor: Cell<bool>,
 
         pub(crate) last_export_dir: RefCell<Option<gio::File>>,
@@ -174,6 +175,7 @@ mod imp {
                 unsaved_changes: Cell::new(false),
                 empty: Cell::new(true),
                 touch_drawing: Cell::new(false),
+                touch_id: Cell::new(None),
                 show_drawing_cursor: Cell::new(false),
 
                 last_export_dir: RefCell::new(None),


### PR DESCRIPTION
Beware : quite experimental and not fully tested.

In particular, the current version creates a lot of 
```
(rnote.exe:11404): GLib-GObject-CRITICAL **: 23:44:59.380: g_boxed_copy: assertion 'src_boxed != NULL' failed

(rnote.exe:11404): GLib-GObject-CRITICAL **: 23:44:59.380: g_boxed_free: assertion 'boxed != NULL' failed
```
And seems to increase drastically the compilation time.

This replaces `event.device().unwrap().num_touches()` by another approach, using the fact that each touch sequence is associated to a unique (and constant) sequence. Hence we can use `event.event_sequence().as_ptr() as usize` to distinguish different touches and follow it.

This prevents any zip-zap when there are multiple fingers on the screen when `Draw with Touch` is enabled.

Apparently, the `EventSequence` type is touch specific (so maybe it would be possible to add this into #672 ? Though I don't know if you'd segfault if the function is called on a non touch event).
