### PR TITLE
feat: animation events

### DIFF
--- a/crates/rnote-compose/src/builders/arrowbuilder.rs
+++ b/crates/rnote-compose/src/builders/arrowbuilder.rs
@@ -58,6 +58,7 @@ impl Buildable for ArrowBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/builders/coordsystem2dbuilder.rs
+++ b/crates/rnote-compose/src/builders/coordsystem2dbuilder.rs
@@ -56,6 +56,7 @@ impl Buildable for CoordSystem2DBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/builders/coordsystem3dbuilder.rs
+++ b/crates/rnote-compose/src/builders/coordsystem3dbuilder.rs
@@ -56,6 +56,7 @@ impl Buildable for CoordSystem3DBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/builders/cubbezbuilder.rs
+++ b/crates/rnote-compose/src/builders/cubbezbuilder.rs
@@ -143,6 +143,7 @@ impl Buildable for CubBezBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/builders/ellipsebuilder.rs
+++ b/crates/rnote-compose/src/builders/ellipsebuilder.rs
@@ -53,6 +53,7 @@ impl Buildable for EllipseBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/builders/fociellipsebuilder.rs
+++ b/crates/rnote-compose/src/builders/fociellipsebuilder.rs
@@ -114,6 +114,7 @@ impl Buildable for FociEllipseBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/builders/gridbuilder.rs
+++ b/crates/rnote-compose/src/builders/gridbuilder.rs
@@ -103,6 +103,7 @@ impl Buildable for GridBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/builders/linebuilder.rs
+++ b/crates/rnote-compose/src/builders/linebuilder.rs
@@ -58,6 +58,7 @@ impl Buildable for LineBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/builders/penpathcurvedbuilder.rs
+++ b/crates/rnote-compose/src/builders/penpathcurvedbuilder.rs
@@ -75,7 +75,8 @@ impl Buildable for PenPathCurvedBuilder {
             }
             (_, PenEvent::Proximity { .. })
             | (_, PenEvent::KeyPressed { .. })
-            | (_, PenEvent::Text { .. }) => BuilderProgress::InProgress,
+            | (_, PenEvent::Text { .. })
+            | (_, PenEvent::AnimationFrame) => BuilderProgress::InProgress,
             (_, PenEvent::Cancel) => {
                 self.reset();
 
@@ -87,6 +88,7 @@ impl Buildable for PenPathCurvedBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/builders/penpathmodeledbuilder.rs
+++ b/crates/rnote-compose/src/builders/penpathmodeledbuilder.rs
@@ -86,9 +86,10 @@ impl Buildable for PenPathModeledBuilder {
 
                 BuilderProgress::Finished(segments)
             }
-            PenEvent::Proximity { .. } | PenEvent::KeyPressed { .. } | PenEvent::Text { .. } => {
-                BuilderProgress::InProgress
-            }
+            PenEvent::Proximity { .. }
+            | PenEvent::KeyPressed { .. }
+            | PenEvent::Text { .. }
+            | PenEvent::AnimationFrame => BuilderProgress::InProgress,
             PenEvent::Cancel => BuilderProgress::Finished(vec![]),
         };
 
@@ -96,6 +97,7 @@ impl Buildable for PenPathModeledBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/builders/penpathsimplebuilder.rs
+++ b/crates/rnote-compose/src/builders/penpathsimplebuilder.rs
@@ -49,9 +49,10 @@ impl Buildable for PenPathSimpleBuilder {
 
                 BuilderProgress::Finished(segments)
             }
-            PenEvent::Proximity { .. } | PenEvent::KeyPressed { .. } | PenEvent::Text { .. } => {
-                BuilderProgress::InProgress
-            }
+            PenEvent::Proximity { .. }
+            | PenEvent::KeyPressed { .. }
+            | PenEvent::Text { .. }
+            | PenEvent::AnimationFrame => BuilderProgress::InProgress,
             PenEvent::Cancel => {
                 self.reset();
                 BuilderProgress::Finished(vec![])
@@ -62,6 +63,7 @@ impl Buildable for PenPathSimpleBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/builders/polygonbuilder.rs
+++ b/crates/rnote-compose/src/builders/polygonbuilder.rs
@@ -91,7 +91,7 @@ impl Buildable for PolygonBuilder {
                 }
                 _ => BuilderProgress::InProgress,
             },
