### PR TITLE
Capitalize file format names because they are acronyms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 > Sketch and take handwritten notes.  
 
 Rnote is an open-source vector-based drawing app for sketching, handwritten notes and to annotate documents and pictures.
-It is targeted at students, teachers and those who own a drawing tablet and provides features like Pdf and picture import and export,
+It is targeted at students, teachers and those who own a drawing tablet and provides features like PDF and picture import and export,
 an infinite canvas and an adaptive UI for big and small screens.
 
 Written in Rust and GTK4.
@@ -35,8 +35,8 @@ Written in Rust and GTK4.
 - Reconfigurable stylus button shortcuts
 - An integrated workspace browser for quick access to related files
 - Drag & Drop, clipboard support
-- Pdf, Bitmap and Svg image import
-- Documents can be exported to Svg, Pdf and Xopp. Document pages and selections to Svg, Png and Jpeg.
+- PDF, Bitmap and SVG image import
+- Documents can be exported to SVG, PDF and XOPP. Document pages and selections to SVG, Png and Jpeg.
 - Save and load the documents in the native `.rnote` file format
 - Tabs to work on multiple documents at the same time
 - Autosave, printing

--- a/crates/rnote-cli/src/cli.rs
+++ b/crates/rnote-cli/src/cli.rs
@@ -7,7 +7,7 @@ use rnote_engine::engine::export::{
     DocExportFormat, DocPagesExportFormat, DocPagesExportPrefs, SelectionExportFormat,
     SelectionExportPrefs,
 };
-use rnote_engine::engine::import::XoppImportPrefs;
+use rnote_engine::engine::import::XOPPImportPrefs;
 use rnote_engine::SelectionCollision;
 use smol::fs::File;
 use smol::io::{AsyncReadExt, AsyncWriteExt};
@@ -41,7 +41,7 @@ pub(crate) enum Command {
         #[arg(short = 'i', long)]
         input_file: PathBuf,
         /// When importing a .xopp file, the import dpi can be specified.
-        #[arg(long, default_value_t = XoppImportPrefs::default().dpi)]
+        #[arg(long, default_value_t = XOPPImportPrefs::default().dpi)]
         xopp_dpi: f64,
     },
     /// Exports the Rnote file(s) and saves it/them in the desired format.{n}

