### PR TITLE
zstd with parallelism instead of gzip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3404,6 +3404,7 @@ dependencies = [
  "unicode-segmentation",
  "usvg",
  "xmlwriter",
+ "zstd",
 ]
 
 [[package]]
@@ -4876,6 +4877,34 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ winresource = "0.1.17"
 xmlwriter = "0.1.0"
 # Enabling feature > v20_9 causes linker errors on mingw
 poppler-rs = { version = "0.23.0", features = ["v20_9"] }
+zstd = { version =  "0.13", features = ["zstdmt"] }
 
 [patch.crates-io]
 # once a new piet (current v0.6.2) is released with updated cairo and kurbo deps, this can be removed.

--- a/crates/rnote-engine/Cargo.toml
+++ b/crates/rnote-engine/Cargo.toml
@@ -55,6 +55,7 @@ tracing = { workspace = true }
 unicode-segmentation = { workspace = true }
 usvg = { workspace = true }
 xmlwriter = { workspace = true }
+zstd = { workspace = true, features = ["zstdmt"] }
 # the long-term plan is to remove the gtk4 dependency entirely after switching to another renderer.
 gtk4 = { workspace = true, optional = true }
 

--- a/crates/rnote-engine/src/fileformats/rnoteformat/mod.rs
+++ b/crates/rnote-engine/src/fileformats/rnoteformat/mod.rs
@@ -42,10 +42,10 @@ fn decompress_from_gzip(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
             .len()
             .checked_sub(4)
             // only happens if the file has less than 4 bytes
-            .ok_or_else(|| {
-                anyhow::anyhow!("Invalid file")
-                    .context("Failed to get the size of the decompressed data")
-            })?;
+            .ok_or(
+                anyhow::anyhow!("Not a valid gzip-compressed file")
+                    .context("Failed to get the size of the decompressed data"),
+            )?;
         decompressed_size.copy_from_slice(&compressed[idx_start..]);
         // u32 -> usize to avoid issues on 32-bit architectures
         // also more reasonable since the uncompressed size is given by 4 bytes
@@ -55,6 +55,96 @@ fn decompress_from_gzip(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
     let mut decoder = flate2::read::MultiGzDecoder::new(compressed);
     decoder.read_to_end(&mut bytes)?;
     Ok(bytes)
+}
+
+/// Decompress bytes with zstd
+pub fn decompress_from_zstd(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
+    // Optimization for the zstd format, less pretty than for gzip but this does shave off a bit of time
+    // https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#frame_header
+    let mut bytes: Vec<u8> = {
+        let frame_header_descriptor = compressed.get(4).ok_or(
+            anyhow::anyhow!("Not a valid zstd-compressed file")
+                .context("Failed to get the frame header descriptor of the file"),
+        )?;
+
+        let frame_content_size_flag = frame_header_descriptor >> 6;
+        let single_segment_flag = (frame_header_descriptor >> 5) & 1;
+        let did_field_size = {
+            let dictionary_id_flag = frame_header_descriptor & 11;
+            if dictionary_id_flag == 3 {
+                4
+            } else {
+                dictionary_id_flag
+            }
+        };
+        // frame header size start index
+        let fcs_sidx = (6 + did_field_size - single_segment_flag) as usize;
+        // magic number: 4 bytes + window descriptor: 1 byte if single segment flag is not set + frame header descriptor: 1 byte + dict. field size: 0-4 bytes
+        // testing suggests that dicts. don't improve the compression ratio and worsen writing/reading speeds, therefore they won't be used
+        // thus this part could be simplified, but wouldn't strictly adhere to zstd standards
+
+        match frame_content_size_flag {
+            // not worth it to potentially pre-allocate a maximum of 255 bytes
+            0 => Vec::new(),
+            1 => {
+                let mut decompressed_size: [u8; 2] = [0; 2];
+                decompressed_size.copy_from_slice(
+                    compressed.get(fcs_sidx..fcs_sidx + 2).ok_or(
+                        anyhow::anyhow!("Not a valid zstd-compressed file").context(
+                            "Failed to get the uncompressed size of the data from two bytes",
+                        ),
+                    )?,
+                );
+                Vec::with_capacity(usize::from(256 + u16::from_le_bytes(decompressed_size)))
+            }
+            2 => {
+                let mut decompressed_size: [u8; 4] = [0; 4];
+                decompressed_size.copy_from_slice(
+                    compressed.get(fcs_sidx..fcs_sidx + 4).ok_or(
+                        anyhow::anyhow!("Not a valid zstd-compressed file").context(
+                            "Failed to get the uncompressed size of the data from four bytes",
+                        ),
+                    )?,
+                );
+                Vec::with_capacity(
+                    u32::from_le_bytes(decompressed_size)
+                        .try_into()
+                        .unwrap_or(usize::MAX),
+                )
+            }
+            // in practice this should not happen, as a rnote file being larger than 4 GiB is very unlikely
+            3 => {
+                let mut decompressed_size: [u8; 8] = [0; 8];
+                decompressed_size.copy_from_slice(compressed.get(fcs_sidx..fcs_sidx + 8).ok_or(
+                    anyhow::anyhow!("Not a valid zstd-compressed file").context(
+                        "Failed to get the uncompressed size of the data from eight bytes",
+                    ),
+                )?);
+                Vec::with_capacity(
+                    u64::from_le_bytes(decompressed_size)
+                        .try_into()
+                        .unwrap_or(usize::MAX),
+                )
+            }
+            // unreachable since our u8 is formed by only 2 bits
+            4.. => unreachable!(),
+        }
+    };
+    let mut decoder = zstd::Decoder::new(compressed)?;
+    decoder.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+/// Compress bytes with zstd
+pub fn compress_to_zstd(to_compress: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
+    let mut encoder = zstd::Encoder::new(Vec::<u8>::new(), 9)?;
+    encoder.set_pledged_src_size(Some(to_compress.len() as u64))?;
+    encoder.include_contentsize(true)?;
+    if let Ok(num_workers) = std::thread::available_parallelism() {
+        encoder.multithread(num_workers.get() as u32)?;
+    }
+    encoder.write_all(to_compress)?;
+    Ok(encoder.finish()?)
 }
 
 /// The rnote file wrapper.


### PR DESCRIPTION
https://github.com/anesthetice/rnote-compression-benchmarking/

From the compression methods tested, zstd seems to be a better choice for the  rnote file format:

- Better compression ratio
- Faster reads + writes
- Simple multi-threading

<img src="https://github.com/anesthetice/rnote-compression-benchmarking/blob/main/images/AMD_Ryzen_5_5500U_with_Radeon_Graphics_gzip-5_brotli-2-4096-24_brotli-4-4096-24_par-gzip-9_par-zstd-9_par-zstd-9-opt.png?raw=true" alt="median out of 16 samples" width="70%"/>

