### PR TITLE
add custom css for windows

### DIFF
--- a/crates/rnote-ui/src/env.rs
+++ b/crates/rnote-ui/src/env.rs
@@ -124,3 +124,45 @@ fn macos_is_in_app_bundle(canonicalized_exec_dir: impl AsRef<Path>) -> bool {
             }
         })
 }
+
+#[cfg(target_os = "windows")]
+/// Workaround for windows for shadow that intercept mouse events outside of the
+/// actual window. See https://github.com/flxzt/rnote/issues/1372
+///
+/// Taken from gaphor
+/// See commment from https://github.com/gaphor/gaphor/blob/a7b35712b166a38b78933a79613eab330f7bd885/gaphor/ui/styling-windows.css
+/// and https://gitlab.gnome.org/GNOME/gtk/-/issues/6255#note_1952796
+pub fn window_styling_workaround() -> anyhow::Result<()> {
+    use gtk4::{gdk, style_context_add_provider_for_display};
+
+    // gtk needs to be initialized for the style provider to work
+    gtk4::init()?;
+
+    let default_display = gdk::Display::default();
+    let style_provider = gtk4::CssProvider::new();
+    style_provider.load_from_string(
+        "
+            .csd {
+          box-shadow: 0 3px 9px 1px alpha(black, 0.35),
+                      0 0 0 1px alpha(black, 0.18);
+        }
+        
+        .csd:backdrop {
+          box-shadow: 0 3px 9px 1px transparent,
+                      0 2px 6px 2px alpha(black, 1),
+                      0 0 0 1px alpha(black, 0.06);
+        }",
+    );
+
+    match default_display {
+        Some(display) => {
+            style_context_add_provider_for_display(
+                &display,
+                &style_provider,
+                gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
+            );
+            Ok(())
+        }
+        None => Err(anyhow::anyhow!("Could not find a default display")),
+    }
+}

--- a/crates/rnote-ui/src/main.rs
+++ b/crates/rnote-ui/src/main.rs
@@ -86,7 +86,8 @@ fn main() -> glib::ExitCode {
 
     // window specific workaround for shadow that intercept mouse clicks outside the window
     // See issue https://github.com/flxzt/rnote/issues/1372
-    if cfg!(target_os = "windows") {
+    #[cfg(target_os = "windows")]
+    {
         if let Err(e) = env::window_styling_workaround() {
             eprintln!("failed to setup custom css for windows, Err: {e:?}");
         }

--- a/crates/rnote-ui/src/main.rs
+++ b/crates/rnote-ui/src/main.rs
@@ -83,6 +83,14 @@ fn main() -> glib::ExitCode {
     }
 
     let app = RnApp::new();
+
+    // window specific workaround for shadow that intercept mouse clicks outside the window
+    // See issue https://github.com/flxzt/rnote/issues/1372
+    if cfg!(target_os = "windows") {
+        if let Err(e) = env::window_styling_workaround() {
+            eprintln!("failed to setup custom css for windows, Err: {e:?}");
+        }
+    }
     app.run()
 }
 


### PR DESCRIPTION
Fixes/workaround for #1372 (this makes it possible to click outside the window without having the mouse click intercepted).

Taken from https://github.com/gaphor/gaphor/blob/1f53cfa8cc8eced7ce8b6776218d218dc121fae3/gaphor/ui/styling-windows.css#L4-L10

```
 * The issue: shadows defined by LibAdwaita are very wide: up to 60px.
 * The shadow is drawn inside the (clickable) window.
 *
 * These styles change the (window) background to be a lot more compact.
 * This results in a smaller shadow around the window, and as such a
 * smaller click surface for the whole window, making it feel less awkward
 * when you click just outside the window.
```

This potentially helps as well when the shadow isn't transparent #842 as the shadow won't be as large if it doesn't render (maybe we can remove the shadow entirely using the same technique if we wanted to)