-            PenEvent::Text { .. } => BuilderProgress::InProgress,
+            PenEvent::Text { .. } | PenEvent::AnimationFrame => BuilderProgress::InProgress,
             PenEvent::Cancel => {
                 self.pen_state = PenState::Up;
                 self.finish = false;
@@ -103,6 +103,7 @@ impl Buildable for PolygonBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/builders/polylinebuilder.rs
+++ b/crates/rnote-compose/src/builders/polylinebuilder.rs
@@ -91,7 +91,7 @@ impl Buildable for PolylineBuilder {
                 }
                 _ => BuilderProgress::InProgress,
             },
-            PenEvent::Text { .. } => BuilderProgress::InProgress,
+            PenEvent::Text { .. } | PenEvent::AnimationFrame => BuilderProgress::InProgress,
             PenEvent::Cancel => {
                 self.pen_state = PenState::Up;
                 self.finish = false;
@@ -103,6 +103,7 @@ impl Buildable for PolylineBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/builders/quadbezbuilder.rs
+++ b/crates/rnote-compose/src/builders/quadbezbuilder.rs
@@ -99,6 +99,7 @@ impl Buildable for QuadBezBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/builders/quadrantcoordsystem2dbuilder.rs
+++ b/crates/rnote-compose/src/builders/quadrantcoordsystem2dbuilder.rs
@@ -56,6 +56,7 @@ impl Buildable for QuadrantCoordSystem2DBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/builders/rectanglebuilder.rs
+++ b/crates/rnote-compose/src/builders/rectanglebuilder.rs
@@ -54,6 +54,7 @@ impl Buildable for RectangleBuilder {
             handled: true,
             propagate: EventPropagation::Stop,
             progress,
+            request_animation_frame: false,
         }
     }
 

--- a/crates/rnote-compose/src/eventresult.rs
+++ b/crates/rnote-compose/src/eventresult.rs
@@ -13,6 +13,8 @@ where
     pub propagate: EventPropagation,
     /// The pen progress.
     pub progress: T,
+    /// Whether an animated frame should be requested.
+    pub request_animation_frame: bool,
 }
 
 /// Whether the event should be propagated further.

--- a/crates/rnote-compose/src/penevent.rs
+++ b/crates/rnote-compose/src/penevent.rs
@@ -44,6 +44,8 @@ pub enum PenEvent {
         /// The committed text.
         text: String,
     },
+    /// Animation frame event.
+    AnimationFrame,
     /// Cancel event when the pen vanishes unexpected.
     ///
     /// Should finish all current actions and reset all state.

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -134,8 +134,6 @@ pub enum EngineTask {
     },
     /// Requests that the typewriter cursor should be blinked/toggled
     BlinkTypewriterCursor,
-    /// Emits an animation frame event.
-    // EmitAnimationFrame,
     /// Change the permanent zoom to the given value
     Zoom(f64),
     /// Indicates that the application is quitting. Sent to quit the handler which receives the tasks.
@@ -488,13 +486,6 @@ impl Engine {
                     widget_flags.redraw = true;
                 }
             }
-            // EngineTask::EmitAnimationFrame => {
-            //     self.animation.reset();
-
-            //     widget_flags |= self
-            //         .handle_pen_event(PenEvent::AnimationFrame, None, Instant::now())
-            //         .1;
-            // }
             EngineTask::Zoom(zoom) => {
                 widget_flags |= self.camera.zoom_temporarily_to(1.0) | self.camera.zoom_to(zoom);
 

--- a/crates/rnote-engine/src/pens/brush.rs
+++ b/crates/rnote-engine/src/pens/brush.rs
@@ -118,12 +118,14 @@ impl PenBehaviour for Brush {
                         handled: true,
                         propagate: EventPropagation::Stop,
                         progress: PenProgress::InProgress,
+                        request_animation_frame: false,
                     }
                 } else {
                     EventResult {
                         handled: false,
                         propagate: EventPropagation::Proceed,
                         progress: PenProgress::Idle,
+                        request_animation_frame: false,
                     }
                 }
             }
@@ -131,6 +133,7 @@ impl PenBehaviour for Brush {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::Idle,
+                request_animation_frame: false,
             },
             (
                 BrushState::Drawing {
@@ -161,6 +164,7 @@ impl PenBehaviour for Brush {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::Finished,
+                    request_animation_frame: false,
                 }
             }
             (
@@ -256,6 +260,7 @@ impl PenBehaviour for Brush {
                     handled,
                     propagate,
                     progress,
+                    request_animation_frame: false,
                 }
             }
         };

