### PR TITLE
change logic to keep selection on hover/pen up

### DIFF
--- a/crates/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/crates/rnote-engine/src/pens/typewriter/penevents.rs
@@ -454,15 +454,22 @@ impl Typewriter {
                 pen_down,
                 ..
             } => {
-                // detect hover state
-                *modify_state = if typewriter_bounds
-                    .map(|b| b.contains_local_point(&element.pos.into()))
-                    .unwrap_or(false)
-                {
-                    ModifyState::Hover(element.pos)
-                } else {
-                    ModifyState::Up
-                };
+                match modify_state {
+                    ModifyState::Selecting { .. } => {
+                        // do nothing in this case : this keeps the text selected when using a pen
+                    }
+                    _ => {
+                        // detect hover state
+                        *modify_state = if typewriter_bounds
+                            .map(|b| b.contains_local_point(&element.pos.into()))
+                            .unwrap_or(false)
+                        {
+                            ModifyState::Hover(element.pos)
+                        } else {
+                            ModifyState::Up
+                        };
+                    }
+                }
                 *pen_down = false;
 
                 EventResult {

--- a/crates/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/crates/rnote-engine/src/pens/typewriter/penevents.rs
@@ -454,21 +454,18 @@ impl Typewriter {
                 pen_down,
                 ..
             } => {
-                match modify_state {
-                    ModifyState::Selecting { .. } => {
-                        // do nothing in this case : this keeps the text selected when using a pen
-                    }
-                    _ => {
-                        // detect hover state
-                        *modify_state = if typewriter_bounds
-                            .map(|b| b.contains_local_point(&element.pos.into()))
-                            .unwrap_or(false)
-                        {
-                            ModifyState::Hover(element.pos)
-                        } else {
-                            ModifyState::Up
-                        };
-                    }
+                if !matches!(modify_state, ModifyState::Selecting { .. }) {
+                    // we do nothing if the state is selected : this keeps the text selected when using a pen
+
+                    // detect hover state
+                    *modify_state = if typewriter_bounds
+                        .map(|b| b.contains_local_point(&element.pos.into()))
+                        .unwrap_or(false)
+                    {
+                        ModifyState::Hover(element.pos)
+                    } else {
+                        ModifyState::Up
+                    };
                 }
                 *pen_down = false;
 


### PR DESCRIPTION
Fixes  #1222

This prevents the state from switching to up/hover state if the pen is lifted when a selection is active (aka the `ModifyState` is `Selecting`).

I'm not sure how useful the hover state is right now. 