### PR TITLE
Add confirmation prompt to deletion action

### DIFF
--- a/crates/rnote-ui/data/ui/dialogs/dialogs.ui
+++ b/crates/rnote-ui/data/ui/dialogs/dialogs.ui
@@ -206,7 +206,7 @@ Changes which are not saved will be permanently lost.</property>
 
   <object class="AdwAlertDialog" id="dialog_trash_file">
     <property name="heading" translatable="yes">Trash File</property>
-    <property name="body" translatable="yes">Are you sure you want to delete this file?</property>
+    <property name="body" translatable="yes">Are you sure you want to move this file to the trash?</property>
     <property name="default-response">cancel</property>
     <property name="close-response">cancel</property>
     <responses>

--- a/crates/rnote-ui/data/ui/dialogs/dialogs.ui
+++ b/crates/rnote-ui/data/ui/dialogs/dialogs.ui
@@ -207,7 +207,7 @@ Changes which are not saved will be permanently lost.</property>
   <object class="AdwAlertDialog" id="dialog_trash_file">
     <property name="heading" translatable="yes">Trash File</property>
     <property name="body" translatable="yes">Are you sure you want to delete this file?</property>
-    <property name="default-response">trash</property>
+    <property name="default-response">cancel</property>
     <property name="close-response">cancel</property>
     <responses>
       <response id="cancel" translatable="yes">Cancel</response>

--- a/crates/rnote-ui/data/ui/dialogs/dialogs.ui
+++ b/crates/rnote-ui/data/ui/dialogs/dialogs.ui
@@ -203,4 +203,15 @@ Changes which are not saved will be permanently lost.</property>
       <object class="RnIconPicker" id="edit_selected_workspace_icon_picker"></object>
     </child>
   </object>
+
+  <object class="AdwAlertDialog" id="dialog_trash_file">
+    <property name="heading" translatable="yes">Trash File</property>
+    <property name="body" translatable="yes">Are you sure you want to delete this file?</property>
+    <property name="default-response">trash</property>
+    <property name="close-response">cancel</property>
+    <responses>
+      <response id="cancel" translatable="yes">Cancel</response>
+      <response id="trash" appearance="destructive" translatable="yes">Trash</response>
+    </responses>
+  </object>
 </interface>

