### PR TITLE
chore: update `gettext`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "gettext-rs"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e49ea8a8fad198aaa1f9655a2524b64b70eb06b2f3ff37da407566c93054f364"
+checksum = "4a6716b8a0db461a2720b850ba1623e5b69e4b1aa0224cf5e1fb23a0fe49e65c"
 dependencies = [
  "gettext-sys",
  "locale_config",
@@ -1365,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "gettext-sys"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63ce2e00f56a206778276704bbe38564c8695249fdc8f354b4ef71c57c3839d"
+checksum = "f7b8797f28f2dabfbe2caadb6db4f7fd739e251b5ede0a2ba49e506071edcf67"
 dependencies = [
  "cc",
  "temp-dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ flate2 = "1.0"
 fs_extra = "1.3"
 futures = "0.3.30"
 geo = "0.28.0"
-gettext-rs = { version = "0.7.0", features = ["gettext-system"] }
+gettext-rs = { version = "0.7.1", features = ["gettext-system"] }
 gio = "0.19.5"
 glib = "0.19.7"
 glib-build-tools = "0.19.0"

--- a/misc/building/rnote-macos-build.md
+++ b/misc/building/rnote-macos-build.md
@@ -79,8 +79,9 @@ meson setup --prefix=usr/local _mesonbuild
 Next, we have to build `rnote`.
 
 ```sh
-meson compile -C _mesonbuild
+CFLAGS=-Wno-error=incompatible-function-pointer-types meson compile -C _mesonbuild
 ```
+(the additional flags are added to workaround issue https://github.com/gettext-rs/gettext-rs/issues/121)
 
 Now, we can install the binary and place resource files in their desired
 locations. `sudo` is required because `prefix` is set to `/usr/local`. You can

--- a/misc/building/rnote-macos-build.md
+++ b/misc/building/rnote-macos-build.md
@@ -79,9 +79,8 @@ meson setup --prefix=usr/local _mesonbuild
 Next, we have to build `rnote`.
 
 ```sh
-CFLAGS=-Wno-error=incompatible-function-pointer-types meson compile -C _mesonbuild
+meson compile -C _mesonbuild
 ```
-(the additional flags are added to workaround issue https://github.com/gettext-rs/gettext-rs/issues/121)
 
 Now, we can install the binary and place resource files in their desired
 locations. `sudo` is required because `prefix` is set to `/usr/local`. You can


### PR DESCRIPTION
Add a note for building on mac os.

From https://github.com/gettext-rs/gettext-rs/commit/11a78d658b945cda29d20f641c8d5803075fe97d, this shouldn't be needed once `gettext-rs` releases a new version.

I'll leave this as a draft for now, and maybe change this to a version upgrade once `gettext-rs` is updated.