### PR TITLE
feat: duplicate offset taking into account snap

### DIFF
--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -850,7 +850,10 @@ impl Engine {
     }
 
     pub fn duplicate_selection(&mut self) -> WidgetFlags {
-        let new_selected = self.store.duplicate_selection();
+        let new_selected = self.store.duplicate_selection(
+            self.document.background.pattern_size,
+            self.document.snap_positions,
+        );
         self.store.update_geometry_for_strokes(&new_selected);
         self.current_pen_update_state()
             | self.doc_resize_autoexpand()

--- a/crates/rnote-engine/src/pens/selector/penevents.rs
+++ b/crates/rnote-engine/src/pens/selector/penevents.rs
@@ -628,7 +628,10 @@ impl Selector {
                     KeyboardKey::Unicode('d') => {
                         //Duplicate selection
                         if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
-                            let duplicated = engine_view.store.duplicate_selection();
+                            let duplicated = engine_view.store.duplicate_selection(
+                                engine_view.document.background.pattern_size,
+                                engine_view.document.snap_positions,
+                            );
                             engine_view.store.update_geometry_for_strokes(&duplicated);
                             engine_view.store.regenerate_rendering_for_strokes_threaded(
                                 engine_view.tasks_tx.clone(),

--- a/crates/rnote-engine/src/store/selection_comp.rs
+++ b/crates/rnote-engine/src/store/selection_comp.rs
@@ -95,7 +95,11 @@ impl StrokeStore {
     /// Duplicate the selected keys.
     ///
     /// The returned, duplicated strokes then need to update their geometry and rendering.
-    pub(crate) fn duplicate_selection(&mut self, pattern_size:na::Vector2<f64>, snap_mode:bool) -> Vec<StrokeKey> {
+    pub(crate) fn duplicate_selection(
+        &mut self,
+        pattern_size: na::Vector2<f64>,
+        snap_mode: bool,
+    ) -> Vec<StrokeKey> {
         let old_selected = self.selection_keys_as_rendered();
         self.set_selected_keys(&old_selected, false);
 

--- a/crates/rnote-engine/src/store/selection_comp.rs
+++ b/crates/rnote-engine/src/store/selection_comp.rs
@@ -95,7 +95,7 @@ impl StrokeStore {
     /// Duplicate the selected keys.
     ///
     /// The returned, duplicated strokes then need to update their geometry and rendering.
-    pub(crate) fn duplicate_selection(&mut self) -> Vec<StrokeKey> {
+    pub(crate) fn duplicate_selection(&mut self, pattern_size:na::Vector2<f64>, snap_mode:bool) -> Vec<StrokeKey> {
         let old_selected = self.selection_keys_as_rendered();
         self.set_selected_keys(&old_selected, false);
 
@@ -126,8 +126,14 @@ impl StrokeStore {
             .collect::<Vec<StrokeKey>>();
 
         // Offsetting the new selected stroke to make the duplication apparent
-        self.translate_strokes(&new_selected, Stroke::IMPORT_OFFSET_DEFAULT);
-        self.translate_strokes_images(&new_selected, Stroke::IMPORT_OFFSET_DEFAULT);
+        // check if snap position is activated or not here
+        let offset = if snap_mode {
+            pattern_size
+        } else {
+            Stroke::IMPORT_OFFSET_DEFAULT
+        };
+        self.translate_strokes(&new_selected, offset);
+        self.translate_strokes_images(&new_selected, offset);
 
         new_selected
     }


### PR DESCRIPTION
If snap is activated, the offset is one exactly the size of one grid element, and if not, uses the previous value.

We could do fancier things there. Always take into account the grid size (but switch based on whether the grid is visible or not). Or do an offset based on content (find a place that does not overlap with what's already there if possible)