### PR TITLE
Make `insert_stroke` public

### DIFF
--- a/crates/rnote-engine/src/store/mod.rs
+++ b/crates/rnote-engine/src/store/mod.rs
@@ -314,7 +314,7 @@ impl StrokeStore {
     /// Optionally a desired layer can be specified, or the default stroke layer is used.
     ///
     /// The stroke then needs to update its rendering.
-    pub(crate) fn insert_stroke(
+    pub fn insert_stroke(
         &mut self,
         stroke: Stroke,
         layer: Option<StrokeLayer>,

--- a/crates/rnote-engine/src/store/mod.rs
+++ b/crates/rnote-engine/src/store/mod.rs
@@ -314,11 +314,7 @@ impl StrokeStore {
     /// Optionally a desired layer can be specified, or the default stroke layer is used.
     ///
     /// The stroke then needs to update its rendering.
-    pub fn insert_stroke(
-        &mut self,
-        stroke: Stroke,
-        layer: Option<StrokeLayer>,
-    ) -> StrokeKey {
+    pub fn insert_stroke(&mut self, stroke: Stroke, layer: Option<StrokeLayer>) -> StrokeKey {
         let bounds = stroke.bounds();
         let layer = layer.unwrap_or_else(|| stroke.extract_default_layer());
 


### PR DESCRIPTION
This makes it easier to use rnote as a rust library if the intent is to add strokes programmatically to a rnote file.