--- a/crates/rnote-engine/src/pens/eraser.rs
+++ b/crates/rnote-engine/src/pens/eraser.rs
@@ -66,6 +66,7 @@ impl PenBehaviour for Eraser {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::InProgress,
+                    request_animation_frame: false,
                 }
             }
             (EraserState::Up | EraserState::Down { .. }, PenEvent::Proximity { element, .. }) => {
@@ -74,6 +75,7 @@ impl PenBehaviour for Eraser {
                     handled: false,
                     propagate: EventPropagation::Proceed,
                     progress: PenProgress::Idle,
+                    request_animation_frame: false,
                 }
             }
             (
@@ -83,6 +85,7 @@ impl PenBehaviour for Eraser {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::Idle,
+                request_animation_frame: false,
             },
             (EraserState::Down(current_element), PenEvent::Down { element, .. }) => {
                 widget_flags |= erase(element, engine_view);
@@ -91,6 +94,7 @@ impl PenBehaviour for Eraser {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::InProgress,
+                    request_animation_frame: false,
                 }
             }
             (EraserState::Down { .. }, PenEvent::Up { element, .. }) => {
@@ -101,12 +105,14 @@ impl PenBehaviour for Eraser {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::Finished,
+                    request_animation_frame: false,
                 }
             }
             (EraserState::Down(_), PenEvent::KeyPressed { .. }) => EventResult {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::InProgress,
+                request_animation_frame: false,
             },
             (EraserState::Proximity(_), PenEvent::Up { .. }) => {
                 self.state = EraserState::Up;
@@ -114,6 +120,7 @@ impl PenBehaviour for Eraser {
                     handled: false,
                     propagate: EventPropagation::Proceed,
                     progress: PenProgress::Idle,
+                    request_animation_frame: false,
                 }
             }
             (EraserState::Proximity(current_element), PenEvent::Proximity { element, .. }) => {
@@ -122,6 +129,7 @@ impl PenBehaviour for Eraser {
                     handled: false,
                     propagate: EventPropagation::Proceed,
                     progress: PenProgress::Idle,
+                    request_animation_frame: false,
                 }
             }
             (EraserState::Proximity { .. } | EraserState::Down { .. }, PenEvent::Cancel) => {
@@ -131,28 +139,37 @@ impl PenBehaviour for Eraser {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::Finished,
+                    request_animation_frame: false,
                 }
             }
             (EraserState::Proximity(_), PenEvent::KeyPressed { .. }) => EventResult {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::Idle,
+                request_animation_frame: false,
             },
-            (EraserState::Up, PenEvent::Text { .. }) => EventResult {
+            (EraserState::Up, PenEvent::Text { .. } | PenEvent::AnimationFrame) => EventResult {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::Idle,
+                request_animation_frame: false,
             },
-            (EraserState::Proximity(_), PenEvent::Text { .. }) => EventResult {
-                handled: false,
-                propagate: EventPropagation::Proceed,
-                progress: PenProgress::Idle,
-            },
-            (EraserState::Down(_), PenEvent::Text { .. }) => EventResult {
-                handled: false,
-                propagate: EventPropagation::Proceed,
-                progress: PenProgress::InProgress,
-            },
+            (EraserState::Proximity(_), PenEvent::Text { .. } | PenEvent::AnimationFrame) => {
+                EventResult {
+                    handled: false,
+                    propagate: EventPropagation::Proceed,
+                    progress: PenProgress::Idle,
+                    request_animation_frame: false,
+                }
+            }
+            (EraserState::Down(_), PenEvent::Text { .. } | PenEvent::AnimationFrame) => {
+                EventResult {
+                    handled: false,
+                    propagate: EventPropagation::Proceed,
+                    progress: PenProgress::InProgress,
+                    request_animation_frame: false,
+                }
+            }
         };
 
         (event_result, widget_flags)

--- a/crates/rnote-engine/src/pens/selector/mod.rs
+++ b/crates/rnote-engine/src/pens/selector/mod.rs
@@ -152,6 +152,7 @@ impl PenBehaviour for Selector {
                 modifier_keys,
             } => self.handle_pen_event_keypressed(keyboard_key, modifier_keys, now, engine_view),
             PenEvent::Text { text } => self.handle_pen_event_text(text, now, engine_view),
+            PenEvent::AnimationFrame => self.handle_pen_event_animation_frame(now, engine_view),
             PenEvent::Cancel => self.handle_pen_event_cancel(now, engine_view),
         }
     }

