### PR TITLE
make zooming consistent and better support for keypad keys

### DIFF
--- a/crates/rnote-ui/src/appwindow/actions.rs
+++ b/crates/rnote-ui/src/appwindow/actions.rs
@@ -719,8 +719,8 @@ impl RnAppWindow {
                     return;
                 };
                 let viewport_center = canvas.engine_ref().camera.viewport_center();
-                let new_zoom =
-                    canvas.engine_ref().camera.total_zoom() * (1.0/(1.0 + RnCanvas::ZOOM_SCROLL_STEP));
+                let new_zoom = canvas.engine_ref().camera.total_zoom()
+                    * (1.0 / (1.0 + RnCanvas::ZOOM_SCROLL_STEP));
                 let mut widget_flags = canvas.engine_mut().zoom_w_timeout(new_zoom);
                 widget_flags |= canvas
                     .engine_mut()
@@ -1125,21 +1125,24 @@ impl RnAppWindow {
         app.set_accels_for_action("win.print-doc", &["<Ctrl>p"]);
         app.set_accels_for_action("win.add-page-to-doc", &["<Ctrl><Shift>a"]);
         app.set_accels_for_action("win.remove-page-from-doc", &["<Ctrl><Shift>r"]);
-        app.set_accels_for_action("win.zoom-in", &["<Ctrl>plus","<Ctrl>equal","<Ctrl>KP_Add"]);
-        app.set_accels_for_action("win.zoom-reset",&["<Ctrl>0","<Ctrl>KP_0"]);
-        app.set_accels_for_action("win.zoom-out", &["<Ctrl>minus","<Ctrl>KP_Subtract"]);
+        app.set_accels_for_action(
+            "win.zoom-in",
+            &["<Ctrl>plus", "<Ctrl>equal", "<Ctrl>KP_Add"],
+        );
+        app.set_accels_for_action("win.zoom-reset", &["<Ctrl>0", "<Ctrl>KP_0"]);
+        app.set_accels_for_action("win.zoom-out", &["<Ctrl>minus", "<Ctrl>KP_Subtract"]);
         app.set_accels_for_action("win.import-file", &["<Ctrl>i"]);
         app.set_accels_for_action("win.undo", &["<Ctrl>z"]);
         app.set_accels_for_action("win.redo", &["<Ctrl><Shift>z"]);
         app.set_accels_for_action("win.clipboard-copy", &["<Ctrl>c"]);
         app.set_accels_for_action("win.clipboard-cut", &["<Ctrl>x"]);
         app.set_accels_for_action("win.clipboard-paste", &["<Ctrl>v"]);
-        app.set_accels_for_action("win.pen-style::brush", &["<Ctrl>1","<Ctrl>KP_1"]);
-        app.set_accels_for_action("win.pen-style::shaper", &["<Ctrl>2","<Ctrl>KP_2"]);
-        app.set_accels_for_action("win.pen-style::typewriter", &["<Ctrl>3","<Ctrl>KP_3"]);
-        app.set_accels_for_action("win.pen-style::eraser", &["<Ctrl>4","<Ctrl>KP_4"]);
-        app.set_accels_for_action("win.pen-style::selector", &["<Ctrl>5","<Ctrl>KP_5"]);
-        app.set_accels_for_action("win.pen-style::tools", &["<Ctrl>6","<Ctrl>KP_6"]);
+        app.set_accels_for_action("win.pen-style::brush", &["<Ctrl>1", "<Ctrl>KP_1"]);
+        app.set_accels_for_action("win.pen-style::shaper", &["<Ctrl>2", "<Ctrl>KP_2"]);
+        app.set_accels_for_action("win.pen-style::typewriter", &["<Ctrl>3", "<Ctrl>KP_3"]);
+        app.set_accels_for_action("win.pen-style::eraser", &["<Ctrl>4", "<Ctrl>KP_4"]);
+        app.set_accels_for_action("win.pen-style::selector", &["<Ctrl>5", "<Ctrl>KP_5"]);
+        app.set_accels_for_action("win.pen-style::tools", &["<Ctrl>6", "<Ctrl>KP_6"]);
 
         // shortcuts for devel build
         if config::PROFILE.to_lowercase().as_str() == "devel" {

--- a/crates/rnote-ui/src/appwindow/actions.rs
+++ b/crates/rnote-ui/src/appwindow/actions.rs
@@ -720,7 +720,7 @@ impl RnAppWindow {
                 };
                 let viewport_center = canvas.engine_ref().camera.viewport_center();
                 let new_zoom =
-                    canvas.engine_ref().camera.total_zoom() * (1.0 - RnCanvas::ZOOM_SCROLL_STEP);
+                    canvas.engine_ref().camera.total_zoom() * (1.0/(1.0 + RnCanvas::ZOOM_SCROLL_STEP));
                 let mut widget_flags = canvas.engine_mut().zoom_w_timeout(new_zoom);
                 widget_flags |= canvas
                     .engine_mut()
@@ -1125,20 +1125,21 @@ impl RnAppWindow {
         app.set_accels_for_action("win.print-doc", &["<Ctrl>p"]);
         app.set_accels_for_action("win.add-page-to-doc", &["<Ctrl><Shift>a"]);
         app.set_accels_for_action("win.remove-page-from-doc", &["<Ctrl><Shift>r"]);
-        app.set_accels_for_action("win.zoom-in", &["<Ctrl>plus"]);
-        app.set_accels_for_action("win.zoom-out", &["<Ctrl>minus"]);
+        app.set_accels_for_action("win.zoom-in", &["<Ctrl>plus","<Ctrl>equal","<Ctrl>KP_Add"]);
+        app.set_accels_for_action("win.zoom-reset",&["<Ctrl>0","<Ctrl>KP_0"]);
+        app.set_accels_for_action("win.zoom-out", &["<Ctrl>minus","<Ctrl>KP_Subtract"]);
         app.set_accels_for_action("win.import-file", &["<Ctrl>i"]);
         app.set_accels_for_action("win.undo", &["<Ctrl>z"]);
         app.set_accels_for_action("win.redo", &["<Ctrl><Shift>z"]);
         app.set_accels_for_action("win.clipboard-copy", &["<Ctrl>c"]);
         app.set_accels_for_action("win.clipboard-cut", &["<Ctrl>x"]);
         app.set_accels_for_action("win.clipboard-paste", &["<Ctrl>v"]);
-        app.set_accels_for_action("win.pen-style::brush", &["<Ctrl>1"]);
-        app.set_accels_for_action("win.pen-style::shaper", &["<Ctrl>2"]);
-        app.set_accels_for_action("win.pen-style::typewriter", &["<Ctrl>3"]);
-        app.set_accels_for_action("win.pen-style::eraser", &["<Ctrl>4"]);
-        app.set_accels_for_action("win.pen-style::selector", &["<Ctrl>5"]);
-        app.set_accels_for_action("win.pen-style::tools", &["<Ctrl>6"]);
+        app.set_accels_for_action("win.pen-style::brush", &["<Ctrl>1","<Ctrl>KP_1"]);
+        app.set_accels_for_action("win.pen-style::shaper", &["<Ctrl>2","<Ctrl>KP_2"]);
+        app.set_accels_for_action("win.pen-style::typewriter", &["<Ctrl>3","<Ctrl>KP_3"]);
+        app.set_accels_for_action("win.pen-style::eraser", &["<Ctrl>4","<Ctrl>KP_4"]);
+        app.set_accels_for_action("win.pen-style::selector", &["<Ctrl>5","<Ctrl>KP_5"]);
+        app.set_accels_for_action("win.pen-style::tools", &["<Ctrl>6","<Ctrl>KP_6"]);
 
         // shortcuts for devel build
         if config::PROFILE.to_lowercase().as_str() == "devel" {

--- a/crates/rnote-ui/src/canvaswrapper.rs
+++ b/crates/rnote-ui/src/canvaswrapper.rs
@@ -351,7 +351,7 @@ mod imp {
                         let new_zoom = if dy < 0.0 {
                             old_zoom * (1.0 - dy * RnCanvas::ZOOM_SCROLL_STEP)
                         } else {
-                            old_zoom * (1.0/(1.0 + dy * RnCanvas::ZOOM_SCROLL_STEP))
+                            old_zoom * (1.0 / (1.0 + dy * RnCanvas::ZOOM_SCROLL_STEP))
                         };
 
                         if (Camera::ZOOM_MIN..=Camera::ZOOM_MAX).contains(&new_zoom) {

--- a/crates/rnote-ui/src/canvaswrapper.rs
+++ b/crates/rnote-ui/src/canvaswrapper.rs
@@ -348,7 +348,11 @@ mod imp {
                         }
                         let canvas = canvaswrapper.canvas();
                         let old_zoom = canvas.engine_ref().camera.total_zoom();
-                        let new_zoom = old_zoom * (1.0 - dy * RnCanvas::ZOOM_SCROLL_STEP);
+                        let new_zoom = if dy < 0.0 {
+                            old_zoom * (1.0 - dy * RnCanvas::ZOOM_SCROLL_STEP)
+                        } else {
+                            old_zoom * (1.0/(1.0 + dy * RnCanvas::ZOOM_SCROLL_STEP))
+                        };
 
                         if (Camera::ZOOM_MIN..=Camera::ZOOM_MAX).contains(&new_zoom) {
                             let camera_offset = canvas.engine_ref().camera.offset();


### PR DESCRIPTION
make zoom consistent

Take 1/zoom_in for zoom_out so that doing one zoom in then one zoom out ends up back to the same place

add more accelerators for zoom and keypad

- accelerator to reset zoom : ctrl + 0 (be it on the keyboard or numpad)
- added accelerators for keypad 1 to 6 for the selection of tools
- add `ctrl + =` for zoom in
- add `ctrl + +` and `ctrl + -` for + and -  the numpad keys

Fixes #1280 (and related to #1180)