### PR TITLE
Bump MSRV and LLVM to latest stable

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -60,7 +60,7 @@ The flatpak Gnome Runtime, SDK and some extensions are needed:
 
 ```bash
 flatpak install org.gnome.Platform//47 org.gnome.Sdk//47 org.freedesktop.Sdk.Extension.rust-stable//24.08 \
-org.freedesktop.Sdk.Extension.llvm18//24.08
+org.freedesktop.Sdk.Extension.llvm19//24.08
 ```
 
 Use Gnome Builder or VSCode with the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 homepage = "https://rnote.flxzt.net"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/flxzt/rnote"
-rust-version = "1.81"
+rust-version = "1.82"
 version = "0.11.0"
 
 [workspace.dependencies]

--- a/build-aux/com.github.flxzt.rnote.Devel.json
+++ b/build-aux/com.github.flxzt.rnote.Devel.json
@@ -8,7 +8,7 @@
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.rust-stable",
-    "org.freedesktop.Sdk.Extension.llvm18"
+    "org.freedesktop.Sdk.Extension.llvm19"
   ],
   "command": "rnote",
   "finish-args": [
@@ -29,7 +29,7 @@
     "--env=GST_DEBUG=3"
   ],
   "build-options": {
-    "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm18/bin",
+    "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm19/bin",
     "env": {
       "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER": "clang",
       "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS": "-C link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold",
@@ -43,7 +43,7 @@
       "--socket=x11",
       "--share=network"
     ],
-    "prepend-ld-library-path": "/usr/lib/sdk/llvm18/lib"
+    "prepend-ld-library-path": "/usr/lib/sdk/llvm19/lib"
   },
   "modules": [
     {

--- a/build-aux/com.github.flxzt.rnote.Devel.yaml
+++ b/build-aux/com.github.flxzt.rnote.Devel.yaml
@@ -6,7 +6,7 @@ runtime-version: "47"
 sdk: org.gnome.Sdk
 sdk-extensions:
     - org.freedesktop.Sdk.Extension.rust-stable
-    - org.freedesktop.Sdk.Extension.llvm18
+    - org.freedesktop.Sdk.Extension.llvm19
 command: rnote
 finish-args:
     - "--socket=wayland"
@@ -25,7 +25,7 @@ finish-args:
     - "--env=GTK_PATH=/app/lib/gtk-4.0"
     - "--env=GST_DEBUG=3"
 build-options:
-    append-path: "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm18/bin"
+    append-path: "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm19/bin"
     env:
         CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
         CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold"
@@ -36,7 +36,7 @@ build-options:
     test-args:
         - "--socket=x11"
         - "--share=network"
-    prepend-ld-library-path: /usr/lib/sdk/llvm18/lib
+    prepend-ld-library-path: /usr/lib/sdk/llvm19/lib
 modules:
     - name: poppler
       buildsystem: cmake-ninja


### PR DESCRIPTION
As I already said in #1242 I think for binaries tracking the latest stable is best. Some discussion by distro maintainers around this can also be found [here](https://github.com/BurntSushi/ripgrep/issues/1019). Since Rust 1.82 just released, the latest LLVM 19 is now also stabilized, so I bumped them both up together :)