### PR TITLE
Optimizations for compress_to_gzip and decompress_from_gzip

### DIFF
--- a/crates/rnote-engine/src/fileformats/rnoteformat/mod.rs
+++ b/crates/rnote-engine/src/fileformats/rnoteformat/mod.rs
@@ -30,9 +30,9 @@ fn compress_to_gzip(to_compress: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
 
 /// Decompress from gzip.
 fn decompress_from_gzip(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
-    // Optimisation for the gzip format, defined by RFC 1952
-    // vector's capacity defined by the size of the uncompressed data
-    // size given in little endian format, last 4 bytes of "compressed"
+    // Optimization for the gzip format, defined by RFC 1952
+    // capacity of the vector defined by the size of the uncompressed data
+    // given in little endian format, by the last 4 bytes of "compressed"
     //
     //   ISIZE (Input SIZE)
     //     This contains the size of the original (uncompressed) input data modulo 2^32.

--- a/crates/rnote-engine/src/fileformats/rnoteformat/mod.rs
+++ b/crates/rnote-engine/src/fileformats/rnoteformat/mod.rs
@@ -129,9 +129,7 @@ impl FileFormatSaver for RnoteFile {
             data: ijson::to_value(self).context("converting RnoteFile to JSON value failed.")?,
         };
         let compressed = compress_to_gzip(
-            serde_json::to_string(&wrapper)
-                .context("Serializing RnoteFileWrapper failed.")?
-                .as_bytes(),
+            &serde_json::to_vec(&wrapper).context("Serializing RnoteFileWrapper failed.")?,
         )
         .context("compressing bytes failed.")?;
 

--- a/crates/rnote-engine/src/fileformats/rnoteformat/mod.rs
+++ b/crates/rnote-engine/src/fileformats/rnoteformat/mod.rs
@@ -37,13 +37,19 @@ fn decompress_from_gzip(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
     //   ISIZE (Input SIZE)
     //     This contains the size of the original (uncompressed) input data modulo 2^32.
     let mut bytes: Vec<u8> = {
-        let mut decompressed_size: [u8; 8] = [0; 8];
+        let mut decompressed_size: [u8; 4] = [0; 4];
         let idx_start = compressed
             .len()
             .checked_sub(4)
-            .ok_or_else(|| anyhow::anyhow!("Invalid file format"))?;
-        decompressed_size[0..4].copy_from_slice(&compressed[idx_start..]);
-        Vec::with_capacity(usize::from_le_bytes(decompressed_size))
+            // only happens if the file has less than 4 bytes
+            .ok_or_else(|| {
+                anyhow::anyhow!("Invalid file")
+                    .context("Failed to get the size of the decompressed data")
+            })?;
+        decompressed_size.copy_from_slice(&compressed[idx_start..]);
+        // u32 -> usize to avoid issues on 32-bit architectures
+        // also more reasonable since the uncompressed size is given by 4 bytes
+        Vec::with_capacity(u32::from_le_bytes(decompressed_size) as usize)
     };
 
     let mut decoder = flate2::read::MultiGzDecoder::new(compressed);

--- a/crates/rnote-engine/src/fileformats/rnoteformat/mod.rs
+++ b/crates/rnote-engine/src/fileformats/rnoteformat/mod.rs
@@ -23,8 +23,7 @@ use std::io::{Read, Write};
 
 /// Compress bytes with gzip.
 fn compress_to_gzip(to_compress: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
-    let mut encoder =
-        flate2::write::GzEncoder::new(Vec::<u8>::new(), flate2::Compression::default());
+    let mut encoder = flate2::write::GzEncoder::new(Vec::<u8>::new(), flate2::Compression::new(5));
     encoder.write_all(to_compress)?;
     Ok(encoder.finish()?)
 }


### PR DESCRIPTION
## compress_to_gzip :
compression level reduced to 5 from 6 (default)
minuscule increase in file sizes, better save times
![2024-07-20-234720_hyprshot](https://github.com/user-attachments/assets/cf3bdb04-3eb1-4c14-a5c9-312d43eadae3)

## decompress_from_gzip
Vec::with_capacity() optimization
roughly ~15% faster