### PR TITLE
feat: keyboard paste at pointer position

### DIFF
--- a/crates/rnote-ui/src/canvaswrapper.rs
+++ b/crates/rnote-ui/src/canvaswrapper.rs
@@ -807,6 +807,10 @@ impl RnCanvasWrapper {
         self.set_property("inertial-scrolling", inertial_scrolling);
     }
 
+    pub(crate) fn pointer_pos(&self) -> Option<na::Vector2<f64>> {
+        self.imp().pointer_pos.get()
+    }
+
     pub(crate) fn last_contextmenu_pos(&self) -> Option<na::Vector2<f64>> {
         self.imp().last_contextmenu_pos.get()
     }


### PR DESCRIPTION
Makes content pasted using CTRL + V appear at the cursor location instead of the top left corner of the page. Falls back to the previous behavior if the cursor is outside of the canvas.

- Fixes #1304.