### PR TITLE
Bump GNOME Runtime to Version 48

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -59,7 +59,7 @@ flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.f
 The flatpak Gnome Runtime, SDK and some extensions are needed:
 
 ```bash
-flatpak install org.gnome.Platform//47 org.gnome.Sdk//47 org.freedesktop.Sdk.Extension.rust-stable//24.08 \
+flatpak install org.gnome.Platform//48 org.gnome.Sdk//48 org.freedesktop.Sdk.Extension.rust-stable//24.08 \
 org.freedesktop.Sdk.Extension.llvm19//24.08
 ```
 

--- a/build-aux/com.github.flxzt.rnote.Devel.json
+++ b/build-aux/com.github.flxzt.rnote.Devel.json
@@ -4,7 +4,7 @@
     "development"
   ],
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "48",
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.rust-stable",

--- a/build-aux/com.github.flxzt.rnote.Devel.yaml
+++ b/build-aux/com.github.flxzt.rnote.Devel.yaml
@@ -2,7 +2,7 @@ id: com.github.flxzt.rnote.Devel
 tags:
     - development
 runtime: org.gnome.Platform
-runtime-version: "47"
+runtime-version: "48"
 sdk: org.gnome.Sdk
 sdk-extensions:
     - org.freedesktop.Sdk.Extension.rust-stable


### PR DESCRIPTION
New GNOME release, new runtime. Just the regular maintenance work to make sure, that the next release is up to speed, so we won't run into an EOL warning in a year's time again.

Did some testing for a few minutes with the usual stuff included in my workflow and I see no functional difference.