### PR TITLE
Build Rnote and Installer for Windows Arm64

### DIFF
--- a/build-aux/cargo_build.py
+++ b/build-aux/cargo_build.py
@@ -32,7 +32,7 @@ if sys.platform == 'win32':
 else:
     rustflags = ''
 
-cargo_call = f"env {cargo_env} {cargo_cmd} build {cargo_options}"
+cargo_call = f"env {cargo_env} RUSTFLAGS='{rustflags}' {cargo_cmd} build {cargo_options}"
 cp_call = f"cp {bin_output} {output_file}"
 
 print(cargo_call, file=sys.stderr)

--- a/build-aux/cargo_build.py
+++ b/build-aux/cargo_build.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import platform
 
 project_build_root = sys.argv[1]
 project_src_root = sys.argv[2]
@@ -21,6 +22,15 @@ print(f"""
     bin_output: {bin_output}
     output_file: {output_file}
 """, file=sys.stderr)
+
+# Detecting architecture
+if sys.platform == 'win32':
+    if platform.machine().lower() == 'arm64':
+        rustflags = '-C linker=clang'
+    else:
+        rustflags = ''
+else:
+    rustflags = ''
 
 cargo_call = f"env {cargo_env} {cargo_cmd} build {cargo_options}"
 cp_call = f"cp {bin_output} {output_file}"

--- a/build-aux/cargo_build.py
+++ b/build-aux/cargo_build.py
@@ -11,6 +11,7 @@ cargo_cmd = sys.argv[4]
 cargo_options = sys.argv[5]
 bin_output = sys.argv[6]
 output_file = sys.argv[7]
