### PR TITLE
refactor: reinstall pen only if necessary

### DIFF
--- a/crates/rnote-compose/src/builders/penpathcurvedbuilder.rs
+++ b/crates/rnote-compose/src/builders/penpathcurvedbuilder.rs
@@ -71,7 +71,10 @@ impl Buildable for PenPathCurvedBuilder {
             (_, PenEvent::Up { element, .. }) => {
                 self.buffer.push(element);
 
-                BuilderProgress::Finished(self.try_build_segments_end())
+                let segments = self.try_build_segments_end();
+                self.reset();
+
+                BuilderProgress::Finished(segments)
             }
             (_, PenEvent::Proximity { .. })
             | (_, PenEvent::KeyPressed { .. })

--- a/crates/rnote-engine/src/pens/penholder.rs
+++ b/crates/rnote-engine/src/pens/penholder.rs
@@ -485,9 +485,8 @@ impl PenHolder {
                 // take the style override when pen is finished
                 if self.pen_mode_state.take_style_override().is_some() {
                     widget_flags.refresh_ui = true;
+                    widget_flags |= self.reinstall_pen_current_style(engine_view);
                 }
-
-                widget_flags |= self.reinstall_pen_current_style(engine_view);
             }
         }
 

--- a/crates/rnote-engine/src/pens/selector/mod.rs
+++ b/crates/rnote-engine/src/pens/selector/mod.rs
@@ -778,21 +778,14 @@ impl Selector {
         // Select all keys
         let all_strokes = engine_view.store.stroke_keys_as_rendered();
 
-        if let Some(new_bounds) = engine_view.store.bounds_for_strokes(&all_strokes) {
+        if !all_strokes.is_empty() {
             engine_view.store.set_selected_keys(&all_strokes, true);
-            *widget_flags |= engine_view
-                .document
-                .resize_autoexpand(engine_view.store, engine_view.camera);
-
-            self.state = SelectorState::ModifySelection {
-                modify_state: ModifyState::default(),
-                selection: all_strokes,
-                selection_bounds: new_bounds,
-            };
 
             widget_flags.store_modified = true;
             widget_flags.deselect_color_setters = true;
         }
+
+        *widget_flags |= self.update_state(engine_view);
     }
 }
 

--- a/crates/rnote-engine/src/pens/selector/mod.rs
+++ b/crates/rnote-engine/src/pens/selector/mod.rs
@@ -17,12 +17,11 @@ use p2d::bounding_volume::{Aabb, BoundingSphere, BoundingVolume};
 use p2d::query::PointQuery;
 use piet::RenderContext;
 use rnote_compose::ext::{AabbExt, Vector2Ext};
-use rnote_compose::penevent::{ModifierKey, PenEvent, PenProgress, PenState};
+use rnote_compose::penevent::{PenEvent, PenProgress, PenState};
 use rnote_compose::penpath::Element;
 use rnote_compose::style::indicators;
 use rnote_compose::EventResult;
 use rnote_compose::{color, Color};
-use std::collections::HashSet;
 use std::time::Instant;
 use tracing::error;
 
@@ -775,31 +774,24 @@ impl Selector {
         Ok(())
     }
 
-    fn select_all(
-        &mut self,
-        modifier_keys: HashSet<ModifierKey>,
-        engine_view: &mut EngineViewMut,
-        widget_flags: &mut WidgetFlags,
-    ) {
-        if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
-            // Select all keys
-            let all_strokes = engine_view.store.stroke_keys_as_rendered();
+    fn select_all(&mut self, engine_view: &mut EngineViewMut, widget_flags: &mut WidgetFlags) {
+        // Select all keys
+        let all_strokes = engine_view.store.stroke_keys_as_rendered();
 
-            if let Some(new_bounds) = engine_view.store.bounds_for_strokes(&all_strokes) {
-                engine_view.store.set_selected_keys(&all_strokes, true);
-                *widget_flags |= engine_view
-                    .document
-                    .resize_autoexpand(engine_view.store, engine_view.camera);
+        if let Some(new_bounds) = engine_view.store.bounds_for_strokes(&all_strokes) {
+            engine_view.store.set_selected_keys(&all_strokes, true);
+            *widget_flags |= engine_view
+                .document
+                .resize_autoexpand(engine_view.store, engine_view.camera);
 
-                self.state = SelectorState::ModifySelection {
-                    modify_state: ModifyState::default(),
-                    selection: all_strokes,
-                    selection_bounds: new_bounds,
-                };
+            self.state = SelectorState::ModifySelection {
+                modify_state: ModifyState::default(),
+                selection: all_strokes,
+                selection_bounds: new_bounds,
+            };
 
-                widget_flags.store_modified = true;
-                widget_flags.deselect_color_setters = true;
-            }
+            widget_flags.store_modified = true;
+            widget_flags.deselect_color_setters = true;
         }
     }
 }

--- a/crates/rnote-engine/src/pens/selector/penevents.rs
+++ b/crates/rnote-engine/src/pens/selector/penevents.rs
@@ -2,6 +2,7 @@
 use super::{ModifyState, ResizeCorner, Selector, SelectorState};
 use crate::engine::EngineViewMut;
 use crate::pens::pensconfig::selectorconfig::SelectorStyle;
+use crate::pens::PenBehaviour;
 use crate::snap::SnapCorner;
 use crate::store::StrokeKey;
 use crate::{DrawableOnDoc, WidgetFlags};
@@ -475,21 +476,17 @@ impl Selector {
                         }
                     }
                 };
