### PR TITLE
Styled/Dashed Lines for Shapes

### DIFF
--- a/crates/rnote-compose/src/style/smooth/mod.rs
+++ b/crates/rnote-compose/src/style/smooth/mod.rs
@@ -1,8 +1,10 @@
 // Modules
 mod smoothoptions;
 
+use piet::StrokeStyle;
 // Re-exports
 pub use smoothoptions::SmoothOptions;
+use tracing::info;
 
 // Imports
 use super::Composer;
@@ -26,7 +28,13 @@ impl Composer<SmoothOptions> for Line {
 
         if let Some(stroke_color) = options.stroke_color {
             let stroke_brush = cx.solid_brush(stroke_color.into());
-            cx.stroke(line, &stroke_brush, options.stroke_width);
+            let stroke_style = StrokeStyle::new()
+                .dash_pattern(&[2.0, 3.0])
+                .line_cap(piet::LineCap::Round)
+                .dash_offset(0.0);
+
+            info!("{:#?}", stroke_style);
+            cx.stroke_styled(line, &stroke_brush, options.stroke_width, &stroke_style);
         }
         cx.restore().unwrap();
     }


### PR DESCRIPTION
Dashed lines are pretty easy to create using piet's StrokeStyle. I think the main issue is how all of this should be integrated into Rnote's UI.

<img src="https://github.com/user-attachments/assets/0b624dcf-e75c-4de2-84ba-b9d52ca40563" width=70%/>

would fix #852 and #375 