### PR TITLE
Export selection potential fix

### DIFF
--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -853,47 +853,51 @@ pub(crate) async fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, can
     export_selection_button_confirm.connect_clicked(clone!(@weak selected_file, @weak dialog, @weak canvas, @weak appwindow => move |_| {
         dialog.close();
 
-        glib::spawn_future_local(clone!(@weak selected_file, @weak canvas, @weak appwindow => async move {
-            let Some(file) = selected_file.take() else {
-                appwindow
-                    .overlays()
-                    .dispatch_toast_error(&gettext("Exporting selection failed, no file selected"));
-                return;
-            };
-            appwindow.overlays().progressbar_start_pulsing();
+        if let Some(file) = selected_file.take() {
+            debug!("calling `spawn_future_local`");
+            glib::spawn_future_local(clone!(@weak canvas, @weak appwindow => async move {
+                appwindow.overlays().progressbar_start_pulsing();
+                debug!("Exporting the selection");
 
-            if let Err(e) = canvas.export_selection(&file, None).await {
-                error!("Exporting selection failed, Err: {e:?}");
 
-                appwindow
-                    .overlays()
-                    .dispatch_toast_error(&gettext("Exporting selection failed"));
-                appwindow.overlays().progressbar_abort();
-            } else {
-                appwindow.overlays().dispatch_toast_w_button(
-                    &gettext("Exported selection successfully"),
-                    &gettext("View in file manager"),
-                    clone!(@weak canvas, @weak appwindow => move |_reload_toast| {
-                                let Some(folder_path_string) = file
-                                    .parent()
-                                    .and_then(|p|
-                                        p.path())
-                                    .and_then(|p| p.into_os_string().into_string().ok()) else {
-                                        error!("Failed to get the parent folder of the output file `{file:?}.");
-                                        appwindow.overlays().dispatch_toast_error(&gettext("Exporting document failed"));
-                                        return;
-                                };
+                if let Err(e) = canvas.export_selection(&file, None).await {
+                    error!("Exporting selection failed, Err: {e:?}");
 
-                                if let Err(e) = open::that(&folder_path_string) {
-                                    error!("Opening the parent folder '{folder_path_string}' in the file manager failed, Err: {e:?}");
-                                    appwindow.overlays().dispatch_toast_error(&gettext("Failed to open the file in the file manager"));
-                                }
-                    }),
-                    crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT,
-                );
-                appwindow.overlays().progressbar_finish();
-            }
-            }));
+                    appwindow
+                        .overlays()
+                        .dispatch_toast_error(&gettext("Exporting selection failed"));
+                    appwindow.overlays().progressbar_abort();
+                } else {
+                    appwindow.overlays().dispatch_toast_w_button(
+                        &gettext("Exported selection successfully"),
+                        &gettext("View in file manager"),
+                        clone!(@weak canvas, @weak appwindow => move |_reload_toast| {
+                                    let Some(folder_path_string) = file
+                                        .parent()
+                                        .and_then(|p|
+                                            p.path())
+                                        .and_then(|p| p.into_os_string().into_string().ok()) else {
+                                            error!("Failed to get the parent folder of the output file `{file:?}.");
+                                            appwindow.overlays().dispatch_toast_error(&gettext("Exporting document failed"));
+                                            return;
+                                    };
+
+                                    if let Err(e) = open::that(&folder_path_string) {
+                                        error!("Opening the parent folder '{folder_path_string}' in the file manager failed, Err: {e:?}");
+                                        appwindow.overlays().dispatch_toast_error(&gettext("Failed to open the file in the file manager"));
+                                    }
+                        }),
+                        crate::overlays::TEXT_TOAST_TIMEOUT_DEFAULT,
+                    );
+                    appwindow.overlays().progressbar_finish();
+                }
+                }));
+        }
+        else {
+            appwindow
+            .overlays()
+            .dispatch_toast_error(&gettext("Exporting selection failed, no file selected"));
+    }
     }));
 
     dialog.present(appwindow);


### PR DESCRIPTION
make export selection match the other output modes

There is a minute difference.
On the two other modes we have
`if let Some(file)`
then we call `span_future_local`

This was the reverse for the selection export.
Trying to see if this fixes https://github.com/flxzt/rnote/issues/1199.
I've added a few debug trace to help with debugging for this issue

(it will only be a style PR otherwise)