--- a/crates/rnote-engine/src/pens/selector/penevents.rs
+++ b/crates/rnote-engine/src/pens/selector/penevents.rs
@@ -41,6 +41,7 @@ impl Selector {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::InProgress,
+                    request_animation_frame: false,
                 }
             }
             SelectorState::Selecting { path } => {
@@ -67,6 +68,7 @@ impl Selector {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::InProgress,
+                    request_animation_frame: false,
                 }
             }
             SelectorState::ModifySelection {
@@ -399,6 +401,7 @@ impl Selector {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress,
+                    request_animation_frame: false,
                 }
             }
         };
@@ -421,6 +424,7 @@ impl Selector {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::Idle,
+                request_animation_frame: false,
             },
             SelectorState::Selecting { path } => {
                 let mut progress = PenProgress::Finished;
@@ -495,6 +499,7 @@ impl Selector {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress,
+                    request_animation_frame: false,
                 }
             }
             SelectorState::ModifySelection {
@@ -542,6 +547,7 @@ impl Selector {
                     handled: true,
                     propagate: EventPropagation::Proceed,
                     progress: PenProgress::InProgress,
+                    request_animation_frame: false,
                 }
             }
         };
@@ -564,11 +570,13 @@ impl Selector {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::Idle,
+                request_animation_frame: false,
             },
             SelectorState::Selecting { .. } => EventResult {
                 handled: true,
                 propagate: EventPropagation::Stop,
                 progress: PenProgress::InProgress,
+                request_animation_frame: false,
             },
             SelectorState::ModifySelection { modify_state, .. } => {
                 *modify_state = if selector_bounds
@@ -583,6 +591,7 @@ impl Selector {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::InProgress,
+                    request_animation_frame: false,
                 }
             }
         };
@@ -607,12 +616,14 @@ impl Selector {
                         handled: true,
                         propagate: EventPropagation::Stop,
                         progress: PenProgress::InProgress,
+                        request_animation_frame: false,
                     }
                 }
                 _ => EventResult {
                     handled: false,
                     propagate: EventPropagation::Proceed,
                     progress: PenProgress::InProgress,
+                    request_animation_frame: false,
                 },
             },
             SelectorState::Selecting { .. } => match keyboard_key {
@@ -622,12 +633,14 @@ impl Selector {
                         handled: true,
                         propagate: EventPropagation::Stop,
                         progress: PenProgress::InProgress,
+                        request_animation_frame: false,
                     }
                 }
                 _ => EventResult {
                     handled: false,
                     propagate: EventPropagation::Proceed,
                     progress: PenProgress::InProgress,
+                    request_animation_frame: false,
                 },
             },
             SelectorState::ModifySelection { selection, .. } => {
@@ -638,6 +651,7 @@ impl Selector {
                             handled: true,
                             propagate: EventPropagation::Stop,
                             progress: PenProgress::InProgress,
+                            request_animation_frame: false,
                         }
                     }
                     KeyboardKey::Unicode('d') => {
@@ -660,6 +674,7 @@ impl Selector {
                             handled: true,
                             propagate: EventPropagation::Stop,
                             progress: PenProgress::Finished,
+                            request_animation_frame: false,
                         }
                     }
                     KeyboardKey::Delete | KeyboardKey::BackSpace => {
@@ -670,6 +685,7 @@ impl Selector {
                             handled: true,
                             propagate: EventPropagation::Stop,
                             progress: PenProgress::Finished,
+                            request_animation_frame: false,
                         }
                     }
                     KeyboardKey::Escape => {
@@ -679,12 +695,14 @@ impl Selector {
                             handled: true,
                             propagate: EventPropagation::Stop,
                             progress: PenProgress::Finished,
+                            request_animation_frame: false,
                         }
                     }
                     _ => EventResult {
                         handled: false,
                         propagate: EventPropagation::Proceed,
                         progress: PenProgress::InProgress,
+                        request_animation_frame: false,
                     },
                 }
             }
@@ -706,16 +724,38 @@ impl Selector {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::Idle,
+                request_animation_frame: false,
             },