+rustflags = sys.argv[8]
 
 print(f"""
 ### executing cargo build script with arguments: ###
@@ -21,16 +22,8 @@ print(f"""
     cargo_options: {cargo_options}
     bin_output: {bin_output}
     output_file: {output_file}
+    rustflags: {rustflags}
 """, file=sys.stderr)
-
-# Detecting architecture
-if sys.platform == 'win32':
-    if platform.machine().lower() == 'arm64':
-        rustflags = '-C linker=clang'
-    else:
-        rustflags = ''
-else:
-    rustflags = ''
 
 cargo_call = f"env {cargo_env} RUSTFLAGS='{rustflags}' {cargo_cmd} build {cargo_options}"
 cp_call = f"cp {bin_output} {output_file}"

--- a/build-aux/rnote_inno.iss.in
+++ b/build-aux/rnote_inno.iss.in
@@ -40,9 +40,9 @@ DisableProgramGroupPage=yes
 Compression=lzma2/ultra64
 SolidCompression=yes
 WizardStyle=modern
-; Run in 64-bit mode, restrict to x64 architecture.
-ArchitecturesAllowed=x64
-ArchitecturesInstallIn64BitMode=x64
+; Run in 64-bit mode, restrict to x64 and ARM64 architecture.
+ArchitecturesAllowed=x64 arm64
+ArchitecturesInstallIn64BitMode=x64 arm64
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/meson.build
+++ b/meson.build
@@ -204,8 +204,12 @@ if build_ui == true
         ui_cargo_options += ['--release']
     endif
 
+    rust_flags = ['']
     if host_machine.system() == 'windows'
         ui_output = app_name + '.exe'
+        if host_machine.cpu_family() == 'aarch64'
+            rust_flags += ['-C linker=clang']
+        endif
     else
         ui_output = app_name
     endif
@@ -261,6 +265,7 @@ if build_ui == true
             ' '.join(ui_cargo_options),
             cargo_target_dir / rust_target_folder / app_name,
             meson.project_build_root() / '@OUTPUT@',
+            rust_flags,
         ],
     )
 
@@ -343,11 +348,16 @@ if build_cli == true
         cli_cargo_options += ['--release']
     endif
 
+    rust_flags = ['']
     if host_machine.system() == 'windows'
         cli_output = cli_name + '.exe'
+        if host_machine.cpu_family() == 'aarch64'
+            rust_flags += ['-C linker=clang']
+        endif
     else
         cli_output = cli_name
     endif
+
 
     cli_sources = [
         rnote_compose_sources,
@@ -413,6 +423,7 @@ if build_cli == true
             ' '.join(cli_cargo_options),
             cargo_target_dir / rust_target_folder / cli_name,
             meson.project_build_root() / '@OUTPUT@',
+            rust_flags,
         ],
     )
 endif

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,14 @@ profile = get_option('profile')
 build_ui = get_option('ui')
 build_cli = get_option('cli')
 ci = get_option('ci')
-win_build_environment_path = get_option('win-build-environment-path')
+
+# Detecting architecture
+if host_machine.cpu_family() == 'aarch64'
+    win_build_environment_path = get_option('win-arm64-build-environment-path')
+else
+    win_build_environment_path = get_option('win-build-environment-path')
+endif
+
 win_installer_name = get_option('win-installer-name')
 
 app_name = 'rnote'

--- a/meson.build
+++ b/meson.build
@@ -22,14 +22,7 @@ profile = get_option('profile')
 build_ui = get_option('ui')
 build_cli = get_option('cli')
 ci = get_option('ci')
-
-# Detecting architecture
-if host_machine.cpu_family() == 'aarch64'
-    win_build_environment_path = get_option('win-arm64-build-environment-path')
-else
-    win_build_environment_path = get_option('win-build-environment-path')
-endif
-
+win_build_environment_path = get_option('win-build-environment-path')
 win_installer_name = get_option('win-installer-name')
 
 app_name = 'rnote'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -33,11 +33,5 @@ option(
   'win-build-environment-path',
   type: 'string',
   value: 'C:\\msys64\\mingw64',
-  description: 'Only relevant for builds on Windows: the path of the installed msys/mingw64 environment.',
-)
-option(
-  'win-arm64-build-environment-path',
-  type: 'string',
-  value: 'C:\\msys64\\clangarm64',
-  description: 'Only relevant for ARM64 builds on Windows: the path of the installed msys/clangarm64 environment.',
+  description: 'Only relevant for builds on Windows: the path of the installed msys/mingw64 (or msys/clangarm64) environment.',
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -35,3 +35,9 @@ option(
   value: 'C:\\msys64\\mingw64',
   description: 'Only relevant for builds on Windows: the path of the installed msys/mingw64 environment.',
 )
+option(
+  'win-arm64-build-environment-path',
+  type: 'string',
+  value: 'C:\\msys64\\clangarm64',
+  description: 'Only relevant for ARM64 builds on Windows: the path of the installed msys/clangarm64 environment.',
+)

--- a/misc/building/rnote-windows-arm64-build.md
+++ b/misc/building/rnote-windows-arm64-build.md
@@ -43,12 +43,12 @@ pacman -S mingw-w64-clang-aarch64-rust
 
 ### Configuration
 
-Add the following line to the end of the `C:\msys64\home\ZhouZhiwu\.bashrc` file to add the Rust binary directory to MSYS2's `PATH`:
+Add the following line to the end of the `C:\msys64\home\<user>\.bashrc` file to add the Rust binary directory to MSYS2's `PATH`:
 
 ```
 export PATH=$PATH:/c/msys64/clangarm64/bin
 ```
-If you have installed Inno Setup, add the following line to the end of the `C:\msys64\home\ZhouZhiwu\.bashrc` file:
+If you have installed Inno Setup, add the following line to the end of the `C:\msys64\home\<user>\.bashrc` file:
 
 ```
 export PATH=$PATH:/c/msys64/clangarm64/bin:/c/Program\ Files\ \(x86\)/Inno\ Setup\ 6

--- a/misc/building/rnote-windows-arm64-build.md
+++ b/misc/building/rnote-windows-arm64-build.md
@@ -1,0 +1,96 @@
+# Build Instructions for Windows arm64
+
+## Prerequisites
+### Clone the repository
+
+```bash
+git clone https://github.com/flxzt/rnote
+git submodule update --init --recursive
+```
+
+### Install MSYS2
+- Install MSYS2 (using CLANGARM64 environment)
+- Update MSYS2:
+   ```Bash
+   pacman -Suy
+   ```
+- Add MSYS2 binary directories `C:\msys64\clangarm64\bin` and `C:\msys64\usr\bin` to the system environment variable Path.
+
+### (Optional) Install Inno Setup (for building the installer)
+
+### Install Dependencies
+Run the following command in the MSYS2 CLANGARM64 terminal to install necessary dependencies:
+
+```bash
+pacman -S mingw-w64-clang-aarch64-xz mingw-w64-clang-aarch64-pkgconf mingw-w64-clang-aarch64-clang \
+mingw-w64-clang-aarch64-toolchain mingw-w64-clang-aarch64-autotools mingw-w64-clang-aarch64-make mingw-w64-clang-aarch64-cmake \
+mingw-w64-clang-aarch64-meson mingw-w64-clang-aarch64-desktop-file-utils mingw-w64-clang-aarch64-appstream \
+mingw-w64-clang-aarch64-gtk4 mingw-w64-clang-aarch64-libadwaita mingw-w64-clang-aarch64-poppler mingw-w64-clang-aarch64-poppler-data \
+mingw-w64-clang-aarch64-angleproject
+```
+All the above packages are clang-aarch64 versions corresponding to x86_64 versions.
+The mingw-w64-x86_64-diffutils package doesn't have a corresponding clang-aarch64 version, so install mingw-w64-x86_64-diffutils directly:
+
+```bash
+pacman -S mingw-w64-x86_64-diffutils
+```
+
+### Install Rust
+Install Rust provided by MSYS2 (important)
+```bash
+pacman -S mingw-w64-clang-aarch64-rust
+```
+
+### Configuration
+
+Add the following line to the end of the `C:\msys64\home\ZhouZhiwu\.bashrc` file to add the Rust binary directory to MSYS2's `PATH`:
+
+```
+export PATH=$PATH:/c/msys64/clangarm64/bin
+```
+If you have installed Inno Setup, add the following line to the end of the `C:\msys64\home\ZhouZhiwu\.bashrc` file:
+
+```
+export PATH=$PATH:/c/msys64/clangarm64/bin:/c/Program\ Files\ \(x86\)/Inno\ Setup\ 6
+```
+Apply the configuration:
+
+```bash
+source ~/.bashrc
+```
+
+# Compile Rnote
+
+1. First, make sure you're in the correct directory:
+   ```bash
+   cd /c/rnote
+   ```
+   
+2. Clean previous build files:
+   ```bash
+   rm -rf _mesonbuild
+   ```
+   
+3. Reconfigure the project:
+    ```bash
+    meson setup --prefix=C:/msys64/clangarm64 -Dwin-installer-name='windows_arm64_installer' _mesonbuild
+    ```
+
+4. Compile the project:
+   ```bash
+   meson compile -C _mesonbuild
+   ```
+   
+5. Install the project:
+   ```bash
+   meson install -C _mesonbuild
+   ```
+# Build the installer
+
+```bash
+meson compile rnote-gmo -C _mesonbuild
+```
+
+```bash
+meson compile build-installer -C _mesonbuild
+```

--- a/misc/building/rnote-windows-arm64-build.md
+++ b/misc/building/rnote-windows-arm64-build.md
@@ -73,7 +73,7 @@ source ~/.bashrc
    
 3. Reconfigure the project:
     ```bash
-    meson setup --prefix=C:/msys64/clangarm64 -Dwin-installer-name='windows_arm64_installer' _mesonbuild
+    meson setup --prefix="C:/msys64/clangarm64" -Dwin-installer-name='windows_arm64_installer' -Dwin-build-environment-path='C:\\msys64\\clangarm64' _mesonbuild
     ```
 
 4. Compile the project:


### PR DESCRIPTION
Following @Doublonmousse 's advice in #1209 ,I made some adjustments to the former request #1209 to add support for building Rnote on Windows ARM64 while not breaking the x86 build process. architecture. The changes include:

1. Added a new Meson option 'win-arm64-build-environment-path' in meson_options.txt to specify the path for the ARM64 build environment. I also changed the meson.build to detect architecture and chose build environment accordingly.

2. Modified cargo_build.py to detect the system architecture and set appropriate Rust flags:
   - Added platform detection for Windows ARM64.
   - Set '-C linker=clang' flag for ARM64 builds on Windows.

3. Updated rnote_inno.iss.in to include ARM64 architecture support for the Windows installer. 

And the issue about black borders is fixed. See https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/7692.

**I’ve only been able to test the build on a Microsoft Surface Pro 11, so I'm unsure how it will perform on other ARM devices.**