### PR TITLE
fix: don't deny event sequence after zoom

### DIFF
--- a/crates/rnote-ui/src/canvaswrapper.rs
+++ b/crates/rnote-ui/src/canvaswrapper.rs
@@ -564,8 +564,7 @@ mod imp {
                 self.canvas_zoom_gesture.connect_end(clone!(
                     #[weak(rename_to=canvaswrapper)]
                     obj,
-                    move |gesture, _event_sequence| {
-                        gesture.set_state(EventSequenceState::Denied);
+                    move |_gesture, _event_sequence| {
                         let widget_flags = canvaswrapper
                             .canvas()
                             .engine_mut()


### PR DESCRIPTION
Keeps the event sequence of zoom gestures claimed if they were not canceled. This prevents the sequences from propagating to other events like the long press gesture. I haven't noticed any unintended side effects.

- Fixes #1220.

Would be nice to have some feedback on this before merging it into main, gestures tend to behave very differently in different environments ;)