### PR TITLE
feat: add inkml parser and writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4238,6 +4238,7 @@ dependencies = [
  "tracing",
  "unicode-segmentation",
  "usvg",
+ "writer_inkml",
  "xmlwriter",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5929,7 +5929,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "writer_inkml"
 version = "0.1.0"
-source = "git+https://github.com/Doublonmousse/writer_reader_inkml?rev=6f5f903199a16996d5c2cb2a074cfd98cebd3f67#6f5f903199a16996d5c2cb2a074cfd98cebd3f67"
+source = "git+https://github.com/Doublonmousse/writer_reader_inkml?rev=9370cf6a65ce566d91c232ca47d2cf08008e605e#9370cf6a65ce566d91c232ca47d2cf08008e605e"
 dependencies = [
  "anyhow",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5929,7 +5929,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "writer_inkml"
 version = "0.1.0"
-source = "git+https://github.com/Doublonmousse/writer_reader_inkml#9498471ca978be417fb104e015151c1f8ade2f6a"
+source = "git+https://github.com/Doublonmousse/writer_reader_inkml?rev=9498471ca978be417fb104e015151c1f8ade2f6a#9498471ca978be417fb104e015151c1f8ade2f6a"
 dependencies = [
  "anyhow",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5929,7 +5929,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "writer_inkml"
 version = "0.1.0"
-source = "git+https://github.com/Doublonmousse/writer_reader_inkml?rev=9498471ca978be417fb104e015151c1f8ade2f6a#9498471ca978be417fb104e015151c1f8ade2f6a"
+source = "git+https://github.com/Doublonmousse/writer_reader_inkml?rev=6f5f903199a16996d5c2cb2a074cfd98cebd3f67#6f5f903199a16996d5c2cb2a074cfd98cebd3f67"
 dependencies = [
  "anyhow",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4134,6 +4134,7 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "winresource",
+ "writer_inkml",
 ]
 
 [[package]]
@@ -5925,10 +5926,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "writer_inkml"
+version = "0.1.0"
+source = "git+https://github.com/Doublonmousse/writer_reader_inkml#9498471ca978be417fb104e015151c1f8ade2f6a"
+dependencies = [
+ "anyhow",
+ "tracing",
+ "xml",
+]
+
+[[package]]
 name = "xi-unicode"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
+
+[[package]]
+name = "xml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede1c99c55b4b3ad0349018ef0eccbe954ce9c342334410707ee87177fcf2ab4"
+dependencies = [
+ "xml-rs",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
 
 [[package]]
 name = "xml5ever"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,8 @@ url = "2.5"
 usvg = "0.47.0"
 winresource = "0.1.20"
 xmlwriter = "0.1.0"
+# inkml parser/writer
+writer_inkml = {git = "https://github.com/Doublonmousse/writer_reader_inkml"}
 
 [patch.crates-io]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ usvg = "0.47.0"
 winresource = "0.1.20"
 xmlwriter = "0.1.0"
 # inkml parser/writer
-writer_inkml = {git = "https://github.com/Doublonmousse/writer_reader_inkml", rev = "6f5f903199a16996d5c2cb2a074cfd98cebd3f67"}
+writer_inkml = {git = "https://github.com/Doublonmousse/writer_reader_inkml", rev = "9370cf6a65ce566d91c232ca47d2cf08008e605e"}
 
 [patch.crates-io]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ usvg = "0.47.0"
 winresource = "0.1.20"
 xmlwriter = "0.1.0"
 # inkml parser/writer
-writer_inkml = {git = "https://github.com/Doublonmousse/writer_reader_inkml", rev = "9498471ca978be417fb104e015151c1f8ade2f6a"}
+writer_inkml = {git = "https://github.com/Doublonmousse/writer_reader_inkml", rev = "6f5f903199a16996d5c2cb2a074cfd98cebd3f67"}
 
 [patch.crates-io]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ usvg = "0.47.0"
 winresource = "0.1.20"
 xmlwriter = "0.1.0"
 # inkml parser/writer
-writer_inkml = {git = "https://github.com/Doublonmousse/writer_reader_inkml"}
+writer_inkml = {git = "https://github.com/Doublonmousse/writer_reader_inkml", rev = "9498471ca978be417fb104e015151c1f8ade2f6a"}
 
 [patch.crates-io]
 

--- a/crates/rnote-engine/Cargo.toml
+++ b/crates/rnote-engine/Cargo.toml
@@ -59,6 +59,7 @@ usvg = { workspace = true }
 xmlwriter = { workspace = true }
 # the long-term plan is to remove the gtk4 dependency entirely after switching to another renderer.
 gtk4 = { workspace = true, optional = true }
+writer_inkml = {workspace = true}
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/rnote-engine/src/engine/strokecontent.rs
+++ b/crates/rnote-engine/src/engine/strokecontent.rs
@@ -168,13 +168,11 @@ impl StrokeContent {
         Ok(())
     }
 
-    pub fn to_inkml(&self, current_dpi: f64) -> Result<Vec<u8>, std::io::Error> {
+    pub fn to_inkml(&self, current_dpi: f64) -> anyhow::Result<Vec<u8>> {
         writer_inkml::writer(
             self.strokes
                 .iter()
-                .map(|stroke| stroke.into_inkml(current_dpi))
-                .filter(|x| x.is_some())
-                .map(|x| x.unwrap())
+                .filter_map(|stroke| stroke.into_inkml(current_dpi))
                 .collect(),
         )
     }

--- a/crates/rnote-engine/src/engine/strokecontent.rs
+++ b/crates/rnote-engine/src/engine/strokecontent.rs
@@ -167,4 +167,15 @@ impl StrokeContent {
 
         Ok(())
     }
+
+    pub fn to_inkml(&self, current_dpi: f64) -> Result<Vec<u8>, std::io::Error> {
+        writer_inkml::writer(
+            self.strokes
+                .iter()
+                .map(|stroke| stroke.into_inkml(current_dpi))
+                .filter(|x| x.is_some())
+                .map(|x| x.unwrap())
+                .collect(),
+        )
+    }
 }

--- a/crates/rnote-engine/src/fileformats/inkmlformat.rs
+++ b/crates/rnote-engine/src/fileformats/inkmlformat.rs
@@ -1,0 +1,51 @@
+use crate::strokes::BrushStroke;
+use crate::strokes::Stroke;
+use rnote_compose::Color;
+use rnote_compose::PenPath;
+use rnote_compose::penpath::Element;
+use rnote_compose::style::PressureCurve;
+use rnote_compose::style::smooth::SmoothOptions;
+use std::sync::Arc;
+use writer_inkml::{Brush, FormattedStroke};
+
+const MM_TO_PX: f64 = 1.0 / (10.0 * 2.54);
+
+pub fn inkml_to_stroke(
+    formatted_stroke: FormattedStroke,
+    brush: Brush,
+    dpi: &f64,
+) -> Option<Arc<Stroke>> {
+    let mut smooth_options = SmoothOptions::default();
+    smooth_options.stroke_color = Some(Color::new(
+        brush.color.0 as f64 / 255.0,
+        brush.color.1 as f64 / 255.0,
+        brush.color.2 as f64 / 255.0,
+        1.0 - brush.transparency as f64 / 255.0,
+    ));
+
+    // converting from mm to px
+    smooth_options.stroke_width = dpi * brush.stroke_width * MM_TO_PX;
+
+    // pressure curve
+    if brush.ignorepressure {
+        smooth_options.pressure_curve = PressureCurve::Const;
+    } else {
+        smooth_options.pressure_curve = PressureCurve::Linear;
+    }
+
+    let penpath = PenPath::try_from_elements(
+        formatted_stroke
+            .x
+            .into_iter()
+            .zip(formatted_stroke.y)
+            .zip(formatted_stroke.f)
+            .map(|((x, y), f)| Element::new(*dpi * na::vector![x, y] / 2.54, f)),
+    );
+    if let Some(path) = penpath {
+        let new_stroke =
+            BrushStroke::from_penpath(path, rnote_compose::Style::Smooth(smooth_options));
+        Some(Arc::new(Stroke::BrushStroke(new_stroke)))
+    } else {
+        None
+    }
+}

--- a/crates/rnote-engine/src/fileformats/inkmlformat.rs
+++ b/crates/rnote-engine/src/fileformats/inkmlformat.rs
@@ -8,7 +8,7 @@ use rnote_compose::style::smooth::SmoothOptions;
 use std::sync::Arc;
 use writer_inkml::{Brush, FormattedStroke};
 
-const MM_TO_PX: f64 = 1.0 / (10.0 * 2.54);
+const INCH_TO_CM: f64 = 2.54;
 
 pub fn inkml_to_stroke(
     formatted_stroke: FormattedStroke,
@@ -23,8 +23,8 @@ pub fn inkml_to_stroke(
         1.0 - brush.transparency as f64 / 255.0,
     ));
 
-    // converting from mm to px
-    smooth_options.stroke_width = dpi * brush.stroke_width * MM_TO_PX;
+    // converting from cm to px
+    smooth_options.stroke_width = dpi * brush.stroke_width_cm / INCH_TO_CM;
 
     // pressure curve
     if brush.ignorepressure {

--- a/crates/rnote-engine/src/fileformats/mod.rs
+++ b/crates/rnote-engine/src/fileformats/mod.rs
@@ -1,4 +1,5 @@
 // Modules
+pub mod inkmlformat;
 pub mod rnoteformat;
 pub mod xoppformat;
 

--- a/crates/rnote-engine/src/pens/selector/mod.rs
+++ b/crates/rnote-engine/src/pens/selector/mod.rs
@@ -199,9 +199,11 @@ impl PenBehaviour for Selector {
                                 str::from_utf8(&inkml_bytes)
                             );
                             clipboard_content.push((
-                                inkml_bytes,
+                                inkml_bytes.clone(),
                                 "application/x.windows.InkML Format".to_string(),
                             ));
+                            clipboard_content
+                                .push((inkml_bytes, "application/inkml+xml".to_string()));
                         }
                         Err(e) => error!(
                             "Could not convert strokes to inkml to add to the clipboard, {e}"

--- a/crates/rnote-engine/src/pens/selector/mod.rs
+++ b/crates/rnote-engine/src/pens/selector/mod.rs
@@ -198,10 +198,12 @@ impl PenBehaviour for Selector {
                                 "generated inkml :  {:?}",
                                 str::from_utf8(&inkml_bytes)
                             );
-                            clipboard_content.push((
-                                inkml_bytes.clone(),
-                                "application/x.windows.InkML Format".to_string(),
-                            ));
+                            if cfg!(target_os = "windows") {
+                                clipboard_content.push((
+                                    inkml_bytes.clone(),
+                                    "application/x.windows.InkML Format".to_string(),
+                                ));
+                            }
                             clipboard_content
                                 .push((inkml_bytes, "application/inkml+xml".to_string()));
                         }

--- a/crates/rnote-engine/src/pens/selector/mod.rs
+++ b/crates/rnote-engine/src/pens/selector/mod.rs
@@ -194,13 +194,18 @@ impl PenBehaviour for Selector {
                     let inkml_contents = stroke_content.to_inkml(dpi);
                     match inkml_contents {
                         Ok(inkml_bytes) => {
-                            println!("generated inkml :  {:?}", str::from_utf8(&inkml_bytes));
+                            tracing::debug!(
+                                "generated inkml :  {:?}",
+                                str::from_utf8(&inkml_bytes)
+                            );
                             clipboard_content.push((
                                 inkml_bytes,
                                 "application/x.windows.InkML Format".to_string(),
                             ));
                         }
-                        _ => (),
+                        Err(e) => error!(
+                            "Could not convert strokes to inkml to add to the clipboard, {e}"
+                        ),
                     }
 
                     if let Some(stroke_content_svg) = stroke_content_svg {

--- a/crates/rnote-engine/src/pens/selector/mod.rs
+++ b/crates/rnote-engine/src/pens/selector/mod.rs
@@ -11,6 +11,7 @@ use crate::snap::SnapCorner;
 use crate::store::StrokeKey;
 use crate::strokes::Content;
 use crate::{Camera, DrawableOnDoc, Engine, WidgetFlags};
+use core::str;
 use futures::channel::oneshot;
 use kurbo::Shape;
 use p2d::bounding_volume::{Aabb, BoundingSphere, BoundingVolume};
@@ -171,6 +172,8 @@ impl PenBehaviour for Selector {
             None
         };
 
+        let dpi = engine_view.document.config.format.dpi();
+
         rayon::spawn(move || {
             let result = move || {
                 if let Some(stroke_content) = stroke_content {
@@ -186,6 +189,20 @@ impl PenBehaviour for Selector {
                         serde_json::to_string(&stroke_content)?.into_bytes(),
                         StrokeContent::MIME_TYPE.to_string(),
                     ));
+
+                    // add inkml content
+                    let inkml_contents = stroke_content.to_inkml(dpi);
+                    match inkml_contents {
+                        Ok(inkml_bytes) => {
+                            println!("generated inkml :  {:?}", str::from_utf8(&inkml_bytes));
+                            clipboard_content.push((
+                                inkml_bytes,
+                                "application/x.windows.InkML Format".to_string(),
+                            ));
+                        }
+                        _ => (),
+                    }
+
                     if let Some(stroke_content_svg) = stroke_content_svg {
                         // Add generated Svg
                         clipboard_content.push((

--- a/crates/rnote-engine/src/strokes/stroke.rs
+++ b/crates/rnote-engine/src/strokes/stroke.rs
@@ -763,9 +763,45 @@ impl Stroke {
                     ),
                 ))
             }
-            Stroke::ShapeStroke(_) => {
-                // could be done : relatively easy to do for lines, the rest would have to be discretized
-                None
+            Stroke::ShapeStroke(ShapeStroke { shape, style, .. }) => {
+                // partial support for shapes
+                // everything with no fill
+                let stroke_color = style.stroke_color().unwrap_or_default();
+                let brush = writer_inkml::Brush::init(
+                    String::from(""),
+                    (
+                        (stroke_color.r * 255.0) as u8,
+                        (stroke_color.g * 255.0) as u8,
+                        (stroke_color.b * 255.0) as u8,
+                    ),
+                    true,
+                    ((1.0 - stroke_color.a) * 255.0) as u8,
+                    style.stroke_width() * pixel_to_cm_factor,
+                );
+                let mut out_elements: Vec<(f64, f64)> = vec![];
+                kurbo::flatten(shape.outline_path(), 0.25, |path_el| match path_el {
+                    kurbo::PathEl::MoveTo(pt) => out_elements.push((pt.x, pt.y)),
+                    // technically, a moveto should create a new brush
+                    kurbo::PathEl::LineTo(pt) => out_elements.push((pt.x, pt.y)),
+                    kurbo::PathEl::ClosePath => {
+                        out_elements.push(out_elements[0]);
+                    }
+                    _ => {}
+                });
+                // we return ONE stroke at most for now
+                // only affect arrows for now (though they still render fine ?)
+                let formatted_stroke = writer_inkml::FormattedStroke {
+                    x: out_elements
+                        .iter()
+                        .map(|element| pixel_to_cm_factor * element.0)
+                        .collect(), // need the scale !
+                    y: out_elements
+                        .iter()
+                        .map(|element| pixel_to_cm_factor * element.1)
+                        .collect(),
+                    f: out_elements.iter().map(|_| 1.0).collect(),
+                };
+                Some((formatted_stroke, brush))
             }
             Stroke::TextStroke(_) => None,
             Stroke::VectorImage(_) => None,

--- a/crates/rnote-engine/src/strokes/stroke.rs
+++ b/crates/rnote-engine/src/strokes/stroke.rs
@@ -729,7 +729,7 @@ impl Stroke {
                 let elements = brushstroke.path.clone().into_elements();
                 let ignore_pressure = match &brushstroke.style {
                     Style::Smooth(smooth_options) => {
-                        !matches!(smooth_options.pressure_curve, PressureCurve::Const)
+                        matches!(smooth_options.pressure_curve, PressureCurve::Const)
                     }
                     Style::Rough(_) => false,
                     Style::Textured(_) => false,

--- a/crates/rnote-engine/src/strokes/stroke.rs
+++ b/crates/rnote-engine/src/strokes/stroke.rs
@@ -16,8 +16,8 @@ use p2d::bounding_volume::Aabb;
 use rnote_compose::ext::AabbExt;
 use rnote_compose::penpath::Element;
 use rnote_compose::shapes::{Rectangle, Shapeable};
-use rnote_compose::style::smooth::SmoothOptions;
 use rnote_compose::style::PressureCurve;
+use rnote_compose::style::smooth::SmoothOptions;
 use rnote_compose::transform::Transform;
 use rnote_compose::transform::Transformable;
 use rnote_compose::{Color, PenPath, Style};
@@ -728,10 +728,9 @@ impl Stroke {
                 let fill_color = brushstroke.style.stroke_color().unwrap_or_default();
                 let elements = brushstroke.path.clone().into_elements();
                 let ignore_pressure = match &brushstroke.style {
-                    Style::Smooth(smooth_options) => match smooth_options.pressure_curve {
-                        PressureCurve::Const => false,
-                        _ => true,
-                    },
+                    Style::Smooth(smooth_options) => {
+                        !matches!(smooth_options.pressure_curve, PressureCurve::Const)
+                    }
                     Style::Rough(_) => false,
                     Style::Textured(_) => false,
                 };

--- a/crates/rnote-engine/src/strokes/stroke.rs
+++ b/crates/rnote-engine/src/strokes/stroke.rs
@@ -17,6 +17,7 @@ use rnote_compose::ext::AabbExt;
 use rnote_compose::penpath::Element;
 use rnote_compose::shapes::{Rectangle, Shapeable};
 use rnote_compose::style::smooth::SmoothOptions;
+use rnote_compose::style::PressureCurve;
 use rnote_compose::transform::Transform;
 use rnote_compose::transform::Transformable;
 use rnote_compose::{Color, PenPath, Style};
@@ -711,6 +712,65 @@ impl Stroke {
                     },
                 ))
             }
+        }
+    }
+
+    /// converts a stroke into the input format used by the inkml writer
+    pub fn into_inkml(
+        &self,
+        current_dpi: f64,
+    ) -> Option<(writer_inkml::FormattedStroke, writer_inkml::Brush)> {
+        let pixel_to_cm_factor = 2.54 / current_dpi;
+        match self {
+            Stroke::BrushStroke(brushstroke) => {
+                // remark : style is not preserved here, we will always get a smooth
+                // version
+                let fill_color = brushstroke.style.stroke_color().unwrap_or_default();
+                let elements = brushstroke.path.clone().into_elements();
+                let ignore_pressure = match &brushstroke.style {
+                    Style::Smooth(smooth_options) => match smooth_options.pressure_curve {
+                        PressureCurve::Const => false,
+                        _ => true,
+                    },
+                    Style::Rough(_) => false,
+                    Style::Textured(_) => false,
+                };
+                tracing::debug!("formatting strokes");
+                Some((
+                    writer_inkml::FormattedStroke {
+                        x: elements
+                            .iter()
+                            .map(|element| pixel_to_cm_factor * element.pos.x)
+                            .collect(), // need the scale !
+                        y: elements
+                            .iter()
+                            .map(|element| pixel_to_cm_factor * element.pos.y)
+                            .collect(),
+                        f: elements
+                            .iter()
+                            .map(|element| pixel_to_cm_factor * element.pressure)
+                            .collect(),
+                    },
+                    writer_inkml::Brush::init(
+                        String::from(""),
+                        (
+                            (fill_color.r * 255.0) as u8,
+                            (fill_color.g * 255.0) as u8,
+                            (fill_color.b * 255.0) as u8,
+                        ),
+                        ignore_pressure,
+                        ((1.0 - fill_color.a) * 255.0) as u8,
+                        brushstroke.style.stroke_width() * pixel_to_cm_factor,
+                    ),
+                ))
+            }
+            Stroke::ShapeStroke(_) => {
+                // could be done : relatively easy to do for lines, the rest would have to be discretized
+                None
+            }
+            Stroke::TextStroke(_) => None,
+            Stroke::VectorImage(_) => None,
+            Stroke::BitmapImage(_) => None,
         }
     }
 }

--- a/crates/rnote-ui/Cargo.toml
+++ b/crates/rnote-ui/Cargo.toml
@@ -57,6 +57,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 unicode-segmentation = { workspace = true }
 url = { workspace = true }
+writer_inkml = { workspace = true}
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/rnote-ui/src/appwindow/actions.rs
+++ b/crates/rnote-ui/src/appwindow/actions.rs
@@ -8,30 +8,21 @@ use gtk4::{
     prelude::*,
 };
 use p2d::bounding_volume::BoundingVolume;
-use rnote_compose::Color;
-use rnote_compose::PenPath;
 use rnote_compose::SplitOrder;
 use rnote_compose::penevent::ShortcutKey;
-use rnote_compose::penpath::Element;
-use rnote_compose::style::PressureCurve;
-use rnote_compose::style::smooth::SmoothOptions;
 use rnote_engine::engine::StrokeContent;
 use rnote_engine::ext::GraphenePointExt;
 use rnote_engine::pens::PenStyle;
-use rnote_engine::strokes::resize::{ImageSizeOption, Resize};
-use rnote_engine::strokes::BrushStroke;
-use rnote_engine::strokes::Stroke;
 use rnote_engine::strokes::resize::{ImageSizeOption, Resize};
 use rnote_engine::strokes::textstroke::TextAttribute;
 use rnote_engine::{Camera, Engine};
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::time::Instant;
 use tracing::{debug, error};
+use rnote_engine::fileformats::inkmlformat;
 
 const CLIPBOARD_INPUT_STREAM_BUFSIZE: usize = 4096;
-const MM_TO_PX: f64 = 1. / (10.0 * 2.54);
 
 impl RnAppWindow {
     /// Boolean actions have no target, and a boolean state. They have a default implementation for the activate signal,
@@ -1336,63 +1327,22 @@ impl RnAppWindow {
                                     Ok(text) => {
                                         let stroke_result =
                                             writer_inkml::parse_formatted(text.as_bytes());
+                                        let dpi = canvas.engine_ref().document.config.format.dpi();
+
                                         debug!("stroke result {:?}", stroke_result);
 
                                         if let Ok(strokes) = stroke_result {
-                                            let mut generated_strokes: Vec<Arc<Stroke>> = vec![];
-                                            for (formatted_stroke, brush) in strokes {
-                                                let dpi = canvas
-                                                    .engine_ref()
-                                                    .document
-                                                    .config
-                                                    .format
-                                                    .dpi();
+                                            let generated_strokes = strokes
+                                                .into_iter()
+                                                .filter_map(|(formatted_stroke, brush)| {
+                                                    inkmlformat::inkml_to_stroke(
+                                                        formatted_stroke,
+                                                        brush,
+                                                        &dpi,
+                                                    )
+                                                })
+                                                .collect();
 
-                                                let smooth_options = SmoothOptions {
-                                                    stroke_color: Some(Color::new(
-                                                        brush.color.0 as f64 / 255.0,
-                                                        brush.color.1 as f64 / 255.0,
-                                                        brush.color.2 as f64 / 255.0,
-                                                        1.0 - brush.transparency as f64 / 255.0,
-                                                    )),
-                                                    // stroke width in px
-                                                    stroke_width: dpi
-                                                        * brush.stroke_width
-                                                        * MM_TO_PX,
-                                                    pressure_curve: if brush.ignorepressure {
-                                                        PressureCurve::Const
-                                                    } else {
-                                                        PressureCurve::Linear
-                                                    },
-                                                    ..Default::default()
-                                                };
-
-                                                let penpath = PenPath::try_from_elements(
-                                                    formatted_stroke
-                                                        .x
-                                                        .into_iter()
-                                                        .zip(formatted_stroke.y)
-                                                        .zip(formatted_stroke.f)
-                                                        .map(|((x, y), f)| {
-                                                            Element::new(
-                                                                dpi * na::vector![x, y] / 2.54,
-                                                                f,
-                                                            )
-                                                        }),
-                                                );
-                                                if let Some(path) = penpath {
-                                                    let new_stroke = BrushStroke::from_penpath(
-                                                        path,
-                                                        rnote_compose::Style::Smooth(
-                                                            smooth_options,
-                                                        ),
-                                                    );
-                                                    generated_strokes.push(Arc::new(
-                                                        Stroke::BrushStroke(new_stroke),
-                                                    ));
-                                                }
-                                            }
-                                            // then push
                                             let mut stroke_content = StrokeContent {
                                                 strokes: generated_strokes,
                                                 bounds: None,

--- a/crates/rnote-ui/src/appwindow/actions.rs
+++ b/crates/rnote-ui/src/appwindow/actions.rs
@@ -18,6 +18,7 @@ use rnote_compose::style::smooth::SmoothOptions;
 use rnote_engine::engine::StrokeContent;
 use rnote_engine::ext::GraphenePointExt;
 use rnote_engine::pens::PenStyle;
+use rnote_engine::strokes::resize::{ImageSizeOption, Resize};
 use rnote_engine::strokes::BrushStroke;
 use rnote_engine::strokes::Stroke;
 use rnote_engine::strokes::resize::{ImageSizeOption, Resize};

--- a/crates/rnote-ui/src/appwindow/actions.rs
+++ b/crates/rnote-ui/src/appwindow/actions.rs
@@ -12,6 +12,7 @@ use rnote_compose::SplitOrder;
 use rnote_compose::penevent::ShortcutKey;
 use rnote_engine::engine::StrokeContent;
 use rnote_engine::ext::GraphenePointExt;
+use rnote_engine::fileformats::inkmlformat;
 use rnote_engine::pens::PenStyle;
 use rnote_engine::strokes::resize::{ImageSizeOption, Resize};
 use rnote_engine::strokes::textstroke::TextAttribute;
@@ -20,7 +21,6 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Instant;
 use tracing::{debug, error};
-use rnote_engine::fileformats::inkmlformat;
 
 const CLIPBOARD_INPUT_STREAM_BUFSIZE: usize = 4096;
 

--- a/crates/rnote-ui/src/appwindow/actions.rs
+++ b/crates/rnote-ui/src/appwindow/actions.rs
@@ -8,20 +8,29 @@ use gtk4::{
     prelude::*,
 };
 use p2d::bounding_volume::BoundingVolume;
+use rnote_compose::Color;
+use rnote_compose::PenPath;
 use rnote_compose::SplitOrder;
 use rnote_compose::penevent::ShortcutKey;
+use rnote_compose::penpath::Element;
+use rnote_compose::style::PressureCurve;
+use rnote_compose::style::smooth::SmoothOptions;
 use rnote_engine::engine::StrokeContent;
 use rnote_engine::ext::GraphenePointExt;
 use rnote_engine::pens::PenStyle;
+use rnote_engine::strokes::BrushStroke;
+use rnote_engine::strokes::Stroke;
 use rnote_engine::strokes::resize::{ImageSizeOption, Resize};
 use rnote_engine::strokes::textstroke::TextAttribute;
 use rnote_engine::{Camera, Engine};
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Instant;
 use tracing::{debug, error};
 
 const CLIPBOARD_INPUT_STREAM_BUFSIZE: usize = 4096;
+const MM_TO_PX: f64 = 1. / (10.0 * 2.54);
 
 impl RnAppWindow {
     /// Boolean actions have no target, and a boolean state. They have a default implementation for the activate signal,
@@ -1265,7 +1274,7 @@ impl RnAppWindow {
                                                 respect_borders: appwindow.respect_borders(),
                                             });
                                         if let Err(e) = canvas
-                                            .insert_stroke_content(
+                                            .deserialize_and_insert_stroke_content(
                                                 json_string.to_string(),
                                                 resize_argument,
                                                 target_pos,
@@ -1288,6 +1297,157 @@ impl RnAppWindow {
                             error!(
                                 "Reading clipboard failed while pasting as `{}`, Err: {e:?}",
                                 StrokeContent::MIME_TYPE
+                            );
+                        }
+                    };
+                }
+            ));
+        }
+        // test if we see inkml
+        // mimetype expected : application/inkml+xml
+        else if content_formats.contain_mime_type("application/inkml+xml")
+            || content_formats.contain_mime_type("application/x.windows.InkML Format")
+        {
+            glib::spawn_future_local(clone!(
+                #[weak]
+                canvas,
+                #[weak(rename_to=appwindow)]
+                self,
+                async move {
+                    debug!("Recognized clipboard content: inkml");
+
+                    match appwindow
+                        .clipboard()
+                        .read_future(
+                            &[
+                                "application/inkml+xml",
+                                "application/x.windows.InkML Format",
+                            ],
+                            glib::source::Priority::DEFAULT,
+                        )
+                        .await
+                    {
+                        Ok((input_stream, _)) => {
+                            let acc = collect_clipboard_data(input_stream).await;
+
+                            if !acc.is_empty() {
+                                match crate::utils::str_from_u8_nul_utf8(&acc) {
+                                    Ok(text) => {
+                                        let stroke_result =
+                                            writer_inkml::parse_formatted(text.as_bytes());
+                                        debug!("stroke result {:?}", stroke_result);
+
+                                        if let Ok(strokes) = stroke_result {
+                                            let mut generated_strokes: Vec<Arc<Stroke>> = vec![];
+                                            for (formatted_stroke, brush) in strokes {
+                                                let dpi = canvas
+                                                    .engine_ref()
+                                                    .document
+                                                    .config
+                                                    .format
+                                                    .dpi();
+
+                                                let smooth_options = SmoothOptions {
+                                                    stroke_color: Some(Color::new(
+                                                        brush.color.0 as f64 / 255.0,
+                                                        brush.color.1 as f64 / 255.0,
+                                                        brush.color.2 as f64 / 255.0,
+                                                        1.0 - brush.transparency as f64 / 255.0,
+                                                    )),
+                                                    // stroke width in px
+                                                    stroke_width: dpi
+                                                        * brush.stroke_width
+                                                        * MM_TO_PX,
+                                                    pressure_curve: if brush.ignorepressure {
+                                                        PressureCurve::Const
+                                                    } else {
+                                                        PressureCurve::Linear
+                                                    },
+                                                    ..Default::default()
+                                                };
+
+                                                let penpath = PenPath::try_from_elements(
+                                                    formatted_stroke
+                                                        .x
+                                                        .into_iter()
+                                                        .zip(formatted_stroke.y)
+                                                        .zip(formatted_stroke.f)
+                                                        .map(|((x, y), f)| {
+                                                            Element::new(
+                                                                dpi * na::vector![x, y] / 2.54,
+                                                                f,
+                                                            )
+                                                        }),
+                                                );
+                                                if let Some(path) = penpath {
+                                                    let new_stroke = BrushStroke::from_penpath(
+                                                        path,
+                                                        rnote_compose::Style::Smooth(
+                                                            smooth_options,
+                                                        ),
+                                                    );
+                                                    generated_strokes.push(Arc::new(
+                                                        Stroke::BrushStroke(new_stroke),
+                                                    ));
+                                                }
+                                            }
+                                            // then push
+                                            let mut stroke_content = StrokeContent {
+                                                strokes: generated_strokes,
+                                                bounds: None,
+                                                background: None,
+                                            };
+                                            stroke_content.bounds = stroke_content.bounds();
+
+                                            let resize_argument =
+                                                ImageSizeOption::ResizeImage(Resize {
+                                                    width: canvas
+                                                        .engine_ref()
+                                                        .document
+                                                        .config
+                                                        .format
+                                                        .width(),
+                                                    height: canvas
+                                                        .engine_ref()
+                                                        .document
+                                                        .config
+                                                        .format
+                                                        .height(),
+                                                    layout_fixed_width: canvas
+                                                        .engine_ref()
+                                                        .document
+                                                        .config
+                                                        .layout
+                                                        .is_fixed_width(),
+                                                    max_viewpoint: None,
+                                                    restrain_to_viewport: false,
+                                                    respect_borders: appwindow.respect_borders(),
+                                                });
+                                            if let Err(e) = canvas
+                                                .insert_stroke_content(
+                                                    stroke_content,
+                                                    resize_argument,
+                                                    target_pos,
+                                                )
+                                                .await
+                                            {
+                                                error!(
+                                                    "Failed to insert stroke content while pasting as `inkml`, Err: {e:?}"
+                                                );
+                                            }
+                                        } else {
+                                            error!("could not parse the inkml file");
+                                        }
+                                    }
+                                    Err(e) => error!(
+                                        "Failed to get string from clipboard data while pasting as inkml, Err: {e:?}"
+                                    ),
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            error!(
+                                "Failed to read clipboard data while pasting as inkml, Err: {e:?}"
                             );
                         }
                     };

--- a/crates/rnote-ui/src/canvas/imexport.rs
+++ b/crates/rnote-ui/src/canvas/imexport.rs
@@ -178,7 +178,7 @@ impl RnCanvas {
     /// Deserializes the stroke content and inserts it into the engine.
     ///
     /// The data is usually coming from the clipboard, drop source, etc.
-    pub(crate) async fn insert_stroke_content(
+    pub(crate) async fn deserialize_and_insert_stroke_content(
         &self,
         json_string: String,
         resize_option: ImageSizeOption,
@@ -202,6 +202,25 @@ impl RnCanvas {
         let widget_flags = self
             .engine_mut()
             .insert_stroke_content(content, pos, resize_option);
+
+        self.emit_handle_widget_flags(widget_flags);
+        Ok(())
+    }
+
+    /// Take stroke content and inserts it into the engine.
+    ///
+    /// The data is usually coming from the clipboard, drop source, etc.
+    pub(crate) async fn insert_stroke_content(
+        &self,
+        stroke_content: StrokeContent,
+        resize_option: ImageSizeOption,
+        target_pos: Option<na::Vector2<f64>>,
+    ) -> anyhow::Result<()> {
+        let pos = self.determine_stroke_import_pos(target_pos);
+
+        let widget_flags =
+            self.engine_mut()
+                .insert_stroke_content(stroke_content, pos, resize_option);
 
         self.emit_handle_widget_flags(widget_flags);
         Ok(())


### PR DESCRIPTION
Related to #744 (import of selected onenote strokes, but exclusive to that. No text nor images are read).

As I'm on windows, I'm using #1282 for now.
The parser/writer crate is on a separate repository here https://github.com/Doublonmousse/writer_reader_inkml

Export and import are supported (from the clipboard).
- I think it would make sense to move some of the import code inside the engine (conversion from inkml to stroke ?)
- The export part is only for brush strokes (I could extend it to shapes with lines being the easiest to do, and other shapes would have to be discretized)
- I'm using the windows equivalent of the mime type for the inkml clipboard export part
- The crate still needs some polishing (better error message and removing some potentially panic inducing unwrap with error propagation instead).
 
I've encountered a weird behavior with clipboards in gtk and windows (that ofc I can't reproduce today ...). Copying ink content then an image from a source application wouldn't work as somehow gtk would think the inkml format was still present before failing with a gio quark error. 