-            SelectorState::Selecting { .. } => EventResult {
+            _ => EventResult {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::InProgress,
+                request_animation_frame: false,
             },
-            SelectorState::ModifySelection { .. } => EventResult {
+        };
+
+        (event_result, widget_flags)
+    }
+
+    pub(super) fn handle_pen_event_animation_frame(
+        &mut self,
+        _now: Instant,
+        _engine_view: &mut EngineViewMut,
+    ) -> (EventResult<PenProgress>, WidgetFlags) {
+        let widget_flags = WidgetFlags::default();
+
+        let event_result = match &mut self.state {
+            SelectorState::Idle => EventResult {
+                handled: false,
+                propagate: EventPropagation::Proceed,
+                progress: PenProgress::Idle,
+                request_animation_frame: false,
+            },
+            _ => EventResult {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::InProgress,
+                request_animation_frame: false,
             },
         };
 
@@ -734,6 +774,7 @@ impl Selector {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::Idle,
+                request_animation_frame: false,
             },
             SelectorState::Selecting { .. } => {
                 self.state = SelectorState::Idle;
@@ -741,6 +782,7 @@ impl Selector {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::Finished,
+                    request_animation_frame: false,
                 }
             }
             SelectorState::ModifySelection { selection, .. } => {
@@ -750,6 +792,7 @@ impl Selector {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::Finished,
+                    request_animation_frame: false,
                 }
             }
         };

--- a/crates/rnote-engine/src/pens/shaper.rs
+++ b/crates/rnote-engine/src/pens/shaper.rs
@@ -81,12 +81,14 @@ impl PenBehaviour for Shaper {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::InProgress,
+                    request_animation_frame: false,
                 }
             }
             (ShaperState::Idle, _) => EventResult {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::Idle,
+                request_animation_frame: false,
             },
             (ShaperState::BuildShape { .. }, PenEvent::Cancel) => {
                 self.state = ShaperState::Idle;
@@ -95,6 +97,7 @@ impl PenBehaviour for Shaper {
                     handled: false,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::Finished,
+                    request_animation_frame: false,
                 }
             }
             (ShaperState::BuildShape { builder }, event) => {
@@ -113,7 +116,7 @@ impl PenBehaviour for Shaper {
                     | PenEvent::KeyPressed {
                         ref modifier_keys, ..
                     } => constraints.enabled ^ modifier_keys.contains(&ModifierKey::KeyboardCtrl),
-                    PenEvent::Text { .. } | PenEvent::Cancel => false,
+                    PenEvent::Text { .. } | PenEvent::AnimationFrame | PenEvent::Cancel => false,
                 };
                 let builder_result = builder.handle_event(event.clone(), now, constraints);
                 let handled = builder_result.handled;
@@ -196,6 +199,7 @@ impl PenBehaviour for Shaper {
                     handled,
                     propagate,
                     progress,
+                    request_animation_frame: false,
                 }
             }
         };

--- a/crates/rnote-engine/src/pens/tools.rs
+++ b/crates/rnote-engine/src/pens/tools.rs
@@ -377,12 +377,14 @@ impl PenBehaviour for Tools {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::InProgress,
+                    request_animation_frame: false,
                 }
             }
-            (ToolsState::Idle, _) => EventResult {
+            (ToolsState::Idle, _) | (_, PenEvent::AnimationFrame) => EventResult {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::Idle,
+                request_animation_frame: false,
             },
             (ToolsState::Active, PenEvent::Down { element, .. }) => {
                 match engine_view.pens_config.tools_config.style {
@@ -489,6 +491,7 @@ impl PenBehaviour for Tools {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::InProgress,
+                    request_animation_frame: false,
                 }
             }
             (ToolsState::Active, PenEvent::Up { .. }) => {
@@ -520,17 +523,20 @@ impl PenBehaviour for Tools {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::Finished,
+                    request_animation_frame: false,
                 }
             }
             (ToolsState::Active, PenEvent::Proximity { .. }) => EventResult {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::InProgress,
+                request_animation_frame: false,
             },
             (ToolsState::Active, PenEvent::KeyPressed { .. }) => EventResult {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::InProgress,
+                request_animation_frame: false,
             },
             (ToolsState::Active, PenEvent::Cancel) => {
                 widget_flags |= engine_view
@@ -549,12 +555,14 @@ impl PenBehaviour for Tools {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::Finished,
+                    request_animation_frame: false,
                 }
             }
             (ToolsState::Active, PenEvent::Text { .. }) => EventResult {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::InProgress,
+                request_animation_frame: false,
             },
         };
 

--- a/crates/rnote-engine/src/pens/typewriter/mod.rs
+++ b/crates/rnote-engine/src/pens/typewriter/mod.rs
@@ -374,6 +374,7 @@ impl PenBehaviour for Typewriter {
                 modifier_keys,
             } => self.handle_pen_event_keypressed(keyboard_key, modifier_keys, now, engine_view),
             PenEvent::Text { text } => self.handle_pen_event_text(text, now, engine_view),
+            PenEvent::AnimationFrame => self.handle_pen_event_animation_frame(now, engine_view),
             PenEvent::Cancel => self.handle_pen_event_cancel(now, engine_view),
         };
 

