### PR TITLE
change `RnUnitEntry` to not grab scroll focus

### DIFF
--- a/crates/rnote-ui/data/ui/settingspanel.ui
+++ b/crates/rnote-ui/data/ui/settingspanel.ui
@@ -183,37 +183,23 @@ gets disabled.</property>
                       </object>
                     </child>
                     <child>
-                      <object class="AdwActionRow" id="format_width_row">
+                      <object class="RnUnitEntry" id="format_width_unitentry">
                         <property name="title" translatable="yes">Width</property>
                         <property name="subtitle" translatable="yes">Set the format width</property>
-                        <style>
-                          <class name="spin" />
-                        </style>
-                        <child type="suffix">
-                          <object class="RnUnitEntry" id="format_width_unitentry">
-                            <property name="vexpand">false</property>
-                            <property name="hexpand">false</property>
-                            <property name="halign">end</property>
-                            <property name="valign">center</property>
-                          </object>
-                        </child>
+                        <property name="vexpand">false</property>
+                        <property name="hexpand">false</property>
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
                       </object>
                     </child>
                     <child>
-                      <object class="AdwActionRow" id="format_height_row">
+                      <object class="RnUnitEntry" id="format_height_unitentry">
                         <property name="title" translatable="yes">Height</property>
                         <property name="subtitle" translatable="yes">Set the format height</property>
-                        <style>
-                          <class name="spin" />
-                        </style>
-                        <child type="suffix">
-                          <object class="RnUnitEntry" id="format_height_unitentry">
-                            <property name="vexpand">false</property>
-                            <property name="hexpand">false</property>
-                            <property name="halign">end</property>
-                            <property name="valign">center</property>
-                          </object>
-                        </child>
+                        <property name="vexpand">false</property>
+                        <property name="hexpand">false</property>
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
                       </object>
                     </child>
                     <child>

--- a/crates/rnote-ui/data/ui/unitentry.ui
+++ b/crates/rnote-ui/data/ui/unitentry.ui
@@ -1,37 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- ### UnitEntry ### -->
 <interface>
-  <template class="RnUnitEntry" parent="GtkWidget">
-    <property name="layout-manager">
-      <object class="GtkBoxLayout" />
-    </property>
+  <template class="RnUnitEntry" parent="AdwSpinRow" id="value_spinner">
+    <property name="adjustment">value_adj</property>
+    <property name="vexpand">false</property>
+    <property name="valign">center</property>
+    <property name="wrap">false</property>
+    <property name="numeric">true</property>
+    <property name="width-chars">6</property>
     <child>
       <object class="GtkAdjustment" id="value_adj">
         <property name="step-increment">1</property>
       </object>
       <object class="AdwSpinRow" id="value_spinner">
-        <property name="adjustment">value_adj</property>
-        <property name="vexpand">false</property>
-        <property name="valign">center</property>
-        <property name="wrap">false</property>
-        <property name="numeric">true</property>
-        <property name="width-chars">6</property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkDropDown" id="unit_dropdown">
-        <property name="margin-start">6</property>
-        <property name="valign">center</property>
-        <property name="width-request">70</property>
-        <property name="model">
-          <object class="GtkStringList">
-            <items>
-              <item translatable="false">Px</item>
-              <item translatable="false">Mm</item>
-              <item translatable="false">Cm</item>
-            </items>
+        <child>
+          <object class="GtkDropDown" id="unit_dropdown">
+            <property name="margin-start">6</property>
+            <property name="valign">center</property>
+            <property name="width-request">70</property>
+            <property name="model">
+              <object class="GtkStringList">
+                <items>
+                  <item translatable="false">Px</item>
+                  <item translatable="false">Mm</item>
+                  <item translatable="false">Cm</item>
+                </items>
+              </object>
+            </property>
           </object>
-        </property>
+        </child>
       </object>
     </child>
   </template>

--- a/crates/rnote-ui/data/ui/unitentry.ui
+++ b/crates/rnote-ui/data/ui/unitentry.ui
@@ -9,7 +9,7 @@
       <object class="GtkAdjustment" id="value_adj">
         <property name="step-increment">1</property>
       </object>
-      <object class="GtkSpinButton" id="value_spinner">
+      <object class="AdwSpinRow" id="value_spinner">
         <property name="adjustment">value_adj</property>
         <property name="vexpand">false</property>
         <property name="valign">center</property>

