### PR TITLE
More resilient file saving by a two-stage file save process - Issue 1096

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,6 +3252,7 @@ dependencies = [
  "async-fs",
  "base64",
  "cairo-rs",
+ "crc32fast",
  "fs_extra",
  "futures",
  "gettext-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ base64 = "0.22.1"
 cairo-rs = { version = "0.19.4", features = ["v1_18", "png", "svg", "pdf"] }
 chrono = "0.4.38"
 clap = { version = "4.5", features = ["derive"] }
+crc32fast = "1.4"
 dialoguer = "0.11.0"
 flate2 = "1.0"
 fs_extra = "1.3"

--- a/crates/rnote-ui/Cargo.toml
+++ b/crates/rnote-ui/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = { workspace = true }
 async-fs = { workspace = true }
 base64 = { workspace = true }
 cairo-rs = { workspace = true }
+crc32fast = { workspace = true }
 fs_extra = { workspace = true }
 futures = { workspace = true }
 gettext-rs = { workspace = true }

--- a/crates/rnote-ui/src/canvas/imexport.rs
+++ b/crates/rnote-ui/src/canvas/imexport.rs
@@ -280,8 +280,6 @@ impl RnCanvas {
         };
         file_check_operation.await?;
 
-        use std::time::Instant;
-        let _start = Instant::now();
         let file_swap_operation = async {
             if file_path.exists() {
                 // zeroize the previous version of the save file
@@ -310,7 +308,7 @@ impl RnCanvas {
 
                 // finally remove the previous save file after it was zeroized
                 async_fs::remove_file(&file_path).await.context(format!(
-                    "Failed to remove old save file with path '{}'",
+                    "Failed to remove previous save file with path '{}'",
                     &file_path.display()
                 ))?;
             }
@@ -321,7 +319,6 @@ impl RnCanvas {
             Ok::<(), anyhow::Error>(())
         };
         file_swap_operation.await?;
-        tracing::info!("file swap op : {:.7}", _start.elapsed().as_secs_f64());
 
         self.set_output_file(Some(gio::File::for_path(&file_path)));
         self.set_unsaved_changes(false);


### PR DESCRIPTION
Implementation of a two-stage file save process:

1. Serialized and compressed data saved to a temporary file in the same directory (.tmp)
2. Checksum calculated from the internal bytes using crc32fast (MIT license)
3. External checksum calculated from the temporary file
4. If the checksum match, the previous save file is zeroed and deleted, and the temporary file is renamed
5. File watcher updated with the new save file

According to my simple benchmarks (EndeavourOS, Ryzen 5 5500U) , this does impact the saving time, but not significantly so:

![2024-07-19-110837_hyprshot](https://github.com/user-attachments/assets/a0d20552-7f9d-4bca-a79f-e6fde253b460)
![2024-07-19-110925_hyprshot](https://github.com/user-attachments/assets/2816e2b4-473d-4b84-8085-e5d56f6f8cdc)

I'll try to find the courage to test this on windows as well

