### PR TITLE
Bump GNOME runtime and LLVM version

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ jobs:
   flatpak:
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-46
+      image: bilelmoussaoui/flatpak-github-actions:gnome-47
       options: --privileged
     steps:
     - uses: actions/checkout@v4

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -59,8 +59,8 @@ flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.f
 The flatpak Gnome Runtime, SDK and some extensions are needed:
 
 ```bash
-flatpak install org.gnome.Platform//46 org.gnome.Sdk//46 org.freedesktop.Sdk.Extension.rust-stable//23.08 \
-org.freedesktop.Sdk.Extension.llvm17//23.08
+flatpak install org.gnome.Platform//47 org.gnome.Sdk//47 org.freedesktop.Sdk.Extension.rust-stable//24.08 \
+org.freedesktop.Sdk.Extension.llvm18//24.08
 ```
 
 Use Gnome Builder or VSCode with the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 homepage = "https://rnote.flxzt.net"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/flxzt/rnote"
-rust-version = "1.74"
+rust-version = "1.79"
 version = "0.11.0"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 homepage = "https://rnote.flxzt.net"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/flxzt/rnote"
-rust-version = "1.79"
+rust-version = "1.81"
 version = "0.11.0"
 
 [workspace.dependencies]

--- a/build-aux/com.github.flxzt.rnote.Devel.json
+++ b/build-aux/com.github.flxzt.rnote.Devel.json
@@ -4,11 +4,11 @@
     "development"
   ],
   "runtime": "org.gnome.Platform",
-  "runtime-version": "46",
+  "runtime-version": "47",
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.rust-stable",
-    "org.freedesktop.Sdk.Extension.llvm17"
+    "org.freedesktop.Sdk.Extension.llvm18"
   ],
   "command": "rnote",
   "finish-args": [
@@ -29,7 +29,7 @@
     "--env=GST_DEBUG=3"
   ],
   "build-options": {
-    "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm17/bin",
+    "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm18/bin",
     "env": {
       "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER": "clang",
       "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS": "-C link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold",
@@ -43,7 +43,7 @@
       "--socket=x11",
       "--share=network"
     ],
-    "prepend-ld-library-path": "/usr/lib/sdk/llvm17/lib"
+    "prepend-ld-library-path": "/usr/lib/sdk/llvm18/lib"
   },
   "modules": [
     {

--- a/build-aux/com.github.flxzt.rnote.Devel.yaml
+++ b/build-aux/com.github.flxzt.rnote.Devel.yaml
@@ -2,11 +2,11 @@ id: com.github.flxzt.rnote.Devel
 tags:
     - development
 runtime: org.gnome.Platform
-runtime-version: "46"
+runtime-version: "47"
 sdk: org.gnome.Sdk
 sdk-extensions:
     - org.freedesktop.Sdk.Extension.rust-stable
-    - org.freedesktop.Sdk.Extension.llvm17
+    - org.freedesktop.Sdk.Extension.llvm18
 command: rnote
 finish-args:
     - "--socket=wayland"
@@ -25,7 +25,7 @@ finish-args:
     - "--env=GTK_PATH=/app/lib/gtk-4.0"
     - "--env=GST_DEBUG=3"
 build-options:
-    append-path: "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm17/bin"
+    append-path: "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm18/bin"
     env:
         CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
         CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold"
@@ -36,7 +36,7 @@ build-options:
     test-args:
         - "--socket=x11"
         - "--share=network"
-    prepend-ld-library-path: /usr/lib/sdk/llvm17/lib
+    prepend-ld-library-path: /usr/lib/sdk/llvm18/lib
 modules:
     - name: poppler
       buildsystem: cmake-ninja

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -12,6 +12,7 @@ use rnote_compose::shapes::Shapeable;
 use rnote_compose::transform::Transformable;
 use rnote_compose::Color;
 use std::sync::Arc;
+#[cfg(feature = "ui")]
 use tracing::error;
 
 /// Systems that are related to the stroke components.


### PR DESCRIPTION
This is just pure maintenance PR. This bumps the GNOME runtime to 47 and LLVM to 18. I tested both changes and everything works fine. I've used the changes for a bit doing my regular work with all kinds of different tools and tasks, everything seemed fine and maybe even a bit smoother (although that might easily be placebo). It probably still makes sense to test this for a bit before applying to the Flatpak, which is why I opened the PR here instead of on Flathub. Although I've never seen a runtime change break something if building worked fine.