### PR TITLE
refactor: avoid using format! when String creation is unnecessary

### DIFF
--- a/crates/rnote-cli/src/export.rs
+++ b/crates/rnote-cli/src/export.rs
@@ -649,8 +649,10 @@ fn doc_page_determine_output_file(
     // user facing number is one-indexed
     page_i += 1;
     let leading_zeros = pages_amount.to_string().len();
-    let number = format!("{page_i:0fill$}", fill = leading_zeros);
-    let mut out = output_dir.join(format!("{output_file_stem} - page {number}.{out_ext}"));
+    let mut out = output_dir.join(format!(
+        "{output_file_stem} - page {number}.{out_ext}",
+        number = format_args!("{page_i:0fill$}", fill = leading_zeros)
+    ));
     if let Some(new_out) =
         file_conflict_prompt_action(out.as_ref(), on_conflict, on_conflict_overwrite)?
     {

--- a/crates/rnote-ui/src/dialogs/import.rs
+++ b/crates/rnote-ui/src/dialogs/import.rs
@@ -408,28 +408,12 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
 
         // pdf info
         pdf_info_label.set_label(
-            (String::from("")
-                + "<b>"
-                + &gettext("File name:")
-                + "  </b>"
-                + &format!("{file_name}\n")
-                + "<b>"
-                + &gettext("Title:")
-                + "  </b>"
-                + &format!("{title}\n")
-                + "<b>"
-                + &gettext("Author:")
-                + "  </b>"
-                + &format!("{author}\n")
-                + "<b>"
-                + &gettext("Modification date:")
-                + "  </b>"
-                + &format!("{mod_date}\n")
-                + "<b>"
-                + &gettext("Pages:")
-                + "  </b>"
-                + &format!("{n_pages}\n"))
-                .as_str(),
+            &format!("<b>{}  </b>{file_name}\n<b>{}  </b>{title}\n<b>{}  </b>{author}\n<b>{}  </b>{mod_date}\n<b>{}  </b>{n_pages}\n",
+                &gettext("File name:"),
+                &gettext("Title:"),
+                &gettext("Author:"),
+                &gettext("Modification date:"),
+                &gettext("Pages:"))
         );
 
         // Configure pages spinners

--- a/crates/rnote-ui/src/workspacebrowser/workspacesbar/workspacerow.rs
+++ b/crates/rnote-ui/src/workspacebrowser/workspacesbar/workspacerow.rs
@@ -151,20 +151,12 @@ mod imp {
             let color = self.entry.borrow().color().into_compose_color();
             let name = self.entry.borrow().name();
 
-            let workspacerow_color = format!(
-                "rgba({0}, {1}, {2}, {3:.3})",
-                (color.r * 255.0) as i32,
-                (color.g * 255.0) as i32,
-                (color.b * 255.0) as i32,
-                (color.a * 1000.0).round() / 1000.0,
-            );
-
             let workspacerow_fg_color = if color == Color::TRANSPARENT {
-                String::from("@window_fg_color")
+                "@window_fg_color"
             } else if color.luma() < color::FG_LUMINANCE_THRESHOLD {
-                String::from("@light_1")
+                "@light_1"
             } else {
-                String::from("@dark_5")
+                "@dark_5"
             };
 
             let css = CssProvider::new();
@@ -177,7 +169,14 @@ mod imp {
             self.folder_image.set_icon_name(Some(&icon));
 
             let custom_css = format!(
-                "@define-color workspacerow_color {workspacerow_color};@define-color workspacerow_fg_color {workspacerow_fg_color};",
+                "@define-color workspacerow_color {};@define-color workspacerow_fg_color {workspacerow_fg_color};",
+                format_args!(
+                    "rgba({0}, {1}, {2}, {3:.3})",
+                        (color.r * 255.0) as i32,
+                        (color.g * 255.0) as i32,
+                        (color.b * 255.0) as i32,
+                        (color.a * 1000.0).round() / 1000.0,
+                )
             );
 
             css.load_from_string(&custom_css);


### PR DESCRIPTION
- When String creation is unnecessary, replace `format!()` with `format_args!()` to avoid overhead of heap allocation.