### PR TITLE
Missing tooltips

### DIFF
--- a/crates/rnote-ui/data/ui/mainheader.ui
+++ b/crates/rnote-ui/data/ui/mainheader.ui
@@ -85,10 +85,14 @@
               <object class="GtkBox">
                 <property name="spacing">3</property>
                 <child>
-                  <object class="RnCanvasMenu" id="canvasmenu"></object>
+                  <object class="RnCanvasMenu" id="canvasmenu">
+                    <property name="tooltip-text" translatable="yes">Canvas Menu</property>
+                  </object> 
                 </child>
                 <child>
-                  <object class="RnAppMenu" id="appmenu"></object>
+                  <object class="RnAppMenu" id="appmenu">
+                    <property name="tooltip-text" translatable="yes">App Menu</property>
+                  </object>
                 </child>
               </object>
             </child>

--- a/crates/rnote-ui/data/ui/penssidebar/selectorpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/selectorpage.ui
@@ -70,7 +70,7 @@
 
         <child>
           <object class="GtkToggleButton" id="resize_lock_aspectratio_togglebutton">
-            <property name="tooltip_text" translatable="yes">Lock Aspectratio While Resizing the Selection</property>
+            <property name="tooltip_text" translatable="yes">Lock Aspect Ratio While Resizing the Selection</property>
             <property name="icon_name">selection-resize-lock-aspectratio-symbolic</property>
             <style>
               <class name="flat" />

--- a/crates/rnote-ui/data/ui/penssidebar/typewriterpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/typewriterpage.ui
@@ -26,6 +26,7 @@
     </child>
     <child>
       <object class="GtkSpinButton" id="font_size_spinbutton">
+        <property name="tooltip-text" translatable="yes">Edit Font Size</property>
         <property name="orientation">vertical</property>
         <property name="numeric">true</property>
         <property name="digits">0</property>

--- a/crates/rnote-ui/data/ui/penssidebar/typewriterpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/typewriterpage.ui
@@ -11,6 +11,7 @@
     <property name="vexpand">false</property>
     <child>
       <object class="GtkButton" id="fontdialog_button">
+        <property name="tooltip-text" translatable="yes">Font Chooser</property>
         <property name="icon-name">pen-typewriter-fontchooser-symbolic</property>
         <style>
           <class name="flat" />

--- a/crates/rnote-ui/data/ui/strokewidthpicker.ui
+++ b/crates/rnote-ui/data/ui/strokewidthpicker.ui
@@ -17,6 +17,7 @@
         <property name="value">2.0</property>
       </object>
       <object class="GtkSpinButton" id="spinbutton">
+        <property name="tooltip-text" translatable="yes">Edit Stroke Size</property>
         <property name="orientation">vertical</property>
         <property name="adjustment">adj</property>
         <property name="numeric">true</property>


### PR DESCRIPTION
A couple of small updates for tooltip text.
- Some of them were missing for the header bar and tool section
- Added generic tooltips for spin buttons