### PR TITLE
refactor: use macros for constructing engine views

### DIFF
--- a/crates/rnote-engine/src/engine/import.rs
+++ b/crates/rnote-engine/src/engine/import.rs
@@ -1,6 +1,7 @@
 // Imports
-use super::{EngineConfig, EngineViewMut, StrokeContent};
+use super::{EngineConfig, StrokeContent};
 use crate::document::Layout;
+use crate::engine_view_mut;
 use crate::pens::Pen;
 use crate::pens::PenStyle;
 use crate::store::chrono_comp::StrokeLayer;
@@ -169,14 +170,7 @@ impl Engine {
 
         widget_flags |= self
             .penholder
-            .reinstall_pen_current_style(&mut EngineViewMut {
-                tasks_tx: self.tasks_tx.clone(),
-                pens_config: &mut self.pens_config,
-                document: &mut self.document,
-                store: &mut self.store,
-                camera: &mut self.camera,
-                audioplayer: &mut self.audioplayer,
-            });
+            .reinstall_pen_current_style(&mut engine_view_mut!(self));
         widget_flags |= self.doc_resize_to_fit_content();
         widget_flags.redraw = true;
         widget_flags.refresh_ui = true;
@@ -203,14 +197,7 @@ impl Engine {
 
         widget_flags |= self
             .penholder
-            .reinstall_pen_current_style(&mut EngineViewMut {
-                tasks_tx: self.tasks_tx.clone(),
-                pens_config: &mut self.pens_config,
-                document: &mut self.document,
-                store: &mut self.store,
-                camera: &mut self.camera,
-                audioplayer: &mut self.audioplayer,
-            });
+            .reinstall_pen_current_style(&mut engine_view_mut!(self));
         widget_flags |= self.doc_resize_to_fit_content();
         widget_flags.redraw = true;
         widget_flags.refresh_ui = true;
@@ -433,18 +420,7 @@ impl Engine {
         widget_flags |= self.change_pen_style(PenStyle::Typewriter);
 
         if let Pen::Typewriter(typewriter) = self.penholder.current_pen_mut() {
-            widget_flags |= typewriter.insert_text(
-                text,
-                pos,
-                &mut EngineViewMut {
-                    tasks_tx: self.tasks_tx.clone(),
-                    pens_config: &mut self.pens_config,
-                    document: &mut self.document,
-                    store: &mut self.store,
-                    camera: &mut self.camera,
-                    audioplayer: &mut self.audioplayer,
-                },
-            );
+            widget_flags |= typewriter.insert_text(text, pos, &mut engine_view_mut!(self));
         }
 
         widget_flags |= self.store.record(Instant::now());
@@ -487,14 +463,9 @@ impl Engine {
             self.camera.image_scale(),
         );
 
-        widget_flags |= self.penholder.current_pen_update_state(&mut EngineViewMut {
-            tasks_tx: self.tasks_tx.clone(),
-            pens_config: &mut self.pens_config,
-            document: &mut self.document,
-            store: &mut self.store,
-            camera: &mut self.camera,
-            audioplayer: &mut self.audioplayer,
-        });
+        widget_flags |= self
+            .penholder
+            .current_pen_update_state(&mut engine_view_mut!(self));
 
         widget_flags |= self.store.record(Instant::now());
         widget_flags.redraw = true;

--- a/crates/rnote-engine/src/engine/rendering.rs
+++ b/crates/rnote-engine/src/engine/rendering.rs
@@ -163,7 +163,7 @@ impl Engine {
     ) -> anyhow::Result<()> {
         use crate::drawable::DrawableOnDoc;
         use crate::engine::visual_debug;
-        use crate::engine::EngineView;
+        use crate::engine_view;
         use gtk4::prelude::*;
 
         let doc_bounds = self.document.bounds();
@@ -190,17 +190,8 @@ impl Engine {
                    self.camera.image_scale(),
                );
         */
-        self.penholder.draw_on_doc_to_gtk_snapshot(
-            snapshot,
-            &EngineView {
-                tasks_tx: self.engine_tasks_tx(),
-                pens_config: &self.pens_config,
-                document: &self.document,
-                store: &self.store,
-                camera: &self.camera,
-                audioplayer: &self.audioplayer,
-            },
-        )?;
+        self.penholder
+            .draw_on_doc_to_gtk_snapshot(snapshot, &engine_view!(self))?;
 
         if self.visual_debug {
             snapshot.save();

--- a/crates/rnote-engine/src/engine/visual_debug.rs
+++ b/crates/rnote-engine/src/engine/visual_debug.rs
@@ -204,7 +204,7 @@ pub(crate) fn draw_stroke_debug_to_gtk_snapshot(
     surface_bounds: p2d::bounding_volume::Aabb,
 ) -> anyhow::Result<()> {
     use crate::drawable::DrawableOnDoc;
-    use crate::engine::EngineView;
+    use crate::engine_view;
     use p2d::bounding_volume::BoundingVolume;
 
     let viewport = engine.camera.viewport();
@@ -228,14 +228,7 @@ pub(crate) fn draw_stroke_debug_to_gtk_snapshot(
         .draw_debug_to_gtk_snapshot(snapshot, engine, surface_bounds)?;
 
     // Draw the current pen bounds
-    if let Some(bounds) = engine.penholder.bounds_on_doc(&EngineView {
-        tasks_tx: engine.engine_tasks_tx(),
-        pens_config: &engine.pens_config,
-        document: &engine.document,
-        store: &engine.store,
-        camera: &engine.camera,
-        audioplayer: &engine.audioplayer,
-    }) {
+    if let Some(bounds) = engine.penholder.bounds_on_doc(&engine_view!(engine)) {
         draw_bounds_to_gtk_snapshot(bounds, COLOR_SELECTOR_BOUNDS, snapshot, border_widths);
     }
 


### PR DESCRIPTION
Adds macros for constructing `EngineView`s and `EngineViewMut`s from identifiers. This reduces repetition and makes it less tedious to modify the view structs.

The macros deliberately use `ident` instead of `expr` because we don't want to evaluate an expression for every field of the view structs. We can't "precompute" the expression by first storing it in a variable, because that would mutably borrow the engine, which is the reason why we need a macro for this in the first place.

### Things to Discuss

- We might want to keep the `Engine#view()` and `Engine#view_mut()` functions around, but there's even less use for them now. They're currently removed.
- I believe that non-mutable `EngineView`s *could* be constructed using regular functions, but that would be a bit inconsistent. In fact, all of the existing code constructs `EngineView`s manually instead of using the (also already existing) `Engine#view()` function - probably for consistency reasons.