--- a/crates/rnote-ui/src/settingspanel/mod.rs
+++ b/crates/rnote-ui/src/settingspanel/mod.rs
@@ -64,11 +64,7 @@ mod imp {
         #[template_child]
         pub(crate) format_orientation_landscape_toggle: TemplateChild<ToggleButton>,
         #[template_child]
-        pub(crate) format_width_row: TemplateChild<adw::ActionRow>,
-        #[template_child]
         pub(crate) format_width_unitentry: TemplateChild<RnUnitEntry>,
-        #[template_child]
-        pub(crate) format_height_row: TemplateChild<adw::ActionRow>,
         #[template_child]
         pub(crate) format_height_unitentry: TemplateChild<RnUnitEntry>,
         #[template_child]
@@ -241,12 +237,12 @@ mod imp {
 
             match predefined_format {
                 PredefinedFormat::Custom => {
-                    self.format_width_row.set_sensitive(true);
-                    self.format_height_row.set_sensitive(true);
+                    self.format_width_unitentry.set_sensitive(true);
+                    self.format_height_unitentry.set_sensitive(true);
                 }
                 _ => {
-                    self.format_width_row.set_sensitive(false);
-                    self.format_height_row.set_sensitive(false);
+                    self.format_width_unitentry.set_sensitive(false);
+                    self.format_height_unitentry.set_sensitive(false);
                 }
             };
         }

--- a/crates/rnote-ui/src/unitentry.rs
+++ b/crates/rnote-ui/src/unitentry.rs
@@ -19,7 +19,7 @@ mod imp {
         pub(crate) dpi: Cell<f64>,
 
         #[template_child]
-        pub(crate) value_spinner: TemplateChild<SpinButton>,
+        pub(crate) value_spinner: TemplateChild<adw::SpinRow>,
         #[template_child]
         pub(crate) unit_dropdown: TemplateChild<DropDown>,
     }
@@ -30,7 +30,7 @@ mod imp {
                 value: Cell::new(1.0),
                 unit: Cell::new(MeasureUnit::Px),
                 dpi: Cell::new(96.0),
-                value_spinner: TemplateChild::<SpinButton>::default(),
+                value_spinner: TemplateChild::<adw::SpinRow>::default(),
                 unit_dropdown: TemplateChild::<DropDown>::default(),
             }
         }
@@ -169,15 +169,12 @@ mod imp {
         const MIN_VAL_IN_PX: f64 = 1.0;
         const MAX_VAL_IN_PX: f64 = 100_000.0;
 
-        const STEP_INCREMENT_PX: f64 = 1.0;
         const CLIMB_RATE_PX: f64 = 2.0;
         const DIGITS_PX: u32 = 0;
 
-        const STEP_INCREMENT_MM: f64 = 1.0;
         const CLIMB_RATE_MM: f64 = 2.0;
         const DIGITS_MM: u32 = 1;
 
-        const STEP_INCREMENT_CM: f64 = 0.1;
         const CLIMB_RATE_CM: f64 = 0.2;
         const DIGITS_CM: u32 = 2;
 
@@ -197,27 +194,13 @@ mod imp {
                 dpi,
             );
 
-            let (step_increment, climb_rate, digits) = match unit {
-                MeasureUnit::Px => (
-                    Self::STEP_INCREMENT_PX,
-                    Self::CLIMB_RATE_PX,
-                    Self::DIGITS_PX,
-                ),
-                MeasureUnit::Mm => (
-                    Self::STEP_INCREMENT_MM,
-                    Self::CLIMB_RATE_MM,
-                    Self::DIGITS_MM,
-                ),
-                MeasureUnit::Cm => (
-                    Self::STEP_INCREMENT_CM,
-                    Self::CLIMB_RATE_CM,
-                    Self::DIGITS_CM,
-                ),
+            let (climb_rate, digits) = match unit {
+                MeasureUnit::Px => (Self::CLIMB_RATE_PX, Self::DIGITS_PX),
+                MeasureUnit::Mm => (Self::CLIMB_RATE_MM, Self::DIGITS_MM),
+                MeasureUnit::Cm => (Self::CLIMB_RATE_CM, Self::DIGITS_CM),
             };
 
             self.value_spinner.set_range(min_val, max_val);
-            self.value_spinner
-                .set_increments(step_increment, 2.0 * step_increment);
             self.value_spinner.set_climb_rate(climb_rate);
             self.value_spinner.set_digits(digits);
         }


### PR DESCRIPTION
`SpinButton` changed to `adw::SpinRow` to not grab scroll focus.

This prevents accidentally large changes in values when scrolling with the mouse the settings window.