### PR TITLE
feat: multi-click selections

### DIFF
--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -845,6 +845,32 @@ impl Engine {
         widget_flags
     }
 
+    pub fn text_select_closest_word(&mut self) {
+        if let Pen::Typewriter(typewriter) = self.penholder.current_pen_mut() {
+            typewriter.select_closest_word(&mut EngineViewMut {
+                tasks_tx: self.tasks_tx.clone(),
+                pens_config: &mut self.pens_config,
+                document: &mut self.document,
+                store: &mut self.store,
+                camera: &mut self.camera,
+                audioplayer: &mut self.audioplayer,
+            })
+        }
+    }
+
+    pub fn text_select_closest_line(&mut self) {
+        if let Pen::Typewriter(typewriter) = self.penholder.current_pen_mut() {
+            typewriter.select_closest_line(&mut EngineViewMut {
+                tasks_tx: self.tasks_tx.clone(),
+                pens_config: &mut self.pens_config,
+                document: &mut self.document,
+                store: &mut self.store,
+                camera: &mut self.camera,
+                audioplayer: &mut self.audioplayer,
+            })
+        }
+    }
+
     pub fn text_selection_toggle_attribute(
         &mut self,
         text_attribute: TextAttribute,

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -847,27 +847,13 @@ impl Engine {
 
     pub fn text_select_closest_word(&mut self) {
         if let Pen::Typewriter(typewriter) = self.penholder.current_pen_mut() {
-            typewriter.select_closest_word(&mut EngineViewMut {
-                tasks_tx: self.tasks_tx.clone(),
-                pens_config: &mut self.pens_config,
-                document: &mut self.document,
-                store: &mut self.store,
-                camera: &mut self.camera,
-                audioplayer: &mut self.audioplayer,
-            })
+            typewriter.select_closest_word(&mut engine_view_mut!(self))
         }
     }
 
     pub fn text_select_closest_line(&mut self) {
         if let Pen::Typewriter(typewriter) = self.penholder.current_pen_mut() {
-            typewriter.select_closest_line(&mut EngineViewMut {
-                tasks_tx: self.tasks_tx.clone(),
-                pens_config: &mut self.pens_config,
-                document: &mut self.document,
-                store: &mut self.store,
-                camera: &mut self.camera,
-                audioplayer: &mut self.audioplayer,
-            })
+            typewriter.select_closest_line(&mut engine_view_mut!(self))
         }
     }
 

--- a/crates/rnote-engine/src/pens/typewriter/mod.rs
+++ b/crates/rnote-engine/src/pens/typewriter/mod.rs
@@ -25,11 +25,26 @@ use tracing::error;
 use unicode_segmentation::GraphemeCursor;
 
 #[derive(Debug, Clone)]
+pub(super) enum SelectionMode {
+    /// Select individual characters.
+    Caret,
+    /// Select whole words.
+    ///
+    /// The values represent the start and end of the initially selected word.
+    Word(usize, usize),
+    /// Select whole lines.
+    ///
+    /// The values represent the start and end of the initially selected line.
+    Line(usize, usize),
+}
+
+#[derive(Debug, Clone)]
 pub(super) enum ModifyState {
     Up,
     Hover(na::Vector2<f64>),
     Selecting {
         selection_cursor: GraphemeCursor,
+        mode: SelectionMode,
         /// Whether selecting is finished.
         ///
         /// If true, the state will get reset on the next click.

--- a/crates/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/crates/rnote-engine/src/pens/typewriter/penevents.rs
@@ -219,6 +219,7 @@ impl Typewriter {
                                         if let Ok(new_cursor) =
                                             textstroke.get_cursor_for_global_coord(element.pos)
                                         {
+                                            let previous_cursor_position = cursor.cur_cursor();
                                             *cursor = new_cursor;
 
                                             match mode {
@@ -253,7 +254,9 @@ impl Typewriter {
                                                 SelectionMode::Caret => {}
                                             }
 
-                                            self.reset_blink();
+                                            if previous_cursor_position != cursor.cur_cursor() {
+                                                self.reset_blink();
+                                            }
                                         }
                                     }
                                 }

--- a/crates/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/crates/rnote-engine/src/pens/typewriter/penevents.rs
@@ -1229,4 +1229,58 @@ impl Typewriter {
 
         (event_result, widget_flags)
     }
+
+    pub fn select_closest_word(&mut self, engine_view: &mut EngineViewMut) {
+        match &mut self.state {
+            TypewriterState::Modifying {
+                modify_state,
+                stroke_key,
+                cursor,
+                pen_down: _,
+            } => {
+                if let Some(Stroke::TextStroke(ref mut textstroke)) =
+                    engine_view.store.get_stroke_mut(*stroke_key)
+                {
+                    textstroke.move_cursor_word_forward(cursor);
+
+                    *modify_state = ModifyState::Selecting {
+                        selection_cursor: GraphemeCursor::new(
+                            textstroke.get_prev_word_start_index(cursor.cur_cursor()),
+                            textstroke.text.len(),
+                            true,
+                        ),
+                        finished: true,
+                    };
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub fn select_closest_line(&mut self, engine_view: &mut EngineViewMut) {
+        match &mut self.state {
+            TypewriterState::Modifying {
+                modify_state,
+                stroke_key,
+                cursor,
+                pen_down: _,
+            } => {
+                if let Some(Stroke::TextStroke(ref mut textstroke)) =
+                    engine_view.store.get_stroke_mut(*stroke_key)
+                {
+                    textstroke.move_cursor_line_start(cursor);
+
+                    *modify_state = ModifyState::Selecting {
+                        selection_cursor: GraphemeCursor::new(
+                            textstroke.get_line_end_index(cursor),
+                            textstroke.text.len(),
+                            true,
+                        ),
+                        finished: true,
+                    };
+                }
+            }
+            _ => {}
+        }
+    }
 }

--- a/crates/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/crates/rnote-engine/src/pens/typewriter/penevents.rs
@@ -226,12 +226,16 @@ impl Typewriter {
                                                 SelectionMode::Word(start, end) => {
                                                     let mouse_position = cursor.cur_cursor();
 
-                                                    if mouse_position < *start {
+                                                    if mouse_position <= *start {
                                                         selection_cursor.set_cursor(*end);
-                                                        textstroke.move_cursor_word_back(cursor);
-                                                    } else if mouse_position > *end {
+                                                        textstroke
+                                                            .move_cursor_word_boundary_back(cursor);
+                                                    } else if mouse_position >= *end {
                                                         selection_cursor.set_cursor(*start);
-                                                        textstroke.move_cursor_word_forward(cursor);
+                                                        textstroke
+                                                            .move_cursor_word_boundary_forward(
+                                                                cursor,
+                                                            );
                                                     } else {
                                                         selection_cursor.set_cursor(*start);
                                                         cursor.set_cursor(*end);
@@ -1291,10 +1295,10 @@ impl Typewriter {
                 if let Some(Stroke::TextStroke(ref mut textstroke)) =
                     engine_view.store.get_stroke_mut(*stroke_key)
                 {
-                    textstroke.move_cursor_word_forward(cursor);
+                    textstroke.move_cursor_word_boundary_forward(cursor);
 
                     let mut selection_cursor = cursor.clone();
-                    textstroke.move_cursor_word_back(&mut selection_cursor);
+                    textstroke.move_cursor_word_boundary_back(&mut selection_cursor);
 
                     *modify_state = ModifyState::Selecting {
                         mode: SelectionMode::Word(

--- a/crates/rnote-engine/src/strokes/textstroke.rs
+++ b/crates/rnote-engine/src/strokes/textstroke.rs
@@ -830,7 +830,7 @@ impl TextStroke {
         selection_cursor.set_cursor(0);
     }
 
-    pub fn get_prev_word_start_index(&self, current_char_index: usize) -> usize {
+    fn get_prev_word_start_index(&self, current_char_index: usize) -> usize {
         for (start_index, _) in self.text.unicode_word_indices().rev() {
             if start_index < current_char_index {
                 return start_index;

--- a/crates/rnote-engine/src/strokes/textstroke.rs
+++ b/crates/rnote-engine/src/strokes/textstroke.rs
@@ -840,11 +840,43 @@ impl TextStroke {
         current_char_index
     }
 
+    fn get_prev_word_boundary_index(&self, current_char_index: usize) -> usize {
+        for (start_index, word) in self.text.unicode_word_indices().rev() {
+            let end_index = start_index + word.len();
+
+            if end_index < current_char_index {
+                return end_index;
+            }
+
+            if start_index < current_char_index {
+                return start_index;
+            }
+        }
+
+        current_char_index
+    }
+
     fn get_next_word_end_index(&self, current_char_index: usize) -> usize {
         for (start_index, word) in self.text.unicode_word_indices() {
             let end_index = start_index + word.len();
 
             if end_index > current_char_index {
+                return end_index;
+            }
+        }
+
+        current_char_index
+    }
+
+    fn get_next_word_boundary_index(&self, current_char_index: usize) -> usize {
+        for (start_index, word) in self.text.unicode_word_indices() {
+            if start_index >= current_char_index {
+                return start_index;
+            }
+
+            let end_index = start_index + word.len();
+
+            if end_index >= current_char_index {
                 return end_index;
             }
         }
@@ -866,8 +898,16 @@ impl TextStroke {
         cursor.set_cursor(self.get_prev_word_start_index(cursor.cur_cursor()));
     }
 
+    pub fn move_cursor_word_boundary_back(&self, cursor: &mut GraphemeCursor) {
+        cursor.set_cursor(self.get_prev_word_boundary_index(cursor.cur_cursor()));
+    }
+
     pub fn move_cursor_word_forward(&self, cursor: &mut GraphemeCursor) {
         cursor.set_cursor(self.get_next_word_end_index(cursor.cur_cursor()));
+    }
+
+    pub fn move_cursor_word_boundary_forward(&self, cursor: &mut GraphemeCursor) {
+        cursor.set_cursor(self.get_next_word_boundary_index(cursor.cur_cursor()));
     }
 
     pub fn move_cursor_text_start(&self, cursor: &mut GraphemeCursor) {

--- a/crates/rnote-engine/src/strokes/textstroke.rs
+++ b/crates/rnote-engine/src/strokes/textstroke.rs
@@ -892,7 +892,7 @@ impl TextStroke {
         }
     }
 
-    pub fn get_line_end_index(&self, cursor: &GraphemeCursor) -> usize {
+    pub fn move_cursor_line_end(&self, cursor: &mut GraphemeCursor) {
         if let (Ok(lines), Ok(hittest_position)) = (
             self.text_style
                 .lines(&mut piet_cairo::CairoText::new(), self.text.clone()),
@@ -926,14 +926,8 @@ impl TextStroke {
                 offset -= 1;
             }
 
-            return offset;
+            cursor.set_cursor(offset);
         }
-
-        0
-    }
-
-    pub fn move_cursor_line_end(&self, cursor: &mut GraphemeCursor) {
-        cursor.set_cursor(self.get_line_end_index(cursor));
     }
 
     pub fn move_cursor_line_down(&self, cursor: &mut GraphemeCursor) {

--- a/crates/rnote-engine/src/strokes/textstroke.rs
+++ b/crates/rnote-engine/src/strokes/textstroke.rs
@@ -830,7 +830,7 @@ impl TextStroke {
         selection_cursor.set_cursor(0);
     }
 
-    fn get_prev_word_start_index(&self, current_char_index: usize) -> usize {
+    pub fn get_prev_word_start_index(&self, current_char_index: usize) -> usize {
         for (start_index, _) in self.text.unicode_word_indices().rev() {
             if start_index < current_char_index {
                 return start_index;
@@ -892,7 +892,7 @@ impl TextStroke {
         }
     }
 
-    pub fn move_cursor_line_end(&self, cursor: &mut GraphemeCursor) {
+    pub fn get_line_end_index(&self, cursor: &GraphemeCursor) -> usize {
         if let (Ok(lines), Ok(hittest_position)) = (
             self.text_style
                 .lines(&mut piet_cairo::CairoText::new(), self.text.clone()),
@@ -926,8 +926,14 @@ impl TextStroke {
                 offset -= 1;
             }
 
-            cursor.set_cursor(offset);
+            return offset;
         }
+
+        0
+    }
+
+    pub fn move_cursor_line_end(&self, cursor: &mut GraphemeCursor) {
+        cursor.set_cursor(self.get_line_end_index(cursor));
     }
 
     pub fn move_cursor_line_down(&self, cursor: &mut GraphemeCursor) {

--- a/crates/rnote-ui/src/canvas/input.rs
+++ b/crates/rnote-ui/src/canvas/input.rs
@@ -300,7 +300,7 @@ fn trace_gdk_event(event: &gdk::Event) {
 }
 
 /// Returns true if input should be rejected
-fn reject_pointer_input(event: &gdk::Event, touch_drawing: bool) -> bool {
+pub(crate) fn reject_pointer_input(event: &gdk::Event, touch_drawing: bool) -> bool {
     if touch_drawing {
         if event.device().unwrap().num_touches() > 1 {
             return true;

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -6,6 +6,7 @@ mod widgetflagsboxed;
 
 // Re-exports
 pub(crate) use canvaslayout::RnCanvasLayout;
+pub(crate) use input::reject_pointer_input;
 pub(crate) use widgetflagsboxed::WidgetFlagsBoxed;
 
 // Imports


### PR DESCRIPTION
Adds multi-click selection within typewriter text fields, mimicking the behavior of most text editors/browsers. 

- Fixes #872.
- Double click to select the current word. Drag after the second click to extend the selection onto other words.
- Triple click to select the current line. Drag after the third click to extend the selection onto other lines.
- Cycles through selection modes (caret, word, line) in case of more than 3 clicks.

### TODO
- [X] Performing a double click selection while hovering over whitespace will select the next word, but immediately expand the selection backwards onto the previous word (i.e. cover two words). This is nearly identical to the behavior of Firefox; the only difference being that Firefox only expands the selection after the mouse is moved in any way. Chromium and GNOME Text Editor simply select the whitespace because they generally snap the selection to any word boundary (start *and* end). I'd personally prefer the way Chromium/GNOME Text Editor handles this. EDIT: Switched to the Chromium variant.
- [X] The caret blink is always reset if the mouse moves, even if the selection doesn't change. This has been the case before but is more noticeable with multi-click selections, since the selections change less often. Not sure what the intended behavior is. EDIT: Cursor blink is now only reset if the position changes.

### Things to Discuss

- The gesture used for detecting multiple button presses is currently always enabled and has a generic name. It could either be tailored to this feature specifically and disabled when the typewriter tool is not selected, or an early return could be added (keeping it generic enough for potential future features that make use of the gesture).