### PR TITLE
feat: Open workspace folder option

### DIFF
--- a/crates/rnote-ui/data/ui/workspacebrowser.ui
+++ b/crates/rnote-ui/data/ui/workspacebrowser.ui
@@ -163,6 +163,10 @@
             <attribute name="label" translatable="yes">Create new Folder</attribute>
             <attribute name="action">workspacebrowser.create-folder</attribute>
           </item>
+          <item>
+            <attribute name="label" translatable="yes">Open Workspace Folder</attribute>
+            <attribute name="action">workspacebrowser.open-folder</attribute>
+          </item>
         </section>
       </menu>
     </object>

--- a/crates/rnote-ui/src/workspacebrowser/mod.rs
+++ b/crates/rnote-ui/src/workspacebrowser/mod.rs
@@ -195,6 +195,9 @@ impl RnWorkspaceBrowser {
         self.imp()
             .action_group
             .add_action(&workspaceactions::create_folder(self, appwindow));
+        self.imp()
+            .action_group
+            .add_action(&workspaceactions::open_folder(self, appwindow));
     }
 
     fn setup_dir_controls(&self, _appwindow: &RnAppWindow) {

--- a/crates/rnote-ui/src/workspacebrowser/workspaceactions/mod.rs
+++ b/crates/rnote-ui/src/workspacebrowser/workspaceactions/mod.rs
@@ -1,5 +1,7 @@
 // Modules
 mod createfolder;
+mod openfolder;
 
 // Re-exports
 pub(crate) use createfolder::create_folder;
+pub(crate) use openfolder::open_folder;

--- a/crates/rnote-ui/src/workspacebrowser/workspaceactions/openfolder.rs
+++ b/crates/rnote-ui/src/workspacebrowser/workspaceactions/openfolder.rs
@@ -1,0 +1,31 @@
+use crate::{RnAppWindow, RnWorkspaceBrowser};
+use gettextrs::gettext;
+use gtk4::{gio, glib, glib::clone, prelude::*};
+
+pub(crate) fn open_folder(
+    workspacebrowser: &RnWorkspaceBrowser,
+    appwindow: &RnAppWindow,
+) -> gio::SimpleAction {
+    let open_folder_action = gio::SimpleAction::new("open-folder", None);
+
+    open_folder_action.connect_activate(clone!(
+        #[weak]
+        workspacebrowser,
+        #[weak]
+        appwindow,
+        move |_, _| {
+        if let Some(parent_path) = workspacebrowser.dir_list_file().and_then(|f| f.path()) {
+            if let Err(e) = open::that(&parent_path) {
+                let path_string =   &parent_path.into_os_string().into_string().ok().unwrap_or(String::from("Failed to get the path of the workspace folder"));
+                tracing::error!("Opening the parent folder '{path_string}' in the file manager failed, Err: {e:?}");
+                appwindow.overlays().dispatch_toast_error(&gettext("Failed to open the file in the file manager"));
+            }
+        } else {
+            tracing::warn!("No path found");
+            appwindow.overlays().dispatch_toast_error(&gettext("Failed to open the file in the file manager"));
+        }
+    }
+    ));
+
+    open_folder_action
+}


### PR DESCRIPTION
Fixes #1053.

Initially I wanted to add a way to also reveal a file inside of a folder (with another crate), as well as reveal the file upon export rather than the folder, thought it used another crate (and switching to the other one makes us loose the `_detached` guarantee).

I think it's more reasonable to just stop here (one issue fixed, and no crate added).