+
                 if !new_selection.is_empty() {
                     engine_view.store.set_selected_keys(&new_selection, true);
+
                     widget_flags.store_modified = true;
                     widget_flags.deselect_color_setters = true;
 
-                    if let Some(new_bounds) = engine_view.store.bounds_for_strokes(&new_selection) {
-                        // Change to the modify state
-                        self.state = SelectorState::ModifySelection {
-                            modify_state: ModifyState::default(),
-                            selection: new_selection,
-                            selection_bounds: new_bounds,
-                        };
-                        progress = PenProgress::InProgress;
-                    }
+                    progress = PenProgress::InProgress;
                 }
+
+                widget_flags |= self.update_state(engine_view);
 
                 EventResult {
                     handled: true,
@@ -602,11 +599,20 @@ impl Selector {
         let event_result = match &mut self.state {
             SelectorState::Idle => match keyboard_key {
                 KeyboardKey::Unicode('a') => {
-                    self.select_all(modifier_keys, engine_view, &mut widget_flags);
-                    EventResult {
-                        handled: true,
-                        propagate: EventPropagation::Stop,
-                        progress: PenProgress::InProgress,
+                    if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
+                        self.select_all(engine_view, &mut widget_flags);
+
+                        EventResult {
+                            handled: true,
+                            propagate: EventPropagation::Stop,
+                            progress: PenProgress::InProgress,
+                        }
+                    } else {
+                        EventResult {
+                            handled: false,
+                            propagate: EventPropagation::Proceed,
+                            progress: PenProgress::InProgress,
+                        }
                     }
                 }
                 _ => EventResult {
@@ -617,11 +623,20 @@ impl Selector {
             },
             SelectorState::Selecting { .. } => match keyboard_key {
                 KeyboardKey::Unicode('a') => {
-                    self.select_all(modifier_keys, engine_view, &mut widget_flags);
-                    EventResult {
-                        handled: true,
-                        propagate: EventPropagation::Stop,
-                        progress: PenProgress::InProgress,
+                    if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
+                        self.select_all(engine_view, &mut widget_flags);
+
+                        EventResult {
+                            handled: true,
+                            propagate: EventPropagation::Stop,
+                            progress: PenProgress::InProgress,
+                        }
+                    } else {
+                        EventResult {
+                            handled: false,
+                            propagate: EventPropagation::Proceed,
+                            progress: PenProgress::InProgress,
+                        }
                     }
                 }
                 _ => EventResult {
@@ -633,11 +648,20 @@ impl Selector {
             SelectorState::ModifySelection { selection, .. } => {
                 match keyboard_key {
                     KeyboardKey::Unicode('a') => {
-                        self.select_all(modifier_keys, engine_view, &mut widget_flags);
-                        EventResult {
-                            handled: true,
-                            propagate: EventPropagation::Stop,
-                            progress: PenProgress::InProgress,
+                        if modifier_keys.contains(&ModifierKey::KeyboardCtrl) {
+                            self.select_all(engine_view, &mut widget_flags);
+
+                            EventResult {
+                                handled: true,
+                                propagate: EventPropagation::Stop,
+                                progress: PenProgress::InProgress,
+                            }
+                        } else {
+                            EventResult {
+                                handled: false,
+                                propagate: EventPropagation::Proceed,
+                                progress: PenProgress::InProgress,
+                            }
                         }
                     }
                     KeyboardKey::Unicode('d') => {
@@ -655,11 +679,20 @@ impl Selector {
                             widget_flags |= engine_view.store.record(Instant::now());
                             widget_flags.resize = true;
                             widget_flags.store_modified = true;
-                        }
-                        EventResult {
-                            handled: true,
-                            propagate: EventPropagation::Stop,
-                            progress: PenProgress::Finished,
+
+                            widget_flags |= self.update_state(engine_view);
+
+                            EventResult {
+                                handled: true,
+                                propagate: EventPropagation::Stop,
+                                progress: PenProgress::InProgress,
+                            }
+                        } else {
+                            EventResult {
+                                handled: false,
+                                propagate: EventPropagation::Proceed,
+                                progress: PenProgress::InProgress,
+                            }
                         }
                     }
                     KeyboardKey::Delete | KeyboardKey::BackSpace => {

--- a/crates/rnote-engine/src/pens/tools/laser.rs
+++ b/crates/rnote-engine/src/pens/tools/laser.rs
@@ -126,8 +126,6 @@ impl LaserTool {
                 }
             }
             (ToolsState::Active, PenEvent::Up { .. }) => {
-                let mut progress = PenProgress::Finished;
-
                 if let Some(builder) = &mut self.path_builder {
                     let builder_result = builder.handle_event(event, now, Constraints::default());
 
@@ -135,7 +133,6 @@ impl LaserTool {
                     self.start_fade(now);
 
                     engine_view.animation.claim_frame();
-                    progress = PenProgress::InProgress;
                 }
 
                 self.reset(false);
@@ -143,7 +140,7 @@ impl LaserTool {
                 EventResult {
                     handled: true,
                     propagate: EventPropagation::Stop,
-                    progress,
+                    progress: PenProgress::Finished,
                 }
             }
             (ToolsState::Active, PenEvent::Proximity { .. }) => EventResult {


### PR DESCRIPTION
This PR refactors the pen progress handling to only reinstall the current pen if necessary, i.e. if there was an override. It also fixes a few bugs along the way:

1. Fixes temporarily switching to the laser tool and back.
2. The D key no longer deselects all strokes during selection.
3. (Proper event results when the A key is pressed during selection. Does not seem to have an effect.)

The state of the laser tool and its strokes is now retained after `PenProgress::Finished`, making the first bug fix possible (without breaking something else).

Previously, all events that ended with `PenProgress::Finished` always caused a cancel pen event, a full state reset of the pen and a subsequent call to `update_state()`. Some pens relied on this, which this PR attempts to fix/change **without** changing their previous behavior.

If anyone decides to test this and finds some unintentional changes to the previous behavior, please let me know.