### PR TITLE
fix: prevent accidental resizes when interacting with buttons in the titlebar

### DIFF
--- a/crates/rnote-ui/data/ui/mainheader.ui
+++ b/crates/rnote-ui/data/ui/mainheader.ui
@@ -59,7 +59,7 @@
           </object>
         </child>
         <child type="end">
-          <object class="GtkBox">
+          <object class="GtkBox" id="right_buttons">
             <property name="spacing">3</property>
             <child>
               <object class="GtkButton">

--- a/crates/rnote-ui/data/ui/mainheader.ui
+++ b/crates/rnote-ui/data/ui/mainheader.ui
@@ -59,7 +59,7 @@
           </object>
         </child>
         <child type="end">
-          <object class="GtkBox" id="right_buttons">
+          <object class="GtkBox" id="right_buttons_box">
             <property name="spacing">3</property>
             <child>
               <object class="GtkButton">

--- a/crates/rnote-ui/src/mainheader.rs
+++ b/crates/rnote-ui/src/mainheader.rs
@@ -1,7 +1,8 @@
 // Imports
 use crate::{appmenu::RnAppMenu, appwindow::RnAppWindow, canvasmenu::RnCanvasMenu};
 use gtk4::{
-    glib, prelude::*, subclass::prelude::*, CompositeTemplate, Label, ToggleButton, Widget,
+    glib, prelude::*, subclass::prelude::*, Box, CompositeTemplate, EventControllerLegacy, Label,
+    ToggleButton, Widget,
 };
 
 mod imp {
@@ -24,6 +25,10 @@ mod imp {
         pub(crate) canvasmenu: TemplateChild<RnCanvasMenu>,
         #[template_child]
         pub(crate) appmenu: TemplateChild<RnAppMenu>,
+        #[template_child]
+        pub(crate) quickactions_box: TemplateChild<Box>,
+        #[template_child]
+        pub(crate) right_buttons: TemplateChild<Box>,
     }
 
     #[glib::object_subclass]
@@ -105,5 +110,23 @@ impl RnMainHeader {
 
         imp.canvasmenu.get().init(appwindow);
         imp.appmenu.get().init(appwindow);
+
+        // add controllers to elements to prevent accidental resizes: left buttons
+        let capture_left = EventControllerLegacy::builder()
+            .name("capture_event_left")
+            .propagation_phase(gtk4::PropagationPhase::Bubble)
+            .build();
+
+        capture_left.connect_event(|_, _| glib::Propagation::Stop);
+        imp.quickactions_box.add_controller(capture_left);
+
+        // add controllers to elements to prevent accidental resizes: right buttons
+        let capture_right = EventControllerLegacy::builder()
+            .name("capture_event_right")
+            .propagation_phase(gtk4::PropagationPhase::Bubble)
+            .build();
+
+        capture_right.connect_event(|_, _| glib::Propagation::Stop);
+        imp.right_buttons.add_controller(capture_right);
     }
 }

--- a/crates/rnote-ui/src/mainheader.rs
+++ b/crates/rnote-ui/src/mainheader.rs
@@ -28,7 +28,7 @@ mod imp {
         #[template_child]
         pub(crate) quickactions_box: TemplateChild<Box>,
         #[template_child]
-        pub(crate) right_buttons: TemplateChild<Box>,
+        pub(crate) right_buttons_box: TemplateChild<Box>,
     }
 
     #[glib::object_subclass]
@@ -127,6 +127,6 @@ impl RnMainHeader {
             .build();
 
         capture_right.connect_event(|_, _| glib::Propagation::Stop);
-        imp.right_buttons.add_controller(capture_right);
+        imp.right_buttons_box.add_controller(capture_right);
     }
 }


### PR DESCRIPTION
Prevent events that occur on buttons to propagate to the titlebar. This makes it impossible to accidentally resize the window when clicking or touching on a button in the titlebar.

Fixes #1142 