--- a/crates/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/crates/rnote-engine/src/pens/typewriter/penevents.rs
@@ -89,6 +89,7 @@ impl Typewriter {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::InProgress,
+                    request_animation_frame: false,
                 }
             }
             TypewriterState::Modifying {
@@ -174,6 +175,7 @@ impl Typewriter {
                             handled: true,
                             propagate: EventPropagation::Stop,
                             progress,
+                            request_animation_frame: false,
                         }
                     }
                     ModifyState::Selecting { finished, .. } => {
@@ -230,6 +232,7 @@ impl Typewriter {
                             handled: true,
                             propagate: EventPropagation::Stop,
                             progress,
+                            request_animation_frame: false,
                         }
                     }
                     ModifyState::Translating { current_pos, .. } => {
@@ -276,6 +279,7 @@ impl Typewriter {
                             handled: true,
                             propagate: EventPropagation::Stop,
                             progress: PenProgress::InProgress,
+                            request_animation_frame: false,
                         }
                     }
                     ModifyState::AdjustTextWidth {
@@ -314,6 +318,7 @@ impl Typewriter {
                             handled: true,
                             propagate: EventPropagation::Stop,
                             progress: PenProgress::InProgress,
+                            request_animation_frame: false,
                         }
                     }
                 }
@@ -338,11 +343,13 @@ impl Typewriter {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::Idle,
+                request_animation_frame: false,
             },
             TypewriterState::Start(_) => EventResult {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::InProgress,
+                request_animation_frame: false,
             },
             TypewriterState::Modifying {
                 modify_state,
@@ -421,6 +428,7 @@ impl Typewriter {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::InProgress,
+                    request_animation_frame: false,
                 }
             }
         };
@@ -443,11 +451,13 @@ impl Typewriter {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::Idle,
+                request_animation_frame: false,
             },
             TypewriterState::Start(_) => EventResult {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::InProgress,
+                request_animation_frame: false,
             },
             TypewriterState::Modifying {
                 modify_state,
@@ -469,6 +479,7 @@ impl Typewriter {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::InProgress,
+                    request_animation_frame: false,
                 }
             }
         };
@@ -493,6 +504,7 @@ impl Typewriter {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::Idle,
+                request_animation_frame: false,
             },
             TypewriterState::Start(pos) => {
                 super::play_sound(Some(keyboard_key), engine_view.audioplayer);
@@ -531,12 +543,14 @@ impl Typewriter {
                             handled: true,
                             propagate: EventPropagation::Stop,
                             progress: PenProgress::InProgress,
+                            request_animation_frame: false,
                         }
                     }
                     _ => EventResult {
                         handled: false,
                         propagate: EventPropagation::Proceed,
                         progress: PenProgress::InProgress,
+                        request_animation_frame: false,
                     },
                 }
             }
