### PR TITLE
More versatile rnote file format, issue 1173

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3404,6 +3404,7 @@ dependencies = [
  "unicode-segmentation",
  "usvg",
  "xmlwriter",
+ "zstd",
 ]
 
 [[package]]
@@ -4876,6 +4877,34 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ winresource = "0.1.17"
 xmlwriter = "0.1.0"
 # Enabling feature > v20_9 causes linker errors on mingw
 poppler-rs = { version = "0.23.0", features = ["v20_9"] }
+zstd = { version =  "0.13", features = ["zstdmt"] }
 
 [patch.crates-io]
 # once a new piet (current v0.6.2) is released with updated cairo and kurbo deps, this can be removed.

--- a/crates/rnote-engine/Cargo.toml
+++ b/crates/rnote-engine/Cargo.toml
@@ -55,6 +55,7 @@ tracing = { workspace = true }
 unicode-segmentation = { workspace = true }
 usvg = { workspace = true }
 xmlwriter = { workspace = true }
+zstd = { workspace = true, features = ["zstdmt"] }
 # the long-term plan is to remove the gtk4 dependency entirely after switching to another renderer.
 gtk4 = { workspace = true, optional = true }
 

--- a/crates/rnote-engine/src/engine/export.rs
+++ b/crates/rnote-engine/src/engine/export.rs
@@ -332,6 +332,7 @@ impl Engine {
         rayon::spawn(move || {
             let result = || -> anyhow::Result<Vec<u8>> {
                 let rnote_file = RnoteFile {
+                    header: RnoteHeader::default(),
                     engine_snapshot: ijson::to_value(&engine_snapshot)?,
                 };
                 rnote_file.save_as_bytes(&file_name)

--- a/crates/rnote-engine/src/engine/export.rs
+++ b/crates/rnote-engine/src/engine/export.rs
@@ -1,6 +1,6 @@
 // Imports
 use super::{Engine, EngineConfig, StrokeContent};
-use crate::fileformats::rnoteformat::RnoteFile;
+use crate::fileformats::rnoteformat::maj0min12::RnoteFileMaj0Min12;
 use crate::fileformats::{xoppformat, FileFormatSaver};
 use crate::CloneConfig;
 use anyhow::Context;
@@ -331,10 +331,7 @@ impl Engine {
         let engine_snapshot = self.take_snapshot();
         rayon::spawn(move || {
             let result = || -> anyhow::Result<Vec<u8>> {
-                let rnote_file = RnoteFile {
-                    header: RnoteHeader::default(),
-                    engine_snapshot: ijson::to_value(&engine_snapshot)?,
-                };
+                let rnote_file = RnoteFileMaj0Min12::try_from(engine_snapshot)?;
                 rnote_file.save_as_bytes(&file_name)
             };
             if oneshot_sender.send(result()).is_err() {

--- a/crates/rnote-engine/src/engine/snapshot.rs
+++ b/crates/rnote-engine/src/engine/snapshot.rs
@@ -51,7 +51,7 @@ impl EngineSnapshot {
             let result = || -> anyhow::Result<Self> {
                 let rnote_file = rnoteformat::RnoteFile::load_from_bytes(&bytes)
                     .context("loading RnoteFile from bytes failed.")?;
-                Ok(ijson::from_value(&rnote_file.engine_snapshot)?)
+                Ok(Self::try_from(rnote_file)?)
             };
 
             if let Err(_data) = snapshot_sender.send(result()) {

--- a/crates/rnote-engine/src/fileformats/rnoteformat/legacy.rs
+++ b/crates/rnote-engine/src/fileformats/rnoteformat/legacy.rs
@@ -1,0 +1,101 @@
+// Imports
+use super::maj0min5patch8::RnoteFileMaj0Min5Patch8;
+use super::maj0min5patch9::RnoteFileMaj0Min5Patch9;
+use super::maj0min6::RnoteFileMaj0Min6;
+use super::maj0min9::RnoteFileMaj0Min9;
+use super::FileFormatLoader;
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use std::io::Read;
+
+/// Decompress from gzip.
+fn decompress_from_gzip(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
+    // Optimization for the gzip format, defined by RFC 1952
+    // capacity of the vector defined by the size of the uncompressed data
+    // given in little endian format, by the last 4 bytes of "compressed"
+    //
+    //   ISIZE (Input SIZE)
+    //     This contains the size of the original (uncompressed) input data modulo 2^32.
+    let mut bytes: Vec<u8> = {
+        let mut decompressed_size: [u8; 4] = [0; 4];
+        let idx_start = compressed
+            .len()
+            .checked_sub(4)
+            // only happens if the file has less than 4 bytes
+            .ok_or(
+                anyhow::anyhow!("Not a valid gzip-compressed file")
+                    .context("Failed to get the size of the decompressed data"),
+            )?;
+        decompressed_size.copy_from_slice(&compressed[idx_start..]);
+        // u32 -> usize to avoid issues on 32-bit architectures
+        // also more reasonable since the uncompressed size is given by 4 bytes
+        Vec::with_capacity(u32::from_le_bytes(decompressed_size) as usize)
+    };
+
+    let mut decoder = flate2::read::MultiGzDecoder::new(compressed);
+    decoder.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+/// The rnote file wrapper.
+///
+/// Used to extract and match the version up front, before deserializing the data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename = "rnotefile_wrapper")]
+struct LegacyRnoteFileWrapper {
+    #[serde(rename = "version")]
+    version: semver::Version,
+    #[serde(rename = "data")]
+    data: ijson::IValue,
+}
+
+pub type LegacyRnoteFile = RnoteFileMaj0Min9;
+
+impl FileFormatLoader for LegacyRnoteFile {
+    fn load_from_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
+        let wrapper =
+            serde_json::from_slice::<LegacyRnoteFileWrapper>(&decompress_from_gzip(bytes)?)
+                .context("deserializing RnotefileWrapper from bytes failed.")?;
+
+        // Conversions for older file format versions happen here
+        if semver::VersionReq::parse(">=0.9.0")
+            .unwrap()
+            .matches(&wrapper.version)
+        {
+            ijson::from_value::<RnoteFileMaj0Min9>(&wrapper.data)
+                .context("deserializing RnoteFileMaj0Min9 failed.")
+        } else if semver::VersionReq::parse(">=0.5.10")
+            .unwrap()
+            .matches(&wrapper.version)
+        {
+            ijson::from_value::<RnoteFileMaj0Min6>(&wrapper.data)
+                .context("deserializing RnoteFileMaj0Min6 failed.")
+                .and_then(RnoteFileMaj0Min9::try_from)
+                .context("converting RnoteFileMaj0Min6 to newest file version failed.")
+        } else if semver::VersionReq::parse(">=0.5.9")
+            .unwrap()
+            .matches(&wrapper.version)
+        {
+            ijson::from_value::<RnoteFileMaj0Min5Patch9>(&wrapper.data)
+                .context("deserializing RnoteFileMaj0Min5Patch9 failed.")
+                .and_then(RnoteFileMaj0Min6::try_from)
+                .and_then(RnoteFileMaj0Min9::try_from)
+                .context("converting RnoteFileMaj0Min5Patch9 to newest file version failed.")
+        } else if semver::VersionReq::parse(">=0.5.0")
+            .unwrap()
+            .matches(&wrapper.version)
+        {
+            ijson::from_value::<RnoteFileMaj0Min5Patch8>(&wrapper.data)
+                .context("deserializing RnoteFileMaj0Min5Patch8 failed")
+                .and_then(RnoteFileMaj0Min5Patch9::try_from)
+                .and_then(RnoteFileMaj0Min6::try_from)
+                .and_then(RnoteFileMaj0Min9::try_from)
+                .context("converting RnoteFileMaj0Min5Patch8 to newest file version failed.")
+        } else {
+            Err(anyhow::anyhow!(
+                "failed to load rnote file from bytes, unsupported version: {}.",
+                wrapper.version
+            ))
+        }
+    }
+}

--- a/crates/rnote-engine/src/fileformats/rnoteformat/maj0min12.rs
+++ b/crates/rnote-engine/src/fileformats/rnoteformat/maj0min12.rs
@@ -1,0 +1,47 @@
+use super::{maj0min9::RnoteFileMaj0Min9, CompressionMethods, SerializationMethods};
+use serde::{Deserialize, Serialize};
+
+/// ## Rnote 0.12.0 format
+/// ### rnote magic number
+/// [u8; 9] "RNOTEϕλ""
+/// ### version
+/// [u8; 3] [major, minor, patch]
+/// ### header size
+/// size of the json-encoded header, represented by two bytes, little endian
+/// [u8; 2]
+/// ### header
+/// describes how to decompress and deserialize the data
+/// ### data
+/// serialized and compressed engine snapshot
+#[derive(Debug, Clone)]
+pub struct RnoteFileMaj0Min12 {
+    pub header: RnoteHeaderMaj0Min12,
+    /// A compressed and serialized snapshot of the engine.
+    pub engine_snapshot: Vec<u8>,
+}
+
+impl RnoteFileMaj0Min12 {
+    // "RNOTEΦΛ"
+    pub const MAGIC_NUMBER: [u8; 9] = [0x52, 0x4e, 0x4f, 0x54, 0x45, 0xce, 0xa6, 0xce, 0x9b];
+    pub const VERSION: [u8; 3] = [0, 12, 0];
+}
+
+impl From<RnoteFileMaj0Min9> for RnoteFileMaj0Min12 {
+    fn from(value: RnoteFileMaj0Min9) -> Self {
+        Self {
+            header: RnoteHeaderMaj0Min12 {
+                serialization: SerializationMethods::Json,
+                compression: CompressionMethods::None,
+                size: 0,
+            },
+            engine_snapshot: serde_json::to_vec(&value.engine_snapshot)?,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RnoteHeaderMaj0Min12 {
+    pub serialization: SerializationMethods,
+    pub compression: CompressionMethods,
+    pub size: u64,
+}

--- a/crates/rnote-engine/src/fileformats/rnoteformat/maj0min12.rs
+++ b/crates/rnote-engine/src/fileformats/rnoteformat/maj0min12.rs
@@ -26,16 +26,17 @@ impl RnoteFileMaj0Min12 {
     pub const VERSION: [u8; 3] = [0, 12, 0];
 }
 
-impl From<RnoteFileMaj0Min9> for RnoteFileMaj0Min12 {
-    fn from(value: RnoteFileMaj0Min9) -> Self {
-        Self {
+impl TryFrom<RnoteFileMaj0Min9> for RnoteFileMaj0Min12 {
+    type Error = anyhow::Error;
+    fn try_from(value: RnoteFileMaj0Min9) -> Result<Self, Self::Error> {
+        Ok(Self {
             header: RnoteHeaderMaj0Min12 {
                 serialization: SerializationMethods::Json,
                 compression: CompressionMethods::None,
                 size: 0,
             },
             engine_snapshot: serde_json::to_vec(&value.engine_snapshot)?,
-        }
+        })
     }
 }
 

--- a/crates/rnote-engine/src/fileformats/rnoteformat/mod.rs
+++ b/crates/rnote-engine/src/fileformats/rnoteformat/mod.rs
@@ -6,125 +6,50 @@
 //! Then [TryFrom] can be implemented to allow conversions and chaining from older to newer versions.
 
 // Modules
+pub(crate) mod legacy;
+pub(crate) mod maj0min12;
 pub(crate) mod maj0min5patch8;
 pub(crate) mod maj0min5patch9;
 pub(crate) mod maj0min6;
 pub(crate) mod maj0min9;
 
-// Imports
-use self::maj0min5patch8::RnoteFileMaj0Min5Patch8;
-use self::maj0min5patch9::RnoteFileMaj0Min5Patch9;
-use self::maj0min6::RnoteFileMaj0Min6;
-use self::maj0min9::RnoteFileMaj0Min9;
+use crate::engine::EngineSnapshot;
+
 use super::{FileFormatLoader, FileFormatSaver};
-use anyhow::Context;
+use legacy::LegacyRnoteFile;
 use serde::{Deserialize, Serialize};
-use std::io::{Read, Write};
+use std::{
+    io::{Read, Write},
+    usize,
+};
 
-/// Decompress from gzip.
-fn decompress_from_gzip(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
-    // Optimization for the gzip format, defined by RFC 1952
-    // capacity of the vector defined by the size of the uncompressed data
-    // given in little endian format, by the last 4 bytes of "compressed"
-    //
-    //   ISIZE (Input SIZE)
-    //     This contains the size of the original (uncompressed) input data modulo 2^32.
-    let mut bytes: Vec<u8> = {
-        let mut decompressed_size: [u8; 4] = [0; 4];
-        let idx_start = compressed
-            .len()
-            .checked_sub(4)
-            // only happens if the file has less than 4 bytes
-            .ok_or(
-                anyhow::anyhow!("Not a valid gzip-compressed file")
-                    .context("Failed to get the size of the decompressed data"),
-            )?;
-        decompressed_size.copy_from_slice(&compressed[idx_start..]);
-        // u32 -> usize to avoid issues on 32-bit architectures
-        // also more reasonable since the uncompressed size is given by 4 bytes
-        Vec::with_capacity(u32::from_le_bytes(decompressed_size) as usize)
-    };
-
-    let mut decoder = flate2::read::MultiGzDecoder::new(compressed);
-    decoder.read_to_end(&mut bytes)?;
-    Ok(bytes)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CompressionMethods {
+    None,
+    Gzip,
+    Zstd,
 }
 
-/// Decompress bytes with zstd
-pub fn decompress_from_zstd(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
-    // Optimization for the zstd format, less pretty than for gzip but this does shave off a bit of time
-    // https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#frame_header
-    let mut bytes: Vec<u8> = {
-        let frame_header_descriptor = compressed.get(4).ok_or(
-            anyhow::anyhow!("Not a valid zstd-compressed file")
-                .context("Failed to get the frame header descriptor of the file"),
-        )?;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SerializationMethods {
+    Bincode,
+    Json,
+}
 
-        let frame_content_size_flag = frame_header_descriptor >> 6;
-        let single_segment_flag = (frame_header_descriptor >> 5) & 1;
-        let did_field_size = {
-            let dictionary_id_flag = frame_header_descriptor & 11;
-            if dictionary_id_flag == 3 {
-                4
-            } else {
-                dictionary_id_flag
-            }
-        };
-        // frame header size start index
-        let fcs_sidx = (6 + did_field_size - single_segment_flag) as usize;
-        // magic number: 4 bytes + window descriptor: 1 byte if single segment flag is not set + frame header descriptor: 1 byte + dict. field size: 0-4 bytes
-        // testing suggests that dicts. don't improve the compression ratio and worsen writing/reading speeds, therefore they won't be used
-        // thus this part could be simplified, but wouldn't strictly adhere to zstd standards
+/// Compress bytes with gzip.
+fn compress_to_gzip(to_compress: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
+    let mut encoder = flate2::write::GzEncoder::new(Vec::<u8>::new(), flate2::Compression::new(5));
+    encoder.write_all(to_compress)?;
+    Ok(encoder.finish()?)
+}
 
-        match frame_content_size_flag {
-            // not worth it to potentially pre-allocate a maximum of 255 bytes
-            0 => Vec::new(),
-            1 => {
-                let mut decompressed_size: [u8; 2] = [0; 2];
-                decompressed_size.copy_from_slice(
-                    compressed.get(fcs_sidx..fcs_sidx + 2).ok_or(
-                        anyhow::anyhow!("Not a valid zstd-compressed file").context(
-                            "Failed to get the uncompressed size of the data from two bytes",
-                        ),
-                    )?,
-                );
-                // 256 offset
-                Vec::with_capacity(usize::from(256 + u16::from_le_bytes(decompressed_size)))
-            }
-            2 => {
-                let mut decompressed_size: [u8; 4] = [0; 4];
-                decompressed_size.copy_from_slice(
-                    compressed.get(fcs_sidx..fcs_sidx + 4).ok_or(
-                        anyhow::anyhow!("Not a valid zstd-compressed file").context(
-                            "Failed to get the uncompressed size of the data from four bytes",
-                        ),
-                    )?,
-                );
-                Vec::with_capacity(
-                    u32::from_le_bytes(decompressed_size)
-                        .try_into()
-                        .unwrap_or(usize::MAX),
-                )
-            }
-            // in practice this should not happen, as a rnote file being larger than 4 GiB is very unlikely
-            3 => {
-                let mut decompressed_size: [u8; 8] = [0; 8];
-                decompressed_size.copy_from_slice(compressed.get(fcs_sidx..fcs_sidx + 8).ok_or(
-                    anyhow::anyhow!("Not a valid zstd-compressed file").context(
-                        "Failed to get the uncompressed size of the data from eight bytes",
-                    ),
-                )?);
-                Vec::with_capacity(
-                    u64::from_le_bytes(decompressed_size)
-                        .try_into()
-                        .unwrap_or(usize::MAX),
-                )
-            }
-            // unreachable since our u8 is formed by only 2 bits
-            4.. => unreachable!(),
-        }
-    };
-    let mut decoder = zstd::Decoder::new(compressed)?;
+/// Decompress from gzip.
+fn decompress_from_gzip(
+    compressed: &[u8],
+    uncompressed_siez: usize,
+) -> Result<Vec<u8>, anyhow::Error> {
+    let mut bytes: Vec<u8> = Vec::with_capacity(uncompressed_siez);
+    let mut decoder = flate2::read::MultiGzDecoder::new(compressed);
     decoder.read_to_end(&mut bytes)?;
     Ok(bytes)
 }
@@ -132,8 +57,6 @@ pub fn decompress_from_zstd(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error>
 /// Compress bytes with zstd
 pub fn compress_to_zstd(to_compress: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
     let mut encoder = zstd::Encoder::new(Vec::<u8>::new(), 9)?;
-    encoder.set_pledged_src_size(Some(to_compress.len() as u64))?;
-    encoder.include_contentsize(true)?;
     if let Ok(num_workers) = std::thread::available_parallelism() {
         encoder.multithread(num_workers.get() as u32)?;
     }
@@ -141,99 +64,104 @@ pub fn compress_to_zstd(to_compress: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
     Ok(encoder.finish()?)
 }
 
-/// The rnote file wrapper.
-///
-/// Used to extract and match the version up front, before deserializing the data.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename = "rnotefile_wrapper")]
-struct RnotefileWrapper {
-    #[serde(rename = "version")]
-    version: semver::Version,
-    #[serde(rename = "data")]
-    data: ijson::IValue,
+/// Decompress bytes with zstd
+pub fn decompress_from_zstd(
+    compressed: &[u8],
+    uncompressed_siez: usize,
+) -> Result<Vec<u8>, anyhow::Error> {
+    let mut bytes: Vec<u8> = Vec::with_capacity(uncompressed_siez);
+    let mut decoder = zstd::Decoder::new(compressed)?;
+    decoder.read_to_end(&mut bytes)?;
+    Ok(bytes)
 }
 
-/// The Rnote file in the newest format version.
-///
-/// This struct exists to allow for upgrading older versions before loading the file in.
-pub type RnoteFile = RnoteFileMaj0Min9;
-
-impl RnoteFile {
-    pub const SEMVER: &'static str = crate::utils::crate_version();
-}
-
-impl FileFormatLoader for RnoteFile {
-    fn load_from_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
-        let wrapper = serde_json::from_slice::<RnotefileWrapper>(&{
-            // zstd magic number
-            if bytes.starts_with(&[0x28, 0xb5, 0x2f, 0xfd]) {
-                decompress_from_zstd(bytes)?
-            }
-            // gzip ID1 and ID2
-            else if bytes.starts_with(&[0x1f, 0x8b]) {
-                decompress_from_gzip(bytes)?
-            } else {
-                Err(anyhow::anyhow!(
-                    "Unknown compression format, expected zstd or gzip"
-                ))?
-            }
-        })
-        .context("deserializing RnotefileWrapper from bytes failed.")?;
-
-        // Conversions for older file format versions happen here
-        if semver::VersionReq::parse(">=0.9.0")
-            .unwrap()
-            .matches(&wrapper.version)
-        {
-            ijson::from_value::<RnoteFileMaj0Min9>(&wrapper.data)
-                .context("deserializing RnoteFileMaj0Min9 failed.")
-        } else if semver::VersionReq::parse(">=0.5.10")
-            .unwrap()
-            .matches(&wrapper.version)
-        {
-            ijson::from_value::<RnoteFileMaj0Min6>(&wrapper.data)
-                .context("deserializing RnoteFileMaj0Min6 failed.")
-                .and_then(RnoteFileMaj0Min9::try_from)
-                .context("converting RnoteFileMaj0Min6 to newest file version failed.")
-        } else if semver::VersionReq::parse(">=0.5.9")
-            .unwrap()
-            .matches(&wrapper.version)
-        {
-            ijson::from_value::<RnoteFileMaj0Min5Patch9>(&wrapper.data)
-                .context("deserializing RnoteFileMaj0Min5Patch9 failed.")
-                .and_then(RnoteFileMaj0Min6::try_from)
-                .and_then(RnoteFileMaj0Min9::try_from)
-                .context("converting RnoteFileMaj0Min5Patch9 to newest file version failed.")
-        } else if semver::VersionReq::parse(">=0.5.0")
-            .unwrap()
-            .matches(&wrapper.version)
-        {
-            ijson::from_value::<RnoteFileMaj0Min5Patch8>(&wrapper.data)
-                .context("deserializing RnoteFileMaj0Min5Patch8 failed")
-                .and_then(RnoteFileMaj0Min5Patch9::try_from)
-                .and_then(RnoteFileMaj0Min6::try_from)
-                .and_then(RnoteFileMaj0Min9::try_from)
-                .context("converting RnoteFileMaj0Min5Patch8 to newest file version failed.")
-        } else {
-            Err(anyhow::anyhow!(
-                "failed to load rnote file from bytes, unsupported version: {}.",
-                wrapper.version
-            ))
-        }
-    }
-}
+pub type RnoteFile = maj0min12::RnoteFileMaj0Min12;
 
 impl FileFormatSaver for RnoteFile {
     fn save_as_bytes(&self, _file_name: &str) -> anyhow::Result<Vec<u8>> {
-        let wrapper = RnotefileWrapper {
-            version: semver::Version::parse(Self::SEMVER).unwrap(),
-            data: ijson::to_value(self).context("converting RnoteFile to JSON value failed.")?,
-        };
-        let compressed = compress_to_zstd(
-            &serde_json::to_vec(&wrapper).context("Serializing RnoteFileWrapper failed.")?,
-        )
-        .context("compressing bytes failed.")?;
+        let json_header = serde_json::to_vec(&self.header)?;
+        let header = [
+            &Self::MAGIC_NUMBER[..],
+            &Self::VERSION[..],
+            &u16::try_from(json_header.len())?.to_le_bytes(),
+            &json_header,
+        ]
+        .concat();
+        let mut buffer: Vec<u8> = Vec::new();
+        buffer.write_all(&header)?;
+        buffer.write_all(&self.engine_snapshot)?;
+        Ok(buffer)
+    }
+}
 
-        Ok(compressed)
+impl FileFormatLoader for RnoteFile {
+    fn load_from_bytes(bytes: &[u8]) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        let magic_number = bytes
+            .get(..9)
+            .ok_or(anyhow::anyhow!("Failed to get magic number"))?;
+
+        if magic_number != Self::MAGIC_NUMBER {
+            if magic_number[..2] == [0x1f, 0x8b] {
+                return Ok(RnoteFile::from(LegacyRnoteFile::load_from_bytes(bytes)?));
+            } else {
+                Err(anyhow::anyhow!("Unkown file"))?;
+            }
+        }
+
+        let mut version: [u8; 3] = [0; 3];
+        version.copy_from_slice(
+            bytes
+                .get(9..12)
+                .ok_or(anyhow::anyhow!("Failed to get version"))?,
+        );
+
+        let mut header_size: [u8; 2] = [0; 2];
+        header_size.copy_from_slice(
+            bytes
+                .get(12..14)
+                .ok_or(anyhow::anyhow!("Failed to get header size"))?,
+        );
+        let header_size = u16::from_le_bytes(header_size);
+
+        let header_slice = bytes
+            .get(14..14 + header_size as usize)
+            .ok_or(anyhow::anyhow!("Missing header"))?;
+
+        let body_slice = bytes
+            .get(14 + header_size as usize..)
+            .ok_or(anyhow::anyhow!("Missing body"))?;
+
+        Ok(Self {
+            header: serde_json::from_slice(header_slice)?,
+            engine_snapshot: body_slice.to_vec(),
+        })
+    }
+}
+
+impl TryFrom<RnoteFile> for EngineSnapshot {
+    type Error = anyhow::Error;
+
+    fn try_from(value: RnoteFile) -> Result<Self, Self::Error> {
+        let uncompressed = match value.header.compression {
+            CompressionMethods::None => value.engine_snapshot,
+            CompressionMethods::Gzip => decompress_from_gzip(
+                &value.engine_snapshot,
+                usize::try_from(value.header.size).unwrap_or(usize::MAX),
+            )?,
+            CompressionMethods::Zstd => decompress_from_zstd(
+                &value.engine_snapshot,
+                usize::try_from(value.header.size).unwrap_or(usize::MAX),
+            )?,
+        };
+
+        match value.header.serialization {
+            SerializationMethods::Json => Ok(ijson::from_value(&serde_json::from_slice::<
+                ijson::IValue,
+            >(&uncompressed)?)?),
+            SerializationMethods::Bincode => unreachable!(),
+        }
     }
 }

--- a/crates/rnote-engine/src/fileformats/rnoteformat/mod.rs
+++ b/crates/rnote-engine/src/fileformats/rnoteformat/mod.rs
@@ -42,10 +42,10 @@ fn decompress_from_gzip(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
             .len()
             .checked_sub(4)
             // only happens if the file has less than 4 bytes
-            .ok_or_else(|| {
-                anyhow::anyhow!("Invalid file")
-                    .context("Failed to get the size of the decompressed data")
-            })?;
+            .ok_or(
+                anyhow::anyhow!("Not a valid gzip-compressed file")
+                    .context("Failed to get the size of the decompressed data"),
+            )?;
         decompressed_size.copy_from_slice(&compressed[idx_start..]);
         // u32 -> usize to avoid issues on 32-bit architectures
         // also more reasonable since the uncompressed size is given by 4 bytes
@@ -55,6 +55,96 @@ fn decompress_from_gzip(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
     let mut decoder = flate2::read::MultiGzDecoder::new(compressed);
     decoder.read_to_end(&mut bytes)?;
     Ok(bytes)
+}
+
+/// Decompress bytes with zstd
+pub fn decompress_from_zstd(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
+    // Optimization for the zstd format, less pretty than for gzip but this does shave off a bit of time
+    // https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#frame_header
+    let mut bytes: Vec<u8> = {
+        let frame_header_descriptor = compressed.get(4).ok_or(
+            anyhow::anyhow!("Not a valid zstd-compressed file")
+                .context("Failed to get the frame header descriptor of the file"),
+        )?;
+
+        let frame_content_size_flag = frame_header_descriptor >> 6;
+        let single_segment_flag = (frame_header_descriptor >> 5) & 1;
+        let did_field_size = {
+            let dictionary_id_flag = frame_header_descriptor & 11;
+            if dictionary_id_flag == 3 {
+                4
+            } else {
+                dictionary_id_flag
+            }
+        };
+        // frame header size start index
+        let fcs_sidx = (6 + did_field_size - single_segment_flag) as usize;
+        // magic number: 4 bytes + window descriptor: 1 byte if single segment flag is not set + frame header descriptor: 1 byte + dict. field size: 0-4 bytes
+        // testing suggests that dicts. don't improve the compression ratio and worsen writing/reading speeds, therefore they won't be used
+        // thus this part could be simplified, but wouldn't strictly adhere to zstd standards
+
+        match frame_content_size_flag {
+            // not worth it to potentially pre-allocate a maximum of 255 bytes
+            0 => Vec::new(),
+            1 => {
+                let mut decompressed_size: [u8; 2] = [0; 2];
+                decompressed_size.copy_from_slice(
+                    compressed.get(fcs_sidx..fcs_sidx + 2).ok_or(
+                        anyhow::anyhow!("Not a valid zstd-compressed file").context(
+                            "Failed to get the uncompressed size of the data from two bytes",
+                        ),
+                    )?,
+                );
+                Vec::with_capacity(usize::from(256 + u16::from_le_bytes(decompressed_size)))
+            }
+            2 => {
+                let mut decompressed_size: [u8; 4] = [0; 4];
+                decompressed_size.copy_from_slice(
+                    compressed.get(fcs_sidx..fcs_sidx + 4).ok_or(
+                        anyhow::anyhow!("Not a valid zstd-compressed file").context(
+                            "Failed to get the uncompressed size of the data from four bytes",
+                        ),
+                    )?,
+                );
+                Vec::with_capacity(
+                    u32::from_le_bytes(decompressed_size)
+                        .try_into()
+                        .unwrap_or(usize::MAX),
+                )
+            }
+            // in practice this should not happen, as a rnote file being larger than 4 GiB is very unlikely
+            3 => {
+                let mut decompressed_size: [u8; 8] = [0; 8];
+                decompressed_size.copy_from_slice(compressed.get(fcs_sidx..fcs_sidx + 8).ok_or(
+                    anyhow::anyhow!("Not a valid zstd-compressed file").context(
+                        "Failed to get the uncompressed size of the data from eight bytes",
+                    ),
+                )?);
+                Vec::with_capacity(
+                    u64::from_le_bytes(decompressed_size)
+                        .try_into()
+                        .unwrap_or(usize::MAX),
+                )
+            }
+            // unreachable since our u8 is formed by only 2 bits
+            4.. => unreachable!(),
+        }
+    };
+    let mut decoder = zstd::Decoder::new(compressed)?;
+    decoder.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+/// Compress bytes with zstd
+pub fn compress_to_zstd(to_compress: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
+    let mut encoder = zstd::Encoder::new(Vec::<u8>::new(), 9)?;
+    encoder.set_pledged_src_size(Some(to_compress.len() as u64))?;
+    encoder.include_contentsize(true)?;
+    if let Ok(num_workers) = std::thread::available_parallelism() {
+        encoder.multithread(num_workers.get() as u32)?;
+    }
+    encoder.write_all(to_compress)?;
+    Ok(encoder.finish()?)
 }
 
 /// The rnote file wrapper.


### PR DESCRIPTION
## proposal
![Untitled-2024-08-14-1317](https://github.com/user-attachments/assets/048add4a-5cd6-4acc-b44b-347eb4f93944)


## todo

- [ ] agree on a format standard
- [ ] implement proper forward-compatibility
- [ ] configuration
- [ ] conversions to alternative save

https://github.com/flxzt/rnote/issues/1173

