### PR TITLE
page indicator for fixed layouts

### DIFF
--- a/crates/rnote-engine/src/document/mod.rs
+++ b/crates/rnote-engine/src/document/mod.rs
@@ -165,7 +165,7 @@ impl Document {
     }
 
     #[allow(unused)]
-    pub(crate) fn calc_n_pages(&self) -> u32 {
+    pub fn calc_n_pages(&self) -> u32 {
         // Avoid div by 0
         if self.format.height() > 0.0 && self.format.width() > 0.0 {
             (self.width / self.format.width()).ceil() as u32

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -680,6 +680,17 @@ impl Engine {
         self.camera_set_offset_expand(new_offset)
     }
 
+    /// go to the page number for fixed layouts
+    pub fn go_to_page(&mut self, page_number: f64) -> WidgetFlags {
+        let zoom = self.camera.zoom();
+        let previous_offset = self.camera.offset();
+        let new_offset = na::vector![
+            previous_offset.x,
+            (page_number - 1.0) * self.document.format.height() * zoom
+        ];
+        self.camera_set_offset_expand(new_offset)
+    }
+
     /// Resize the doc when in autoexpanding layouts. called e.g. when finishing a new stroke.
     ///
     /// Background rendering then needs to be updated.

--- a/crates/rnote-ui/data/ui/mainheader.ui
+++ b/crates/rnote-ui/data/ui/mainheader.ui
@@ -62,6 +62,12 @@
           <object class="GtkBox" id="right_buttons_box">
             <property name="spacing">3</property>
             <child>
+              <object class="GtkSpinButton" id="page_spin">
+                <property name="orientation">horizontal</property>
+                <property name="numeric">true</property>
+              </object>
+            </child>
+            <child>
               <object class="GtkButton">
                 <property name="tooltip-text" translatable="yes">Save Document</property>
                 <property name="icon-name">doc-save-symbolic</property>

--- a/crates/rnote-ui/src/canvas/canvaslayout.rs
+++ b/crates/rnote-ui/src/canvas/canvaslayout.rs
@@ -105,6 +105,11 @@ mod imp {
                     .engine_mut()
                     .update_content_rendering_current_viewport();
             }
+
+            if old_viewport != new_viewport {
+                // update the page number
+                canvas.set_refresh_pages(true);
+            }
         }
     }
 }

--- a/crates/rnote-ui/src/canvas/input.rs
+++ b/crates/rnote-ui/src/canvas/input.rs
@@ -171,6 +171,7 @@ pub(crate) fn handle_pointer_controller_event(
             match pen_state {
                 PenState::Up => {
                     canvas.enable_drawing_cursor(false);
+                    // refresh the page number
 
                     let (ep, wf) = canvas.engine_mut().handle_pen_event(
                         PenEvent::Up {

--- a/crates/rnote-ui/src/canvaswrapper.rs
+++ b/crates/rnote-ui/src/canvaswrapper.rs
@@ -351,7 +351,6 @@ mod imp {
                         widget_flags |= canvas.engine_mut().camera_set_offset_expand(new_camera_offset);
                         canvas.emit_handle_widget_flags(widget_flags);
                     }
-
                     glib::Propagation::Stop
                 }));
             }

--- a/crates/rnote-ui/src/settingspanel/mod.rs
+++ b/crates/rnote-ui/src/settingspanel/mod.rs
@@ -641,6 +641,7 @@ impl RnSettingsPanel {
                         .canvasmenu()
                         .fixedsize_quickactions_box()
                         .set_sensitive(document_layout == Layout::FixedSize);
+                    appwindow.refresh_pages(&canvas);
 
                     if canvas.engine_ref().document.layout != document_layout {
                         let mut widget_flags = canvas.engine_mut().set_doc_layout(document_layout);


### PR DESCRIPTION
Partial fix for #639 

[Screencast_20240722_132148.webm](https://github.com/user-attachments/assets/45cc0397-1ea5-4a7c-bfc3-eb0f6f06519c)


This does not include any page menu, only a page number indicator to show the current page number and change the page. For now this is only implemented for fixed layouts (infinite layouts would need a little more work as page positions and number depend on a little more than the current canvas size, like which pages include strokes. Having a page number might be a little more difficult as well).

There's probably a few things to improve (these are suggestions)
- [ ] make it work for infinite layouts (?)
- [ ] make it async ? (there's no need to halt some other calculations for the page number to be calculated, not sure it currently is the case)
- [ ] show the total number of page (I would like to have a 1/xx inside the spinbutton but that might end up being hard to do with gtk. Having the total number of page on the right would be a little too much wasted space)