@@ -604,6 +618,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::BackSpace => {
@@ -618,6 +633,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::HorizontalTab => {
@@ -628,6 +644,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::CarriageReturn | KeyboardKey::Linefeed => {
@@ -638,6 +655,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::Delete => {
@@ -652,6 +670,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::NavLeft => {
@@ -680,6 +699,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::NavRight => {
@@ -708,6 +728,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::NavUp => {
@@ -727,6 +748,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::NavDown => {
@@ -746,6 +768,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::Home => {
@@ -774,6 +797,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::End => {
@@ -802,12 +826,14 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 _ => EventResult {
                                     handled: false,
                                     propagate: EventPropagation::Proceed,
                                     progress: PenProgress::InProgress,
+                                    request_animation_frame: false,
                                 },
                             }
                         } else {
@@ -815,6 +841,7 @@ impl Typewriter {
                                 handled: false,
                                 propagate: EventPropagation::Proceed,
                                 progress: PenProgress::InProgress,
+                                request_animation_frame: false,
                             }
                         }
                     }
@@ -864,6 +891,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::NavLeft => {
@@ -883,6 +911,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::NavRight => {
@@ -902,6 +931,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::NavUp => {
@@ -913,6 +943,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::NavDown => {
@@ -924,6 +955,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::Home => {
@@ -939,6 +971,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::End => {
@@ -954,6 +987,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::CarriageReturn | KeyboardKey::Linefeed => {
@@ -968,6 +1002,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::BackSpace | KeyboardKey::Delete => {
@@ -982,6 +1017,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::HorizontalTab => {
@@ -996,6 +1032,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                                 KeyboardKey::CtrlLeft
@@ -1005,6 +1042,7 @@ impl Typewriter {
                                     handled: false,
                                     propagate: EventPropagation::Proceed,
                                     progress: PenProgress::InProgress,
+                                    request_animation_frame: false,
                                 },
                                 _ => {
                                     quit_selecting = true;
@@ -1012,6 +1050,7 @@ impl Typewriter {
                                         handled: true,
                                         propagate: EventPropagation::Stop,
                                         progress: PenProgress::InProgress,
+                                        request_animation_frame: false,
                                     }
                                 }
                             };
@@ -1031,6 +1070,7 @@ impl Typewriter {
                                 handled: false,
                                 propagate: EventPropagation::Proceed,
                                 progress: PenProgress::InProgress,
+                                request_animation_frame: false,
                             }
                         }
                     }
@@ -1038,6 +1078,7 @@ impl Typewriter {
                         handled: false,
                         propagate: EventPropagation::Proceed,
                         progress: PenProgress::InProgress,
+                        request_animation_frame: false,
                     },
                 }
             }
@@ -1066,6 +1107,7 @@ impl Typewriter {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::Idle,
+                request_animation_frame: false,
             },
             TypewriterState::Start(pos) => {
                 super::play_sound(None, engine_view.audioplayer);
@@ -1100,6 +1142,7 @@ impl Typewriter {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::InProgress,
+                    request_animation_frame: false,
                 }
             }
             TypewriterState::Modifying {
@@ -1145,6 +1188,7 @@ impl Typewriter {
                             handled: true,
                             propagate: EventPropagation::Stop,
                             progress: PenProgress::InProgress,
+                            request_animation_frame: false,
                         }
                     }
                     ModifyState::Selecting {
@@ -1189,15 +1233,42 @@ impl Typewriter {
                             handled: true,
                             propagate: EventPropagation::Stop,
                             progress: PenProgress::InProgress,
+                            request_animation_frame: false,
                         }
                     }
                     _ => EventResult {
                         handled: false,
                         propagate: EventPropagation::Proceed,
                         progress: PenProgress::InProgress,
+                        request_animation_frame: false,
                     },
                 }
             }
+        };
+
+        (event_result, widget_flags)
+    }
+
+    pub(super) fn handle_pen_event_animation_frame(
+        &mut self,
+        _now: Instant,
+        _engine_view: &mut EngineViewMut,
+    ) -> (EventResult<PenProgress>, WidgetFlags) {
+        let widget_flags = WidgetFlags::default();
+
+        let event_result = match &mut self.state {
+            TypewriterState::Idle => EventResult {
+                handled: false,
+                propagate: EventPropagation::Proceed,
+                progress: PenProgress::Idle,
+                request_animation_frame: false,
+            },
+            _ => EventResult {
+                handled: true,
+                propagate: EventPropagation::Stop,
+                progress: PenProgress::Finished,
+                request_animation_frame: false,
+            },
         };
 
         (event_result, widget_flags)
@@ -1215,6 +1286,7 @@ impl Typewriter {
                 handled: false,
                 propagate: EventPropagation::Proceed,
                 progress: PenProgress::Idle,
+                request_animation_frame: false,
             },
             _ => {
                 self.state = TypewriterState::Idle;
@@ -1223,6 +1295,7 @@ impl Typewriter {
                     handled: true,
                     propagate: EventPropagation::Stop,
                     progress: PenProgress::Finished,
+                    request_animation_frame: false,
                 }
             }
         };

--- a/crates/rnote-ui/src/canvas/input.rs
+++ b/crates/rnote-ui/src/canvas/input.rs
@@ -182,7 +182,7 @@ pub(crate) fn handle_pointer_controller_event(
                 PenState::Up => {
                     canvas.enable_drawing_cursor(false);
 
-                    let (ep, wf) = canvas.engine_mut().handle_pen_event(
+                    let (ep, wf) = canvas.handle_pen_event(
                         PenEvent::Up {
                             element,
                             modifier_keys: modifier_keys.clone(),
@@ -196,7 +196,7 @@ pub(crate) fn handle_pointer_controller_event(
                 PenState::Proximity => {
                     canvas.enable_drawing_cursor(false);
 
-                    let (ep, wf) = canvas.engine_mut().handle_pen_event(
+                    let (ep, wf) = canvas.handle_pen_event(
                         PenEvent::Proximity {
                             element,
                             modifier_keys: modifier_keys.clone(),
@@ -211,7 +211,7 @@ pub(crate) fn handle_pointer_controller_event(
                     canvas.grab_focus();
                     canvas.enable_drawing_cursor(true);
 
-                    let (ep, wf) = canvas.engine_mut().handle_pen_event(
+                    let (ep, wf) = canvas.handle_pen_event(
                         PenEvent::Down {
                             element,
                             modifier_keys: modifier_keys.clone(),
@@ -248,7 +248,7 @@ pub(crate) fn handle_key_controller_key_pressed(
             .engine_mut()
             .handle_pressed_shortcut_key(shortcut_key, now)
     } else {
-        canvas.engine_mut().handle_pen_event(
+        canvas.handle_pen_event(
             PenEvent::KeyPressed {
                 keyboard_key,
                 modifier_keys,
@@ -273,7 +273,7 @@ pub(crate) fn handle_key_controller_key_released(
 pub(crate) fn handle_imcontext_text_commit(canvas: &RnCanvas, text: &str) {
     let now = Instant::now();
 
-    let (_ep, widget_flags) = canvas.engine_mut().handle_pen_event(
+    let (_ep, widget_flags) = canvas.handle_pen_event(
         PenEvent::Text {
             text: text.to_string(),
         },

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -6,9 +6,6 @@ mod widgetflagsboxed;
 
 // Re-exports
 pub(crate) use canvaslayout::RnCanvasLayout;
-use rnote_compose::eventresult::EventPropagation;
-use rnote_compose::PenEvent;
-use rnote_engine::pens::PenMode;
 pub(crate) use widgetflagsboxed::WidgetFlagsBoxed;
 
 // Imports
@@ -25,10 +22,13 @@ use notify::EventKind;
 use notify_debouncer_full::notify;
 use once_cell::sync::Lazy;
 use p2d::bounding_volume::Aabb;
+use rnote_compose::eventresult::EventPropagation;
 use rnote_compose::ext::AabbExt;
 use rnote_compose::penevent::PenState;
+use rnote_compose::PenEvent;
 use rnote_engine::ext::GraphenePointExt;
 use rnote_engine::ext::GrapheneRectExt;
+use rnote_engine::pens::PenMode;
 use rnote_engine::Camera;
 use rnote_engine::{Engine, WidgetFlags};
 use std::cell::{Cell, Ref, RefCell, RefMut};


### PR DESCRIPTION
Adds the ability to (continuously) request `AnimationFrame` pen events to render animations that are not strictly tied to other pen events.

- Needed (in *some* form) for #476 and its upcoming PR.
- An additional struct `Animation` is added to the engine and used to ensure that only one `AnimationFrame` is in flight at a time.

### Things to Discuss
- We can either "pull" `handle_pen_event` out of the engine and into the canvas, which is how it's currently done, or use `EngineTask`s to make the engine call itself (currently commented). The former seems cleaner and likely faster, the latter allows us to get rid of the additional `EventResult` field and request animation frames from anywhere with access to the engine (i.e. also in the event handlers themselves).
- Use a struct instead of the tuple `(EventPropagation, WidgetFlags, bool)` in the `handle_pen_event` functions.
- Give `glib::source::idle_add_local_once` a different priority or use a different method. I just used what works on my machine and seems correct given my limited knowledge of the glib event loop.

EDIT: Perhaps we could turn `request_animated_frame` into a field of `PenProgress::InProgress`. That would reduce the flexibility though.