### PR TITLE
(Fixes cross compilation) Default to using glib-compile-resources bin before using glib_build_tools crate

### DIFF
--- a/crates/rnote-ui/Cargo.toml
+++ b/crates/rnote-ui/Cargo.toml
@@ -58,7 +58,10 @@ url = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }
-glib-build-tools = { workspace = true }
+glib-build-tools = { workspace = true, optional = true }
+
+[features]
+use_glib_build_tools = ["glib-build-tools"]
 
 [target.'cfg(windows)'.build-dependencies]
 winresource = { workspace = true }

--- a/crates/rnote-ui/build.rs
+++ b/crates/rnote-ui/build.rs
@@ -1,5 +1,11 @@
 fn main() -> anyhow::Result<()> {
-    compile_gresources()?;
+    let is_cross_compiling = detect_cross_compilation();
+
+    if !is_cross_compiling {
+        println!("cargo:rustc-cfg=feature=\"use_glib_build_tools\"");
+    }
+
+    compile_gresources(is_cross_compiling)?;
 
     #[cfg(windows)]
     compile_icon_winres()?;
@@ -18,11 +24,64 @@ fn compile_icon_winres() -> anyhow::Result<()> {
         .context("Failed to compile winresource resource")
 }
 
-fn compile_gresources() -> anyhow::Result<()> {
-    glib_build_tools::compile_resources(
-        &["data"],
-        "data/resources.gresource.xml",
-        "compiled.gresource",
-    );
-    Ok(())
+fn detect_cross_compilation() -> bool {
+    let host = std::env::var("HOST").unwrap_or_default();
+    let target = std::env::var("TARGET").unwrap_or_default();
+    host != target
+}
+
+fn compile_gresources(is_cross_compiling: bool) -> anyhow::Result<()> {
+    use std::env;
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
+    let output_path = PathBuf::from(&out_dir).join("compiled.gresource");
+
+    // First, try using the system's glib-compile-resources
+    let system_result = Command::new("glib-compile-resources")
+        .args(&[
+            "--sourcedir=data",
+            "data/resources.gresource.xml",
+            &format!("--target={}", output_path.display()),
+        ])
+        .status();
+
+    match system_result {
+        Ok(status) if status.success() => return Ok(()),
+        Ok(_) => println!("glib-compile-resources command failed, trying fallback method..."),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            println!("glib-compile-resources not found, trying fallback method...")
+        }
+        Err(e) => println!(
+            "Error executing glib-compile-resources: {}, trying fallback method...",
+            e
+        ),
+    }
+
+    // If cross-compiling, don't use glib_build_tools
+    if is_cross_compiling {
+        return Err(anyhow::anyhow!(
+            "Failed to compile gresources: system glib-compile-resources failed and we're cross-compiling. \
+            Please ensure you have glib development tools installed on your target system."
+        ));
+    }
+
+    // If not cross-compiling and system command fails, fall back to glib_build_tools if available
+    #[cfg(feature = "use_glib_build_tools")]
+    {
+        println!("Attempting to use glib_build_tools::compile_resources...");
+        glib_build_tools::compile_resources(
+            &["data"],
+            "data/resources.gresource.xml",
+            output_path.to_str().unwrap(),
+        );
+        Ok(())
+    }
+
+    #[cfg(not(feature = "use_glib_build_tools"))]
+    Err(anyhow::anyhow!(
+        "Failed to compile gresources: system glib-compile-resources failed and glib_build_tools is not available. \
+        Please ensure you have glib development tools installed on your system."
+    ))
 }


### PR DESCRIPTION
…ary as the default option and fallback to glib_build_tools

make the glib_build_tools crate optional which is used only when target == host

If cross compiling and glib-compile-resources is not found then glib_build_tools will be skipped and instead an error telling the user to install the glib dev tools will be outputted If compiling natively, then it'll proceed to using glib_build_tools crate assuming glib-compile-resources failed

This is necessary, otherwise this error will get spout by crates/rnote-ui/build.rs when cross compiling

```
error: linking with `cc` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin:/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin:/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin:/home/builder/.cargo/bin:/home/builder/.termux-build/_cache/ninja-1.12.1:/home/builder/.termux-build/rnote/build/_wrapper/bin:/home/builder/.termux-build/_cache/cmake-3.29.3/bin:/home/builder/.termux-build/_cache/android-r27-api-24-v1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" VSLANG="1033" "cc" "-m64" "/tmp/rustcGu8nNz/symbols.o" "/home/builder/.termux-build/rnote/src/target/release/build/rnote-8b7f48c74841d903/build_script_build-8b7f48c74841d903.build_script_build.1fec9ada91832d77-cgu.0.rcgu.o" "/home/builder/.termux-build/rnote/src/target/release/build/rnote-8b7f48c74841d903/build_script_build-8b7f48c74841d903.e3hi0mxzsq5x7jaoy7uwkrn7j.rcgu.o" "-Wl,--as-needed" "-L" "/home/builder/.termux-build/rnote/src/target/release/deps" "-L" "/data/data/com.termux/files/usr/lib" "-L" "/data/data/com.termux/files/usr/lib" "-L" "/data/data/com.termux/files/usr/lib" "-L" "/data/data/com.termux/files/usr/lib" "-L" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-Wl,-Bstatic" "/home/builder/.termux-build/rnote/src/target/release/deps/libglib_build_tools-2c631208f602ea58.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libgio-6f27d4bcb23daac4.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libfutures_io-b52e8e4cf1115fae.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libglib-af73e043d8f8248b.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libfutures_executor-41090b1f0d7dcd8d.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libmemchr-1d69502a51160c96.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libsmallvec-a4340643a4f90233.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libthiserror-27268a9b41d020ae.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libfutures_util-36ed3e0dfd487c82.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libslab-0e82e5682068df74.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libpin_project_lite-f6b2f26fd9c9b716.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libpin_utils-4594a3b34143379d.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libfutures_task-aaeaddb5e4d9001e.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libfutures_channel-15be244035db1983.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libfutures_core-54b4d5ebfe20e74a.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libbitflags-7d0831c16b4e8103.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libgio_sys-95786d4aad73da0b.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libgobject_sys-317da89ae50c481e.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libglib_sys-37c72fb7737ec437.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/liblibc-05c4e04dbda0b9b3.rlib" "/home/builder/.termux-build/rnote/src/target/release/deps/libanyhow-3ac73b91949d787c.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-0fbbe72b9e0d57dc.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libpanic_unwind-4cbc28d57c85be7b.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libobject-d583e13b4b2d89a2.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libmemchr-5d2a1bfb1589ab43.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libaddr2line-dcf90797fbd00d23.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgimli-3b6828d7a1725131.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_demangle-f75bdd612dd19f44.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd_detect-130d6997e9e34e6a.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libhashbrown-c9c9da5b4611a660.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_alloc-0f5b4153173c663b.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libminiz_oxide-877178c8f84ba478.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libadler-3907ca7c36d3c032.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libunwind-e8b263070ac20a8a.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcfg_if-d1969118c6f0c13e.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-d48855f89c749535.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc-9a1cbc1305da137e.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_core-d290b706bbcc90ac.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcore-fd707bd9d5d3d672.rlib" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcompiler_builtins-d4ebcca572002f93.rlib" "-Wl,-Bdynamic" "-lgobject-2.0" "-lgio-2.0" "-lgobject-2.0" "-lglib-2.0" "-lgobject-2.0" "-lglib-2.0" "-lgobject-2.0" "-lglib-2.0" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/home/builder/.rustup/toolchains/1.80.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/home/builder/.termux-build/rnote/src/target/release/build/rnote-8b7f48c74841d903/build_script_build-8b7f48c74841d903" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs"
  = note: ld: error: /data/data/com.termux/files/usr/lib/libgobject-2.0.so is incompatible with elf64-x86-64
          ld: error: /data/data/com.termux/files/usr/lib/libgio-2.0.so is incompatible with elf64-x86-64
          ld: error: /data/data/com.termux/files/usr/lib/libgobject-2.0.so is incompatible with elf64-x86-64
          ld: error: /data/data/com.termux/files/usr/lib/libglib-2.0.so is incompatible with elf64-x86-64
          ld: error: /data/data/com.termux/files/usr/lib/libgobject-2.0.so is incompatible with elf64-x86-64
          ld: error: /data/data/com.termux/files/usr/lib/libglib-2.0.so is incompatible with elf64-x86-64
          ld: error: /data/data/com.termux/files/usr/lib/libgobject-2.0.so is incompatible with elf64-x86-64
          ld: error: /data/data/com.termux/files/usr/lib/libglib-2.0.so is incompatible with elf64-x86-64
          collect2: error: ld returned 1 exit status
          

error: could not compile `rnote` (build script) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```