### PR TITLE
feat: long hold pen for lines/shape recognition

### DIFF
--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -17,7 +17,7 @@ pub use strokecontent::StrokeContent;
 
 // Imports
 use crate::document::Layout;
-use crate::pens::{Pen, PenBehaviour, PenStyle};
+use crate::pens::{Pen, PenStyle};
 use crate::pens::{PenMode, PensConfig};
 use crate::store::render_comp::{self, RenderCompState};
 use crate::store::StrokeKey;

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -467,23 +467,21 @@ impl Engine {
                 // hence for a mouse that's not moving, we re send an event at the same location
                 // not implemented
 
-                // for now we have a
-                //    3.110231056s ERROR rnote_engine::tasks: Could not quit periodic task while handle is being dropped, Err: Sending `Quit` message to periodic task failed.
-                // from waiting for the pen event to finish ?
+                //
 
-                let (_, wf) = self.handle_pen_event(
-                    PenEvent::Down {
-                        element: Element {
-                            pos: na::Vector2::new(1.0, 1.0), //for now this is a dummy
-                            pressure: 1.0,
-                        },
-                        modifier_keys: HashSet::new(),
-                    },
-                    None,
-                    Instant::now(),
-                );
-                widget_flags |= wf;
-                widget_flags.long_hold = true;
+                // let (_, wf) = self.handle_pen_event(
+                //     PenEvent::Down {
+                //         element: Element {
+                //             pos: na::Vector2::new(1.0, 1.0), //for now this is a dummy
+                //             pressure: 1.0,
+                //         },
+                //         modifier_keys: HashSet::new(),
+                //     },
+                //     None,
+                //     Instant::now(),
+                // );
+                // widget_flags |= wf;
+                // widget_flags.long_hold = true;
             }
             EngineTask::Zoom(zoom) => {
                 widget_flags |= self.camera.zoom_temporarily_to(1.0) | self.camera.zoom_to(zoom);

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -459,29 +459,29 @@ impl Engine {
             }
             EngineTask::LongPressStatic => {
                 println!("long press event");
-                // for now just detect is good enough
-                // we should sent an event (what event ?)
-                // the idea is that we need to send events to this task
-                // hence we reply with the lastest such event
-                // with a wf set to long_hold true as well
-                // hence for a mouse that's not moving, we re send an event at the same location
-                // not implemented
 
-                //
+                // TODO
+                // re send the latest event
+                // this event will be part of the vecdeques of the brush
+                // this decque can't be empty !
+                let position = match self.penholder.current_pen_mut() {
+                    Pen::Brush(brush) => brush.long_press_detector.get_latest_pos(),
+                    _ => na::Vector2::new(1.0, 1.0),
+                };
 
-                // let (_, wf) = self.handle_pen_event(
-                //     PenEvent::Down {
-                //         element: Element {
-                //             pos: na::Vector2::new(1.0, 1.0), //for now this is a dummy
-                //             pressure: 1.0,
-                //         },
-                //         modifier_keys: HashSet::new(),
-                //     },
-                //     None,
-                //     Instant::now(),
-                // );
-                // widget_flags |= wf;
-                // widget_flags.long_hold = true;
+                let (_, wf) = self.handle_pen_event(
+                    PenEvent::Down {
+                        element: Element {
+                            pos: position,
+                            pressure: 1.0,
+                        },
+                        modifier_keys: HashSet::new(),
+                    },
+                    None,
+                    Instant::now(),
+                );
+                widget_flags |= wf;
+                widget_flags.long_hold = true;
             }
             EngineTask::Zoom(zoom) => {
                 widget_flags |= self.camera.zoom_temporarily_to(1.0) | self.camera.zoom_to(zoom);

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -101,6 +101,10 @@ pub enum EngineTask {
     BlinkTypewriterCursor,
     /// Change the permanent zoom to the given value
     Zoom(f64),
+    /// Task for a pen that's held down at the same position for a long time
+    /// We do that through a task to take into account the case of a mouse that's
+    /// held down at the same position without giving any new event
+    LongPressStatic,
     /// Indicates that the application is quitting. Sent to quit the handler which receives the tasks.
     Quit,
 }
@@ -463,6 +467,9 @@ impl Engine {
             EngineTask::Quit => {
                 widget_flags |= self.set_active(false);
                 quit = true;
+            }
+            EngineTask::LongPressStatic => {
+                todo!()
             }
         }
 

--- a/crates/rnote-engine/src/pens/brush.rs
+++ b/crates/rnote-engine/src/pens/brush.rs
@@ -415,6 +415,12 @@ impl DrawableOnDoc for Brush {
 
 impl Brush {
     const INPUT_OVERSHOOT: f64 = 30.0;
+
+    // reset the long press
+    pub fn reset_long_press(&mut self) {
+        self.time_start = Some(Instant::now());
+        // this resets the time to the current one (dummy test)
+    }
 }
 
 fn play_marker_sound(engine_view: &mut EngineViewMut) {

--- a/crates/rnote-engine/src/pens/mod.rs
+++ b/crates/rnote-engine/src/pens/mod.rs
@@ -54,12 +54,21 @@ impl Default for Pen {
 }
 
 impl Pen {
-    // intermediary function
-    // result/error propagation ?
-    pub fn reset_long_press(&mut self, element: Element, now: Instant) {
+    // intermediary function for mutability
+    pub fn reset_long_press(&mut self, now: Instant) -> Result<(), ()> {
         match self {
-            Pen::Brush(brush) => brush.reset_long_press(element, now),
-            _ => panic!("can't reset a pen that's not a brush"),
+            Pen::Brush(brush) => {
+                // get the last element stored in the recognizer
+                brush.reset_long_press(
+                    Element {
+                        pos: brush.long_press_detector.get_latest_pos(),
+                        pressure: 1.0,
+                    },
+                    now,
+                );
+                Ok(())
+            }
+            _ => Err(()),
         }
     }
 }

--- a/crates/rnote-engine/src/pens/mod.rs
+++ b/crates/rnote-engine/src/pens/mod.rs
@@ -52,6 +52,16 @@ impl Default for Pen {
     }
 }
 
+impl Pen {
+    // need an intermediary
+    pub fn reset_long_press(&mut self) {
+        match self {
+            Pen::Brush(brush) => brush.reset_long_press(),
+            _ => panic!("can't reset a not brush"),
+        }
+    }
+}
+
 impl PenBehaviour for Pen {
     fn init(&mut self, engine_view: &EngineView) -> WidgetFlags {
         match self {

--- a/crates/rnote-engine/src/pens/mod.rs
+++ b/crates/rnote-engine/src/pens/mod.rs
@@ -18,6 +18,7 @@ pub use penbehaviour::PenBehaviour;
 pub use penholder::PenHolder;
 pub use penmode::PenMode;
 pub use pensconfig::PensConfig;
+use rnote_compose::penpath::Element;
 pub use selector::Selector;
 pub use shaper::Shaper;
 pub use shortcuts::Shortcuts;
@@ -53,11 +54,12 @@ impl Default for Pen {
 }
 
 impl Pen {
-    // need an intermediary
-    pub fn reset_long_press(&mut self) {
+    // intermediary function
+    // result/error propagation ?
+    pub fn reset_long_press(&mut self, element: Element, now: Instant) {
         match self {
-            Pen::Brush(brush) => brush.reset_long_press(),
-            _ => panic!("can't reset a not brush"),
+            Pen::Brush(brush) => brush.reset_long_press(element, now),
+            _ => panic!("can't reset a pen that's not a brush"),
         }
     }
 }

--- a/crates/rnote-engine/src/pens/penholder.rs
+++ b/crates/rnote-engine/src/pens/penholder.rs
@@ -13,7 +13,6 @@ use crate::{CloneConfig, DrawableOnDoc};
 use futures::channel::oneshot;
 use p2d::bounding_volume::Aabb;
 use piet::RenderContext;
-use rand::Rng;
 use rnote_compose::builders::ShapeBuilderType;
 use rnote_compose::eventresult::EventPropagation;
 use rnote_compose::penevent::{KeyboardKey, ModifierKey, PenEvent, PenProgress, ShortcutKey};
@@ -264,9 +263,6 @@ impl PenHolder {
             }
             false => None,
         };
-        //normally this wouldn't be the case as we are doing this on a cancel which is not the real thing !
-        //if cancel the pen is reinitialized !
-        // could be done further done like the rest
 
         //let's get our stroke key here as well
         // should only trigger if wf.long_hold TODO
@@ -298,7 +294,7 @@ impl PenHolder {
             println!("the path is {:?}", path);
 
             // random chance between recognition and not (to replace with a real recognizer)
-            if false {
+            if true {
                 println!("recognition successful");
 
                 // cancel the stroke
@@ -349,7 +345,12 @@ impl PenHolder {
                 println!("recognition failed");
                 // here we have to reset both the status for the long press recogniser that is done by event
                 // and the one on the dedicated thread
-                self.current_pen.reset_long_press();
+                // ISSUE HERE
+                self.current_pen
+                    .reset_long_press(path.unwrap().segments.last().unwrap().end(), now);
+                // not too robust is it ?
+                // could this happen with no element ?
+                // ?? is this okay now ?
 
                 // ideally we could keep the same vec for the path and extend it with only new elements if this happens multiple times
             }

--- a/crates/rnote-engine/src/pens/penholder.rs
+++ b/crates/rnote-engine/src/pens/penholder.rs
@@ -16,7 +16,6 @@ use piet::RenderContext;
 use rnote_compose::builders::ShapeBuilderType;
 use rnote_compose::eventresult::EventPropagation;
 use rnote_compose::penevent::{KeyboardKey, ModifierKey, PenEvent, PenProgress, ShortcutKey};
-use rnote_compose::penpath::Element;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::time::{Duration, Instant};

--- a/crates/rnote-engine/src/pens/penholder.rs
+++ b/crates/rnote-engine/src/pens/penholder.rs
@@ -298,9 +298,7 @@ impl PenHolder {
             println!("the path is {:?}", path);
 
             // random chance between recognition and not (to replace with a real recognizer)
-            let mut rng = rand::thread_rng();
-            let value = rng.gen_bool(0.5);
-            if value {
+            if false {
                 println!("recognition successful");
 
                 // cancel the stroke
@@ -321,6 +319,11 @@ impl PenHolder {
                 }
                 // then add two new events
                 // or edit directly the shaper ?
+                // we probably will have to do custom methods
+                // one thing that's lacking here is the stroke width that's not set
+                // but we shouldn't make the settings for the shape tool change for a stroke
+                // recognition
+
                 // first event is the original position (to get back up from somewhere ...)
                 let (_, wf) = self.current_pen.handle_event(
                     PenEvent::Down {
@@ -344,6 +347,11 @@ impl PenHolder {
                 // maybe try with the other method : modify the thing manually
             } else {
                 println!("recognition failed");
+                // here we have to reset both the status for the long press recogniser that is done by event
+                // and the one on the dedicated thread
+                self.current_pen.reset_long_press();
+
+                // ideally we could keep the same vec for the path and extend it with only new elements if this happens multiple times
             }
         }
 

--- a/crates/rnote-engine/src/pens/pensconfig/brushconfig.rs
+++ b/crates/rnote-engine/src/pens/pensconfig/brushconfig.rs
@@ -148,4 +148,12 @@ impl BrushConfig {
             }
         }
     }
+
+    pub(crate) fn get_stroke_width(&self) -> f64 {
+        match &self.style {
+            BrushStyle::Marker => self.marker_options.stroke_width,
+            BrushStyle::Solid => self.solid_options.stroke_width,
+            BrushStyle::Textured => self.textured_options.stroke_width,
+        }
+    }
 }

--- a/crates/rnote-engine/src/widgetflags.rs
+++ b/crates/rnote-engine/src/widgetflags.rs
@@ -26,6 +26,10 @@ pub struct WidgetFlags {
     /// Meaning, when enabled instead of key events, text events are then emitted
     /// for regular unicode text. Used when writing text with the typewriter.
     pub enable_text_preprocessing: Option<bool>,
+    /// long press event to take into account
+    /// This triggers actions on the engine further up (additional events)
+    /// to take it into consideration
+    pub long_hold: bool,
 }
 
 impl Default for WidgetFlags {
@@ -42,6 +46,7 @@ impl Default for WidgetFlags {
             hide_undo: None,
             hide_redo: None,
             enable_text_preprocessing: None,
+            long_hold: false,
         }
     }
 }
@@ -74,5 +79,6 @@ impl std::ops::BitOrAssign for WidgetFlags {
         if rhs.enable_text_preprocessing.is_some() {
             self.enable_text_preprocessing = rhs.enable_text_preprocessing;
         }
+        self.long_hold |= rhs.long_hold;
     }
 }


### PR DESCRIPTION
This is still a draft but I want to be sure that the general structure is correct before going further.
At the moment it always transform the pen path into a line between the start and end position if the gesture is detected.

For now what I'm worried about
- [ ] does the current implementation works without mutation issues on the engine ?
- [ ] I'm not fully sure the use of the `OneOffTask` is completly correct
- [ ] tweak the settings and test it with touch/pen input (does it work correctly).

Then there is a lot of functionality missing 
- [ ] toggle the setting in the UI (and have this propagate into the rest of the code so no power is lost detecting a gesture for nothing)
- [ ] emit shapes with the correct stroke width (and extend it further than just lines, for now I'm not entirely sure how that could be done, there's probably new methods to add to the shaper to be able to do that from a single function call)
- [ ] implement the shape recognizer. For now there is no shape recognizer as I was only searching for a way to make the gesture work. At least the general form of the recognizer should be a `PenPath -> Option<Shape>' so it either recognizes something and returns it or it doesn't. 

Issues : #384 and maybe #120 if the last point is developped further than just lines/not lines