### PR TITLE
fix: change logic to keep selection on hover/pen up 

### DIFF
--- a/crates/rnote-engine/src/pens/typewriter/mod.rs
+++ b/crates/rnote-engine/src/pens/typewriter/mod.rs
@@ -206,7 +206,7 @@ impl DrawableOnDoc for Typewriter {
                     );
                     let adjust_text_width_node_state = match modify_state {
                         ModifyState::AdjustTextWidth { .. } => PenState::Down,
-                        ModifyState::Idle => {
+                        ModifyState::Idle | ModifyState::Selecting { .. } => {
                             if let Some(pos) = self.pos {
                                 if adjust_text_width_node_bounds.contains_local_point(&pos.into()) {
                                     PenState::Proximity
@@ -238,7 +238,7 @@ impl DrawableOnDoc for Typewriter {
                             Self::translate_node_bounds(typewriter_bounds, engine_view.camera);
                         let translate_node_state = match modify_state {
                             ModifyState::Translating { .. } => PenState::Down,
-                            ModifyState::Idle => {
+                            ModifyState::Idle | ModifyState::Selecting { .. } => {
                                 if let Some(pos) = self.pos {
                                     if translate_node_bounds.contains_local_point(&pos.into()) {
                                         PenState::Proximity

--- a/crates/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/crates/rnote-engine/src/pens/typewriter/penevents.rs
@@ -445,7 +445,12 @@ impl Typewriter {
                 pen_down,
                 ..
             } => {
-                *modify_state = ModifyState::Idle;
+                if !matches!(modify_state, ModifyState::Selecting { .. }) {
+                    // do nothing if the state is selected
+                    // This prevents text from becoming deselected when hovering the pen
+                    // see issue #1222
+                    *modify_state = ModifyState::Idle;
+                }
                 *pen_down = false;
 
                 EventResult {


### PR DESCRIPTION
Fixes #1222.

The text is not deselected when the pen hovers.
And the nodes are highlighted when the pen or mouse hovers over them whether text is selected or not.