--- a/crates/rnote-cli/src/export.rs
+++ b/crates/rnote-cli/src/export.rs
@@ -311,9 +311,9 @@ pub(crate) fn create_doc_export_prefs_from_args(
 
 fn doc_export_format_from_ext_str(format: &str) -> anyhow::Result<DocExportFormat> {
     match format {
-        "svg" => Ok(DocExportFormat::Svg),
-        "xopp" => Ok(DocExportFormat::Xopp),
-        "pdf" => Ok(DocExportFormat::Pdf),
+        "svg" => Ok(DocExportFormat::SVG),
+        "xopp" => Ok(DocExportFormat::XOPP),
+        "pdf" => Ok(DocExportFormat::PDF),
         ext => Err(anyhow::anyhow!(
             "Exporting document to format with extension \"{ext}\" is not supported."
         )),
@@ -390,7 +390,7 @@ pub(crate) fn create_selection_export_prefs_from_args(
 
 fn get_selection_export_format(format: &str) -> anyhow::Result<SelectionExportFormat> {
     match format {
-        "svg" => Ok(SelectionExportFormat::Svg),
+        "svg" => Ok(SelectionExportFormat::SVG),
         "png" => Ok(SelectionExportFormat::Png),
         "jpg" | "jpeg" => Ok(SelectionExportFormat::Jpeg),
         ext => Err(anyhow::anyhow!(

--- a/crates/rnote-cli/src/import.rs
+++ b/crates/rnote-cli/src/import.rs
@@ -10,7 +10,7 @@ pub(crate) async fn run_import(
     xopp_dpi: f64,
 ) -> anyhow::Result<()> {
     validators::file_has_ext(rnote_file, "rnote")?;
-    // Xopp files don't require file extensions
+    // XOPP files don't require file extensions
     validators::path_is_file(input_file)?;
 
     let mut engine = Engine::default();

--- a/crates/rnote-compose/src/transform/mod.rs
+++ b/crates/rnote-compose/src/transform/mod.rs
@@ -120,7 +120,7 @@ impl Transform {
         .unwrap();
     }
 
-    /// Convert the transform to a Svg attribute string, insertable into svg elements.
+    /// Convert the transform to a SVG attribute string, insertable into svg elements.
     pub fn to_svg_transform_attr_str(&self) -> String {
         let matrix = self.affine;
 

--- a/crates/rnote-compose/src/utils.rs
+++ b/crates/rnote-compose/src/utils.rs
@@ -27,7 +27,7 @@ pub fn remove_xml_header(svg: &str) -> String {
     String::from(re.replace_all(svg, ""))
 }
 
-/// Wrap a Svg root element around the Svg string.
+/// Wrap a SVG root element around the SVG string.
 pub fn wrap_svg_root(
     svg_data: &str,
     bounds: Option<Aabb>,
@@ -79,7 +79,7 @@ pub fn wrap_svg_root(
         .set("preserveAspectRatio", preserve_aspectratio.as_str())
         .add(svg::node::Blob::new(svg_data));
 
-    // unwrapping because we know its a valid Svg
+    // unwrapping because we know its a valid SVG
     svg_node_to_string(&svg_root).unwrap()
 }
 
@@ -104,7 +104,7 @@ pub fn new_rng_default_pcg64(seed: Option<u64>) -> rand_pcg::Pcg64 {
     }
 }
 
-/// Generate a alphanumeric random prefix for Svg Id's to avoid Id collisions.
+/// Generate a alphanumeric random prefix for SVG Id's to avoid Id collisions.
 pub fn svg_random_id_prefix() -> String {
     rand::thread_rng()
         .sample_iter(&rand::distributions::Alphanumeric)

--- a/crates/rnote-engine/src/document/background.rs
+++ b/crates/rnote-engine/src/document/background.rs
@@ -408,13 +408,13 @@ impl Background {
         na::vector![tile_width, tile_height]
     }
 
-    /// Generate the background svg, without Xml header or Svg root.
+    /// Generate the background svg, without Xml header or SVG root.
     pub(crate) fn gen_svg(
         &self,
         bounds: Aabb,
         with_pattern: bool,
         optimize_printing: bool,
-    ) -> Result<render::Svg, anyhow::Error> {
+    ) -> Result<render::SVG, anyhow::Error> {
         let (color, pattern_color) = if optimize_printing {
             if self.color.luma() > 0.5 {
                 // original background color is bright, don't invert pattern color
@@ -489,9 +489,9 @@ impl Background {
         }
 
         let svg_data = rnote_compose::utils::svg_node_to_string(&svg_group)
-            .context("Converting Svg group node to String failed.")?;
+            .context("Converting SVG group node to String failed.")?;
 
-        Ok(render::Svg { svg_data, bounds })
+        Ok(render::SVG { svg_data, bounds })
     }
 
     pub(crate) fn gen_tile_image(&self, image_scale: f64) -> Result<render::Image, anyhow::Error> {

--- a/crates/rnote-engine/src/engine/export.rs
+++ b/crates/rnote-engine/src/engine/export.rs
@@ -30,16 +30,16 @@ use tracing::error;
 #[serde(rename = "doc_export_format")]
 pub enum DocExportFormat {
     #[serde(rename = "svg")]
-    Svg,
+    SVG,
     #[serde(rename = "pdf")]
-    Pdf,
+    PDF,
     #[serde(rename = "xopp")]
-    Xopp,
+    XOPP,
 }
 
 impl Default for DocExportFormat {
     fn default() -> Self {
-        Self::Pdf
+        Self::PDF
     }
 }
 
@@ -60,9 +60,9 @@ impl DocExportFormat {
     /// File extension for the format.
     pub fn file_ext(self) -> String {
         match self {
-            DocExportFormat::Svg => String::from("svg"),
-            DocExportFormat::Pdf => String::from("pdf"),
-            DocExportFormat::Xopp => String::from("xopp"),
+            DocExportFormat::SVG => String::from("svg"),
+            DocExportFormat::PDF => String::from("pdf"),
+            DocExportFormat::XOPP => String::from("xopp"),
         }
     }
 }
@@ -122,7 +122,7 @@ impl DocExportPrefs {
 #[serde(rename = "doc_pages_export_format")]
 pub enum DocPagesExportFormat {
     #[serde(rename = "svg")]
-    Svg,
+    SVG,
     #[serde(rename = "png")]
     Png,
     #[serde(rename = "jpeg")]
@@ -131,7 +131,7 @@ pub enum DocPagesExportFormat {
 
 impl Default for DocPagesExportFormat {
     fn default() -> Self {
-        Self::Svg
+        Self::SVG
     }
 }
 
@@ -151,7 +151,7 @@ impl TryFrom<u32> for DocPagesExportFormat {
 impl DocPagesExportFormat {
     pub fn file_ext(self) -> String {
         match self {
-            Self::Svg => String::from("svg"),
+            Self::SVG => String::from("svg"),
             Self::Png => String::from("png"),
             Self::Jpeg => String::from("jpg"),
         }
@@ -221,7 +221,7 @@ impl Default for DocPagesExportPrefs {
 #[serde(rename = "selection_export_format")]
 pub enum SelectionExportFormat {
     #[serde(rename = "svg")]
-    Svg,
+    SVG,
     #[serde(rename = "png")]
     Png,
     #[serde(rename = "jpeg")]
@@ -230,14 +230,14 @@ pub enum SelectionExportFormat {
 
 impl Default for SelectionExportFormat {
     fn default() -> Self {
-        Self::Svg
+        Self::SVG
     }
 }
 
 impl SelectionExportFormat {
     pub fn file_ext(self) -> String {
         match self {
-            SelectionExportFormat::Svg => String::from("svg"),
+            SelectionExportFormat::SVG => String::from("svg"),
             SelectionExportFormat::Png => String::from("png"),
             SelectionExportFormat::Jpeg => String::from("jpg"),
         }
@@ -289,7 +289,7 @@ impl Default for SelectionExportPrefs {
             with_background: true,
             with_pattern: false,
             optimize_printing: false,
-            export_format: SelectionExportFormat::Svg,
+            export_format: SelectionExportFormat::SVG,
             bitmap_scalefactor: 1.8,
             jpeg_quality: 85,
             margin: 12.0,
@@ -423,15 +423,15 @@ impl Engine {
             doc_export_prefs_override.unwrap_or(self.export_prefs.doc_export_prefs);
 
         match doc_export_prefs.export_format {
-            DocExportFormat::Svg => self.export_doc_as_svg_bytes(doc_export_prefs_override),
-            DocExportFormat::Pdf => self.export_doc_as_pdf_bytes(title, doc_export_prefs_override),
-            DocExportFormat::Xopp => {
+            DocExportFormat::SVG => self.export_doc_as_svg_bytes(doc_export_prefs_override),
+            DocExportFormat::PDF => self.export_doc_as_pdf_bytes(title, doc_export_prefs_override),
+            DocExportFormat::XOPP => {
                 self.export_doc_as_xopp_bytes(title, doc_export_prefs_override)
             }
         }
     }
 
-    /// Export the doc with the strokes as Svg.
+    /// Export the doc with the strokes as SVG.
     fn export_doc_as_svg_bytes(
         &self,
         doc_export_prefs_override: Option<DocExportPrefs>,
@@ -464,14 +464,14 @@ impl Engine {
             };
 
             if oneshot_sender.send(result()).is_err() {
-                error!("Sending result to receiver failed while exporting document as Svg bytes. Receiver already dropped.");
+                error!("Sending result to receiver failed while exporting document as SVG bytes. Receiver already dropped.");
             }
         });
 
         oneshot_receiver
     }
 
-    /// Export the doc with the strokes as Pdf.
+    /// Export the doc with the strokes as PDF.
     fn export_doc_as_pdf_bytes(
         &self,
         title: String,
@@ -486,15 +486,15 @@ impl Engine {
         rayon::spawn(move || {
             let result = || -> anyhow::Result<Vec<u8>> {
                 let target_surface =
-                    cairo::PdfSurface::for_stream(format_size[0], format_size[1], Vec::<u8>::new())
-                        .context("Creating Pdf target surface failed.")?;
+                    cairo::PDFSurface::for_stream(format_size[0], format_size[1], Vec::<u8>::new())
+                        .context("Creating PDF target surface failed.")?;
 
                 target_surface
-                    .set_metadata(cairo::PdfMetadata::Title, title.as_str())
+                    .set_metadata(cairo::PDFMetadata::Title, title.as_str())
                     .context("Set pdf surface title metadata failed.")?;
                 target_surface
                     .set_metadata(
-                        cairo::PdfMetadata::CreateDate,
+                        cairo::PDFMetadata::CreateDate,
                         crate::utils::now_formatted_string().as_str(),
                     )
                     .context("Set pdf surface date metadata failed.")?;
@@ -538,7 +538,7 @@ impl Engine {
             };
 
             if oneshot_sender.send(result()).is_err() {
-                error!("Sending result to receiver failed while exporting document as Pdf bytes. Receiver already dropped.");
+                error!("Sending result to receiver failed while exporting document as PDF bytes. Receiver already dropped.");
             }
         });
 
@@ -560,11 +560,11 @@ impl Engine {
         rayon::spawn(move || {
             let result = || -> anyhow::Result<Vec<u8>> {
                 // Only one background for all pages
-                let xopp_background = xoppformat::XoppBackground {
+                let xopp_background = xoppformat::XOPPBackground {
                     name: None,
-                    bg_type: xoppformat::XoppBackgroundType::Solid {
+                    bg_type: xoppformat::XOPPBackgroundType::Solid {
                         color: crate::utils::xoppcolor_from_color(document.background.color),
-                        style: xoppformat::XoppBackgroundSolidStyle::Plain,
+                        style: xoppformat::XOPPBackgroundSolidStyle::Plain,
                     },
                 };
 
@@ -574,7 +574,7 @@ impl Engine {
                     .into_iter()
                     .filter_map(|page_content| {
                         let page_bounds = page_content.bounds()?;
-                        // Translate strokes to to page mins and convert to XoppStrokStyle
+                        // Translate strokes to to page mins and convert to XOPPStrokStyle
                         let xopp_strokestyles = page_content
                             .strokes
                             .into_iter()
@@ -583,54 +583,54 @@ impl Engine {
                                 stroke.translate(-page_bounds.mins.coords);
                                 stroke.into_xopp(document.format.dpi())
                             })
-                            .collect::<Vec<xoppformat::XoppStrokeType>>();
+                            .collect::<Vec<xoppformat::XOPPStrokeType>>();
 
                         // Extract the strokes
                         let xopp_strokes = xopp_strokestyles
                             .iter()
                             .filter_map(|stroke| {
-                                if let xoppformat::XoppStrokeType::XoppStroke(xoppstroke) = stroke {
+                                if let xoppformat::XOPPStrokeType::XOPPStroke(xoppstroke) = stroke {
                                     Some(xoppstroke.clone())
                                 } else {
                                     None
                                 }
                             })
-                            .collect::<Vec<xoppformat::XoppStroke>>();
+                            .collect::<Vec<xoppformat::XOPPStroke>>();
 
                         // Extract the texts
                         let xopp_texts = xopp_strokestyles
                             .iter()
                             .filter_map(|stroke| {
-                                if let xoppformat::XoppStrokeType::XoppText(xopptext) = stroke {
+                                if let xoppformat::XOPPStrokeType::XOPPText(xopptext) = stroke {
                                     Some(xopptext.clone())
                                 } else {
                                     None
                                 }
                             })
-                            .collect::<Vec<xoppformat::XoppText>>();
+                            .collect::<Vec<xoppformat::XOPPText>>();
 
                         // Extract the images
                         let xopp_images = xopp_strokestyles
                             .iter()
                             .filter_map(|stroke| {
-                                if let xoppformat::XoppStrokeType::XoppImage(xoppstroke) = stroke {
+                                if let xoppformat::XOPPStrokeType::XOPPImage(xoppstroke) = stroke {
                                     Some(xoppstroke.clone())
                                 } else {
                                     None
                                 }
                             })
-                            .collect::<Vec<xoppformat::XoppImage>>();
+                            .collect::<Vec<xoppformat::XOPPImage>>();
 
                         // In Rnote images are always rendered below strokes and text.
                         // To match this behaviour accurately, images are separated into another layer.
-                        let image_layer = xoppformat::XoppLayer {
+                        let image_layer = xoppformat::XOPPLayer {
                             name: None,
                             strokes: vec![],
                             texts: vec![],
                             images: xopp_images,
                         };
 
-                        let strokes_layer = xoppformat::XoppLayer {
+                        let strokes_layer = xoppformat::XOPPLayer {
                             name: None,
                             strokes: xopp_strokes,
                             texts: xopp_texts,
@@ -640,29 +640,29 @@ impl Engine {
                         let page_dimensions = crate::utils::convert_coord_dpi(
                             page_bounds.extents(),
                             document.format.dpi(),
-                            xoppformat::XoppFile::DPI,
+                            xoppformat::XOPPFile::DPI,
                         );
 
-                        Some(xoppformat::XoppPage {
+                        Some(xoppformat::XOPPPage {
                             width: page_dimensions[0],
                             height: page_dimensions[1],
                             background: xopp_background.clone(),
                             layers: vec![image_layer, strokes_layer],
                         })
                     })
-                    .collect::<Vec<xoppformat::XoppPage>>();
+                    .collect::<Vec<xoppformat::XOPPPage>>();
 
                 let xopp_title = String::from(
                     "Xournal++ document - see https://github.com/xournalpp/xournalpp (exported from Rnote - see https://github.com/flxzt/rnote)"
                 );
 
-                let xopp_root = xoppformat::XoppRoot {
+                let xopp_root = xoppformat::XOPPRoot {
                     title: xopp_title,
                     fileversion: String::from("4"),
                     preview: String::from(""),
                     pages,
                 };
-                let xopp_file = xoppformat::XoppFile { xopp_root };
+                let xopp_file = xoppformat::XOPPFile { xopp_root };
 
                 xopp_file.save_as_bytes(&title)
             };
@@ -686,7 +686,7 @@ impl Engine {
             doc_pages_export_prefs_override.unwrap_or(self.export_prefs.doc_pages_export_prefs);
 
         match doc_pages_export_prefs.export_format {
-            DocPagesExportFormat::Svg => {
+            DocPagesExportFormat::SVG => {
                 self.export_doc_pages_as_svgs_bytes(doc_pages_export_prefs_override)
             }
             DocPagesExportFormat::Png | DocPagesExportFormat::Jpeg => {
@@ -695,7 +695,7 @@ impl Engine {
         }
     }
 
-    /// Export the document as Svg.
+    /// Export the document as SVG.
     fn export_doc_pages_as_svgs_bytes(
         &self,
         doc_pages_export_prefs_override: Option<DocPagesExportPrefs>,
@@ -719,7 +719,7 @@ impl Engine {
                                 DocPagesExportPrefs::MARGIN,
                             )?
                             .ok_or(anyhow::anyhow!(
-                                "Generating Svg for page {i} failed, returned None."
+                                "Generating SVG for page {i} failed, returned None."
                             ))?;
                         Ok(rnote_compose::utils::add_xml_header(
                             rnote_compose::utils::wrap_svg_root(
@@ -737,7 +737,7 @@ impl Engine {
 
             if oneshot_sender.send(result()).is_err() {
                 error!(
-                    "Sending result to receiver failed while exporting document pages as Svg bytes. Receiver already dropped."
+                    "Sending result to receiver failed while exporting document pages as SVG bytes. Receiver already dropped."
                 );
             }
         });
@@ -760,7 +760,7 @@ impl Engine {
         rayon::spawn(move || {
             let result = || -> Result<Vec<Vec<u8>>, anyhow::Error> {
                 let image_format = match doc_pages_export_prefs.export_format {
-                    DocPagesExportFormat::Svg => return Err(anyhow::anyhow!("Extracting bitmap image format from doc pages export prefs failed, not set to a bitmap format.")),
+                    DocPagesExportFormat::SVG => return Err(anyhow::anyhow!("Extracting bitmap image format from doc pages export prefs failed, not set to a bitmap format.")),
                     DocPagesExportFormat::Png => image::ImageFormat::Png,
                     DocPagesExportFormat::Jpeg => image::ImageFormat::Jpeg,
                 };
@@ -776,7 +776,7 @@ impl Engine {
                                 DocPagesExportPrefs::MARGIN,
                             )?
                             .ok_or(anyhow::anyhow!(
-                                "Generating Svg for page {i} failed, returned None."
+                                "Generating SVG for page {i} failed, returned None."
                             ))?
                             .gen_image(doc_pages_export_prefs.bitmap_scalefactor)?
                             .into_encoded_bytes(
@@ -803,7 +803,7 @@ impl Engine {
             selection_export_prefs_override.unwrap_or(self.export_prefs.selection_export_prefs);
 
         match selection_export_prefs.export_format {
-            SelectionExportFormat::Svg => {
+            SelectionExportFormat::SVG => {
                 self.export_selection_as_svg_bytes(selection_export_prefs_override)
             }
             SelectionExportFormat::Png | SelectionExportFormat::Jpeg => {
@@ -812,7 +812,7 @@ impl Engine {
         }
     }
 
-    /// Exports the selection as Svg.
+    /// Exports the selection as SVG.
     fn export_selection_as_svg_bytes(
         &self,
         selection_export_prefs_override: Option<SelectionExportPrefs>,
@@ -852,7 +852,7 @@ impl Engine {
                 ))
             };
             if oneshot_sender.send(result()).is_err() {
-                error!("Sending result to receiver failed while exporting selection as Svg bytes. Receiver already dropped.");
+                error!("Sending result to receiver failed while exporting selection as SVG bytes. Receiver already dropped.");
             }
         });
 
@@ -887,7 +887,7 @@ impl Engine {
                     return Ok(None);
                 };
                 let image_format = match selection_export_prefs.export_format {
-                    SelectionExportFormat::Svg => return Err(anyhow::anyhow!("Extracting bitmap image format from doc pages export prefs failed, not set to a bitmap format.")),
+                    SelectionExportFormat::SVG => return Err(anyhow::anyhow!("Extracting bitmap image format from doc pages export prefs failed, not set to a bitmap format.")),
                     SelectionExportFormat::Png => image::ImageFormat::Png,
                     SelectionExportFormat::Jpeg => image::ImageFormat::Jpeg
                 };

--- a/crates/rnote-engine/src/engine/import.rs
+++ b/crates/rnote-engine/src/engine/import.rs
@@ -21,26 +21,26 @@ use tracing::error;
     Debug, Clone, Copy, Serialize, Deserialize, num_derive::FromPrimitive, num_derive::ToPrimitive,
 )]
 #[serde(rename = "pdf_import_pages_type")]
-pub enum PdfImportPagesType {
+pub enum PDFImportPagesType {
     #[serde(rename = "bitmap")]
     Bitmap = 0,
     #[serde(rename = "vector")]
     Vector,
 }
 
-impl Default for PdfImportPagesType {
+impl Default for PDFImportPagesType {
     fn default() -> Self {
         Self::Vector
     }
 }
 
-impl TryFrom<u32> for PdfImportPagesType {
+impl TryFrom<u32> for PDFImportPagesType {
     type Error = anyhow::Error;
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         num_traits::FromPrimitive::from_u32(value).ok_or_else(|| {
             anyhow::anyhow!(
-                "PdfImportPagesType try_from::<u32>() for value {} failed",
+                "PDFImportPagesType try_from::<u32>() for value {} failed",
                 value
             )
         })
@@ -51,62 +51,62 @@ impl TryFrom<u32> for PdfImportPagesType {
     Debug, Clone, Copy, Serialize, Deserialize, num_derive::FromPrimitive, num_derive::ToPrimitive,
 )]
 #[serde(rename = "pdf_import_page_spacing")]
-pub enum PdfImportPageSpacing {
+pub enum PDFImportPageSpacing {
     #[serde(rename = "continuous")]
     Continuous = 0,
     #[serde(rename = "one_per_document_page")]
     OnePerDocumentPage,
 }
 
-impl Default for PdfImportPageSpacing {
+impl Default for PDFImportPageSpacing {
     fn default() -> Self {
         Self::Continuous
     }
 }
 
-impl TryFrom<u32> for PdfImportPageSpacing {
+impl TryFrom<u32> for PDFImportPageSpacing {
     type Error = anyhow::Error;
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         num_traits::FromPrimitive::from_u32(value).ok_or_else(|| {
             anyhow::anyhow!(
-                "PdfImportPageSpacing try_from::<u32>() for value {} failed",
+                "PDFImportPageSpacing try_from::<u32>() for value {} failed",
                 value
             )
         })
     }
 }
 
-/// Pdf import preferences.
+/// PDF import preferences.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(default, rename = "pdf_import_prefs")]
-pub struct PdfImportPrefs {
-    /// Pdf page width in percentage to the format width.
+pub struct PDFImportPrefs {
+    /// PDF page width in percentage to the format width.
     #[serde(rename = "page_width_perc")]
     pub page_width_perc: f64,
-    /// Pdf page spacing.
+    /// PDF page spacing.
     #[serde(rename = "page_spacing")]
-    pub page_spacing: PdfImportPageSpacing,
-    /// Pdf pages import type.
+    pub page_spacing: PDFImportPageSpacing,
+    /// PDF pages import type.
     #[serde(rename = "pages_type")]
-    pub pages_type: PdfImportPagesType,
+    pub pages_type: PDFImportPagesType,
     /// The scalefactor when importing as bitmap image
     #[serde(rename = "bitmap_scalefactor")]
     pub bitmap_scalefactor: f64,
-    /// Whether the imported Pdf pages have drawn borders
+    /// Whether the imported PDF pages have drawn borders
     #[serde(rename = "page_borders")]
     pub page_borders: bool,
-    /// Whether the document layout should be adjusted to the Pdf
+    /// Whether the document layout should be adjusted to the PDF
     #[serde(rename = "adjust_document")]
     pub adjust_document: bool,
 }
 
-impl Default for PdfImportPrefs {
+impl Default for PDFImportPrefs {
     fn default() -> Self {
         Self {
-            pages_type: PdfImportPagesType::default(),
+            pages_type: PDFImportPagesType::default(),
             page_width_perc: 50.0,
-            page_spacing: PdfImportPageSpacing::default(),
+            page_spacing: PDFImportPageSpacing::default(),
             bitmap_scalefactor: 1.8,
             page_borders: true,
             adjust_document: false,
@@ -117,13 +117,13 @@ impl Default for PdfImportPrefs {
 /// Xournal++ `.xopp` file import preferences.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename = "xopp_import_prefs")]
-pub struct XoppImportPrefs {
+pub struct XOPPImportPrefs {
     /// Import DPI.
     #[serde(rename = "pages_type")]
     pub dpi: f64,
 }
 
-impl Default for XoppImportPrefs {
+impl Default for XOPPImportPrefs {
     fn default() -> Self {
         Self { dpi: 96.0 }
     }
@@ -133,12 +133,12 @@ impl Default for XoppImportPrefs {
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 #[serde(default, rename = "import_prefs")]
 pub struct ImportPrefs {
-    /// Pdf import preferences
+    /// PDF import preferences
     #[serde(rename = "pdf_import_prefs")]
-    pub pdf_import_prefs: PdfImportPrefs,
+    pub pdf_import_prefs: PDFImportPrefs,
     /// Xournal++ `.xopp` file import preferences
     #[serde(rename = "xopp_import_prefs")]
-    pub xopp_import_prefs: XoppImportPrefs,
+    pub xopp_import_prefs: XOPPImportPrefs,
 }
 
 impl CloneConfig for ImportPrefs {
@@ -231,7 +231,7 @@ impl Engine {
 
     /// Generate a vectorimage from the bytes.
     ///
-    /// The bytes are expected to be from a valid UTF-8 encoded Svg string.
+    /// The bytes are expected to be from a valid UTF-8 encoded SVG string.
     pub fn generate_vectorimage_from_bytes(
         &self,
         pos: na::Vector2<f64>,
@@ -309,7 +309,7 @@ impl Engine {
 
     /// Generate image strokes for each page for the bytes.
     ///
-    /// The bytes are expected to be from a valid Pdf.
+    /// The bytes are expected to be from a valid PDF.
     ///
     /// Note: `insert_pos` does not have an effect when the `adjust_document` import pref is set true.
     #[allow(clippy::type_complexity)]
@@ -332,7 +332,7 @@ impl Engine {
         rayon::spawn(move || {
             let result = || -> anyhow::Result<Vec<(Stroke, Option<StrokeLayer>)>> {
                 match pdf_import_prefs.pages_type {
-                    PdfImportPagesType::Bitmap => {
+                    PDFImportPagesType::Bitmap => {
                         let bitmapimages = BitmapImage::from_pdf_bytes(
                             &bytes,
                             pdf_import_prefs,
@@ -345,7 +345,7 @@ impl Engine {
                         .collect::<Vec<(Stroke, Option<StrokeLayer>)>>();
                         Ok(bitmapimages)
                     }
-                    PdfImportPagesType::Vector => {
+                    PDFImportPagesType::Vector => {
                         let vectorimages = VectorImage::from_pdf_bytes(
                             &bytes,
                             pdf_import_prefs,
@@ -362,7 +362,7 @@ impl Engine {
             };
 
             if oneshot_sender.send(result()).is_err() {
-                error!("Sending result to receiver while importing Pdf bytes failed. Receiver already dropped");
+                error!("Sending result to receiver while importing PDF bytes failed. Receiver already dropped");
             }
         });
 

--- a/crates/rnote-engine/src/engine/snapshot.rs
+++ b/crates/rnote-engine/src/engine/snapshot.rs
@@ -1,6 +1,6 @@
 // Imports
 use crate::document::background;
-use crate::engine::import::XoppImportPrefs;
+use crate::engine::import::XOPPImportPrefs;
 use crate::fileformats::{rnoteformat, xoppformat, FileFormatLoader};
 use crate::store::{ChronoComponent, StrokeKey};
 use crate::strokes::Stroke;
@@ -68,13 +68,13 @@ impl EngineSnapshot {
     /// To import this snapshot into the current engine, use [`Engine::load_snapshot()`].
     pub async fn load_from_xopp_bytes(
         bytes: Vec<u8>,
-        xopp_import_prefs: XoppImportPrefs,
+        xopp_import_prefs: XOPPImportPrefs,
     ) -> anyhow::Result<Self> {
         let (snapshot_sender, snapshot_receiver) = oneshot::channel::<anyhow::Result<Self>>();
 
         rayon::spawn(move || {
             let result = || -> anyhow::Result<Self> {
-                let xopp_file = xoppformat::XoppFile::load_from_bytes(&bytes)?;
+                let xopp_file = xoppformat::XOPPFile::load_from_bytes(&bytes)?;
 
                 // Extract the largest width of all pages, add together all heights
                 let (doc_width, doc_height) = xopp_file
@@ -90,19 +90,19 @@ impl EngineSnapshot {
 
                 let mut engine = Engine::default();
 
-                // We convert all values from the hardcoded 72 DPI of Xopp files to the preferred dpi
+                // We convert all values from the hardcoded 72 DPI of XOPP files to the preferred dpi
                 engine.document.format.set_dpi(xopp_import_prefs.dpi);
 
                 engine.document.x = 0.0;
                 engine.document.y = 0.0;
                 engine.document.width = crate::utils::convert_value_dpi(
                     doc_width,
-                    xoppformat::XoppFile::DPI,
+                    xoppformat::XOPPFile::DPI,
                     xopp_import_prefs.dpi,
                 );
                 engine.document.height = crate::utils::convert_value_dpi(
                     doc_height,
-                    xoppformat::XoppFile::DPI,
+                    xoppformat::XOPPFile::DPI,
                     xopp_import_prefs.dpi,
                 );
 
@@ -111,7 +111,7 @@ impl EngineSnapshot {
                     .format
                     .set_width(crate::utils::convert_value_dpi(
                         doc_width,
-                        xoppformat::XoppFile::DPI,
+                        xoppformat::XOPPFile::DPI,
                         xopp_import_prefs.dpi,
                     ));
                 engine
@@ -119,17 +119,17 @@ impl EngineSnapshot {
                     .format
                     .set_height(crate::utils::convert_value_dpi(
                         doc_height / (no_pages as f64),
-                        xoppformat::XoppFile::DPI,
+                        xoppformat::XOPPFile::DPI,
                         xopp_import_prefs.dpi,
                     ));
 
                 if let Some(first_page) = xopp_file.xopp_root.pages.first() {
-                    if let xoppformat::XoppBackgroundType::Solid {
+                    if let xoppformat::XOPPBackgroundType::Solid {
                         color: _color,
                         style: _style,
                     } = &first_page.background.bg_type
                     {
-                        // Xopp background styles are not compatible with Rnotes, so everything is plain for now
+                        // XOPP background styles are not compatible with Rnotes, so everything is plain for now
                         engine.document.background.pattern = background::PatternStyle::None;
                     }
                 }
@@ -151,7 +151,7 @@ impl EngineSnapshot {
                                 }
                                 Err(e) => {
                                     error!(
-                                        "Creating Stroke from XoppStroke failed while loading Xopp bytess, Err: {e:?}",
+                                        "Creating Stroke from XOPPStroke failed while loading XOPP bytess, Err: {e:?}",
                                     );
                                 }
                             }
@@ -169,7 +169,7 @@ impl EngineSnapshot {
                                 }
                                 Err(e) => {
                                     error!(
-                                        "Creating Stroke from XoppImage failed while loading Xopp bytes, Err: {e:?}",
+                                        "Creating Stroke from XOPPImage failed while loading XOPP bytes, Err: {e:?}",
                                     );
                                 }
                             }
@@ -179,7 +179,7 @@ impl EngineSnapshot {
                     // Only add to y offset, results in vertical pages
                     offset[1] += crate::utils::convert_value_dpi(
                         page.height,
-                        xoppformat::XoppFile::DPI,
+                        xoppformat::XOPPFile::DPI,
                         xopp_import_prefs.dpi,
                     );
                 }
@@ -188,7 +188,7 @@ impl EngineSnapshot {
             };
 
             if snapshot_sender.send(result()).is_err() {
-                error!("Sending result to receiver while loading Xopp bytes failed. Receiver already dropped");
+                error!("Sending result to receiver while loading XOPP bytes failed. Receiver already dropped");
             }
         });
 

--- a/crates/rnote-engine/src/engine/strokecontent.rs
+++ b/crates/rnote-engine/src/engine/strokecontent.rs
@@ -1,6 +1,6 @@
 // Imports
 use crate::document::Background;
-use crate::render::Svg;
+use crate::render::SVG;
 use crate::strokes::Stroke;
 use crate::Drawable;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
@@ -61,7 +61,7 @@ impl StrokeContent {
         self.bounds().map(|b| b.extents())
     }
 
-    /// Generate a Svg from the content.
+    /// Generate a SVG from the content.
     ///
     /// Moves the bounds to mins: [0.0, 0.0], maxs: extents.
     ///
@@ -72,11 +72,11 @@ impl StrokeContent {
         draw_pattern: bool,
         optimize_printing: bool,
         margin: f64,
-    ) -> anyhow::Result<Option<Svg>> {
+    ) -> anyhow::Result<Option<SVG>> {
         let Some(bounds_loosened) = self.bounds().map(|b| b.loosened(margin)) else {
             return Ok(None);
         };
-        let mut svg = Svg::gen_with_cairo(
+        let mut svg = SVG::gen_with_cairo(
             |cairo_cx| {
                 self.draw_to_cairo(
                     cairo_cx,
@@ -91,7 +91,7 @@ impl StrokeContent {
         )?;
         // The simplification also moves the bounds to mins: [0.0, 0.0], maxs: extents
         if let Err(e) = svg.simplify() {
-            warn!("Simplifying Svg while generating StrokeContent Svg failed, Err: {e:?}");
+            warn!("Simplifying SVG while generating StrokeContent SVG failed, Err: {e:?}");
         };
         Ok(Some(svg))
     }

--- a/crates/rnote-engine/src/fileformats/xoppformat.rs
+++ b/crates/rnote-engine/src/fileformats/xoppformat.rs
@@ -31,25 +31,25 @@ fn decompress_from_gzip(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
 ///
 /// The original Xournal spec can be found here: <http://xournal.sourceforge.net/manual.html#file-format>
 #[derive(Debug)]
-pub struct XoppFile {
+pub struct XOPPFile {
     /// The .xopp Xml root element.
-    pub xopp_root: XoppRoot,
+    pub xopp_root: XOPPRoot,
 }
 
-impl FileFormatLoader for XoppFile {
+impl FileFormatLoader for XOPPFile {
     fn load_from_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
         let decompressed = String::from_utf8(decompress_from_gzip(bytes)?)?;
         let parsed_doc = roxmltree::Document::parse_with_options(
             decompressed.as_str(),
             roxmltree::ParsingOptions::default(),
         )?;
-        let mut xopp_root = XoppRoot::default();
+        let mut xopp_root = XOPPRoot::default();
         xopp_root.load_from_xml(parsed_doc.root_element())?;
         Ok(Self { xopp_root })
     }
 }
 
-impl FileFormatSaver for XoppFile {
+impl FileFormatSaver for XOPPFile {
     fn save_as_bytes(&self, _file_name: &str) -> anyhow::Result<Vec<u8>> {
         let mut xml_writer = xmlwriter::XmlWriter::new(xmlwriter::Options::default());
         self.xopp_root.write_to_xml(&mut xml_writer);
@@ -59,14 +59,14 @@ impl FileFormatSaver for XoppFile {
     }
 }
 
-impl XoppFile {
+impl XOPPFile {
     /// The DPI of `.xopp` files, which is hardcoded to 72 DPI.
     pub const DPI: f64 = 72.0;
 }
 
 /// A Xournal++ Xml root element.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct XoppRoot {
+pub struct XOPPRoot {
     /// The file version.
     pub fileversion: String,
     /// The file title.
@@ -74,10 +74,10 @@ pub struct XoppRoot {
     /// A preview image, encoded as base64.
     pub preview: String,
     /// The pages elements.
-    pub pages: Vec<XoppPage>,
+    pub pages: Vec<XOPPPage>,
 }
 
-impl XmlLoadable for XoppRoot {
+impl XmlLoadable for XOPPRoot {
     fn load_from_xml(&mut self, root_node: Node) -> anyhow::Result<()> {
         if let Some(fileversion) = root_node.attribute("fileversion") {
             self.fileversion = fileversion.to_string();
@@ -100,7 +100,7 @@ impl XmlLoadable for XoppRoot {
                         }
                     }
                     "page" => {
-                        let mut new_page = XoppPage::default();
+                        let mut new_page = XOPPPage::default();
                         new_page.load_from_xml(child)?;
                         self.pages.push(new_page);
                     }
@@ -113,7 +113,7 @@ impl XmlLoadable for XoppRoot {
     }
 }
 
-impl XmlWritable for XoppRoot {
+impl XmlWritable for XOPPRoot {
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter) {
         w.set_preserve_whitespaces(true);
         w.start_element("xournal");
@@ -131,26 +131,26 @@ impl XmlWritable for XoppRoot {
     }
 }
 
-/// A Xopp Page.
+/// A XOPP Page.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct XoppPage {
+pub struct XOPPPage {
     /// The width of the page.
     pub width: f64,
     /// The height of the page.
     pub height: f64,
     /// The Background of the page.
-    pub background: XoppBackground,
+    pub background: XOPPBackground,
     /// The layers of the page.
-    pub layers: Vec<XoppLayer>,
+    pub layers: Vec<XOPPLayer>,
 }
 
-impl XmlLoadable for XoppPage {
+impl XmlLoadable for XOPPPage {
     fn load_from_xml(&mut self, node: Node) -> anyhow::Result<()> {
         self.width = node
             .attribute("width")
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "failed to parse width attribute of XoppPage for node with id {:?}, could not find attribute",
+                    "failed to parse width attribute of XOPPPage for node with id {:?}, could not find attribute",
                     node.id()
                 )
             })?
@@ -160,7 +160,7 @@ impl XmlLoadable for XoppPage {
             .attribute("height")
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "failed to parse height attribute of XoppPage with node id {:?}, could not find attribute",
+                    "failed to parse height attribute of XOPPPage with node id {:?}, could not find attribute",
                     node.id()
                 )
             })?
@@ -173,7 +173,7 @@ impl XmlLoadable for XoppPage {
                         self.background.load_from_xml(child)?;
                     }
                     "layer" => {
-                        let mut new_layer = XoppLayer::default();
+                        let mut new_layer = XOPPLayer::default();
                         new_layer.load_from_xml(child)?;
                         self.layers.push(new_layer);
                     }
@@ -187,7 +187,7 @@ impl XmlLoadable for XoppPage {
     }
 }
 
-impl XmlWritable for XoppPage {
+impl XmlWritable for XOPPPage {
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter) {
         w.start_element("page");
         w.write_attribute("width", &format!("{:.*}", VALS_DEC_PLACES, self.width));
@@ -200,28 +200,28 @@ impl XmlWritable for XoppPage {
     }
 }
 
-/// A Xopp Background type.
+/// A XOPP Background type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum XoppBackgroundType {
+pub enum XOPPBackgroundType {
     /// A solid background with a color and style.
     Solid {
         /// The color.
-        color: XoppColor,
+        color: XOPPColor,
         /// The solid background style.
-        style: XoppBackgroundSolidStyle,
+        style: XOPPBackgroundSolidStyle,
     },
     /// A background with a pixmap.
     Pixmap {
         /// The domain for the pixmap.
-        domain: XoppBackgroundPixmapDomain,
+        domain: XOPPBackgroundPixmapDomain,
         /// The filename that is to the image for the pixmap.
         filename: String,
     },
     /// A background with a pdf. Currently **UNIMPLEMENTED**.
-    Pdf,
+    PDF,
 }
 
-impl XmlWritable for XoppBackgroundType {
+impl XmlWritable for XOPPBackgroundType {
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter) {
         match self {
             Self::Solid { color, style } => {
@@ -234,30 +234,30 @@ impl XmlWritable for XoppBackgroundType {
                 w.write_attribute("domain", &domain.to_xml_attr_value());
                 w.write_attribute("filename", filename);
             }
-            Self::Pdf => {
+            Self::PDF => {
                 w.write_attribute("type", "pdf");
             }
         }
     }
 }
 
-impl Default for XoppBackgroundType {
+impl Default for XOPPBackgroundType {
     fn default() -> Self {
         Self::Solid {
-            color: XoppColor {
+            color: XOPPColor {
                 red: 0,
                 green: 0,
                 blue: 0,
                 alpha: 0xff,
             },
-            style: XoppBackgroundSolidStyle::default(),
+            style: XOPPBackgroundSolidStyle::default(),
         }
     }
 }
 
 /// The xopp background style.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum XoppBackgroundSolidStyle {
+pub enum XOPPBackgroundSolidStyle {
     /// Plain.
     Plain,
     /// Lined.
@@ -276,13 +276,13 @@ pub enum XoppBackgroundSolidStyle {
     IsometricGraph,
 }
 
-impl Default for XoppBackgroundSolidStyle {
+impl Default for XOPPBackgroundSolidStyle {
     fn default() -> Self {
         Self::Plain
     }
 }
 
-impl ToXmlAttributeValue for XoppBackgroundSolidStyle {
+impl ToXmlAttributeValue for XOPPBackgroundSolidStyle {
     fn to_xml_attr_value(&self) -> String {
         match self {
             Self::Plain => String::from("plain"),
@@ -297,7 +297,7 @@ impl ToXmlAttributeValue for XoppBackgroundSolidStyle {
     }
 }
 
-impl FromXmlAttributeValue for XoppBackgroundSolidStyle {
+impl FromXmlAttributeValue for XOPPBackgroundSolidStyle {
     fn from_xml_attr_value(s: &str) -> Result<Self, anyhow::Error>
     where
         Self: Sized,
@@ -312,16 +312,16 @@ impl FromXmlAttributeValue for XoppBackgroundSolidStyle {
             "isodotted" => Ok(Self::IsometricDotted),
             "isograph" => Ok(Self::IsometricGraph),
             o => Err(anyhow::anyhow!(
-                "Err while parsing `style` attribute of XoppBackground, {:?} is not a valid value",
+                "Err while parsing `style` attribute of XOPPBackground, {:?} is not a valid value",
                 o
             )),
         }
     }
 }
 
-/// The Xopp background pixmap domain.
+/// The XOPP background pixmap domain.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum XoppBackgroundPixmapDomain {
+pub enum XOPPBackgroundPixmapDomain {
     /// Absolute.
     Absolute,
     /// Attach.
@@ -330,7 +330,7 @@ pub enum XoppBackgroundPixmapDomain {
     Clone,
 }
 
-impl ToXmlAttributeValue for XoppBackgroundPixmapDomain {
+impl ToXmlAttributeValue for XOPPBackgroundPixmapDomain {
     fn to_xml_attr_value(&self) -> String {
         match self {
             Self::Absolute => String::from("absolute"),
@@ -340,76 +340,76 @@ impl ToXmlAttributeValue for XoppBackgroundPixmapDomain {
     }
 }
 
-impl Default for XoppBackgroundPixmapDomain {
+impl Default for XOPPBackgroundPixmapDomain {
     fn default() -> Self {
         Self::Absolute
     }
 }
 
-/// The Xopp Background.
+/// The XOPP Background.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct XoppBackground {
+pub struct XOPPBackground {
     /// Optional background name.
     pub name: Option<String>,
     /// The background type.
-    pub bg_type: XoppBackgroundType,
+    pub bg_type: XOPPBackgroundType,
 }
 
-impl XmlLoadable for XoppBackground {
+impl XmlLoadable for XOPPBackground {
     fn load_from_xml(&mut self, node: Node) -> anyhow::Result<()> {
         self.name = node.attribute("name").map(|name| name.to_string());
 
         match node.attribute("type").ok_or_else(|| {
             anyhow::anyhow!(
-                "failed to parse `type` attribute of XoppBackground with node id {:?}, could not find attribute",
+                "failed to parse `type` attribute of XOPPBackground with node id {:?}, could not find attribute",
                 node.id()
             )
         })? {
             "solid" => {
-                let style = match XoppBackgroundSolidStyle::from_xml_attr_value(node.attribute("style").ok_or_else(|| {
-                    anyhow::anyhow!("failed to parse `style` attribute in XoppBackground with node id {:?}, could not find attribute", node.id())
+                let style = match XOPPBackgroundSolidStyle::from_xml_attr_value(node.attribute("style").ok_or_else(|| {
+                    anyhow::anyhow!("failed to parse `style` attribute in XOPPBackground with node id {:?}, could not find attribute", node.id())
                 })?) {
                     Ok(s) => s,
                     Err(e) => {
-                        error!("Failed to retrieve the XoppBackgroundSolidStyle from `style` attribute, Err: {e:?}");
-                        XoppBackgroundSolidStyle::Plain
+                        error!("Failed to retrieve the XOPPBackgroundSolidStyle from `style` attribute, Err: {e:?}");
+                        XOPPBackgroundSolidStyle::Plain
                     }
                 };
 
-                let color = XoppColor::from_backgroundcolor_attr_value(
+                let color = XOPPColor::from_backgroundcolor_attr_value(
                     node.attribute("color").ok_or_else(|| {
                         anyhow::anyhow!(
-                            "Failed to parse `color` attribute in XoppBackground with id {:?}",
+                            "Failed to parse `color` attribute in XOPPBackground with id {:?}",
                             node.id()
                         )
                     })?,
                 )?;
-                self.bg_type = XoppBackgroundType::Solid { color, style };
+                self.bg_type = XOPPBackgroundType::Solid { color, style };
             }
             "pixmap" => {
                 let domain = match node.attribute("domain").ok_or_else(|| {
-                    anyhow::anyhow!("Failed to parse `domain` attribute in XoppBackground with node id {:?}, could not find attribute", node.id())
+                    anyhow::anyhow!("Failed to parse `domain` attribute in XOPPBackground with node id {:?}, could not find attribute", node.id())
                 })? {
-                    "absolute" => XoppBackgroundPixmapDomain::Absolute,
-                    "attach" => XoppBackgroundPixmapDomain::Attach,
-                    "clone" => XoppBackgroundPixmapDomain::Clone,
+                    "absolute" => XOPPBackgroundPixmapDomain::Absolute,
+                    "attach" => XOPPBackgroundPixmapDomain::Attach,
+                    "clone" => XOPPBackgroundPixmapDomain::Clone,
                     _ => {
-                        return Err(anyhow::anyhow!("Err while parsing `style` attribute of XoppBackground with node id {:?}, is not a valid value", node.id()));
+                        return Err(anyhow::anyhow!("Err while parsing `style` attribute of XOPPBackground with node id {:?}, is not a valid value", node.id()));
                     }
                 };
                 let filename = node
                     .attribute("filename")
                     .ok_or_else(|| {
-                        anyhow::anyhow!("Failed to parse `filename` attribute in XoppBackground with node id {:?}, could not find attribute", node.id())
+                        anyhow::anyhow!("Failed to parse `filename` attribute in XOPPBackground with node id {:?}, could not find attribute", node.id())
                     })?
                     .to_string();
-                self.bg_type = XoppBackgroundType::Pixmap { domain, filename };
+                self.bg_type = XOPPBackgroundType::Pixmap { domain, filename };
             }
             "pdf" => {
-                self.bg_type = XoppBackgroundType::Pdf;
+                self.bg_type = XOPPBackgroundType::PDF;
             }
             _ => {
-                return Err(anyhow::anyhow!("Failed to parse `type` attribute of XoppBackground with node id {:?}, is not a valid value", node.id()));
+                return Err(anyhow::anyhow!("Failed to parse `type` attribute of XOPPBackground with node id {:?}, is not a valid value", node.id()));
             }
         }
 
@@ -417,7 +417,7 @@ impl XmlLoadable for XoppBackground {
     }
 }
 
-impl XmlWritable for XoppBackground {
+impl XmlWritable for XOPPBackground {
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter) {
         w.start_element("background");
         if let Some(name) = self.name.as_ref() {
@@ -428,20 +428,20 @@ impl XmlWritable for XoppBackground {
     }
 }
 
-/// A Xopp Layer.
+/// A XOPP Layer.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct XoppLayer {
+pub struct XOPPLayer {
     /// Optional layer name.
     pub name: Option<String>,
     /// Strokes on this layer.
-    pub strokes: Vec<XoppStroke>,
+    pub strokes: Vec<XOPPStroke>,
     /// Texts on this layer.
-    pub texts: Vec<XoppText>,
+    pub texts: Vec<XOPPText>,
     /// Images on this layer.
-    pub images: Vec<XoppImage>,
+    pub images: Vec<XOPPImage>,
 }
 
-impl XmlLoadable for XoppLayer {
+impl XmlLoadable for XOPPLayer {
     fn load_from_xml(&mut self, node: Node) -> anyhow::Result<()> {
         self.name = node.attribute("name").map(|name| name.to_string());
 
@@ -449,17 +449,17 @@ impl XmlLoadable for XoppLayer {
             match child.node_type() {
                 NodeType::Element => match child.tag_name().name() {
                     "stroke" => {
-                        let mut new_stroke = XoppStroke::default();
+                        let mut new_stroke = XOPPStroke::default();
                         new_stroke.load_from_xml(child)?;
                         self.strokes.push(new_stroke);
                     }
                     "text" => {
-                        let mut new_text = XoppText::default();
+                        let mut new_text = XOPPText::default();
                         new_text.load_from_xml(child)?;
                         self.texts.push(new_text);
                     }
                     "image" => {
-                        let mut new_image = XoppImage::default();
+                        let mut new_image = XOPPImage::default();
                         new_image.load_from_xml(child)?;
                         self.images.push(new_image);
                     }
@@ -472,7 +472,7 @@ impl XmlLoadable for XoppLayer {
     }
 }
 
-impl XmlWritable for XoppLayer {
+impl XmlWritable for XOPPLayer {
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter) {
         // only do something if we are sure the layer is not empty
         // Fix for #985
@@ -501,11 +501,11 @@ impl XmlWritable for XoppLayer {
     }
 }
 
-/// A Xopp Color.
+/// A XOPP Color.
 ///
 /// Represented in Xml as hexadecimal values in format `#RRGGBBAA`.
 #[derive(Default, Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct XoppColor {
+pub struct XOPPColor {
     /// Red ranging [0 - 255].
     pub red: u8,
     /// Green ranging [0 - 255].
@@ -516,7 +516,7 @@ pub struct XoppColor {
     pub alpha: u8,
 }
 
-impl ToXmlAttributeValue for XoppColor {
+impl ToXmlAttributeValue for XOPPColor {
     fn to_xml_attr_value(&self) -> String {
         format!(
             "#{:02x}{:02x}{:02x}{:02x}",
@@ -525,7 +525,7 @@ impl ToXmlAttributeValue for XoppColor {
     }
 }
 
-impl XoppColor {
+impl XOPPColor {
     /// Parse the color from a attribute value that is format `#RRGGBBAA`.
     fn from_hexcolor_attr_value(s: &str) -> Result<Self, anyhow::Error> {
         let s = s.trim().replace('#', "");
@@ -663,22 +663,22 @@ impl XoppColor {
 ///
 /// Helper to bundle different strokes into one type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum XoppStrokeType {
+pub enum XOPPStrokeType {
     /// A stroke.
-    XoppStroke(XoppStroke),
+    XOPPStroke(XOPPStroke),
     /// A text.
-    XoppText(XoppText),
+    XOPPText(XOPPText),
     /// An image.
-    XoppImage(XoppImage),
+    XOPPImage(XOPPImage),
 }
 
-/// A Xopp Stroke.
+/// A XOPP Stroke.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct XoppStroke {
+pub struct XOPPStroke {
     /// The stroke tool.
-    pub tool: XoppTool,
+    pub tool: XOPPTool,
     /// The stroke color.
-    pub color: XoppColor,
+    pub color: XOPPColor,
     /// Stroke fill. None if is not filled, 255 if fully opaque.
     pub fill: Option<i32>,
     /// The stroke widths.
@@ -697,30 +697,30 @@ pub struct XoppStroke {
     pub audio_filename: Option<String>,
 }
 
-impl XmlLoadable for XoppStroke {
+impl XmlLoadable for XOPPStroke {
     fn load_from_xml(&mut self, node: Node) -> anyhow::Result<()> {
         match node.attribute("tool").ok_or_else(|| {
             anyhow::anyhow!(
-                "failed to parse `tool` attribute in XoppStroke with node id {:?}, could not find attribute",
+                "failed to parse `tool` attribute in XOPPStroke with node id {:?}, could not find attribute",
                 node.id()
             )
         })? {
             "pen" => {
-                self.tool = XoppTool::Pen;
+                self.tool = XOPPTool::Pen;
             }
             "highlighter" => {
-                self.tool = XoppTool::Highlighter;
+                self.tool = XOPPTool::Highlighter;
             }
             "eraser" => {
-                self.tool = XoppTool::Eraser;
+                self.tool = XOPPTool::Eraser;
             }
             _ => {}
         }
 
         self.color =
-            XoppColor::from_strokecolor_attr_value(node.attribute("color").ok_or_else(|| {
+            XOPPColor::from_strokecolor_attr_value(node.attribute("color").ok_or_else(|| {
                 anyhow::anyhow!(
-                    "failed to parse `color` attribute in XoppStroke with node id {:?}, could not find attribute",
+                    "failed to parse `color` attribute in XOPPStroke with node id {:?}, could not find attribute",
                     node.id()
                 )
             })?)?;
@@ -735,7 +735,7 @@ impl XmlLoadable for XoppStroke {
             .attribute("width")
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "failed to parse `width` attribute in XoppStroke with node id {:?}, could not find attribute",
+                    "failed to parse `width` attribute in XOPPStroke with node id {:?}, could not find attribute",
                     node.id()
                 )
             })?
@@ -774,7 +774,7 @@ impl XmlLoadable for XoppStroke {
     }
 }
 
-impl XmlWritable for XoppStroke {
+impl XmlWritable for XOPPStroke {
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter) {
         w.set_preserve_whitespaces(true);
         w.start_element("stroke");
@@ -812,20 +812,20 @@ impl XmlWritable for XoppStroke {
     }
 }
 
-/// A Xopp stroke tool.
+/// A XOPP stroke tool.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum XoppTool {
-    /// The Xopp Pen.
+pub enum XOPPTool {
+    /// The XOPP Pen.
     Pen,
-    /// The Xopp highlighter.
+    /// The XOPP highlighter.
     ///
     /// (alpha = 0.5).
     Highlighter,
-    /// The Xopp eraser.
+    /// The XOPP eraser.
     Eraser,
 }
 
-impl ToXmlAttributeValue for XoppTool {
+impl ToXmlAttributeValue for XOPPTool {
     fn to_xml_attr_value(&self) -> String {
         match self {
             Self::Pen => String::from("pen"),
@@ -835,15 +835,15 @@ impl ToXmlAttributeValue for XoppTool {
     }
 }
 
-impl Default for XoppTool {
+impl Default for XOPPTool {
     fn default() -> Self {
         Self::Pen
     }
 }
 
-/// A Xopp text.
+/// A XOPP text.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct XoppText {
+pub struct XOPPText {
     /// The text font.
     pub font: String,
     /// The text size.
@@ -853,18 +853,18 @@ pub struct XoppText {
     /// The y position of the upper left corner.
     pub y: f64,
     /// The text color.
-    pub color: XoppColor,
+    pub color: XOPPColor,
     /// The text string.
     pub text: String,
 }
 
-impl XmlLoadable for XoppText {
+impl XmlLoadable for XOPPText {
     fn load_from_xml(&mut self, node: Node) -> anyhow::Result<()> {
         self.font = node
             .attribute("font")
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "failed to parse `font` attribute in XoppText with node id {:?}, could not find attribute",
+                    "failed to parse `font` attribute in XOPPText with node id {:?}, could not find attribute",
                     node.id()
                 )
             })?
@@ -874,7 +874,7 @@ impl XmlLoadable for XoppText {
             .attribute("size")
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "failed to parse `size` attribute in XoppText with node id {:?}, could not find attribute",
+                    "failed to parse `size` attribute in XOPPText with node id {:?}, could not find attribute",
                     node.id()
                 )
             })?
@@ -884,7 +884,7 @@ impl XmlLoadable for XoppText {
             .attribute("x")
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "failed to parse `x` attribute in XoppText with node id {:?}, could not find attribute",
+                    "failed to parse `x` attribute in XOPPText with node id {:?}, could not find attribute",
                     node.id()
                 )
             })?
@@ -894,16 +894,16 @@ impl XmlLoadable for XoppText {
             .attribute("y")
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "failed to parse `y` attribute in XoppText with node id {:?}, could not find attribute",
+                    "failed to parse `y` attribute in XOPPText with node id {:?}, could not find attribute",
                     node.id()
                 )
             })?
             .parse::<f64>()?;
 
         self.color =
-            XoppColor::from_strokecolor_attr_value(node.attribute("color").ok_or_else(|| {
+            XOPPColor::from_strokecolor_attr_value(node.attribute("color").ok_or_else(|| {
                 anyhow::anyhow!(
-                    "failed to parse `color` attribute in XoppText with node id {:?}, could not find attribute",
+                    "failed to parse `color` attribute in XOPPText with node id {:?}, could not find attribute",
                     node.id()
                 )
             })?)?;
@@ -916,7 +916,7 @@ impl XmlLoadable for XoppText {
     }
 }
 
-impl XmlWritable for XoppText {
+impl XmlWritable for XOPPText {
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter) {
         w.set_preserve_whitespaces(true);
         w.start_element("text");
@@ -932,9 +932,9 @@ impl XmlWritable for XoppText {
     }
 }
 
-/// A Xopp image.
+/// A XOPP image.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct XoppImage {
+pub struct XOPPImage {
     /// The left x position.
     pub left: f64,
     /// The top y position.
@@ -947,14 +947,14 @@ pub struct XoppImage {
     pub data: String,
 }
 
-impl XmlLoadable for XoppImage {
+impl XmlLoadable for XOPPImage {
     fn load_from_xml(&mut self, node: Node) -> anyhow::Result<()> {
         // Left
         self.left = node
             .attribute("left")
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "failed to parse `left` attribute in XoppText with node id {:?}, could not find attribute",
+                    "failed to parse `left` attribute in XOPPText with node id {:?}, could not find attribute",
                     node.id()
                 )
             })?
@@ -965,7 +965,7 @@ impl XmlLoadable for XoppImage {
             .attribute("top")
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "failed to parse `top` attribute in XoppText with node id {:?}, could not find attribute",
+                    "failed to parse `top` attribute in XOPPText with node id {:?}, could not find attribute",
                     node.id()
                 )
             })?
@@ -976,7 +976,7 @@ impl XmlLoadable for XoppImage {
             .attribute("right")
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "failed to parse `right` attribute in XoppText with node id {:?}, could not find attribute",
+                    "failed to parse `right` attribute in XOPPText with node id {:?}, could not find attribute",
                     node.id()
                 )
             })?
@@ -987,7 +987,7 @@ impl XmlLoadable for XoppImage {
             .attribute("bottom")
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "failed to parse `bottom` attribute in XoppText with node id {:?}, could not find attribute",
+                    "failed to parse `bottom` attribute in XOPPText with node id {:?}, could not find attribute",
                     node.id()
                 )
             })?
@@ -1005,7 +1005,7 @@ impl XmlLoadable for XoppImage {
     }
 }
 
-impl XmlWritable for XoppImage {
+impl XmlWritable for XOPPImage {
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter) {
         w.set_preserve_whitespaces(true);
         w.start_element("image");

--- a/crates/rnote-engine/src/pens/selector/mod.rs
+++ b/crates/rnote-engine/src/pens/selector/mod.rs
@@ -6,7 +6,7 @@ use super::pensconfig::selectorconfig::SelectorStyle;
 use super::PenBehaviour;
 use super::PenStyle;
 use crate::engine::{EngineView, EngineViewMut, StrokeContent};
-use crate::render::Svg;
+use crate::render::SVG;
 use crate::snap::SnapCorner;
 use crate::store::StrokeKey;
 use crate::strokes::Content;
@@ -187,10 +187,10 @@ impl PenBehaviour for Selector {
                         StrokeContent::MIME_TYPE.to_string(),
                     ));
                     if let Some(stroke_content_svg) = stroke_content_svg {
-                        // Add generated Svg
+                        // Add generated SVG
                         clipboard_content.push((
                             stroke_content_svg.svg_data.clone().into_bytes(),
-                            Svg::MIME_TYPE.to_string(),
+                            SVG::MIME_TYPE.to_string(),
                         ));
 
                         // Add rendered Png
@@ -248,10 +248,10 @@ impl PenBehaviour for Selector {
                         StrokeContent::MIME_TYPE.to_string(),
                     ));
                     if let Some(stroke_content_svg) = stroke_content_svg {
-                        // Add generated Svg
+                        // Add generated SVG
                         clipboard_content.push((
                             stroke_content_svg.svg_data.clone().into_bytes(),
-                            Svg::MIME_TYPE.to_string(),
+                            SVG::MIME_TYPE.to_string(),
                         ));
 
                         // Add rendered Png

--- a/crates/rnote-engine/src/render.rs
+++ b/crates/rnote-engine/src/render.rs
@@ -397,16 +397,16 @@ impl Image {
     }
 }
 
-/// A Svg image.
+/// A SVG image.
 #[derive(Debug, Clone)]
-pub struct Svg {
-    /// Svg data String.
+pub struct SVG {
+    /// SVG data String.
     pub svg_data: String,
-    /// Bounds of the Svg.
+    /// Bounds of the SVG.
     pub bounds: Aabb,
 }
 
-impl Svg {
+impl SVG {
     pub const MIME_TYPE: &'static str = "image/svg+xml";
 
     pub fn merge<T>(&mut self, other: T)
@@ -444,7 +444,7 @@ impl Svg {
         self.svg_data = rnote_compose::utils::remove_xml_header(&self.svg_data);
     }
 
-    /// Simplify the Svg by passing it through [usvg].
+    /// Simplify the SVG by passing it through [usvg].
     ///
     /// Also moves the bounds to mins: [0., 0.], maxs: extents
     pub fn simplify(&mut self) -> anyhow::Result<()> {
@@ -482,7 +482,7 @@ impl Svg {
         Ok(())
     }
 
-    /// Generate an Svg through cairo's SvgSurface.
+    /// Generate an SVG through cairo's SVGSurface.
     pub fn gen_with_cairo<F>(draw_func: F, mut bounds: Aabb) -> anyhow::Result<Self>
     where
         F: FnOnce(&cairo::Context) -> anyhow::Result<()>,
@@ -493,12 +493,12 @@ impl Svg {
         let width = bounds.extents()[0];
         let height = bounds.extents()[1];
         let mut svg_surface =
-            cairo::SvgSurface::for_stream(width, height, Vec::new()).map_err(|e| {
+            cairo::SVGSurface::for_stream(width, height, Vec::new()).map_err(|e| {
                 anyhow::anyhow!(
                     "Creating svg surface with dimensions ({width}, {height}) failed, Err: {e:?}"
                 )
             })?;
-        svg_surface.set_document_unit(cairo::SvgUnit::Px);
+        svg_surface.set_document_unit(cairo::SVGUnit::Px);
 
         {
             let cairo_cx = cairo::Context::new(&svg_surface)?;
@@ -512,11 +512,11 @@ impl Svg {
             *svg_surface
                 .finish_output_stream()
                 .map_err(|e| {
-                    anyhow::anyhow!("Finishing Svg surface output stream failed, Err: {e:?}")
+                    anyhow::anyhow!("Finishing SVG surface output stream failed, Err: {e:?}")
                 })?
                 .downcast::<Vec<u8>>()
                 .map_err(|e| {
-                    anyhow::anyhow!("Downcasting Svg surface content failed, Err: {e:?}")
+                    anyhow::anyhow!("Downcasting SVG surface content failed, Err: {e:?}")
                 })?,
         )?;
         let svg_data = rnote_compose::utils::remove_xml_header(&content);
@@ -533,7 +533,7 @@ impl Svg {
         })
     }
 
-    /// Generate an Svg with piet, using the `piet_cairo` backend and cairo's SvgSurface.
+    /// Generate an SVG with piet, using the `piet_cairo` backend and cairo's SVGSurface.
     ///
     /// This might be preferable to the `piet_svg` backend, because especially text alignment and sizes can be different
     /// with it.
@@ -580,7 +580,7 @@ impl Svg {
         Ok(())
     }
 
-    /// Generate an image from an Svg.
+    /// Generate an image from an SVG.
     ///
     /// Using rsvg for rendering.
     pub fn gen_image(&self, image_scale: f64) -> Result<Image, anyhow::Error> {

--- a/crates/rnote-engine/src/strokes/bitmapimage.rs
+++ b/crates/rnote-engine/src/strokes/bitmapimage.rs
@@ -2,7 +2,7 @@
 use super::resize::{calculate_resize_ratio, ImageSizeOption};
 use super::{Content, Stroke};
 use crate::document::Format;
-use crate::engine::import::{PdfImportPageSpacing, PdfImportPrefs};
+use crate::engine::import::{PDFImportPageSpacing, PDFImportPrefs};
 use crate::render;
 use crate::Drawable;
 use anyhow::Context;
@@ -128,7 +128,7 @@ impl BitmapImage {
 
     pub fn from_pdf_bytes(
         to_be_read: &[u8],
-        pdf_import_prefs: PdfImportPrefs,
+        pdf_import_prefs: PDFImportPrefs,
         insert_pos: na::Vector2<f64>,
         page_range: Option<Range<u32>>,
         format: &Format,
@@ -216,10 +216,10 @@ impl BitmapImage {
                     y += height
                 } else {
                     y += match pdf_import_prefs.page_spacing {
-                        PdfImportPageSpacing::Continuous => {
+                        PDFImportPageSpacing::Continuous => {
                             height + Stroke::IMPORT_OFFSET_DEFAULT[1] * 0.5
                         }
-                        PdfImportPageSpacing::OnePerDocumentPage => format.height(),
+                        PDFImportPageSpacing::OnePerDocumentPage => format.height(),
                     };
                 }
 

--- a/crates/rnote-engine/src/strokes/content.rs
+++ b/crates/rnote-engine/src/strokes/content.rs
@@ -25,12 +25,12 @@ pub trait Content: Drawable + Shapeable
 where
     Self: Sized,
 {
-    /// Generate Svg from the content, without the Xml header or the Svg root.
+    /// Generate SVG from the content, without the Xml header or the SVG root.
     ///
     /// Used for exporting.
-    fn gen_svg(&self) -> Result<render::Svg, anyhow::Error> {
+    fn gen_svg(&self) -> Result<render::SVG, anyhow::Error> {
         let bounds = self.bounds();
-        render::Svg::gen_with_cairo(|cx| self.draw_to_cairo(cx, 1.0), bounds)
+        render::SVG::gen_with_cairo(|cx| self.draw_to_cairo(cx, 1.0), bounds)
     }
 
     /// Generate bitmap images for rendering in the app.

--- a/crates/rnote-engine/src/utils.rs
+++ b/crates/rnote-engine/src/utils.rs
@@ -9,7 +9,7 @@ pub const fn crate_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
-pub fn color_from_xopp(xopp_color: xoppformat::XoppColor) -> Color {
+pub fn color_from_xopp(xopp_color: xoppformat::XOPPColor) -> Color {
     Color {
         r: f64::from(xopp_color.red) / 255.0,
         g: f64::from(xopp_color.green) / 255.0,
@@ -18,8 +18,8 @@ pub fn color_from_xopp(xopp_color: xoppformat::XoppColor) -> Color {
     }
 }
 
-pub fn xoppcolor_from_color(color: Color) -> xoppformat::XoppColor {
-    xoppformat::XoppColor {
+pub fn xoppcolor_from_color(color: Color) -> xoppformat::XOPPColor {
+    xoppformat::XOPPColor {
         red: (color.r * 255.0).floor() as u8,
         green: (color.g * 255.0).floor() as u8,
         blue: (color.b * 255.0).floor() as u8,

--- a/crates/rnote-ui/data/app.metainfo.xml.in.in
+++ b/crates/rnote-ui/data/app.metainfo.xml.in.in
@@ -142,7 +142,7 @@
         <ul>
           <li>feat: touch-hold context-menu with basic actions (thanks to @silvasch)</li>
           <li>feat: added polygon shape and builder</li>
-          <li>feat: added adjust-document Pdf import option that configures the document for improved annotation use-case</li>
+          <li>feat: added adjust-document PDF import option that configures the document for improved annotation use-case</li>
           <li>improv: additional color button (default: white) (thanks to @silvasch)</li>
           <li>improv: new keyboard shortcuts for managing windows and tabs (thanks to @silvasch)</li>
           <li>improv: autosave all tabs, but only ones that are flagged modified (thanks to @Doublonmousse)</li>
@@ -264,7 +264,7 @@
           <li>improvement: default view offset when opening documents</li>
           <li>enhancement: move view using arrow keys</li>
           <li>fix: orientation of some popovers when sidebar is on the left</li>
-          <li>fix: restore vectorized images (Pdf pages, Svg) export</li>
+          <li>fix: restore vectorized images (PDF pages, SVG) export</li>
           <li>fix: .rnote file imports that were created pre v0.5.9</li>
           <li>fix: rendering of closed shapes from imported xopp file</li>
         </ul>
@@ -295,7 +295,7 @@ If you are upgrading from a previous version, you need to uninstall the old vers
           <li>improvement: selection highlights for brush-strokes</li>
           <li>improvement: ctrl + scroll following the pointer</li>
           <li>improvement: scale-ratio when resizing the selection with locked aspect-ratio</li>
-          <li>improvement: provide selection content as Svg and Png when copying/cutting to the clipboard</li>
+          <li>improvement: provide selection content as SVG and Png when copying/cutting to the clipboard</li>
           <li>improvement: save file logic in close tab/window dialogs</li>
           <li>improvement: memory consumption when loading rnote files</li>
           <li>UI: page controls for the fixed-size layout were moved into the canvas menu dropdown</li>
@@ -361,9 +361,9 @@ Breakages in the file format will be explicitly announced (but we'll work as har
         <ul>
           <li>feature: configurable shortcuts for drawing pad buttons</li>
           <li>improvement: input events for rate-limited devices (E-Paper/ low-frequency displays)</li>
-          <li>improvement: reduced Svg export size</li>
+          <li>improvement: reduced SVG export size</li>
           <li>fix: artifacts when printing</li>
-          <li>fix: Jpeg images embedded in Pdfs were not rendered</li>
+          <li>fix: Jpeg images embedded in PDFs were not rendered</li>
           <li>fix: select-all with "ctrl+a" included trashed strokes</li>
           <li>fix: units in settings kept resetting to "Px"</li>
           <li>fix: flicker when duplicating large selections</li>
@@ -380,8 +380,8 @@ Breakages in the file format will be explicitly announced (but we'll work as har
           <li>improvement: indicate hover over nodes in the selector and typewriter</li>
           <li>improvement: reduced save and xopp export file sizes</li>
           <li>UI: follow Gnome HIG writing style more closely and fixed string inconsistencies</li>
-          <li>fix: Pdf import with different size pages</li>
-          <li>fix: image and Pdf import offsets now take the document bounds into account</li>
+          <li>fix: PDF import with different size pages</li>
+          <li>fix: image and PDF import offsets now take the document bounds into account</li>
           <li>fix: broken resizing in fixed-size document layout</li>
           <li>fix: crash when navigating up/down into non-ASCII text</li>
           <li>fix: crash on launch when using a custom stylesheet</li>
@@ -479,7 +479,7 @@ Breakages in the file format will be explicitly announced (but we'll work as har
           <li>improvement: Add zoom buttons to the quick-actions overlay</li>
           <li>improvement: By default use the workspace directory for import and export dialogs, and
             document file for save dialogs</li>
-          <li>fix: Pdf export and print sometimes produced empty pages</li>
+          <li>fix: PDF export and print sometimes produced empty pages</li>
           <li>fix: workspace files list not refreshing after modifying the workspace path</li>
           <li>fix: Selector being canceled when attempting to interact with the selection when
             "touch-drawing" was enabled</li>
@@ -503,7 +503,7 @@ Breakages in the file format will be explicitly announced (but we'll work as har
           <li>fix: background pattern tile rendering size</li>
           <li>fix: scrolling with touchpad was not possible when the "permanent hidden scrollbars"
             option was enabled</li>
-          <li>fix: broken Svg export</li>
+          <li>fix: broken SVG export</li>
           <li>fix: image layers when exporting to .xopp</li>
         </ul>
       </description>
@@ -592,7 +592,7 @@ Breakages in the file format will be explicitly announced (but we'll work as har
           <li>disclaimer: breaking file format compatibility</li>
           <li>feature: configurable button shortcuts (stylus, mouse)</li>
           <li>change: moved the marker into the brush pen as a style</li>
-          <li>improvement: faster Pdf export &amp; fix export with large sheet dimensions</li>
+          <li>improvement: faster PDF export &amp; fix export with large sheet dimensions</li>
           <li>bug fixes</li>
         </ul>
       </description>
@@ -625,7 +625,7 @@ Breakages in the file format will be explicitly announced (but we'll work as har
       <description>
         <p>this release changes:</p>
         <ul>
-          <li>new feature: Export as Pdf</li>
+          <li>new feature: Export as PDF</li>
           <li>bug fixes</li>
         </ul>
       </description>
@@ -677,7 +677,7 @@ Breakages in the file format will be explicitly announced (but we'll work as har
       <description>
         <p>this release changes:</p>
         <ul>
-          <li>Pdf import as vector images</li>
+          <li>PDF import as vector images</li>
           <li>bug fixes</li>
         </ul>
       </description>
@@ -708,7 +708,7 @@ Breakages in the file format will be explicitly announced (but we'll work as har
           <li>an updated file format. !!! Breaks compatibility to older versions. Please export
             existing files before upgrading / downgrade temporarily (explained how to downgrade at
             github.com/flxzt/rnote)</li>
-          <li>new features: Pdf import, clipboard and drag&amp;drop support</li>
+          <li>new features: PDF import, clipboard and drag&amp;drop support</li>
           <li>performance improvements in stroke rendering, selecting, erasing by parallelizing
             these operations</li>
           <li>UI improvements</li>

--- a/crates/rnote-ui/data/ui/dialogs/export.ui
+++ b/crates/rnote-ui/data/ui/dialogs/export.ui
@@ -132,9 +132,9 @@
                                 <property name="model">
                                   <object class="GtkStringList">
                                     <items>
-                                      <item translatable="yes">Svg</item>
-                                      <item translatable="yes">Pdf</item>
-                                      <item translatable="yes">Xopp</item>
+                                      <item translatable="yes">SVG</item>
+                                      <item translatable="yes">PDF</item>
+                                      <item translatable="yes">XOPP</item>
                                     </items>
                                   </object>
                                 </property>
@@ -343,7 +343,7 @@ are cut into pages</property>
                                 <property name="model">
                                   <object class="GtkStringList">
                                     <items>
-                                      <item translatable="yes">Svg</item>
+                                      <item translatable="yes">SVG</item>
                                       <item translatable="yes">Png</item>
                                       <item translatable="yes">Jpeg</item>
                                     </items>
@@ -541,7 +541,7 @@ are cut into pages</property>
                                 <property name="model">
                                   <object class="GtkStringList">
                                     <items>
-                                      <item translatable="yes">Svg</item>
+                                      <item translatable="yes">SVG</item>
                                       <item translatable="yes">Png</item>
                                       <item translatable="yes">Jpeg</item>
                                     </items>

--- a/crates/rnote-ui/data/ui/dialogs/import.ui
+++ b/crates/rnote-ui/data/ui/dialogs/import.ui
@@ -2,7 +2,7 @@
 <!-- Import dialogs -->
 <interface>
   <object class="AdwDialog" id="dialog_import_pdf_w_prefs">
-    <property name="title" translatable="yes">Import Pdf</property>
+    <property name="title" translatable="yes">Import PDF</property>
     <child>
       <object class="AdwToolbarView">
         <child type="top">
@@ -78,7 +78,7 @@
                 </child>
                 <child>
                   <object class="AdwPreferencesGroup">
-                    <property name="title" translatable="yes">Pdf Import Preferences</property>
+                    <property name="title" translatable="yes">PDF Import Preferences</property>
                     <property name="halign">fill</property>
                     <child>
                       <object class="AdwSpinRow" id="pdf_page_start_row">
@@ -101,13 +101,13 @@
                     <child>
                       <object class="AdwSwitchRow" id="pdf_import_adjust_document_row">
                         <property name="title" translatable="yes">Adjust Document</property>
-                        <property name="subtitle" translatable="yes">Whether the document layout should be adjusted to the Pdf</property>
+                        <property name="subtitle" translatable="yes">Whether the document layout should be adjusted to the PDF</property>
                       </object>
                     </child>
                     <child>
                       <object class="AdwSpinRow" id="pdf_import_width_row">
                         <property name="title" translatable="yes">Page Width (%)</property>
-                        <property name="subtitle" translatable="yes">Set the width of imported Pdf's in percentage to the format width</property>
+                        <property name="subtitle" translatable="yes">Set the width of imported PDF's in percentage to the format width</property>
                         <property name="adjustment">pdf_import_width_perc_adj</property>
                         <property name="digits">0</property>
                       </object>
@@ -115,7 +115,7 @@
                     <child>
                       <object class="AdwComboRow" id="pdf_import_page_spacing_row">
                         <property name="title" translatable="yes">Page Spacing</property>
-                        <property name="subtitle" translatable="yes">How Pdf pages are spaced</property>
+                        <property name="subtitle" translatable="yes">How PDF pages are spaced</property>
                         <property name="model">
                           <object class="GtkStringList">
                             <items>
@@ -129,7 +129,7 @@
                     <child>
                       <object class="AdwActionRow" id="pdf_import_pages_type_row">
                         <property name="title" translatable="yes">Pages Type</property>
-                        <property name="subtitle" translatable="yes">Set whether Pdf's should be imported as vector or bitmap images</property>
+                        <property name="subtitle" translatable="yes">Set whether PDF's should be imported as vector or bitmap images</property>
                         <child type="suffix">
                           <object class="GtkBox">
                             <property name="orientation">horizontal</property>

--- a/crates/rnote-ui/po/ar.po
+++ b/crates/rnote-ui/po/ar.po
@@ -312,18 +312,18 @@ msgstr "تنسيق التصدير"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
-msgstr "Pdf"
+msgid "PDF"
+msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -466,7 +466,7 @@ msgid "Set the margin around the selected area"
 msgstr "عيِّن الهامش حول المساحة المحدَّدة"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "استورد PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -480,7 +480,7 @@ msgid "Info"
 msgstr "معلومات"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "تفضيلات استيراد ملفَّات PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -500,7 +500,7 @@ msgstr "عدِّل إعدادات المستند"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
 #, fuzzy
 #| msgid "Set whether the background pattern should be exported"
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "حدِّد ما إذا كان يجب تصدير نمط الخلفيَّة"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -508,7 +508,7 @@ msgid "Page Width (%)"
 msgstr "عرض الصفحة (٪)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr "عيِّن نسبة عرض ملفَّات PDF المستوردة إلى عرض التنسيق"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -516,7 +516,7 @@ msgid "Page Spacing"
 msgstr "تباعد الصفحات"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "كمُّ تباعد صفحات PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -532,7 +532,7 @@ msgid "Pages Type"
 msgstr "نوع الصفحات"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr "عيِّن ما إذا كان يجب استيراد ملفَّات PDF صورَ متَّجهات أو نقاط"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -1982,8 +1982,8 @@ msgid "Open File"
 msgstr "افتح ملفًّا"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp، txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP، txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2591,7 +2591,7 @@ msgstr "أبيض"
 #~ msgid "Lecture Note 1"
 #~ msgstr "ملاحظات المحاضرة 1"
 
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "تعليق توضيحيّ على ملفِّ PDF"
 
 #~ msgid "Lecture Note 2"
@@ -2625,7 +2625,7 @@ msgstr "أبيض"
 #~ msgid "Opening Xournal++ file failed"
 #~ msgstr "فشل فتح ملفِّ Xournal++"
 
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "فشل فتح ملفِّ PDF"
 
 #~ msgid "Failed to open file, tried to open folder as file"
@@ -2855,7 +2855,7 @@ msgstr "أبيض"
 
 #, fuzzy
 #~| msgid "PNG / SVG / JPG / PDF file"
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
 #~ msgstr "ملف PNG / SVG / JPG / PDF"
 
 #~ msgid "Drag stroke elements based on proximity"

--- a/crates/rnote-ui/po/bn.po
+++ b/crates/rnote-ui/po/bn.po
@@ -311,18 +311,18 @@ msgstr "রপ্তানি বিন্যাস"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr "এসভিজি"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr "পিডিএফ"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -465,7 +465,7 @@ msgid "Set the margin around the selected area"
 msgstr "নির্বাচিত এলাকার চারপাশে মার্জিন সেট করুন"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "পিডিএফ আমদানি করুন"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -479,7 +479,7 @@ msgid "Info"
 msgstr "তথ্য"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "পিডিএফ আমদানি পছন্দসমূহ"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -495,7 +495,7 @@ msgid "Adjust Document"
 msgstr "নথি এডজাস্ট করুন"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "নথির বিন্যাস পিডিএফের সাথে সংগতি করা হবে কিনা"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -503,7 +503,7 @@ msgid "Page Width (%)"
 msgstr "পৃষ্ঠার প্রস্থ (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr "আমদানি করা পিডিএফগুলির প্রস্থ বিন্যাস এর প্রস্থের শতকরা অনুপাত হিসাবে সেট করুন"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -511,7 +511,7 @@ msgid "Page Spacing"
 msgstr "পৃষ্ঠার ব্যবধান"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "কিভাবে পিডিএফ পৃষ্ঠাগুলি ব্যবধান করা হয়"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -527,7 +527,7 @@ msgid "Pages Type"
 msgstr "পৃষ্ঠার ধরন"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr "পিডিএফ গুলি কি ভেক্টর বা বিটম্যাপ ছবি হিসাবে আমদানি করা উচিত তা ঠিক করুন"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -1966,8 +1966,8 @@ msgid "Open File"
 msgstr "ফাইল খুলুন"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP, Txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2557,7 +2557,7 @@ msgstr "সাদা"
 #~ msgid "Lecture Note 1"
 #~ msgstr "লেকচার নোট ১"
 
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "একটি পিডিএফ টীকা"
 
 #~ msgid "Lecture Note 2"
@@ -2591,7 +2591,7 @@ msgstr "সাদা"
 #~ msgid "Opening Xournal++ file failed"
 #~ msgstr "Xournal++ ফাইল খুলতে ব্যর্থ হয়েছে"
 
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "পিডিএফ ফাইল খোলা ব্যর্থ হয়েছে"
 
 #~ msgid "Failed to open file, tried to open folder as file"
@@ -2838,7 +2838,7 @@ msgstr "সাদা"
 
 #, fuzzy
 #~| msgid "PNG / SVG / JPG / PDF file"
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
 #~ msgstr "PNG / SVG / JPG / PDF ফাইল"
 
 #~ msgid "Drag stroke elements based on proximity"

--- a/crates/rnote-ui/po/bs.po
+++ b/crates/rnote-ui/po/bs.po
@@ -322,17 +322,17 @@ msgstr ""
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
+msgid "XOPP"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
@@ -458,7 +458,7 @@ msgstr ""
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
 #, fuzzy
 #| msgid "_Import file"
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "Uvezi datoteku"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -472,7 +472,7 @@ msgid "Info"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -490,7 +490,7 @@ msgid "Adjust Document"
 msgstr "Izgled dokumenta"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -498,7 +498,7 @@ msgid "Page Width (%)"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -506,7 +506,7 @@ msgid "Page Spacing"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -524,7 +524,7 @@ msgid "Pages Type"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -2074,7 +2074,7 @@ msgid "Open File"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
@@ -2673,7 +2673,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "A PDF annotation"
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "PDF pribilješka"
 
 #, fuzzy
@@ -2698,7 +2698,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "Export _selection"
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "Izvoz izbora"
 
 #, fuzzy

--- a/crates/rnote-ui/po/cs.po
+++ b/crates/rnote-ui/po/cs.po
@@ -311,18 +311,18 @@ msgstr "Formát exportu"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -447,7 +447,7 @@ msgid "Set the margin around the selected area"
 msgstr "Nastavit okraj kolem vybrané oblasti"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "Importovat PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -461,7 +461,7 @@ msgid "Info"
 msgstr "Info"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "Předvolby importu PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -477,15 +477,15 @@ msgid "Adjust Document"
 msgstr "Úprava dokumentu"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
-msgstr "Zda se má rozvržení dokumentu přizpůsobit formátu Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
+msgstr "Zda se má rozvržení dokumentu přizpůsobit formátu PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
 msgid "Page Width (%)"
 msgstr "Šířka stránky (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr "Nastavení šířky importovaných PDF v procentech na šířku formátu"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -493,7 +493,7 @@ msgid "Page Spacing"
 msgstr "Rozestupy mezi stránkami"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "Jak jsou stránky PDF rozděleny"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -509,7 +509,7 @@ msgid "Pages Type"
 msgstr "Typ stránek"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
 "Nastavit, zda se mají soubory PDF importovat jako vektorové nebo bitmapové "
 "obrázky"
@@ -1952,8 +1952,8 @@ msgid "Open File"
 msgstr "Otevřít soubor"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "JPG, PDF, PNG, SVG, Xopp, TXT"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "JPG, PDF, PNG, SVG, XOPP, TXT"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2540,7 +2540,7 @@ msgstr "bílá"
 #~ msgid "Lecture Note 1"
 #~ msgstr "Čtení Poznámka 1"
 
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "Anotace PDF"
 
 #~ msgid "Lecture Note 2"

--- a/crates/rnote-ui/po/de.po
+++ b/crates/rnote-ui/po/de.po
@@ -312,18 +312,18 @@ msgstr "Das Exportformat"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
-msgstr "Pdf"
+msgid "PDF"
+msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -448,8 +448,8 @@ msgid "Set the margin around the selected area"
 msgstr "Abstand des Randes zur Auswahl ändern"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
-msgstr "Pdf importieren"
+msgid "Import PDF"
+msgstr "PDF importieren"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
 #: crates/rnote-ui/data/ui/dialogs/import.ui:218
@@ -462,8 +462,8 @@ msgid "Info"
 msgstr "Info"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
-msgstr "Pdf Importeinstellungen"
+msgid "PDF Import Preferences"
+msgstr "PDF Importeinstellungen"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
 msgid "Start Page"
@@ -478,25 +478,25 @@ msgid "Adjust Document"
 msgstr "Passe Dokument an"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
-msgstr "Ändere, ob das Dokumentenlayout an die Pdf angepasst werden soll"
+msgid "Whether the document layout should be adjusted to the PDF"
+msgstr "Ändere, ob das Dokumentenlayout an die PDF angepasst werden soll"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
 msgid "Page Width (%)"
 msgstr "Seitenbreite (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
-"Ändere die Breite importierter Pdf's in Prozent relativ zur Formatbreite"
+"Ändere die Breite importierter PDF's in Prozent relativ zur Formatbreite"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
 msgid "Page Spacing"
 msgstr "Seitenabstand"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
-msgstr "Wie Pdf Seiten platziert werden"
+msgid "How PDF pages are spaced"
+msgstr "Wie PDF Seiten platziert werden"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
 msgid "Continuous"
@@ -511,8 +511,8 @@ msgid "Pages Type"
 msgstr "Seitentyp"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
-msgstr "Wählt, ob Pdf's als Bitmap- oder Vektorbilder importiert werden"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
+msgstr "Wählt, ob PDF's als Bitmap- oder Vektorbilder importiert werden"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
 msgid "Vector"
@@ -1951,8 +1951,8 @@ msgid "Open File"
 msgstr "Datei öffnen"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP, Txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2542,8 +2542,8 @@ msgstr "weiss"
 #~ msgid "Lecture Note 1"
 #~ msgstr "Vorlesungsnotizen 1"
 
-#~ msgid "A Pdf annotation"
-#~ msgstr "Eine Pdf Anmerkung"
+#~ msgid "A PDF annotation"
+#~ msgstr "Eine PDF Anmerkung"
 
 #~ msgid "Lecture Note 2"
 #~ msgstr "Vorlesungsnotizen 2"
@@ -2576,8 +2576,8 @@ msgstr "weiss"
 #~ msgid "Opening Xournal++ file failed"
 #~ msgstr "Xournal++ Dateiöffnung gescheitert"
 
-#~ msgid "Opening Pdf file failed"
-#~ msgstr "Pdf Dateiöffnung gescheitert"
+#~ msgid "Opening PDF file failed"
+#~ msgstr "PDF Dateiöffnung gescheitert"
 
 #~ msgid "Failed to open file, tried to open folder as file"
 #~ msgstr "Dateiöffnung gescheitert, versucht Ordner als Datei zu öffnen"
@@ -2789,8 +2789,8 @@ msgstr "weiss"
 #~ msgid "Selecting apiece"
 #~ msgstr "Einzeln auswählen"
 
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
-#~ msgstr "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
+#~ msgstr "XOPP, PNG, SVG, JPG, PDF"
 
 #~ msgid "Drag stroke elements based on proximity"
 #~ msgstr "Ziehe Strichelemente in der Nähe"

--- a/crates/rnote-ui/po/es.po
+++ b/crates/rnote-ui/po/es.po
@@ -311,18 +311,18 @@ msgstr "El formato de exportación"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
-msgstr "Pdf"
+msgid "PDF"
+msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -447,7 +447,7 @@ msgid "Set the margin around the selected area"
 msgstr "Establecer el margen alrededor del área seleccionada"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "Importar pdf"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -461,7 +461,7 @@ msgid "Info"
 msgstr "Información"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "Configuración de la importación del pdf"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -477,15 +477,15 @@ msgid "Adjust Document"
 msgstr "Ajustar el documento"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
-msgstr "Si el diseño del documento debe ajustarse al Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
+msgstr "Si el diseño del documento debe ajustarse al PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
 msgid "Page Width (%)"
 msgstr "Ancho de página (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
 "Establecer la relación del aspecto de los archivos pdf importados al ancho "
 "del formato"
@@ -495,8 +495,8 @@ msgid "Page Spacing"
 msgstr "Espacio entre páginas"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
-msgstr "Distancias entre las páginas del Pdf"
+msgid "How PDF pages are spaced"
+msgstr "Distancias entre las páginas del PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
 msgid "Continuous"
@@ -511,7 +511,7 @@ msgid "Pages Type"
 msgstr "Tipo de páginas"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
 "Establecer si los pdf deben importarse como imágenes vectoriales o de mapa "
 "de bits"
@@ -1958,8 +1958,8 @@ msgid "Open File"
 msgstr "Abrir archivo"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP, Txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2549,7 +2549,7 @@ msgstr "blanco"
 #~ msgid "Lecture Note 1"
 #~ msgstr "Nota de clase 1"
 
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "Anotación en el archivo PDF"
 
 #~ msgid "Lecture Note 2"
@@ -2583,8 +2583,8 @@ msgstr "blanco"
 #~ msgid "Opening Xournal++ file failed"
 #~ msgstr "Error al abrir el archivo Xournal++"
 
-#~ msgid "Opening Pdf file failed"
-#~ msgstr "Error al abrir el archivo Pdf"
+#~ msgid "Opening PDF file failed"
+#~ msgstr "Error al abrir el archivo PDF"
 
 #~ msgid "Failed to open file, tried to open folder as file"
 #~ msgstr ""
@@ -2821,7 +2821,7 @@ msgstr "blanco"
 
 #, fuzzy
 #~| msgid "PNG / SVG / JPG / PDF file"
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
 #~ msgstr "Archivo PNG / SVG / JPG / PDF"
 
 #~ msgid "Drag stroke elements based on proximity"

--- a/crates/rnote-ui/po/fa.po
+++ b/crates/rnote-ui/po/fa.po
@@ -315,17 +315,17 @@ msgstr "چارچوب بیرون‌آوری"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr "اس‌وی‌جی"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr "پی‌دی‌اف"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
+msgid "XOPP"
 msgstr "اکس‌اوپی‌پی"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
@@ -471,7 +471,7 @@ msgid "Set the margin around the selected area"
 msgstr "کناره پیرامون پهنه برگزیده‌شده را بنهانید"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "درون‌آوری پی‌دی‌اف"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -485,7 +485,7 @@ msgid "Info"
 msgstr "داده‌ها"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "نخستینگی‌های درون‌آوری پی‌دی‌اف"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -505,7 +505,7 @@ msgstr "بیرون‌آوری نامه"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
 #, fuzzy
 #| msgid "Set whether the background pattern should be exported"
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "بگزینید که نمونه پس‌زمینه بیرون‌آوری شود یا نه"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -513,7 +513,7 @@ msgid "Page Width (%)"
 msgstr "درازای برگه (٪)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr "درازای پی‌دی‌اف‌های درون‌آورده‌شده را به گونه درسد بر درازای چارچوب بنهانید"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -521,7 +521,7 @@ msgid "Page Spacing"
 msgstr "میان‌گذاری برگه‌ها"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "برگه‌های پی‌دی‌اف چگونه میان‌گذاری می‌شوند"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -537,7 +537,7 @@ msgid "Pages Type"
 msgstr "گونه برگه‌ها"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr "بگزینید که پی‌دی‌اف‌ها باید به سان نگاره‌های برداری یا بیت‌مپ درون‌آوری شوند"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -1976,7 +1976,7 @@ msgid "Open File"
 msgstr "بازکردن فایل"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
@@ -2570,7 +2570,7 @@ msgstr ""
 #~ msgid "Lecture Note 1"
 #~ msgstr "یادداشت سخنرانی ۱"
 
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "یک کنارنویسی پی‌دی‌اف"
 
 #~ msgid "Lecture Note 2"

--- a/crates/rnote-ui/po/fi.po
+++ b/crates/rnote-ui/po/fi.po
@@ -312,18 +312,18 @@ msgstr "Viennissä käytettävä muoto"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -450,7 +450,7 @@ msgid "Set the margin around the selected area"
 msgstr "Aseta reunus valitun alueen ympärille"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "Tuo PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -464,7 +464,7 @@ msgid "Info"
 msgstr "Tiedot"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "PDF-tuonnin asetukset"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -480,7 +480,7 @@ msgid "Adjust Document"
 msgstr "Säädä asiakirjaa"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "Säädetänkö asiakirjan asettelua vastaamaan PDF:ää"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -488,7 +488,7 @@ msgid "Page Width (%)"
 msgstr "Sivun leveys (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -496,7 +496,7 @@ msgid "Page Spacing"
 msgstr "Sivujen välistys"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "Miten PDF:n sivut välistetään"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -512,7 +512,7 @@ msgid "Pages Type"
 msgstr "Sivujen tyyppi"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr "Tuodaanko PDF:t vektori- vai bittikarttakuvina"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -1941,8 +1941,8 @@ msgid "Open File"
 msgstr "Avaa tiedosto"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP, Txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"

--- a/crates/rnote-ui/po/fr.po
+++ b/crates/rnote-ui/po/fr.po
@@ -312,18 +312,18 @@ msgstr "Le format d’exportation"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
-msgstr "Pdf"
+msgid "PDF"
+msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -466,7 +466,7 @@ msgid "Set the margin around the selected area"
 msgstr "Définir la marge autour de l’aire sélectionnée"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "Importer un PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -480,7 +480,7 @@ msgid "Info"
 msgstr "Info"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "Paramètres d’importation PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -496,15 +496,15 @@ msgid "Adjust Document"
 msgstr "Ajuster le document"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
-msgstr "Ajuster la mise en page du document au Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
+msgstr "Ajuster la mise en page du document au PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
 msgid "Page Width (%)"
 msgstr "Largeur de page (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
 "Définir la largeur des PDF importés en pourcentage de la largeur de la page"
 
@@ -513,8 +513,8 @@ msgid "Page Spacing"
 msgstr "Espacement des pages"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
-msgstr "Comment les pages du Pdf sont espacées"
+msgid "How PDF pages are spaced"
+msgstr "Comment les pages du PDF sont espacées"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
 msgid "Continuous"
@@ -529,9 +529,9 @@ msgid "Pages Type"
 msgstr "Type de pages"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
-"Définir si les Pdf doivent être importés en tant qu’images vectorielles ou "
+"Définir si les PDF doivent être importés en tant qu’images vectorielles ou "
 "matricielles (bitmap)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -1976,8 +1976,8 @@ msgid "Open File"
 msgstr "Ouvrir le fichier"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "JPG, PDF, PNG, SVG, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "JPG, PDF, PNG, SVG, XOPP, Txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2567,7 +2567,7 @@ msgstr "blanc"
 #~ msgid "Lecture Note 1"
 #~ msgstr "Note de cours 1"
 
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "Une annotation PDF"
 
 #~ msgid "Lecture Note 2"
@@ -2601,8 +2601,8 @@ msgstr "blanc"
 #~ msgid "Opening Xournal++ file failed"
 #~ msgstr "L'ouverture du fichier Xournal++ a échoué"
 
-#~ msgid "Opening Pdf file failed"
-#~ msgstr "L'ouverture du fichier Pdf a échoué"
+#~ msgid "Opening PDF file failed"
+#~ msgstr "L'ouverture du fichier PDF a échoué"
 
 #~ msgid "Failed to open file, tried to open folder as file"
 #~ msgstr ""
@@ -2850,7 +2850,7 @@ msgstr "blanc"
 
 #, fuzzy
 #~| msgid "PNG / SVG / JPG / PDF file"
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
 #~ msgstr "PNG / SVG / JPG / PDF file"
 
 #~ msgid "Drag stroke elements based on proximity"

--- a/crates/rnote-ui/po/he.po
+++ b/crates/rnote-ui/po/he.po
@@ -329,18 +329,18 @@ msgstr "מסמך חדש"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr "גרפיקה וקטורית (SVG)"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr "מסמך PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xournal++ (Xopp)"
+msgid "XOPP"
+msgstr "Xournal++ (XOPP)"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -479,8 +479,8 @@ msgid "Set the margin around the selected area"
 msgstr "הגדרת רוחב השוליים לשטח הנבחר"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
-msgstr "ייבוא Pdf"
+msgid "Import PDF"
+msgstr "ייבוא PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
 #: crates/rnote-ui/data/ui/dialogs/import.ui:218
@@ -494,7 +494,7 @@ msgstr "מידע"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
 #, fuzzy
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "סוג תמונת ה־PDF לייבוא"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -515,7 +515,7 @@ msgstr "מסמך חדש"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
 #, fuzzy
 #| msgid "Set the background color"
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "הגדרת צבע הרקע"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -525,7 +525,7 @@ msgstr "רוחב ייבוא PDF (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
 #, fuzzy
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr "להגדיר את רוחב ה־PDF המיובא באחוזים מתוך רוחב תצורת הגיליון"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -533,7 +533,7 @@ msgid "Page Spacing"
 msgstr "מרווח בין דפים"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "מרווח בין עמודי PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -551,7 +551,7 @@ msgstr "סוג עמודים"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
 #, fuzzy
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr "להגדיר האם לייבא PDFים כווקטורים או כתמונות מפות סיביות"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -2178,7 +2178,7 @@ msgid "Open File"
 msgstr "פתיחת קובץ"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
@@ -2811,7 +2811,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "A PDF annotation"
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "הערות על PDF"
 
 #~ msgid "Lecture Note 2"
@@ -2850,7 +2850,7 @@ msgstr ""
 #~ msgstr "פתיחת הגיליון נכשלה"
 
 #, fuzzy
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "פתיחת הגיליון נכשלה"
 
 #, fuzzy
@@ -3068,7 +3068,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "PNG / SVG / JPG / PDF file"
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
 #~ msgstr "קובץ PNG / SVG / JPG / PDF"
 
 #~ msgid "Drag stroke elements based on proximity"

--- a/crates/rnote-ui/po/hi.po
+++ b/crates/rnote-ui/po/hi.po
@@ -311,17 +311,17 @@ msgstr "निर्यात प्रारूप"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
+msgid "XOPP"
 msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
@@ -447,7 +447,7 @@ msgid "Set the margin around the selected area"
 msgstr "चयनित क्षेत्र के आसपास मार्जिन तय करें"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "PDF आयात करें"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -461,7 +461,7 @@ msgid "Info"
 msgstr "जानकारी"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "PDF आयात प्राथमिकताएं"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -477,7 +477,7 @@ msgid "Adjust Document"
 msgstr "दस्तावेज समायोजित करें"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "क्या दस्तावेज अभिन्यास को PDF में समायोजित किया जाना चाहिए"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -485,7 +485,7 @@ msgid "Page Width (%)"
 msgstr "पृष्ठ की चौड़ाई (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr "आयातित PDF की चौड़ाई को प्रारूप की चौड़ाई के प्रतिशत में निर्धारित करें"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -493,7 +493,7 @@ msgid "Page Spacing"
 msgstr "पृष्ठ रिक्ति"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "PDF पृष्ठों में अंतर कैसे रखा जाता है"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -509,7 +509,7 @@ msgid "Pages Type"
 msgstr "पृष्ठ प्रकार"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
 "निर्धारित करें कि क्या PDF को वेक्टर या बिटमैप छवियों के रूप में आयात किया जाना चाहिए"
 
@@ -1948,8 +1948,8 @@ msgid "Open File"
 msgstr "फाइल खोलें"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP, Txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2536,7 +2536,7 @@ msgstr "सफेद"
 #~ msgid "Lecture Note 1"
 #~ msgstr "लेकचर नोट १"
 
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "एक पीडीएफ एनोटेशन"
 
 #~ msgid "Lecture Note 2"

--- a/crates/rnote-ui/po/hu.po
+++ b/crates/rnote-ui/po/hu.po
@@ -312,17 +312,17 @@ msgstr "Az exportálási formátum"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr "SVG-fájl"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr "PDF-fájl"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
+msgid "XOPP"
 msgstr "XOPP-fájl"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
@@ -466,7 +466,7 @@ msgid "Set the margin around the selected area"
 msgstr "Margó beállítása a kijelölt terület körül"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "PDF importálása"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -480,7 +480,7 @@ msgid "Info"
 msgstr "Adat"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "PDF importálási beállítások"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -496,7 +496,7 @@ msgid "Adjust Document"
 msgstr "Dokumentum beállítása"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "A dokumentum elrendezését a PDF-dokumentumhoz kell-e igazítani"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -504,7 +504,7 @@ msgid "Page Width (%)"
 msgstr "Oldalszélesség (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
 "Az importált PDF-ek szélességének beállítása százalékban a formátum "
 "szélességének megfelelően"
@@ -514,7 +514,7 @@ msgid "Page Spacing"
 msgstr "Oldaltávolság"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "A PDF oldalak közötti távolságok"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -530,7 +530,7 @@ msgid "Pages Type"
 msgstr "Oldalak típusa"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr "A PDF-ek vektoros vagy pontképes importálása"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -1961,8 +1961,8 @@ msgid "Open File"
 msgstr "Fájl megnyitása"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "JPG, PDF, PNG, SVG, txt, Xopp"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "JPG, PDF, PNG, SVG, txt, XOPP"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2560,7 +2560,7 @@ msgstr ""
 #~ msgid "Lecture Note 1"
 #~ msgstr "1. előadási jegyzet"
 
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "PDF-jegyzet"
 
 #~ msgid "Lecture Note 2"
@@ -2594,7 +2594,7 @@ msgstr ""
 #~ msgid "Opening Xournal++ file failed"
 #~ msgstr "A Xournal++ fájl megnyitása sikertelen"
 
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "A PDF fájl megnyitása sikertelen"
 
 #~ msgid "Failed to open file, tried to open folder as file"
@@ -2823,8 +2823,8 @@ msgstr ""
 #~ msgid "Selecting apiece"
 #~ msgstr "Darab kijelölése"
 
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
-#~ msgstr "JPG, PDF, PNG, SVG, Xopp"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
+#~ msgstr "JPG, PDF, PNG, SVG, XOPP"
 
 #~ msgid "Drag stroke elements based on proximity"
 #~ msgstr "Vonalak húzása közelség alapján"

--- a/crates/rnote-ui/po/id.po
+++ b/crates/rnote-ui/po/id.po
@@ -312,18 +312,18 @@ msgstr "Format ekspor"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
-msgstr "Pdf"
+msgid "PDF"
+msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -468,8 +468,8 @@ msgid "Set the margin around the selected area"
 msgstr "Atur margin di sekitar area yang dipilih"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
-msgstr "Impor Pdf"
+msgid "Import PDF"
+msgstr "Impor PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
 #: crates/rnote-ui/data/ui/dialogs/import.ui:218
@@ -482,8 +482,8 @@ msgid "Info"
 msgstr "Info"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
-msgstr "Preferensi Impor Pdf"
+msgid "PDF Import Preferences"
+msgstr "Preferensi Impor PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
 msgid "Start Page"
@@ -498,24 +498,24 @@ msgid "Adjust Document"
 msgstr "Sesuaikan Dokumen"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
-msgstr "Apakah tata letak dokumen harus disesuaikan dengan Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
+msgstr "Apakah tata letak dokumen harus disesuaikan dengan PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
 msgid "Page Width (%)"
 msgstr "Lebar Halaman (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
-msgstr "Atur lebar Pdf yang diimpor dalam persentase terhadap lebar format"
+msgid "Set the width of imported PDF's in percentage to the format width"
+msgstr "Atur lebar PDF yang diimpor dalam persentase terhadap lebar format"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
 msgid "Page Spacing"
 msgstr "Spasi Halaman"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
-msgstr "Bagaimana halaman Pdf diberi spasi"
+msgid "How PDF pages are spaced"
+msgstr "Bagaimana halaman PDF diberi spasi"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
 msgid "Continuous"
@@ -530,8 +530,8 @@ msgid "Pages Type"
 msgstr "Jenis Halaman"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
-msgstr "Atur apakah Pdf harus diimpor sebagai gambar vektor atau bitmap"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
+msgstr "Atur apakah PDF harus diimpor sebagai gambar vektor atau bitmap"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
 msgid "Vector"
@@ -1992,7 +1992,7 @@ msgid "Open File"
 msgstr "Buka File"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
@@ -2589,7 +2589,7 @@ msgstr "putih"
 
 #, fuzzy
 #~| msgid "A PDF annotation"
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "Anotasi PDF"
 
 #~ msgid "Lecture Note 2"
@@ -2624,7 +2624,7 @@ msgstr "putih"
 
 #, fuzzy
 #~| msgid "Opening .rnote file failed."
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "Pembukaan berkas .rnote gagal."
 
 #, fuzzy

--- a/crates/rnote-ui/po/it.po
+++ b/crates/rnote-ui/po/it.po
@@ -312,18 +312,18 @@ msgstr "Il formato da esportare"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
-msgstr "Pdf"
+msgid "PDF"
+msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -448,8 +448,8 @@ msgid "Set the margin around the selected area"
 msgstr "Imposta il margine attorno all'area selezionata"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
-msgstr "Importa Pdf"
+msgid "Import PDF"
+msgstr "Importa PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
 #: crates/rnote-ui/data/ui/dialogs/import.ui:218
@@ -462,8 +462,8 @@ msgid "Info"
 msgstr "Informazioni"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
-msgstr "Preferenze sull'importazione dei Pdf"
+msgid "PDF Import Preferences"
+msgstr "Preferenze sull'importazione dei PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
 msgid "Start Page"
@@ -478,17 +478,17 @@ msgid "Adjust Document"
 msgstr "Regola documento"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
-msgstr "Se il layout del documento deve essere adattato al Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
+msgstr "Se il layout del documento deve essere adattato al PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
 msgid "Page Width (%)"
 msgstr "Larghezza Pagina (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
-"Imposta la larghezza dei Pdf importati in percentuale sulla larghezza del "
+"Imposta la larghezza dei PDF importati in percentuale sulla larghezza del "
 "formato"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -496,8 +496,8 @@ msgid "Page Spacing"
 msgstr "Spaziatura delle pagine"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
-msgstr "Come sono distanziate le pagine Pdf"
+msgid "How PDF pages are spaced"
+msgstr "Come sono distanziate le pagine PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
 msgid "Continuous"
@@ -512,9 +512,9 @@ msgid "Pages Type"
 msgstr "Tipo di pagine"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
-"Imposta se i Pdf devono essere importati come immagini vettoriali o bitmap"
+"Imposta se i PDF devono essere importati come immagini vettoriali o bitmap"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
 msgid "Vector"
@@ -1955,8 +1955,8 @@ msgid "Open File"
 msgstr "Apri File"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP, Txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2546,8 +2546,8 @@ msgstr "bianco"
 #~ msgid "Lecture Note 1"
 #~ msgstr "Appunti Lezione 1"
 
-#~ msgid "A Pdf annotation"
-#~ msgstr "Un'annotazione Pdf"
+#~ msgid "A PDF annotation"
+#~ msgstr "Un'annotazione PDF"
 
 #~ msgid "Lecture Note 2"
 #~ msgstr "Appunti Lezione 2"
@@ -2580,8 +2580,8 @@ msgstr "bianco"
 #~ msgid "Opening Xournal++ file failed"
 #~ msgstr "Apertura file Xournal++ fallita"
 
-#~ msgid "Opening Pdf file failed"
-#~ msgstr "Apertura del file Pdf fallita"
+#~ msgid "Opening PDF file failed"
+#~ msgstr "Apertura del file PDF fallita"
 
 #~ msgid "Failed to open file, tried to open folder as file"
 #~ msgstr ""
@@ -2807,8 +2807,8 @@ msgstr "bianco"
 #~ msgid "Selecting apiece"
 #~ msgstr "Selezione singola"
 
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
-#~ msgstr "Xopp ,PNG,SVG,JPG ,PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
+#~ msgstr "XOPP ,PNG,SVG,JPG ,PDF"
 
 #~ msgid "Drag stroke elements based on proximity"
 #~ msgstr "Trascina gli elementi del tratto in base alla vicinanza"

--- a/crates/rnote-ui/po/ja.po
+++ b/crates/rnote-ui/po/ja.po
@@ -312,18 +312,18 @@ msgstr "エクスポートの形式"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
-msgstr "Pdf"
+msgid "PDF"
+msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -466,7 +466,7 @@ msgid "Set the margin around the selected area"
 msgstr "選択範囲の周囲に余白を設定します"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "PDF をインポート"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -480,7 +480,7 @@ msgid "Info"
 msgstr "情報"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "PDF のインポート設定"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -496,7 +496,7 @@ msgid "Adjust Document"
 msgstr "文書を調整"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "文書レイアウトを PDF に合せるかどうかを設定します"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -504,7 +504,7 @@ msgid "Page Width (%)"
 msgstr "ページ幅 (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr "インポートする PDF の幅を、用紙幅に対する比率で設定します"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -512,7 +512,7 @@ msgid "Page Spacing"
 msgstr "ページ間隔"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "PDF のページ間隔"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -528,7 +528,7 @@ msgid "Pages Type"
 msgstr "ページ種類"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
 "PDF をベクター画像とビットマップ画像のどちらでインポートするか設定します"
 
@@ -1954,8 +1954,8 @@ msgid "Open File"
 msgstr "ファイルを開く"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP, Txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2583,7 +2583,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "Opening bitmap image file failed."
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "ビットマップ画像の読み込みに失敗しました。"
 
 #, fuzzy
@@ -2649,7 +2649,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "PNG / SVG / JPG / PDF file"
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
 #~ msgstr "PNG / SVG / JPG/ PDF ファイル"
 
 #~ msgid "Export selection as PNG"

--- a/crates/rnote-ui/po/ko.po
+++ b/crates/rnote-ui/po/ko.po
@@ -327,18 +327,18 @@ msgstr "내보내기 형식"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
-msgstr "Pdf"
+msgid "PDF"
+msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -471,7 +471,7 @@ msgstr "선택한 영역 주변의 여백을 설정합니다"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
 #, fuzzy
 #| msgid "Import PDF"
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "PDF 가져오기"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -487,7 +487,7 @@ msgstr "정보"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
 #, fuzzy
 #| msgid "PDF Import Preferences"
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "PDF 가져오기 환경설정"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -507,7 +507,7 @@ msgstr "문서"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
 #, fuzzy
 #| msgid "Set whether the background pattern should be exported"
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "배경 패턴을 내보낼지 여부를 설정합니다"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -517,7 +517,7 @@ msgstr "페이지 너비 (%)"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
 #, fuzzy
 #| msgid "Set the width of imported PDF's in percentage to the format width"
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr "가져온 PDF의 너비를 형식 너비에 대한 백분율로 설정합니다"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -527,7 +527,7 @@ msgstr "페이지 간격"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
 #, fuzzy
 #| msgid "How PDF pages are spaced"
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "PDF 페이지 간격 지정 방법"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -545,7 +545,7 @@ msgstr "페이지 유형"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
 #, fuzzy
 #| msgid "Set whether PDFs should be imported as vector or bitmap images"
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr "PDF를 벡터 이미지로 가져올지 비트맵 이미지로 가져올지 설정합니다"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -2030,9 +2030,9 @@ msgstr "파일 열기"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
 #, fuzzy
-#| msgid "Jpg, Pdf, Png, Svg, Xopp"
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp"
+#| msgid "Jpg, PDF, Png, SVG, XOPP"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2674,7 +2674,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "A PDF annotation"
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "PDF 주석"
 
 #~ msgid "Lecture Note 2"
@@ -2707,7 +2707,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "Opening PDF file failed"
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "PDF 파일 열기에 실패했습니다"
 
 #~ msgid "Failed to open file, tried to open folder as file"

--- a/crates/rnote-ui/po/mk.po
+++ b/crates/rnote-ui/po/mk.po
@@ -354,17 +354,17 @@ msgstr "Извади документ"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
+msgid "XOPP"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
@@ -494,7 +494,7 @@ msgstr ""
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
 #, fuzzy
 #| msgid "Import PDF"
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "Внеси PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -510,7 +510,7 @@ msgstr ""
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
 #, fuzzy
 #| msgid "PDF import preferences"
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "Нагодувања при внес на PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -532,7 +532,7 @@ msgstr "Документ"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
 #, fuzzy
 #| msgid "Set the background color"
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "Одреди ја позадинската боја"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -544,7 +544,7 @@ msgstr "Ширина на страница (%)"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
 #, fuzzy
 #| msgid "Set the width of imported PDF's in percentage to the format width"
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr "Одбери ја ширината на внесениот PDF во проценти од ширината на формата"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -556,7 +556,7 @@ msgstr "Проред"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
 #, fuzzy
 #| msgid "How PDF pages are spaced"
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "Како се проредуваат страниците на PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -578,7 +578,7 @@ msgstr "Вид на страници"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
 #, fuzzy
 #| msgid "Set whether PDFs should be imported as vector or bitmap images"
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr "Одреди дали PDF треба да се внесува како вектор или слика"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -2332,7 +2332,7 @@ msgid "Open File"
 msgstr "Отвори датотека"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
@@ -2965,7 +2965,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "A PDF annotation"
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "PDF бележење"
 
 #, fuzzy
@@ -3007,7 +3007,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "Opening PDF file failed."
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "Отворањето на PDF-от беше неуспешно."
 
 #, fuzzy
@@ -3269,7 +3269,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "PNG / SVG / JPG / PDF file"
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
 #~ msgstr "PNG / SVG / JPG / PDF датотека"
 
 #~ msgid "Drag stroke elements based on proximity"

--- a/crates/rnote-ui/po/ml.po
+++ b/crates/rnote-ui/po/ml.po
@@ -312,18 +312,18 @@ msgstr "എക്സ്പോർട്ട് ഫോർമാറ്റ്"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr "എസ് വി ജി"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr "പി ഡി എഫ്"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -450,7 +450,7 @@ msgid "Set the margin around the selected area"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "pdf ഇമ്പോർട്ട് ചെയ്യുക"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -464,7 +464,7 @@ msgid "Info"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -480,7 +480,7 @@ msgid "Adjust Document"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -488,7 +488,7 @@ msgid "Page Width (%)"
 msgstr "പേജിന്റെ വീതി"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr "ഇമ്പോർട്ട്‌ ചെയ്ത പി ഡി എഫിന്റെ വീതി ഫോര്മാറ്റിന്റെ ശതമാനത്തിൽ മാറ്റുക"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -496,8 +496,8 @@ msgid "Page Spacing"
 msgstr "പേജ് സ്പേസിംഗ്"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
-msgstr "Pdf പേജുകൾ എങ്ങനെയാണ് സ്‌പെയ്‌സ് ചെയ്യേണ്ടത്"
+msgid "How PDF pages are spaced"
+msgstr "PDF പേജുകൾ എങ്ങനെയാണ് സ്‌പെയ്‌സ് ചെയ്യേണ്ടത്"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
 msgid "Continuous"
@@ -512,7 +512,7 @@ msgid "Pages Type"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -1918,7 +1918,7 @@ msgid "Open File"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:239

--- a/crates/rnote-ui/po/ms.po
+++ b/crates/rnote-ui/po/ms.po
@@ -310,17 +310,17 @@ msgstr ""
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
+msgid "XOPP"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
@@ -438,7 +438,7 @@ msgid "Set the margin around the selected area"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -452,7 +452,7 @@ msgid "Info"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -468,7 +468,7 @@ msgid "Adjust Document"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -476,7 +476,7 @@ msgid "Page Width (%)"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -484,7 +484,7 @@ msgid "Page Spacing"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -500,7 +500,7 @@ msgid "Pages Type"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -1926,7 +1926,7 @@ msgid "Open File"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
@@ -2521,7 +2521,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "A PDF annotation"
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "Anotasi PDF"
 
 #, fuzzy

--- a/crates/rnote-ui/po/nb_NO.po
+++ b/crates/rnote-ui/po/nb_NO.po
@@ -340,17 +340,17 @@ msgstr "Eksporter"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
+msgid "XOPP"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
@@ -478,7 +478,7 @@ msgstr ""
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
 #, fuzzy
 #| msgid "Import"
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "Importer"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -495,7 +495,7 @@ msgstr ""
 #, fuzzy
 #| msgctxt "shortcut window"
 #| msgid "Import file"
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "Importer fil"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -515,7 +515,7 @@ msgstr "Nytt dokument"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
 #, fuzzy
 #| msgid "Set the background color"
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "Sett bakgrunnsfargen"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -523,7 +523,7 @@ msgid "Page Width (%)"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -531,7 +531,7 @@ msgid "Page Spacing"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -551,7 +551,7 @@ msgid "Pages Type"
 msgstr "Sider:"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -2151,7 +2151,7 @@ msgid "Open File"
 msgstr "Åpne fil"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
@@ -2763,7 +2763,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "A PDF annotation"
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "En PDF-annotering"
 
 #, fuzzy
@@ -2792,7 +2792,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "Opening PDF file failed."
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "Åpning av PDF-fil mislyktes."
 
 #, fuzzy

--- a/crates/rnote-ui/po/ne.po
+++ b/crates/rnote-ui/po/ne.po
@@ -304,17 +304,17 @@ msgstr ""
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
+msgid "XOPP"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
@@ -430,7 +430,7 @@ msgid "Set the margin around the selected area"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -444,7 +444,7 @@ msgid "Info"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -460,7 +460,7 @@ msgid "Adjust Document"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -468,7 +468,7 @@ msgid "Page Width (%)"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -476,7 +476,7 @@ msgid "Page Spacing"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -492,7 +492,7 @@ msgid "Pages Type"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -1898,7 +1898,7 @@ msgid "Open File"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:239

--- a/crates/rnote-ui/po/nl.po
+++ b/crates/rnote-ui/po/nl.po
@@ -311,17 +311,17 @@ msgstr "Het export-bestandsformaat"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
+msgid "XOPP"
 msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
@@ -465,7 +465,7 @@ msgid "Set the margin around the selected area"
 msgstr "Stel de marges rondom het selectiegebied in"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "PDF-bestand importeren"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -479,7 +479,7 @@ msgid "Info"
 msgstr "Info"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "PDF-importvoorkeuren"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -495,7 +495,7 @@ msgid "Adjust Document"
 msgstr "Document aan­passen"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "Of de document­opmaak aangepast moet worden aan de PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -503,7 +503,7 @@ msgid "Page Width (%)"
 msgstr "Paginabreedte (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
 "Stelt de breedte in van geïmporteerde PDF-bestanden als percentage van de "
 "formaatbreedte"
@@ -513,7 +513,7 @@ msgid "Page Spacing"
 msgstr "Pagina-opvulling"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "Hoe PDF-pagina's van elkaar dienen te worden gescheiden"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -529,7 +529,7 @@ msgid "Pages Type"
 msgstr "Paginatype"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
 "Geef aan of PDF-bestanden dienen te worden geïmporteerd als vector- of "
 "bitmap-afbeeldingen"
@@ -1959,7 +1959,7 @@ msgid "Open File"
 msgstr "Bestand openen"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr "JPG, PDF, PNG, SVG, XOPP, TXT"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
@@ -2552,7 +2552,7 @@ msgstr "wit"
 #~ msgid "Lecture Note 1"
 #~ msgstr "College-aantekeningen 1"
 
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "Een PDF-aantekening"
 
 #~ msgid "Lecture Note 2"
@@ -2586,7 +2586,7 @@ msgstr "wit"
 #~ msgid "Opening Xournal++ file failed"
 #~ msgstr "Xournal++-bestand openen mislukt"
 
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "PDF-bestand openen mislukt"
 
 #~ msgid "Failed to open file, tried to open folder as file"
@@ -2817,8 +2817,8 @@ msgstr "wit"
 #~ msgid "Selecting apiece"
 #~ msgstr "Itemselectie"
 
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
-#~ msgstr "Xopp, png, svg, jpg, pdf"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
+#~ msgstr "XOPP, png, svg, jpg, pdf"
 
 #~ msgid "Drag stroke elements based on proximity"
 #~ msgstr "Penseelstreek-elementen verslepen op basis van afstand"
@@ -2868,7 +2868,7 @@ msgstr "wit"
 #~ msgstr "Document exporteren naar .xopp (Xournal++)"
 
 #~ msgid "SVG file"
-#~ msgstr "Svg-bestand"
+#~ msgstr "SVG-bestand"
 
 #~ msgid "PNG file"
 #~ msgstr "Png-bestand"
@@ -2880,7 +2880,7 @@ msgstr "wit"
 #~ msgstr "De selectie is geëxporteerd."
 
 #~ msgid "PDF file"
-#~ msgstr "Pdf-bestand"
+#~ msgstr "PDF-bestand"
 
 #~ msgid "Export document as PDF failed."
 #~ msgstr "Het exporteren is mislukt."

--- a/crates/rnote-ui/po/pl.po
+++ b/crates/rnote-ui/po/pl.po
@@ -313,18 +313,18 @@ msgstr "Format eksportu"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
-msgstr "Pdf"
+msgid "PDF"
+msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -447,8 +447,8 @@ msgid "Set the margin around the selected area"
 msgstr "Ustaw margines wokół wybranego pola"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
-msgstr "Importuj Pdf"
+msgid "Import PDF"
+msgstr "Importuj PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
 #: crates/rnote-ui/data/ui/dialogs/import.ui:218
@@ -461,8 +461,8 @@ msgid "Info"
 msgstr "Informacje"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
-msgstr "Preferencje importu Pdf"
+msgid "PDF Import Preferences"
+msgstr "Preferencje importu PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
 msgid "Start Page"
@@ -477,17 +477,17 @@ msgid "Adjust Document"
 msgstr "Dostosuj Dokument"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
-msgstr "Czy układ dokumentu powinien zostać dostosowany do Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
+msgstr "Czy układ dokumentu powinien zostać dostosowany do PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
 msgid "Page Width (%)"
 msgstr "Szerokość strony (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
-"Ustawianie szerokości importowanych plików Pdf w procentach szerokości "
+"Ustawianie szerokości importowanych plików PDF w procentach szerokości "
 "formatu"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -495,8 +495,8 @@ msgid "Page Spacing"
 msgstr "Odstępy między stronami"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
-msgstr "Sposób rozmieszczenia stron Pdf"
+msgid "How PDF pages are spaced"
+msgstr "Sposób rozmieszczenia stron PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
 msgid "Continuous"
@@ -511,9 +511,9 @@ msgid "Pages Type"
 msgstr "Typ strony"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
-"Ustaw, czy pliki Pdf powinny być importowane jako obrazy wektorowe czy "
+"Ustaw, czy pliki PDF powinny być importowane jako obrazy wektorowe czy "
 "bitmapowe"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -1953,8 +1953,8 @@ msgid "Open File"
 msgstr "Otwórz plik"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP, Txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2546,7 +2546,7 @@ msgstr "biały"
 
 #, fuzzy
 #~| msgid "A PDF annotation"
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "Adnotacja PDF"
 
 #~ msgid "Lecture Note 2"
@@ -2582,7 +2582,7 @@ msgstr "biały"
 
 #, fuzzy
 #~| msgid "Opening PDF file failed"
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "Otwarcie pliku PDF się nie powiodło"
 
 #~ msgid "Failed to open file, tried to open folder as file"
@@ -2820,7 +2820,7 @@ msgstr "biały"
 
 #, fuzzy
 #~| msgid "PNG / SVG / JPG / PDF file"
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
 #~ msgstr "plik PNG / SVG / JPG / PDF"
 
 #, fuzzy

--- a/crates/rnote-ui/po/pt.po
+++ b/crates/rnote-ui/po/pt.po
@@ -322,18 +322,18 @@ msgstr "O formato de exportação"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
-msgstr "Pdf"
+msgid "PDF"
+msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -466,7 +466,7 @@ msgstr "Definir Margem à volta da área seleccionada"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
 #, fuzzy
 #| msgid "Import PDF"
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "Importar PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -482,7 +482,7 @@ msgstr "Informação"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
 #, fuzzy
 #| msgid "PDF Import Preferences"
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "Preferências de Importação de PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -502,7 +502,7 @@ msgstr "Exportar Documento"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
 #, fuzzy
 #| msgid "Set whether the background pattern should be exported"
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "Definir se padrão de fundo deve ser exportado"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -512,7 +512,7 @@ msgstr "Largura da Página (%)"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
 #, fuzzy
 #| msgid "Set the width of imported PDF's in percentage to the format width"
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
 "Definir a largura de PDF's importados em percentagem para a largura do "
 "formato"
@@ -524,7 +524,7 @@ msgstr "Espaçamento da página"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
 #, fuzzy
 #| msgid "How PDF pages are spaced"
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "Como são espaçadas as páginas em PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -542,7 +542,7 @@ msgstr "Tipo de Página"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
 #, fuzzy
 #| msgid "Set whether PDFs should be imported as vector or bitmap images"
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
 "Definir se os PDF's devem ser importados como imagens vectoriais ou mapas de "
 "bits"
@@ -1984,7 +1984,7 @@ msgid "Open File"
 msgstr "Abrir Ficheiro"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
@@ -2582,7 +2582,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "A PDF annotation"
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "Anotação de PDF"
 
 #~ msgid "Lecture Note 2"

--- a/crates/rnote-ui/po/pt_BR.po
+++ b/crates/rnote-ui/po/pt_BR.po
@@ -318,18 +318,18 @@ msgstr "O formato de exportação"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
-msgstr "Pdf"
+msgid "PDF"
+msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -470,8 +470,8 @@ msgid "Set the margin around the selected area"
 msgstr "Definir a margem em volta da área selecionada"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
-msgstr "Importar Pdf"
+msgid "Import PDF"
+msgstr "Importar PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
 #: crates/rnote-ui/data/ui/dialogs/import.ui:218
@@ -484,8 +484,8 @@ msgid "Info"
 msgstr "Informação"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
-msgstr "Preferências de Importação de Pdf"
+msgid "PDF Import Preferences"
+msgstr "Preferências de Importação de PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
 msgid "Start Page"
@@ -505,7 +505,7 @@ msgstr "Documento"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
 #, fuzzy
 #| msgid "Set whether the background pattern should be exported"
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "Definir se o padrão do plano de fundo deve ser exportado"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -513,17 +513,17 @@ msgid "Page Width (%)"
 msgstr "Largura da página (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
-"Definir a largura do Pdf importado em porcentagem para a largura do modelo"
+"Definir a largura do PDF importado em porcentagem para a largura do modelo"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
 msgid "Page Spacing"
 msgstr "Espaçamento da página"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
-msgstr "Como páginas em Pdf são espaçadas"
+msgid "How PDF pages are spaced"
+msgstr "Como páginas em PDF são espaçadas"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
 msgid "Continuous"
@@ -538,8 +538,8 @@ msgid "Pages Type"
 msgstr "Tipo de páginas"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
-msgstr "Definir se o Pdf deverá ser importado como vetor ou imagens bitmap"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
+msgstr "Definir se o PDF deverá ser importado como vetor ou imagens bitmap"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
 msgid "Vector"
@@ -2207,7 +2207,7 @@ msgid "Open File"
 msgstr "Abrir arquivo"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
@@ -2838,8 +2838,8 @@ msgstr ""
 #~ msgid "Lecture Note 1"
 #~ msgstr "Nota da Aula 1"
 
-#~ msgid "A Pdf annotation"
-#~ msgstr "Uma anotação de Pdf"
+#~ msgid "A PDF annotation"
+#~ msgstr "Uma anotação de PDF"
 
 #~ msgid "Lecture Note 2"
 #~ msgstr "Notas da Aula 2"
@@ -2883,7 +2883,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "Opening PDF file failed."
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "Falha ao abrir arquivo PDF."
 
 #, fuzzy
@@ -3146,7 +3146,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "PNG / SVG / JPG / PDF file"
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
 #~ msgstr "Arquivo PNG / SVG / JPG / PDF"
 
 #~ msgid "Drag stroke elements based on proximity"

--- a/crates/rnote-ui/po/rnote.pot
+++ b/crates/rnote-ui/po/rnote.pot
@@ -300,17 +300,17 @@ msgstr ""
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
+msgid "XOPP"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
@@ -426,7 +426,7 @@ msgid "Set the margin around the selected area"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -440,7 +440,7 @@ msgid "Info"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -456,7 +456,7 @@ msgid "Adjust Document"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -464,7 +464,7 @@ msgid "Page Width (%)"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -472,7 +472,7 @@ msgid "Page Spacing"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -488,7 +488,7 @@ msgid "Pages Type"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -1892,7 +1892,7 @@ msgid "Open File"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:239

--- a/crates/rnote-ui/po/ru.po
+++ b/crates/rnote-ui/po/ru.po
@@ -312,17 +312,17 @@ msgstr "Формат для экспорта"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
+msgid "XOPP"
 msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
@@ -457,7 +457,7 @@ msgid "Set the margin around the selected area"
 msgstr "Установить поля вокруг выбранной области"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "Импортировать PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -471,7 +471,7 @@ msgid "Info"
 msgstr "Информация"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "Настройки импорта PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -487,7 +487,7 @@ msgid "Adjust Document"
 msgstr "Адаптация документа"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "Следует ли адаптировать макет документа к формату PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -495,7 +495,7 @@ msgid "Page Width (%)"
 msgstr "Ширина страницы (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr "Установить ширину импортированных PDF в процентах от ширины формата"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -503,7 +503,7 @@ msgid "Page Spacing"
 msgstr "Расстояние между страницами"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "Как расположены страницы PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -519,7 +519,7 @@ msgid "Pages Type"
 msgstr "Тип страниц"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
 "Установить, каким образом должны импортироваться PDF файлы: как векторные "
 "или как растровые изображения"
@@ -1964,7 +1964,7 @@ msgid "Open File"
 msgstr "Открыть файл"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr "JPG, PDF, PNG, SVG, XOPP, TXT"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
@@ -2555,7 +2555,7 @@ msgstr "белый"
 #~ msgid "Lecture Note 1"
 #~ msgstr "Конспект лекции 1"
 
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "Аннотация PDF"
 
 #~ msgid "Lecture Note 2"
@@ -2589,7 +2589,7 @@ msgstr "белый"
 #~ msgid "Opening Xournal++ file failed"
 #~ msgstr "Не удалось открыть файл Xournal++"
 
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "Не удалось открыть файл PDF"
 
 #~ msgid "Failed to open file, tried to open folder as file"
@@ -2832,7 +2832,7 @@ msgstr "белый"
 
 #, fuzzy
 #~| msgid "PNG / SVG / JPG / PDF file"
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
 #~ msgstr "PNG / SVG / JPG / PDF файл"
 
 #~ msgid "Drag stroke elements based on proximity"

--- a/crates/rnote-ui/po/sv.po
+++ b/crates/rnote-ui/po/sv.po
@@ -346,17 +346,17 @@ msgstr "Nytt document"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
+msgid "XOPP"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
@@ -485,7 +485,7 @@ msgstr "Set the margins around the sheet"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
 #, fuzzy
 #| msgid "Import PDF"
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "Importera PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -501,7 +501,7 @@ msgstr ""
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
 #, fuzzy
 #| msgid "PDF import preferences"
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "Preferenser för PDF-import"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -521,7 +521,7 @@ msgstr "Nytt document"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
 #, fuzzy
 #| msgid "Set the background color"
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "Välj bakrundsfärgen"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -532,7 +532,7 @@ msgstr "Sidbredd (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
 #, fuzzy
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr "Ange bredden på importerade PDF-filer i procent till bladbredden"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -544,7 +544,7 @@ msgstr "Sidavstånd"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
 #, fuzzy
 #| msgid "How PDF pages are spaced"
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "Distans mellan sidor i PDF format"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -566,7 +566,7 @@ msgstr "Sidtyp"
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
 #, fuzzy
 #| msgid "Set whether PDFs should be imported as vector or bitmap images"
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr "Ange om PDF-filer ska importeras som vektor- eller bitmappsbilder"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -2192,7 +2192,7 @@ msgid "Open File"
 msgstr "Öppna Fil"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
@@ -2814,7 +2814,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "A PDF annotation"
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "En PDF-anteckning"
 
 #, fuzzy
@@ -2851,7 +2851,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "Opening PDF file failed."
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "Det gick inte att öppna PDF-filen."
 
 #, fuzzy
@@ -3068,7 +3068,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "PNG / SVG / JPG / PDF file"
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
 #~ msgstr "PNG / SVG / JPG / PDF fil"
 
 #~ msgid "Drag stroke elements based on proximity"

--- a/crates/rnote-ui/po/ta.po
+++ b/crates/rnote-ui/po/ta.po
@@ -311,18 +311,18 @@ msgstr "ஏற்றுமதி வடிவமைப்பு"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
-msgstr "Pdf"
+msgid "PDF"
+msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -447,8 +447,8 @@ msgid "Set the margin around the selected area"
 msgstr "தேர்ந்தெடுக்கப்பட்ட பகுதியைச் சுற்றி விளிம்பை அமைக்கவும்"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
-msgstr "Pdf ஐ இறக்குமதி செய்"
+msgid "Import PDF"
+msgstr "PDF ஐ இறக்குமதி செய்"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
 #: crates/rnote-ui/data/ui/dialogs/import.ui:218
@@ -461,8 +461,8 @@ msgid "Info"
 msgstr "தகவல்"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
-msgstr "Pdf இறக்குமதி விருப்பத்தேர்வுகள்"
+msgid "PDF Import Preferences"
+msgstr "PDF இறக்குமதி விருப்பத்தேர்வுகள்"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
 msgid "Start Page"
@@ -477,24 +477,24 @@ msgid "Adjust Document"
 msgstr "ஆவணத்தை சரிசெய்யவும்"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
-msgstr "ஆவண தளவமைப்பை Pdf இல் சரிசெய்ய வேண்டுமா"
+msgid "Whether the document layout should be adjusted to the PDF"
+msgstr "ஆவண தளவமைப்பை PDF இல் சரிசெய்ய வேண்டுமா"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
 msgid "Page Width (%)"
 msgstr "பக்கத்தின் அகலம் (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
-msgstr "இறக்குமதி செய்யப்பட்ட Pdf இன் அகலத்தை வடிவ அகலத்திற்கு சதவீதத்தில் அமைக்கவும்"
+msgid "Set the width of imported PDF's in percentage to the format width"
+msgstr "இறக்குமதி செய்யப்பட்ட PDF இன் அகலத்தை வடிவ அகலத்திற்கு சதவீதத்தில் அமைக்கவும்"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
 msgid "Page Spacing"
 msgstr "பக்க இடைவெளி"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
-msgstr "Pdf பக்கங்கள் எவ்வாறு இடைவெளியில் உள்ளன"
+msgid "How PDF pages are spaced"
+msgstr "PDF பக்கங்கள் எவ்வாறு இடைவெளியில் உள்ளன"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
 msgid "Continuous"
@@ -509,9 +509,9 @@ msgid "Pages Type"
 msgstr "பக்கங்களின் வகை"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
-"Pdfகளை வெக்டரா அல்லது பிட்மேப் படங்களாக இறக்குமதி செய்ய வேண்டுமா என்பதை அமைக்கவும்"
+"PDFகளை வெக்டரா அல்லது பிட்மேப் படங்களாக இறக்குமதி செய்ய வேண்டுமா என்பதை அமைக்கவும்"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
 msgid "Vector"
@@ -1950,8 +1950,8 @@ msgid "Open File"
 msgstr "திறந்த கோப்பு"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP, Txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2541,8 +2541,8 @@ msgstr "வெள்ளை"
 #~ msgid "Lecture Note 1"
 #~ msgstr "விரிவுரை குறிப்பு 1"
 
-#~ msgid "A Pdf annotation"
-#~ msgstr "ஒரு Pdf சிறுகுறிப்பு"
+#~ msgid "A PDF annotation"
+#~ msgstr "ஒரு PDF சிறுகுறிப்பு"
 
 #~ msgid "Lecture Note 2"
 #~ msgstr "விரிவுரை குறிப்பு 2"
@@ -2575,8 +2575,8 @@ msgstr "வெள்ளை"
 #~ msgid "Opening Xournal++ file failed"
 #~ msgstr "Xournal++ கோப்பை திறப்பதில் தோல்வி"
 
-#~ msgid "Opening Pdf file failed"
-#~ msgstr "Pdf கோப்பை திறக்க முடியவில்லை"
+#~ msgid "Opening PDF file failed"
+#~ msgstr "PDF கோப்பை திறக்க முடியவில்லை"
 
 #~ msgid "Failed to open file, tried to open folder as file"
 #~ msgstr "கோப்பை திறக்க முடியவில்லை, கோப்புறையை கோப்பாக திறக்க முயற்சித்தேன்"
@@ -2799,9 +2799,9 @@ msgstr "வெள்ளை"
 #~ msgstr "ஒவ்வொன்றாகத் தேர்ந்தெடுக்கிறது"
 
 #, fuzzy
-#~| msgid "Xopp / PNG / SVG / JPG / PDF file"
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
-#~ msgstr "Xopp / PNG / SVG / JPG / PDF கோப்பு"
+#~| msgid "XOPP / PNG / SVG / JPG / PDF file"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
+#~ msgstr "XOPP / PNG / SVG / JPG / PDF கோப்பு"
 
 #~ msgid "Drag stroke elements based on proximity"
 #~ msgstr "அருகாமையின் அடிப்படையில் ஸ்ட்ரோக் கூறுகளை இழுக்கவும்"

--- a/crates/rnote-ui/po/th.po
+++ b/crates/rnote-ui/po/th.po
@@ -310,18 +310,18 @@ msgstr "ฟอร์แมตของเอกสารที่ต้องก
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
-msgstr "Pdf"
+msgid "PDF"
+msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -464,8 +464,8 @@ msgid "Set the margin around the selected area"
 msgstr "กำหนดระยะเว้นขอบรอบพื้นที่ที่เลือก"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
-msgstr "นำเข้า Pdf"
+msgid "Import PDF"
+msgstr "นำเข้า PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
 #: crates/rnote-ui/data/ui/dialogs/import.ui:218
@@ -478,8 +478,8 @@ msgid "Info"
 msgstr "ข้อมูล"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
-msgstr "ตั้งค่าการนำเข้า Pdf"
+msgid "PDF Import Preferences"
+msgstr "ตั้งค่าการนำเข้า PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
 msgid "Start Page"
@@ -494,24 +494,24 @@ msgid "Adjust Document"
 msgstr "แก้ไขเอกสาร"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
-msgstr "กำหนดว่าการออกแบบหน้ากระดาษควรถูกแก้ไขให้เหมาะกับ Pdf หรือไม่"
+msgid "Whether the document layout should be adjusted to the PDF"
+msgstr "กำหนดว่าการออกแบบหน้ากระดาษควรถูกแก้ไขให้เหมาะกับ PDF หรือไม่"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
 msgid "Page Width (%)"
 msgstr "ความกว้างหน้ากระดาษ (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
-msgstr "กำหนดความกว้างของไฟล์ Pdf ที่นำเข้ามา เป็นเปอร์เซ็นต์อิงจากความกว้างของหน้ากระดาษ"
+msgid "Set the width of imported PDF's in percentage to the format width"
+msgstr "กำหนดความกว้างของไฟล์ PDF ที่นำเข้ามา เป็นเปอร์เซ็นต์อิงจากความกว้างของหน้ากระดาษ"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
 msgid "Page Spacing"
 msgstr "ระยะห่างหน้ากระดาษ"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
-msgstr "การเว้นระยะห่างหน้ากระดาษของไฟล์ Pdf"
+msgid "How PDF pages are spaced"
+msgstr "การเว้นระยะห่างหน้ากระดาษของไฟล์ PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
 msgid "Continuous"
@@ -526,8 +526,8 @@ msgid "Pages Type"
 msgstr "ประเภทของหน้ากระดาษ"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
-msgstr "กำหนดว่าจะนำเข้าไฟล์ Pdf เป็นรูปแบบเวกเตอร์หรือบิตแม็ป"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
+msgstr "กำหนดว่าจะนำเข้าไฟล์ PDF เป็นรูปแบบเวกเตอร์หรือบิตแม็ป"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
 msgid "Vector"
@@ -1966,8 +1966,8 @@ msgid "Open File"
 msgstr "เปิดไฟล์"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP, Txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2561,7 +2561,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "A PDF annotation"
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "การใส่คำอธิบายประกอบ PDF"
 
 #, fuzzy
@@ -2602,7 +2602,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "Opening PDF file failed."
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "การเปิดไฟล์ PDF ล้มเหลว"
 
 #, fuzzy
@@ -2857,7 +2857,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "PNG / SVG / JPG / PDF file"
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
 #~ msgstr "ไฟล์ PNG / SVG / JPG / PDF"
 
 #~ msgid "Drag stroke elements based on proximity"

--- a/crates/rnote-ui/po/tr.po
+++ b/crates/rnote-ui/po/tr.po
@@ -311,18 +311,18 @@ msgstr "Dışa aktarma biçimi"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
-msgstr "Pdf"
+msgid "PDF"
+msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -465,7 +465,7 @@ msgid "Set the margin around the selected area"
 msgstr "Seçilen alanın etrafındaki kenar boşluğunu ayarla"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "PDF İçe Aktar"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -479,7 +479,7 @@ msgid "Info"
 msgstr "Bilgi"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "PDF İçe Aktarma Tercihleri"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -495,7 +495,7 @@ msgid "Adjust Document"
 msgstr "Belgeyi Düzenle"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "Belge düzeninin PDF'ye uydurulma durumu"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -503,7 +503,7 @@ msgid "Page Width (%)"
 msgstr "Sayfa Genişliği (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
 "İçe aktarılan PDFʼlerin genişliğini biçim genişliğine yüzde olarak ayarla"
 
@@ -512,7 +512,7 @@ msgid "Page Spacing"
 msgstr "Sayfa Boşluğu"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "PDF sayfaları nasıl boşluklu"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -528,7 +528,7 @@ msgid "Pages Type"
 msgstr "Sayfa Türü"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
 "PDFʼlerin vektör olarak mı yoksa biteşlem görüntüleri olarak mı içe "
 "aktarılacağını ayarla"
@@ -1972,8 +1972,8 @@ msgid "Open File"
 msgstr "Dosya Aç"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP, Txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2565,7 +2565,7 @@ msgstr "beyaz"
 #~ msgid "Lecture Note 1"
 #~ msgstr "Ders Notu 1"
 
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "PDF açıklaması"
 
 #~ msgid "Lecture Note 2"
@@ -2599,7 +2599,7 @@ msgstr "beyaz"
 #~ msgid "Opening Xournal++ file failed"
 #~ msgstr "Xournal++ dosyası açılamadı"
 
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "PDF dosyası açılamadı"
 
 #~ msgid "Failed to open file, tried to open folder as file"
@@ -2831,8 +2831,8 @@ msgstr "beyaz"
 #~ msgid "Selecting apiece"
 #~ msgstr "Parça seçimi"
 
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
-#~ msgstr "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
+#~ msgstr "XOPP, PNG, SVG, JPG, PDF"
 
 #~ msgid "Drag stroke elements based on proximity"
 #~ msgstr "Yakınlığa bağlı olarak darbe öğelerini sürükle"

--- a/crates/rnote-ui/po/uk.po
+++ b/crates/rnote-ui/po/uk.po
@@ -310,18 +310,18 @@ msgstr "Тип файлу, який буде експортовано"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
-msgstr "Svg"
+msgid "SVG"
+msgstr "SVG"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
-msgstr "Pdf"
+msgid "PDF"
+msgstr "PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xopp"
+msgid "XOPP"
+msgstr "XOPP"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -446,8 +446,8 @@ msgid "Set the margin around the selected area"
 msgstr "Встановіть поле навколо виділеної області"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
-msgstr "Імпортувати Pdf"
+msgid "Import PDF"
+msgstr "Імпортувати PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
 #: crates/rnote-ui/data/ui/dialogs/import.ui:218
@@ -460,8 +460,8 @@ msgid "Info"
 msgstr "Інформація"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
-msgstr "Параметри імпорту Pdf"
+msgid "PDF Import Preferences"
+msgstr "Параметри імпорту PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
 msgid "Start Page"
@@ -476,7 +476,7 @@ msgid "Adjust Document"
 msgstr "Адаптувати документ"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr "Чи потрібно адаптувати макет документа до PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -484,17 +484,17 @@ msgid "Page Width (%)"
 msgstr "Ширина сторінки (%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
-"Встановити ширину імпортованих Pdf-файлів у відсотках від ширини аркуша"
+"Встановити ширину імпортованих PDF-файлів у відсотках від ширини аркуша"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
 msgid "Page Spacing"
 msgstr "Міжсторінковий інтервал"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
-msgstr "Як розділені сторінки Pdf"
+msgid "How PDF pages are spaced"
+msgstr "Як розділені сторінки PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
 msgid "Continuous"
@@ -509,8 +509,8 @@ msgid "Pages Type"
 msgstr "Тип сторінок"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
-msgstr "Імпортувати Pdf-файли як векторні чи растрові зображення"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
+msgstr "Імпортувати PDF-файли як векторні чи растрові зображення"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
 msgid "Vector"
@@ -1949,8 +1949,8 @@ msgid "Open File"
 msgstr "Відкрити файл"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP, Txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2546,8 +2546,8 @@ msgstr "білий"
 #~ msgid "Lecture Note 1"
 #~ msgstr "Конспект лекції 1"
 
-#~ msgid "A Pdf annotation"
-#~ msgstr "Анотація Pdf"
+#~ msgid "A PDF annotation"
+#~ msgstr "Анотація PDF"
 
 #~ msgid "Lecture Note 2"
 #~ msgstr "Конспект лекції 2"
@@ -2580,8 +2580,8 @@ msgstr "білий"
 #~ msgid "Opening Xournal++ file failed"
 #~ msgstr "Не вдалося відкрити файл Xournal++"
 
-#~ msgid "Opening Pdf file failed"
-#~ msgstr "Не вдалося відкрити файл Pdf"
+#~ msgid "Opening PDF file failed"
+#~ msgstr "Не вдалося відкрити файл PDF"
 
 #~ msgid "Failed to open file, tried to open folder as file"
 #~ msgstr "Не вдалося відкрити файл, спробуйте відкрити папку як файл"
@@ -2811,7 +2811,7 @@ msgstr "білий"
 #~ msgstr "Вибір за допомогою прямокутника"
 
 #, fuzzy
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
 #~ msgstr "файл PNG / SVG / JPG / PDF"
 
 #~ msgid "Drag stroke elements based on proximity"

--- a/crates/rnote-ui/po/vi.po
+++ b/crates/rnote-ui/po/vi.po
@@ -316,17 +316,17 @@ msgstr ""
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
+msgid "XOPP"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
@@ -452,7 +452,7 @@ msgstr ""
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
 #, fuzzy
 #| msgid "_Import file"
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "Nhập tệp tin"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -466,7 +466,7 @@ msgid "Info"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -484,7 +484,7 @@ msgid "Adjust Document"
 msgstr "Layout tài liệu"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
@@ -492,7 +492,7 @@ msgid "Page Width (%)"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -500,7 +500,7 @@ msgid "Page Spacing"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -518,7 +518,7 @@ msgid "Pages Type"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr ""
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -2056,7 +2056,7 @@ msgid "Open File"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
 msgstr ""
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
@@ -2653,7 +2653,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "A PDF annotation"
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "Chú thích PDF"
 
 #, fuzzy
@@ -2678,7 +2678,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "Export _selection"
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "Xuất phần chọn"
 
 #, fuzzy

--- a/crates/rnote-ui/po/zh_Hans.po
+++ b/crates/rnote-ui/po/zh_Hans.po
@@ -311,18 +311,18 @@ msgstr "导出的格式"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr "可缩放矢量图（SVG）"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr "便携式文档格式（PDF）"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xournal++ 笔记本（Xopp）"
+msgid "XOPP"
+msgstr "Xournal++ 笔记本（XOPP）"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -465,7 +465,7 @@ msgid "Set the margin around the selected area"
 msgstr "设置选区周围的边距"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "导入 PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -479,7 +479,7 @@ msgid "Info"
 msgstr "信息"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "PDF 导入偏好"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -495,15 +495,15 @@ msgid "Adjust Document"
 msgstr "调整文档"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
-msgstr "文档布局是否应该调整为 Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
+msgstr "文档布局是否应该调整为 PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
 msgid "Page Width (%)"
 msgstr "页面宽度(%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr "设置导入 PDF 相对页面的宽度百分比"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -511,7 +511,7 @@ msgid "Page Spacing"
 msgstr "页间距"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "PDF 页间距大小"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -527,7 +527,7 @@ msgid "Pages Type"
 msgstr "页面类型"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr "设置导入 PDF 为矢量图或位图"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -1967,8 +1967,8 @@ msgid "Open File"
 msgstr "打开文件"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP, Txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2574,7 +2574,7 @@ msgstr ""
 #~ msgid "Lecture Note 1"
 #~ msgstr "讲义1"
 
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "PDF 注释"
 
 #~ msgid "Lecture Note 2"
@@ -2606,7 +2606,7 @@ msgstr ""
 #~ msgid "Opening Xournal++ file failed"
 #~ msgstr "Xournal++ 文件打开失败"
 
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "PDF打开失败"
 
 #~ msgid "Failed to open file, tried to open folder as file"
@@ -2836,7 +2836,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "PNG / SVG / JPG / PDF file"
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
 #~ msgstr "PNG/SVG/JPG/PDF文件"
 
 #~ msgid "Drag stroke elements based on proximity"

--- a/crates/rnote-ui/po/zh_Hant.po
+++ b/crates/rnote-ui/po/zh_Hant.po
@@ -311,18 +311,18 @@ msgstr "匯出的格式"
 #: crates/rnote-ui/src/dialogs/export.rs:304
 #: crates/rnote-ui/src/dialogs/export.rs:635
 #: crates/rnote-ui/src/dialogs/export.rs:954
-msgid "Svg"
+msgid "SVG"
 msgstr "可縮放向量圖（SVG）"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:136
 #: crates/rnote-ui/src/dialogs/export.rs:315
-msgid "Pdf"
+msgid "PDF"
 msgstr "行動式文件格式（PDF）"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:137
 #: crates/rnote-ui/src/dialogs/export.rs:326
-msgid "Xopp"
-msgstr "Xournal++ 筆記本（Xopp）"
+msgid "XOPP"
+msgstr "Xournal++ 筆記本（XOPP）"
 
 #: crates/rnote-ui/data/ui/dialogs/export.ui:145
 #: crates/rnote-ui/data/ui/dialogs/export.ui:356
@@ -465,7 +465,7 @@ msgid "Set the margin around the selected area"
 msgstr "設定選區周圍的邊距"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:5
-msgid "Import Pdf"
+msgid "Import PDF"
 msgstr "匯入 PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:19
@@ -479,7 +479,7 @@ msgid "Info"
 msgstr "資訊"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:81
-msgid "Pdf Import Preferences"
+msgid "PDF Import Preferences"
 msgstr "PDF 匯入偏好"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:85
@@ -495,15 +495,15 @@ msgid "Adjust Document"
 msgstr "調整文件"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:104
-msgid "Whether the document layout should be adjusted to the Pdf"
-msgstr "文件佈局是否應該調整為 Pdf"
+msgid "Whether the document layout should be adjusted to the PDF"
+msgstr "文件佈局是否應該調整為 PDF"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:109
 msgid "Page Width (%)"
 msgstr "頁面寬度(%)"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:110
-msgid "Set the width of imported Pdf's in percentage to the format width"
+msgid "Set the width of imported PDF's in percentage to the format width"
 msgstr "設定匯入 PDF 相對頁面的寬度百分比"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:117
@@ -511,7 +511,7 @@ msgid "Page Spacing"
 msgstr "頁間距"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:118
-msgid "How Pdf pages are spaced"
+msgid "How PDF pages are spaced"
 msgstr "PDF 頁間距大小"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:122
@@ -527,7 +527,7 @@ msgid "Pages Type"
 msgstr "頁面型別"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:132
-msgid "Set whether Pdf's should be imported as vector or bitmap images"
+msgid "Set whether PDF's should be imported as vector or bitmap images"
 msgstr "設定匯入 PDF 為向量圖或點陣圖"
 
 #: crates/rnote-ui/data/ui/dialogs/import.ui:144
@@ -1967,8 +1967,8 @@ msgid "Open File"
 msgstr "開啟檔案"
 
 #: crates/rnote-ui/src/dialogs/import.rs:86
-msgid "Jpg, Pdf, Png, Svg, Xopp, Txt"
-msgstr "Jpg, Pdf, Png, Svg, Xopp, Txt"
+msgid "Jpg, PDF, Png, SVG, XOPP, Txt"
+msgstr "Jpg, PDF, Png, SVG, XOPP, Txt"
 
 #: crates/rnote-ui/src/dialogs/import.rs:239
 msgid "- no file name -"
@@ -2574,7 +2574,7 @@ msgstr ""
 #~ msgid "Lecture Note 1"
 #~ msgstr "講義1"
 
-#~ msgid "A Pdf annotation"
+#~ msgid "A PDF annotation"
 #~ msgstr "PDF 註釋"
 
 #~ msgid "Lecture Note 2"
@@ -2606,7 +2606,7 @@ msgstr ""
 #~ msgid "Opening Xournal++ file failed"
 #~ msgstr "Xournal++ 檔案開啟失敗"
 
-#~ msgid "Opening Pdf file failed"
+#~ msgid "Opening PDF file failed"
 #~ msgstr "PDF開啟失敗"
 
 #~ msgid "Failed to open file, tried to open folder as file"
@@ -2836,7 +2836,7 @@ msgstr ""
 
 #, fuzzy
 #~| msgid "PNG / SVG / JPG / PDF file"
-#~ msgid "Xopp, PNG, SVG, JPG, PDF"
+#~ msgid "XOPP, PNG, SVG, JPG, PDF"
 #~ msgstr "PNG/SVG/JPG/PDF檔案"
 
 #~ msgid "Drag stroke elements based on proximity"

--- a/crates/rnote-ui/src/appwindow/actions.rs
+++ b/crates/rnote-ui/src/appwindow/actions.rs
@@ -894,7 +894,7 @@ impl RnAppWindow {
                                     acc.append(&mut bytes);
                                 }
                                 Err(e) => {
-                                    error!("Failed to read clipboard input stream while pasting as Svg, Err: {e:?}");
+                                    error!("Failed to read clipboard input stream while pasting as SVG, Err: {e:?}");
                                     acc.clear();
                                     break;
                                 }
@@ -906,16 +906,16 @@ impl RnAppWindow {
                                 Ok(text) => {
                                     if let Err(e) = canvas.load_in_vectorimage_bytes(text.as_bytes().to_vec(), target_pos, appwindow.respect_borders()).await {
                                         error!(
-                                            "Loading VectorImage bytes failed while pasting as Svg failed, Err: {e:?}"
+                                            "Loading VectorImage bytes failed while pasting as SVG failed, Err: {e:?}"
                                         );
                                     };
                                 }
-                                Err(e) => error!("Failed to get string from clipboard data while pasting as Svg, Err: {e:?}"),
+                                Err(e) => error!("Failed to get string from clipboard data while pasting as SVG, Err: {e:?}"),
                             }
                         }
                     }
                     Err(e) => {
-                        error!("Failed to read clipboard data while pasting as Svg, Err: {e:?}");
+                        error!("Failed to read clipboard data while pasting as SVG, Err: {e:?}");
                     }
                 };
             }));

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -586,7 +586,7 @@ impl RnAppWindow {
                     .await?;
                 true
             }
-            FileType::XoppFile => {
+            FileType::XOPPFile => {
                 // a new tab for xopp file import
                 let wrapper = self.new_canvas_wrapper();
                 let canvas = wrapper.canvas();
@@ -597,7 +597,7 @@ impl RnAppWindow {
                 }
                 file_imported
             }
-            FileType::PdfFile => {
+            FileType::PDFFile => {
                 let canvas = self.active_tab_wrapper().canvas();
                 dialogs::import::dialog_import_pdf_w_prefs(self, &canvas, input_file, target_pos)
                     .await?

--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -293,7 +293,7 @@ fn create_filedialog_export_doc(
     // See the limitations on FileChooserNative
     // https://gtk-rs.org/gtk3-rs/stable/latest/docs/gtk/struct.FileChooserNative.html#win32-details--gtkfilechooserdialognative-win32
     match doc_export_prefs.export_format {
-        DocExportFormat::Svg => {
+        DocExportFormat::SVG => {
             if cfg!(target_os = "windows") {
                 filter.add_pattern("*.svg");
             } else {
@@ -302,9 +302,9 @@ fn create_filedialog_export_doc(
             if cfg!(target_os = "macos") {
                 filter.add_suffix("svg");
             }
-            filter.set_name(Some(&gettext("Svg")));
+            filter.set_name(Some(&gettext("SVG")));
         }
-        DocExportFormat::Pdf => {
+        DocExportFormat::PDF => {
             if cfg!(target_os = "windows") {
                 filter.add_pattern("*.pdf");
             } else {
@@ -313,9 +313,9 @@ fn create_filedialog_export_doc(
             if cfg!(target_os = "macos") {
                 filter.add_suffix("pdf");
             }
-            filter.set_name(Some(&gettext("Pdf")));
+            filter.set_name(Some(&gettext("PDF")));
         }
-        DocExportFormat::Xopp => {
+        DocExportFormat::XOPP => {
             if cfg!(target_os = "windows") {
                 filter.add_pattern("*.xopp");
             } else {
@@ -324,7 +324,7 @@ fn create_filedialog_export_doc(
             if cfg!(target_os = "macos") {
                 filter.add_suffix("xopp");
             }
-            filter.set_name(Some(&gettext("Xopp")));
+            filter.set_name(Some(&gettext("XOPP")));
         }
     }
     let file_ext = doc_export_prefs.export_format.file_ext();
@@ -624,7 +624,7 @@ fn create_filedialog_export_doc_pages(
     // We always need to be able to select folders
     filter.add_mime_type("inode/directory");
     match doc_pages_export_prefs.export_format {
-        DocPagesExportFormat::Svg => {
+        DocPagesExportFormat::SVG => {
             if cfg!(target_os = "windows") {
                 filter.add_pattern("*.svg");
             } else {
@@ -633,7 +633,7 @@ fn create_filedialog_export_doc_pages(
             if cfg!(target_os = "macos") {
                 filter.add_suffix("svg");
             }
-            filter.set_name(Some(&gettext("Svg")));
+            filter.set_name(Some(&gettext("SVG")));
         }
         DocPagesExportFormat::Png => {
             if cfg!(target_os = "windows") {
@@ -942,7 +942,7 @@ fn create_filedialog_export_selection(
     // See the limitations on FileChooserNative
     // https://gtk-rs.org/gtk3-rs/stable/latest/docs/gtk/struct.FileChooserNative.html#win32-details--gtkfilechooserdialognative-win32
     match selection_export_prefs.export_format {
-        SelectionExportFormat::Svg => {
+        SelectionExportFormat::SVG => {
             if cfg!(target_os = "windows") {
                 filter.add_pattern("*.svg");
             } else {
@@ -951,7 +951,7 @@ fn create_filedialog_export_selection(
             if cfg!(target_os = "macos") {
                 filter.add_suffix("svg");
             }
-            filter.set_name(Some(&gettext("Svg")));
+            filter.set_name(Some(&gettext("SVG")));
         }
         SelectionExportFormat::Png => {
             if cfg!(target_os = "windows") {

--- a/crates/rnote-ui/src/dialogs/import.rs
+++ b/crates/rnote-ui/src/dialogs/import.rs
@@ -11,7 +11,7 @@ use gtk4::{
     Shortcut, ShortcutController, ShortcutTrigger, ToggleButton,
 };
 use num_traits::ToPrimitive;
-use rnote_engine::engine::import::{PdfImportPageSpacing, PdfImportPagesType};
+use rnote_engine::engine::import::{PDFImportPageSpacing, PDFImportPagesType};
 use tracing::{debug, error};
 
 /// Opens a new rnote save file in a new tab
@@ -82,7 +82,7 @@ pub(crate) async fn filedialog_import_file(appwindow: &RnAppWindow) {
     filter.add_suffix("jpg");
     filter.add_suffix("jpeg");
     filter.add_suffix("txt");
-    filter.set_name(Some(&gettext("Jpg, Pdf, Png, Svg, Xopp, Txt")));
+    filter.set_name(Some(&gettext("Jpg, PDF, Png, SVG, XOPP, Txt")));
 
     let filter_list = gio::ListStore::new::<FileFilter>();
     filter_list.append(&filter);
@@ -111,7 +111,7 @@ pub(crate) async fn filedialog_import_file(appwindow: &RnAppWindow) {
     }
 }
 
-/// Imports the file as Pdf with an import dialog.
+/// Imports the file as PDF with an import dialog.
 ///
 /// Returns true when the file was imported, else false.
 pub(crate) async fn dialog_import_pdf_w_prefs(
@@ -159,11 +159,11 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
     // Set the widget state from the pdf import prefs
     pdf_import_width_row.set_value(pdf_import_prefs.page_width_perc);
     match pdf_import_prefs.pages_type {
-        PdfImportPagesType::Bitmap => {
+        PDFImportPagesType::Bitmap => {
             pdf_import_as_bitmap_toggle.set_active(true);
             pdf_import_bitmap_scalefactor_row.set_sensitive(true);
         }
-        PdfImportPagesType::Vector => {
+        PDFImportPagesType::Vector => {
             pdf_import_as_vector_toggle.set_active(true);
             pdf_import_bitmap_scalefactor_row.set_sensitive(false);
         }
@@ -186,7 +186,7 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
     pdf_import_as_vector_toggle.connect_toggled(
         clone!(@weak pdf_import_bitmap_scalefactor_row, @weak canvas, @weak appwindow => move |toggle| {
             if toggle.is_active() {
-                canvas.engine_mut().import_prefs.pdf_import_prefs.pages_type = PdfImportPagesType::Vector;
+                canvas.engine_mut().import_prefs.pdf_import_prefs.pages_type = PDFImportPagesType::Vector;
                 pdf_import_bitmap_scalefactor_row.set_sensitive(false);
             }
         }),
@@ -195,7 +195,7 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
     pdf_import_as_bitmap_toggle.connect_toggled(
         clone!(@weak pdf_import_bitmap_scalefactor_row, @weak canvas, @weak appwindow => move |toggle| {
             if toggle.is_active() {
-                canvas.engine_mut().import_prefs.pdf_import_prefs.pages_type = PdfImportPagesType::Bitmap;
+                canvas.engine_mut().import_prefs.pdf_import_prefs.pages_type = PDFImportPagesType::Bitmap;
                 pdf_import_bitmap_scalefactor_row.set_sensitive(true);
             }
         }),
@@ -209,7 +209,7 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
 
     pdf_import_page_spacing_row.connect_selected_notify(
         clone!(@weak canvas, @weak appwindow => move |row| {
-            let page_spacing = PdfImportPageSpacing::try_from(row.selected()).unwrap();
+            let page_spacing = PDFImportPageSpacing::try_from(row.selected()).unwrap();
 
             canvas.engine_mut().import_prefs.pdf_import_prefs.page_spacing = page_spacing;
         }),
@@ -354,7 +354,7 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
     }
 }
 
-/// Imports the file as Xopp with an import dialog.
+/// Imports the file as XOPP with an import dialog.
 ///
 /// Returns true when the file was imported, else false.
 pub(crate) async fn dialog_import_xopp_w_prefs(

--- a/crates/rnote-ui/src/filetype.rs
+++ b/crates/rnote-ui/src/filetype.rs
@@ -9,8 +9,8 @@ pub(crate) enum FileType {
     RnoteFile,
     VectorImageFile,
     BitmapImageFile,
-    XoppFile,
-    PdfFile,
+    XOPPFile,
+    PDFFile,
     PlaintextFile,
     Unsupported,
 }
@@ -36,10 +36,10 @@ impl FileType {
                                 return Self::BitmapImageFile;
                             }
                             "application/x-xopp" => {
-                                return Self::XoppFile;
+                                return Self::XOPPFile;
                             }
                             "application/pdf" => {
-                                return Self::PdfFile;
+                                return Self::PDFFile;
                             }
                             "text/plain" => {
                                 return Self::PlaintextFile;
@@ -74,10 +74,10 @@ impl FileType {
                         return Self::BitmapImageFile;
                     }
                     "xopp" => {
-                        return Self::XoppFile;
+                        return Self::XOPPFile;
                     }
                     "pdf" => {
-                        return Self::PdfFile;
+                        return Self::PDFFile;
                     }
                     "txt" => {
                         return Self::PlaintextFile;


### PR DESCRIPTION
Capitalizing file format acronyms is standard practice in software.

This pull request replaces every occurence of Pdf, Svg and Xopp with PDF, SVG and XOPP respectively.