--- a/crates/rnote-ui/src/dialogs/mod.rs
+++ b/crates/rnote-ui/src/dialogs/mod.rs
@@ -560,11 +560,11 @@ pub(crate) async fn dialog_trash_file(appwindow: &RnAppWindow, current_file: &gi
 
     match dialog.choose_future(appwindow).await.as_str() {
         "trash" => {
-            glib::spawn_future_local(clone!(@strong current_file, @weak appwindow => async move {
+            glib::spawn_future_local(clone!(@weak appwindow, @strong current_file => async move {
                 current_file.trash_async(
                     glib::source::Priority::DEFAULT,
                     None::<&gio::Cancellable>,
-                    clone!(@strong current_file, @strong current_file => move |res| {
+                    clone!(@weak appwindow, @strong current_file => move |res| {
                         if let Err(e) = res {
                             appwindow.overlays().dispatch_toast_error(&gettext("Trashing file failed"));
                             error!("Trash filerow file `{current_file:?}` failed , Err: {e:?}");

--- a/crates/rnote-ui/src/dialogs/mod.rs
+++ b/crates/rnote-ui/src/dialogs/mod.rs
@@ -567,7 +567,7 @@ pub(crate) async fn dialog_trash_file(appwindow: &RnAppWindow, current_file: &gi
                     clone!(@strong current_file, @strong current_file => move |res| {
                         if let Err(e) = res {
                             appwindow.overlays().dispatch_toast_error(&gettext("Trashing file failed"));
-                            debug!("Trash filerow file `{current_file:?}` failed , Err: {e:?}");
+                            error!("Trash filerow file `{current_file:?}` failed , Err: {e:?}");
                             return;
                         }
                     }),

--- a/crates/rnote-ui/src/dialogs/mod.rs
+++ b/crates/rnote-ui/src/dialogs/mod.rs
@@ -553,7 +553,7 @@ pub(crate) async fn dialog_edit_selected_workspace(appwindow: &RnAppWindow) {
     dialog.present(appwindow);
 }
 
-pub(crate) async fn dialog_trash_file(appwindow: &'static RnAppWindow, filerow: &RnFileRow) -> () {
+pub(crate) async fn dialog_trash_file(appwindow: &RnAppWindow, filerow: &RnFileRow) -> () {
     let builder = Builder::from_resource(
         (String::from(config::APP_IDPATH) + "ui/dialogs/dialogs.ui").as_str(),
     );

--- a/crates/rnote-ui/src/workspacebrowser/filerow/actions/trash.rs
+++ b/crates/rnote-ui/src/workspacebrowser/filerow/actions/trash.rs
@@ -1,28 +1,15 @@
 // Imports
-use crate::workspacebrowser::RnFileRow;
 use crate::RnAppWindow;
-use gettextrs::gettext;
-use gtk4::{gio, glib, glib::clone, prelude::FileExt};
-use tracing::debug;
+use crate::{dialogs, workspacebrowser::RnFileRow};
+use gtk4::{gio, glib, glib::clone};
 
 /// Create a new `trash` action.
 pub(crate) fn trash(filerow: &RnFileRow, appwindow: &RnAppWindow) -> gio::SimpleAction {
     let action = gio::SimpleAction::new("trash-file", None);
     action.connect_activate(
         clone!(@weak filerow, @weak appwindow => move |_action_trash_file, _| {
-            let Some(current_file) = filerow.current_file() else {
-                return;
-            };
-            current_file.trash_async(
-                glib::source::Priority::DEFAULT,
-                None::<&gio::Cancellable>,
-                clone!(@weak filerow, @strong current_file => move |res| {
-                if let Err(e) = res {
-                    appwindow.overlays().dispatch_toast_error(&gettext("Trashing file failed"));
-                    debug!("Trash filerow file `{current_file:?}` failed , Err: {e:?}");
-                    return;
-                }
-                filerow.set_current_file(None);
+            glib::spawn_future_local(clone!(@weak appwindow => async move {
+                dialogs::dialog_trash_file(&appwindow, &filerow).await;
             }));
         }),
     );

--- a/crates/rnote-ui/src/workspacebrowser/filerow/actions/trash.rs
+++ b/crates/rnote-ui/src/workspacebrowser/filerow/actions/trash.rs
@@ -7,9 +7,13 @@ use gtk4::{gio, glib, glib::clone};
 pub(crate) fn trash(filerow: &RnFileRow, appwindow: &RnAppWindow) -> gio::SimpleAction {
     let action = gio::SimpleAction::new("trash-file", None);
     action.connect_activate(clone!(@weak appwindow, @weak filerow => move |_, _| {
-        glib::spawn_future_local(clone!(@weak appwindow, @weak filerow => async move {
-            dialogs::dialog_trash_file(&appwindow, &filerow).await;
+        let Some(current_file) = filerow.current_file() else {
+            return;
+        };
+        glib::spawn_future_local(clone!(@weak appwindow, @strong current_file => async move {
+            dialogs::dialog_trash_file(&appwindow, &current_file).await;
         }));
+        filerow.set_current_file(None);
     }));
     action
 }

--- a/crates/rnote-ui/src/workspacebrowser/filerow/actions/trash.rs
+++ b/crates/rnote-ui/src/workspacebrowser/filerow/actions/trash.rs
@@ -6,12 +6,10 @@ use gtk4::{gio, glib, glib::clone};
 /// Create a new `trash` action.
 pub(crate) fn trash(filerow: &RnFileRow, appwindow: &RnAppWindow) -> gio::SimpleAction {
     let action = gio::SimpleAction::new("trash-file", None);
-    action.connect_activate(
-        clone!(@weak filerow, @weak appwindow => move |_action_trash_file, _| {
-            glib::spawn_future_local(clone!(@weak appwindow => async move {
-                dialogs::dialog_trash_file(&appwindow, &filerow).await;
-            }));
-        }),
-    );
+    action.connect_activate(clone!(@weak appwindow, @weak filerow => move |_, _| {
+        glib::spawn_future_local(clone!(@weak appwindow, @weak filerow => async move {
+            dialogs::dialog_trash_file(&appwindow, &filerow).await;
+        }));
+    }));
     action
 }


### PR DESCRIPTION
This is my WIP attempt to resolve #1136, but it isn't working at the moment. Clearly, I don't understand Rust and the whole borrowing logic enough for me to resolve this at the moment. I tried many different things but can't get the logic "Rusty" enough. At the moment, the issue is that the `&appwindow` reference in trash.rs doesn't live long enough. I tried creating a clone, among other things, but that didn't help either.

Other than that, I tried to copy the style of the other dialogues as much as possible to keep the whole architectural idea the same.

I'll keep working on this sometime, but in the meantime, if someone knows how to properly do this, feel free to point me in the right direction or open a PR.