### PR TITLE
Remove unmaintained "atty" crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,17 +301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,15 +1624,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -3311,7 +3291,6 @@ name = "rnote-cli"
 version = "0.11.0"
 dependencies = [
  "anyhow",
- "atty",
  "clap",
  "dialoguer",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ adw = { version = "0.6.0", package = "libadwaita", features = ["v1_5"] }
 anyhow = "1.0"
 approx = "0.5.1"
 async-fs = "2.1"
-atty = "0.2.14"
 base64 = "0.22.1"
 cairo-rs = { version = "0.19.4", features = ["v1_18", "png", "svg", "pdf"] }
 chrono = "0.4.38"

--- a/crates/rnote-cli/Cargo.toml
+++ b/crates/rnote-cli/Cargo.toml
@@ -13,7 +13,6 @@ rnote-compose = { workspace = true, features = ["clap-derive"] }
 rnote-engine = { workspace = true, features = ["cli"] }
 
 anyhow = { workspace = true }
-atty = { workspace = true }
 clap = { workspace = true }
 dialoguer = { workspace = true }
 indicatif = { workspace = true }

--- a/crates/rnote-cli/src/export.rs
+++ b/crates/rnote-cli/src/export.rs
@@ -10,8 +10,8 @@ use rnote_engine::engine::export::{
 };
 use rnote_engine::engine::EngineSnapshot;
 use rnote_engine::{Engine, SelectionCollision};
-use std::path::{Path, PathBuf};
 use std::io::{self, IsTerminal};
+use std::path::{Path, PathBuf};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_export(

--- a/crates/rnote-cli/src/export.rs
+++ b/crates/rnote-cli/src/export.rs
@@ -11,6 +11,7 @@ use rnote_engine::engine::export::{
 use rnote_engine::engine::EngineSnapshot;
 use rnote_engine::{Engine, SelectionCollision};
 use std::path::{Path, PathBuf};
+use std::io::{self, IsTerminal};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_export(
@@ -427,7 +428,7 @@ pub(crate) fn file_conflict_prompt_action(
     if !output_file.exists() {
         return Ok(None);
     }
-    if atty::isnt(atty::Stream::Stdout) {
+    if !io::stdout().is_terminal() {
         return Err(anyhow::anyhow!(
             "File conflict for file \"{}\" detected and terminal is not interactive. Option \"--on-conflict\" needs to be supplied.", output_file.display()
         ));


### PR DESCRIPTION
I was trying to see if I can get to the bottom of #1063 when I saw the security advisory for the dependency atty which has an (arguably harmless) open [vulnerability](https://rustsec.org/advisories/RUSTSEC-2021-0145.html). Since it is only used a single time and the functionality is available natively in Rust since 1.70 (which Rnote has been using for a while) I quickly got rid of it.