### PR TITLE
Improv : logic changes for selection cancellation

### DIFF
--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -805,6 +805,8 @@ impl Engine {
         // check if we have a selector as a temporary tool and need to change the pen
         let cancel_selection = self.cancel_selection_temporary_pen();
         if cancel_selection {
+            // we trigger a delete press event as this reset the pen back to its
+            // original mode and deletes the content
             let (_, widget_flags) = self.handle_pen_event(
                 rnote_compose::PenEvent::KeyPressed {
                     keyboard_key: KeyboardKey::Delete,

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -790,6 +790,16 @@ impl Engine {
             | self.update_rendering_current_viewport()
     }
 
+    pub fn cancel_selection_temporary_pen(&self) -> bool {
+        let selection_keys = self.store.selection_keys_as_rendered();
+        !selection_keys.is_empty()
+            && self
+                .penholder
+                .pen_mode_state()
+                .take_style_override()
+                .is_some()
+    }
+
     pub fn trash_selection(&mut self) -> WidgetFlags {
         let selection_keys = self.store.selection_keys_as_rendered();
         self.store.set_trashed_keys(&selection_keys, true);

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -35,10 +35,11 @@ use p2d::bounding_volume::{Aabb, BoundingVolume};
 use p2d::math::Vector2;
 use rnote_compose::eventresult::EventPropagation;
 use rnote_compose::ext::AabbExt;
-use rnote_compose::penevent::{PenEvent, ShortcutKey};
+use rnote_compose::penevent::{KeyboardKey, PenEvent, ShortcutKey};
 use rnote_compose::{Color, SplitOrder};
 use serde::{Deserialize, Serialize};
 use snapshot::Snapshotable;
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
@@ -801,12 +802,26 @@ impl Engine {
     }
 
     pub fn trash_selection(&mut self) -> WidgetFlags {
-        let selection_keys = self.store.selection_keys_as_rendered();
-        self.store.set_trashed_keys(&selection_keys, true);
-        self.current_pen_update_state()
-            | self.doc_resize_autoexpand()
-            | self.record(Instant::now())
-            | self.update_rendering_current_viewport()
+        // check if we have a selector as a temporary tool and need to change the pen
+        let cancel_selection = self.cancel_selection_temporary_pen();
+        if cancel_selection {
+            let (_, widget_flags) = self.handle_pen_event(
+                rnote_compose::PenEvent::KeyPressed {
+                    keyboard_key: KeyboardKey::Delete,
+                    modifier_keys: HashSet::new(),
+                },
+                None,
+                Instant::now(),
+            );
+            widget_flags
+        } else {
+            let selection_keys = self.store.selection_keys_as_rendered();
+            self.store.set_trashed_keys(&selection_keys, true);
+            self.current_pen_update_state()
+                | self.doc_resize_autoexpand()
+                | self.record(Instant::now())
+                | self.update_rendering_current_viewport()
+        }
     }
 
     pub fn nothing_selected(&self) -> bool {

--- a/crates/rnote-engine/src/pens/brush.rs
+++ b/crates/rnote-engine/src/pens/brush.rs
@@ -18,6 +18,7 @@ use rnote_compose::builders::{
 use rnote_compose::eventresult::{EventPropagation, EventResult};
 use rnote_compose::penevent::{PenEvent, PenProgress};
 use rnote_compose::penpath::{Element, Segment};
+use rnote_compose::shapes::Shapeable;
 use std::time::Instant;
 
 #[derive(Debug)]
@@ -266,6 +267,29 @@ impl PenBehaviour for Brush {
                                 .pens_config
                                 .brush_config
                                 .style_for_current_options();
+                        }
+
+                        // remove strokes that follow a selection cancellation if they are small
+                        // hence we can write after selecting strokes but we won't leave tiny spots
+                        // behind
+                        let volume = engine_view
+                            .store
+                            .get_stroke_ref(*current_stroke_key)
+                            .unwrap()
+                            .bounds()
+                            .volume();
+                        if engine_view.store.get_cancelled_state()
+                            && volume
+                                < 4.0
+                                    * engine_view
+                                        .config
+                                        .pens_config
+                                        .brush_config
+                                        .get_stroke_width()
+                                        .powi(2)
+                        {
+                            tracing::debug!("VOLUME {volume}");
+                            engine_view.store.remove_stroke(*current_stroke_key);
                         }
 
                         // Finish up the last stroke

--- a/crates/rnote-engine/src/pens/brush.rs
+++ b/crates/rnote-engine/src/pens/brush.rs
@@ -44,6 +44,15 @@ impl Default for Brush {
     }
 }
 
+impl Brush {
+    /// Threshold for the ratio of stroke bounds volume over
+    /// stroke width**2 over which we consider that strokes
+    /// or shapes that are left by pressing the pen down when
+    /// cancelling a selection should be kept. Smaller ratio
+    /// are deleted
+    const VOLUME_RATIO_THRESHOLD: f64 = 5.0;
+}
+
 impl PenBehaviour for Brush {
     fn init(&mut self, _engine_view: &EngineView) -> WidgetFlags {
         WidgetFlags::default()
@@ -280,7 +289,7 @@ impl PenBehaviour for Brush {
                             .volume();
                         if engine_view.store.get_cancelled_state()
                             && volume
-                                < 4.0
+                                < Self::VOLUME_RATIO_THRESHOLD
                                     * engine_view
                                         .config
                                         .pens_config
@@ -288,7 +297,6 @@ impl PenBehaviour for Brush {
                                         .get_stroke_width()
                                         .powi(2)
                         {
-                            tracing::debug!("VOLUME {volume}");
                             engine_view.store.remove_stroke(*current_stroke_key);
                         }
 

--- a/crates/rnote-engine/src/pens/brush.rs
+++ b/crates/rnote-engine/src/pens/brush.rs
@@ -7,6 +7,7 @@ use crate::store::StrokeKey;
 use crate::strokes::BrushStroke;
 use crate::strokes::Stroke;
 use crate::{DrawableOnDoc, WidgetFlags};
+use kurbo::Shape;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use piet::RenderContext;
 use rnote_compose::Constraints;
@@ -20,6 +21,7 @@ use rnote_compose::penevent::{PenEvent, PenProgress};
 use rnote_compose::penpath::{Element, Segment};
 use rnote_compose::shapes::Shapeable;
 use std::time::Instant;
+use tracing::debug;
 
 #[derive(Debug)]
 enum BrushState {
@@ -45,12 +47,11 @@ impl Default for Brush {
 }
 
 impl Brush {
-    /// Threshold for the ratio of stroke bounds volume over
-    /// stroke width**2 over which we consider that strokes
-    /// or shapes that are left by pressing the pen down when
-    /// cancelling a selection should be kept. Smaller ratio
-    /// are deleted
-    const VOLUME_RATIO_THRESHOLD: f64 = 5.0;
+    /// Threshold for the stroke length over which we consider
+    /// that strokes  that are left by pressing the pen down
+    /// when cancelling a selection should be kept.
+    /// Smaller ratio are deleted. Zoom ratio is taken into account
+    const LENGTH_PX_THRESHOLD: f64 = 25.0;
 }
 
 impl PenBehaviour for Brush {
@@ -282,23 +283,28 @@ impl PenBehaviour for Brush {
                         // remove strokes that follow a selection cancellation if they are small
                         // hence we can write after selecting strokes but we won't leave tiny spots
                         // behind
-                        let volume = engine_view
-                            .store
-                            .get_stroke_ref(*current_stroke_key)
-                            .unwrap()
-                            .bounds()
-                            .volume();
-                        if engine_view.store.get_cancelled_state()
-                            && volume
-                                < Self::VOLUME_RATIO_THRESHOLD
-                                    * engine_view
-                                        .config
-                                        .pens_config
-                                        .brush_config
-                                        .get_stroke_width()
-                                        .powi(2)
-                        {
-                            engine_view.store.remove_stroke(*current_stroke_key);
+                        if engine_view.store.get_cancelled_state() {
+                            let current_stroke_width = engine_view
+                                .config
+                                .pens_config
+                                .brush_config
+                                .get_stroke_width();
+                            let length_px = engine_view
+                                .store
+                                .get_stroke_ref(*current_stroke_key)
+                                .unwrap()
+                                .outline_path()
+                                .perimeter(current_stroke_width);
+                            let threshold = Self::LENGTH_PX_THRESHOLD / engine_view.camera.zoom();
+                            debug!(
+                                "perimeter {:?} threshold {:?}, zoom {:?}",
+                                length_px,
+                                threshold,
+                                engine_view.camera.zoom()
+                            );
+                            if length_px < threshold {
+                                engine_view.store.remove_stroke(*current_stroke_key);
+                            }
                         }
 
                         // Finish up the last stroke

--- a/crates/rnote-engine/src/pens/brush.rs
+++ b/crates/rnote-engine/src/pens/brush.rs
@@ -75,6 +75,7 @@ impl PenBehaviour for Brush {
         event: PenEvent,
         now: Instant,
         engine_view: &mut EngineViewMut,
+        _temporary_tool: bool,
     ) -> (EventResult<PenProgress>, WidgetFlags) {
         let mut widget_flags = WidgetFlags::default();
 

--- a/crates/rnote-engine/src/pens/eraser.rs
+++ b/crates/rnote-engine/src/pens/eraser.rs
@@ -55,6 +55,7 @@ impl PenBehaviour for Eraser {
         event: PenEvent,
         _now: Instant,
         engine_view: &mut EngineViewMut,
+        _temporary_tool: bool,
     ) -> (EventResult<PenProgress>, WidgetFlags) {
         let mut widget_flags = WidgetFlags::default();
 

--- a/crates/rnote-engine/src/pens/eraser.rs
+++ b/crates/rnote-engine/src/pens/eraser.rs
@@ -63,7 +63,7 @@ impl PenBehaviour for Eraser {
                 if !engine_view.store.get_cancelled_state() {
                     widget_flags |= erase(element, engine_view);
                     self.state = EraserState::Down(element);
-                    // this means we need one more up/down event here to activate the eraser
+                    // this means we need one more up/down event here to activate the eraser after a selection cancellation
                 }
                 EventResult {
                     handled: true,

--- a/crates/rnote-engine/src/pens/eraser.rs
+++ b/crates/rnote-engine/src/pens/eraser.rs
@@ -60,8 +60,11 @@ impl PenBehaviour for Eraser {
 
         let event_result = match (&mut self.state, event) {
             (EraserState::Up | EraserState::Proximity { .. }, PenEvent::Down { element, .. }) => {
-                widget_flags |= erase(element, engine_view);
-                self.state = EraserState::Down(element);
+                if !engine_view.store.get_cancelled_state() {
+                    widget_flags |= erase(element, engine_view);
+                    self.state = EraserState::Down(element);
+                    // this means we need one more up/down event here to activate the eraser
+                }
                 EventResult {
                     handled: true,
                     propagate: EventPropagation::Stop,

--- a/crates/rnote-engine/src/pens/mod.rs
+++ b/crates/rnote-engine/src/pens/mod.rs
@@ -102,14 +102,19 @@ impl PenBehaviour for Pen {
         event: PenEvent,
         now: Instant,
         engine_view: &mut EngineViewMut,
+        temporary_tool: bool,
     ) -> (EventResult<PenProgress>, WidgetFlags) {
         match self {
-            Pen::Brush(brush) => brush.handle_event(event, now, engine_view),
-            Pen::Shaper(shaper) => shaper.handle_event(event, now, engine_view),
-            Pen::Typewriter(typewriter) => typewriter.handle_event(event, now, engine_view),
-            Pen::Eraser(eraser) => eraser.handle_event(event, now, engine_view),
-            Pen::Selector(selector) => selector.handle_event(event, now, engine_view),
-            Pen::Tools(tools) => tools.handle_event(event, now, engine_view),
+            Pen::Brush(brush) => brush.handle_event(event, now, engine_view, temporary_tool),
+            Pen::Shaper(shaper) => shaper.handle_event(event, now, engine_view, temporary_tool),
+            Pen::Typewriter(typewriter) => {
+                typewriter.handle_event(event, now, engine_view, temporary_tool)
+            }
+            Pen::Eraser(eraser) => eraser.handle_event(event, now, engine_view, temporary_tool),
+            Pen::Selector(selector) => {
+                selector.handle_event(event, now, engine_view, temporary_tool)
+            }
+            Pen::Tools(tools) => tools.handle_event(event, now, engine_view, temporary_tool),
         }
     }
 

--- a/crates/rnote-engine/src/pens/penbehaviour.rs
+++ b/crates/rnote-engine/src/pens/penbehaviour.rs
@@ -30,6 +30,7 @@ pub trait PenBehaviour: DrawableOnDoc {
         event: PenEvent,
         now: Instant,
         engine_view: &mut EngineViewMut,
+        temporary_tool: bool,
     ) -> (EventResult<PenProgress>, WidgetFlags);
 
     /// Handle a requested animation frame.

--- a/crates/rnote-engine/src/pens/penholder.rs
+++ b/crates/rnote-engine/src/pens/penholder.rs
@@ -205,9 +205,8 @@ impl PenHolder {
             widget_flags |= wf;
         }
         // reset the cancelled state as we just handled a pen tool (and not a selection tool) event
-        match event {
-            PenEvent::Up { .. } => engine_view.store.set_cancelled_state(false),
-            _ => (),
+        if matches!(event, PenEvent::Up { .. }) {
+            engine_view.store.set_cancelled_state(false);
         }
 
         // Always redraw after handling a pen event.

--- a/crates/rnote-engine/src/pens/penholder.rs
+++ b/crates/rnote-engine/src/pens/penholder.rs
@@ -45,6 +45,15 @@ pub struct PenHolder {
     toggle_pen_style: Option<PenStyle>,
     #[serde(skip)]
     prev_shortcut_key: Option<ShortcutKey>,
+
+    /// indicates if we toggled a shortcut key
+    /// in temporary mode without changing
+    /// `PenMode` in the current sequence.
+    /// Used to tweak the behavior of tools
+    /// on exit so that we don't exit the tool
+    /// with the shortcut key pressed
+    #[serde(skip)]
+    temporary_style: bool,
 }
 
 impl Default for PenHolder {
@@ -57,6 +66,7 @@ impl Default for PenHolder {
             progress: PenProgress::Idle,
             toggle_pen_style: None,
             prev_shortcut_key: None,
+            temporary_style: false,
         }
     }
 }
@@ -110,6 +120,7 @@ impl PenHolder {
         // When the style is changed externally, the toggle mode / internal states are reset
         self.toggle_pen_style = None;
         self.prev_shortcut_key = None;
+        self.temporary_style = false;
 
         widget_flags
     }
@@ -147,6 +158,7 @@ impl PenHolder {
 
         if self.pen_mode_state.pen_mode() != new_pen_mode {
             self.pen_mode_state.set_pen_mode(new_pen_mode);
+            self.temporary_style = false;
             widget_flags |= self.reinstall_pen_current_style(engine_view);
             widget_flags.refresh_ui = true;
         }
@@ -163,7 +175,7 @@ impl PenHolder {
         // first cancel the current pen
         let (_, mut widget_flags) =
             self.current_pen
-                .handle_event(PenEvent::Cancel, Instant::now(), engine_view);
+                .handle_event(PenEvent::Cancel, Instant::now(), engine_view, false);
 
         // then reinstall a new pen instance
         let mut new_pen = new_pen(self.current_pen_style_w_override(&engine_view.as_im()));
@@ -193,10 +205,14 @@ impl PenHolder {
             widget_flags |= self.change_pen_mode(pen_mode, engine_view);
         }
 
+        if matches!(event, PenEvent::Cancel | PenEvent::Up { .. }) {
+            self.temporary_style = false;
+        }
+
         // Handle the event with the current pen
-        let (mut event_result, wf) = self
-            .current_pen
-            .handle_event(event.clone(), now, engine_view);
+        let (mut event_result, wf) =
+            self.current_pen
+                .handle_event(event.clone(), now, engine_view, self.temporary_style);
         widget_flags |= wf | self.handle_pen_progress(event_result.progress, engine_view);
 
         if !event_result.handled {
@@ -242,6 +258,13 @@ impl PenHolder {
             match action {
                 ShortcutAction::ChangePenStyle { style, mode } => match mode {
                     ShortcutMode::Temporary => {
+                        if self
+                            .pen_mode_state
+                            .current_style_w_override(&engine_view.config.pens_config)
+                            == style
+                        {
+                            self.temporary_style = true;
+                        };
                         widget_flags |= self.change_style_override(Some(style), engine_view);
                     }
                     ShortcutMode::Permanent => {

--- a/crates/rnote-engine/src/pens/penholder.rs
+++ b/crates/rnote-engine/src/pens/penholder.rs
@@ -200,11 +200,16 @@ impl PenHolder {
         widget_flags |= wf | self.handle_pen_progress(event_result.progress, engine_view);
 
         if !event_result.handled {
-            let (propagate, wf) = self.handle_pen_event_global(event, now, engine_view);
+            let (propagate, wf) = self.handle_pen_event_global(event.clone(), now, engine_view);
             event_result.propagate |= propagate;
             widget_flags |= wf;
         }
-
+        // reset the cancelled state as we just handled a pen tool (and not a selection tool) event
+        match event {
+            PenEvent::Up { .. } => engine_view.store.set_cancelled_state(false),
+            _ => (),
+        }
+        
         // Always redraw after handling a pen event.
         //
         // This is also needed because pens might have claimed/requested an animation frame.

--- a/crates/rnote-engine/src/pens/penholder.rs
+++ b/crates/rnote-engine/src/pens/penholder.rs
@@ -209,7 +209,7 @@ impl PenHolder {
             PenEvent::Up { .. } => engine_view.store.set_cancelled_state(false),
             _ => (),
         }
-        
+
         // Always redraw after handling a pen event.
         //
         // This is also needed because pens might have claimed/requested an animation frame.

--- a/crates/rnote-engine/src/pens/pensconfig/brushconfig.rs
+++ b/crates/rnote-engine/src/pens/pensconfig/brushconfig.rs
@@ -148,4 +148,12 @@ impl BrushConfig {
             }
         }
     }
+
+    pub(crate) fn get_stroke_width(&self) -> f64 {
+        match &self.style {
+            BrushStyle::Marker => self.marker_options.stroke_width,
+            BrushStyle::Solid => self.solid_options.stroke_width,
+            BrushStyle::Textured => self.textured_options.stroke_width,
+        }
+    }
 }

--- a/crates/rnote-engine/src/pens/pensconfig/shaperconfig.rs
+++ b/crates/rnote-engine/src/pens/pensconfig/shaperconfig.rs
@@ -118,4 +118,11 @@ impl ShaperConfig {
             }
         }
     }
+
+    pub(crate) fn get_stroke_width(&self) -> f64 {
+        match &self.style {
+            ShaperStyle::Smooth => self.smooth_options.stroke_width,
+            ShaperStyle::Rough => self.rough_options.stroke_width,
+        }
+    }
 }

--- a/crates/rnote-engine/src/pens/pensconfig/shaperconfig.rs
+++ b/crates/rnote-engine/src/pens/pensconfig/shaperconfig.rs
@@ -118,11 +118,4 @@ impl ShaperConfig {
             }
         }
     }
-
-    pub(crate) fn get_stroke_width(&self) -> f64 {
-        match &self.style {
-            ShaperStyle::Smooth => self.smooth_options.stroke_width,
-            ShaperStyle::Rough => self.rough_options.stroke_width,
-        }
-    }
 }

--- a/crates/rnote-engine/src/pens/selector/mod.rs
+++ b/crates/rnote-engine/src/pens/selector/mod.rs
@@ -134,12 +134,15 @@ impl PenBehaviour for Selector {
         event: PenEvent,
         now: Instant,
         engine_view: &mut EngineViewMut,
+        temporary_tool: bool,
     ) -> (EventResult<PenProgress>, WidgetFlags) {
         match event {
             PenEvent::Down {
                 element,
                 modifier_keys,
-            } => self.handle_pen_event_down(element, modifier_keys, now, engine_view),
+            } => {
+                self.handle_pen_event_down(element, modifier_keys, now, engine_view, temporary_tool)
+            }
             PenEvent::Up {
                 element,
                 modifier_keys,

--- a/crates/rnote-engine/src/pens/selector/penevents.rs
+++ b/crates/rnote-engine/src/pens/selector/penevents.rs
@@ -23,6 +23,7 @@ impl Selector {
         modifier_keys: HashSet<ModifierKey>,
         _now: Instant,
         engine_view: &mut EngineViewMut,
+        temporary_tool: bool,
     ) -> (EventResult<PenProgress>, WidgetFlags) {
         let mut widget_flags = WidgetFlags::default();
         self.pos = Some(element.pos);
@@ -201,13 +202,22 @@ impl Selector {
                             // when clicking outside the selection bounds, reset
                             tracing::debug!("cancelling the selection");
                             engine_view.store.set_selected_keys(selection, false);
-                            self.state = SelectorState::Idle;
 
-                            // This event is in the same sequence than the one that
-                            // cancelled the selection. We thus set the variable to true here
-                            engine_view.store.set_cancelled_state(true);
+                            if temporary_tool {
+                                // we had a selection active then for the next sequence
+                                // we activated the temporary mode for the selector and
+                                // clicked outside the selection. We expect to be able
+                                // to do another selection
+                                self.state = SelectorState::Selecting { path: Vec::new() };
+                                progress = PenProgress::InProgress;
+                            } else {
+                                self.state = SelectorState::Idle;
+                                progress = PenProgress::Finished;
 
-                            progress = PenProgress::Finished;
+                                // This event is in the same sequence than the one that
+                                // cancelled the selection. We thus set the variable to true here
+                                engine_view.store.set_cancelled_state(true);
+                            }
                         }
                     }
                     ModifyState::Translate {

--- a/crates/rnote-engine/src/pens/selector/penevents.rs
+++ b/crates/rnote-engine/src/pens/selector/penevents.rs
@@ -203,10 +203,8 @@ impl Selector {
                             engine_view.store.set_selected_keys(selection, false);
                             self.state = SelectorState::Idle;
 
-                            // we create a new engine variable that indicates that the pen event is one from the same
-                            // event sequence that the one that cancelled the selection
-                            // this is done by setting this variable to true here and
-                            // removing it on a pen up event (and doing more things if this variable is true on a pen up)
+                            // This event is in the same sequence than the one that
+                            // cancelled the selection. We thus set the variable to true here
                             engine_view.store.set_cancelled_state(true);
 
                             progress = PenProgress::Finished;

--- a/crates/rnote-engine/src/pens/selector/penevents.rs
+++ b/crates/rnote-engine/src/pens/selector/penevents.rs
@@ -199,8 +199,15 @@ impl Selector {
                             };
                         } else {
                             // when clicking outside the selection bounds, reset
+                            tracing::debug!("cancelling the selection");
                             engine_view.store.set_selected_keys(selection, false);
                             self.state = SelectorState::Idle;
+
+                            // we create a new engine variable that indicates that the pen event is one from the same
+                            // event sequence that the one that cancelled the selection
+                            // this is done by setting this variable to true here and
+                            // removing it on a pen up event (and doing more things if this variable is true on a pen up)
+                            engine_view.store.set_cancelled_state(true);
 
                             progress = PenProgress::Finished;
                         }

--- a/crates/rnote-engine/src/pens/shaper.rs
+++ b/crates/rnote-engine/src/pens/shaper.rs
@@ -62,6 +62,7 @@ impl PenBehaviour for Shaper {
         event: PenEvent,
         now: Instant,
         engine_view: &mut EngineViewMut,
+        _temporary_tool: bool,
     ) -> (EventResult<PenProgress>, WidgetFlags) {
         let mut widget_flags = WidgetFlags::default();
 

--- a/crates/rnote-engine/src/pens/shaper.rs
+++ b/crates/rnote-engine/src/pens/shaper.rs
@@ -6,6 +6,7 @@ use crate::strokes::ShapeStroke;
 use crate::strokes::Stroke;
 use crate::{DrawableOnDoc, WidgetFlags};
 use p2d::bounding_volume::Aabb;
+use p2d::bounding_volume::BoundingVolume;
 use piet::RenderContext;
 use rnote_compose::Shape;
 use rnote_compose::builders::buildable::{Buildable, BuilderCreator, BuilderProgress};
@@ -17,6 +18,7 @@ use rnote_compose::builders::{
 use rnote_compose::eventresult::{EventPropagation, EventResult};
 use rnote_compose::penevent::{KeyboardKey, ModifierKey, PenEvent, PenProgress};
 use rnote_compose::penpath::Element;
+use rnote_compose::shapes::Shapeable;
 use std::time::Instant;
 
 #[derive(Debug)]
@@ -179,18 +181,33 @@ impl PenBehaviour for Shaper {
                             .shaper_config
                             .gen_style_for_current_options();
 
-                        let shapes_emitted = !shapes.is_empty();
-                        for shape in shapes {
-                            let key = engine_view.store.insert_stroke(
-                                Stroke::ShapeStroke(ShapeStroke::new(shape, style.clone())),
-                                None,
-                            );
-                            style.advance_seed();
-                            engine_view.store.regenerate_rendering_for_stroke(
-                                key,
-                                engine_view.camera.viewport(),
-                                engine_view.camera.image_scale(),
-                            );
+                        // calculate the bounds
+                        let bound_condition = shapes
+                            .iter()
+                            .map(|x| x.bounds())
+                            .reduce(|acc, x| acc.merged(&x))
+                            .unwrap_or(Aabb::new_invalid())
+                            .volume()
+                            > engine_view
+                                .pens_config
+                                .shaper_config
+                                .get_stroke_width()
+                                .powi(2);
+
+                        let shapes_emitted = !shapes.is_empty() && bound_condition;
+                        if shapes_emitted {
+                            for shape in shapes {
+                                let key = engine_view.store.insert_stroke(
+                                    Stroke::ShapeStroke(ShapeStroke::new(shape, style.clone())),
+                                    None,
+                                );
+                                style.advance_seed();
+                                engine_view.store.regenerate_rendering_for_stroke(
+                                    key,
+                                    engine_view.camera.viewport(),
+                                    engine_view.camera.image_scale(),
+                                );
+                            }
                         }
 
                         self.state = ShaperState::Idle;

--- a/crates/rnote-engine/src/pens/shaper.rs
+++ b/crates/rnote-engine/src/pens/shaper.rs
@@ -6,7 +6,6 @@ use crate::strokes::ShapeStroke;
 use crate::strokes::Stroke;
 use crate::{DrawableOnDoc, WidgetFlags};
 use p2d::bounding_volume::Aabb;
-use p2d::bounding_volume::BoundingVolume;
 use piet::RenderContext;
 use rnote_compose::Shape;
 use rnote_compose::builders::buildable::{Buildable, BuilderCreator, BuilderProgress};
@@ -18,7 +17,6 @@ use rnote_compose::builders::{
 use rnote_compose::eventresult::{EventPropagation, EventResult};
 use rnote_compose::penevent::{KeyboardKey, ModifierKey, PenEvent, PenProgress};
 use rnote_compose::penpath::Element;
-use rnote_compose::shapes::Shapeable;
 use std::time::Instant;
 
 #[derive(Debug)]
@@ -181,21 +179,7 @@ impl PenBehaviour for Shaper {
                             .shaper_config
                             .gen_style_for_current_options();
 
-                        // calculate the bounds
-                        let bound_condition = shapes
-                            .iter()
-                            .map(|x| x.bounds())
-                            .reduce(|acc, x| acc.merged(&x))
-                            .unwrap_or(Aabb::new_invalid())
-                            .volume()
-                            > engine_view
-                                .config
-                                .pens_config
-                                .shaper_config
-                                .get_stroke_width()
-                                .powi(2);
-
-                        let shapes_emitted = !shapes.is_empty() && bound_condition;
+                        let shapes_emitted = !shapes.is_empty();
                         if shapes_emitted {
                             for shape in shapes {
                                 let key = engine_view.store.insert_stroke(

--- a/crates/rnote-engine/src/pens/shaper.rs
+++ b/crates/rnote-engine/src/pens/shaper.rs
@@ -88,6 +88,7 @@ impl PenBehaviour for Shaper {
                         ),
                     };
                 }
+
                 EventResult {
                     handled: true,
                     propagate: EventPropagation::Stop,

--- a/crates/rnote-engine/src/pens/shaper.rs
+++ b/crates/rnote-engine/src/pens/shaper.rs
@@ -189,6 +189,7 @@ impl PenBehaviour for Shaper {
                             .unwrap_or(Aabb::new_invalid())
                             .volume()
                             > engine_view
+                                .config
                                 .pens_config
                                 .shaper_config
                                 .get_stroke_width()

--- a/crates/rnote-engine/src/pens/shaper.rs
+++ b/crates/rnote-engine/src/pens/shaper.rs
@@ -67,23 +67,26 @@ impl PenBehaviour for Shaper {
 
         let event_result = match (&mut self.state, event) {
             (ShaperState::Idle, PenEvent::Down { mut element, .. }) => {
-                engine_view
-                    .config
-                    .pens_config
-                    .shaper_config
-                    .new_style_seeds();
-                element.pos = engine_view
-                    .document
-                    .snap_position(element.pos, engine_view.config);
+                // here we need an additional up/down event after a selection
+                // cancellation
+                if !engine_view.store.get_cancelled_state() {
+                    engine_view
+                        .config
+                        .pens_config
+                        .shaper_config
+                        .new_style_seeds();
+                    element.pos = engine_view
+                        .document
+                        .snap_position(element.pos, engine_view.config);
 
-                self.state = ShaperState::BuildShape {
-                    builder: new_builder(
-                        engine_view.config.pens_config.shaper_config.builder_type,
-                        element,
-                        now,
-                    ),
-                };
-
+                    self.state = ShaperState::BuildShape {
+                        builder: new_builder(
+                            engine_view.config.pens_config.shaper_config.builder_type,
+                            element,
+                            now,
+                        ),
+                    };
+                }
                 EventResult {
                     handled: true,
                     propagate: EventPropagation::Stop,

--- a/crates/rnote-engine/src/pens/tools/mod.rs
+++ b/crates/rnote-engine/src/pens/tools/mod.rs
@@ -64,6 +64,7 @@ impl PenBehaviour for Tools {
         event: PenEvent,
         now: Instant,
         engine_view: &mut EngineViewMut,
+        _temporary_tool: bool,
     ) -> (EventResult<PenProgress>, WidgetFlags) {
         match engine_view.config.pens_config.tools_config.style {
             ToolStyle::VerticalSpace => {

--- a/crates/rnote-engine/src/pens/typewriter/mod.rs
+++ b/crates/rnote-engine/src/pens/typewriter/mod.rs
@@ -17,6 +17,7 @@ use p2d::math::Vector2;
 use piet::RenderContext;
 use rnote_compose::EventResult;
 use rnote_compose::color;
+use rnote_compose::eventresult::EventPropagation;
 use rnote_compose::ext::{AabbExt, Vector2Ext};
 use rnote_compose::penevent::{PenEvent, PenProgress, PenState};
 use rnote_compose::shapes::Shapeable;
@@ -407,7 +408,20 @@ impl PenBehaviour for Typewriter {
             PenEvent::Down {
                 element,
                 modifier_keys,
-            } => self.handle_pen_event_down(element, modifier_keys, now, engine_view),
+            } => {
+                if !engine_view.store.get_cancelled_state() {
+                    self.handle_pen_event_down(element, modifier_keys, now, engine_view)
+                } else {
+                    (
+                        EventResult {
+                            handled: true,
+                            propagate: EventPropagation::Stop,
+                            progress: PenProgress::InProgress,
+                        },
+                        WidgetFlags::default(),
+                    )
+                }
+            }
             PenEvent::Up {
                 element,
                 modifier_keys,

--- a/crates/rnote-engine/src/pens/typewriter/mod.rs
+++ b/crates/rnote-engine/src/pens/typewriter/mod.rs
@@ -403,6 +403,7 @@ impl PenBehaviour for Typewriter {
         event: PenEvent,
         now: Instant,
         engine_view: &mut EngineViewMut,
+        _temporary_tool: bool,
     ) -> (EventResult<PenProgress>, WidgetFlags) {
         let (event_result, widget_flags) = match event {
             PenEvent::Down {

--- a/crates/rnote-engine/src/store/mod.rs
+++ b/crates/rnote-engine/src/store/mod.rs
@@ -91,8 +91,12 @@ pub struct StrokeStore {
     /// The index of the current live document in the history stack.
     #[serde(skip)]
     live_index: usize,
+    /// Boolean that indicates the pen event is one from the same
+    /// event sequence than the one that cancelled the selection
+    /// Events that cancel a selection should set this to true
+    /// and this should be set back to false on a pen up event
     #[serde(skip)]
-    canceled_selection: bool,
+    canceled_state: bool,
     /// An rtree backed by the slotmap store, for faster spatial queries.
     ///
     /// Needs to be updated with `update_with_key()` when strokes changed their geometry or position!
@@ -112,7 +116,7 @@ impl Default for StrokeStore {
             // Start off with state in the history
             history: VecDeque::from(vec![HistoryEntry::default()]),
             live_index: 0,
-            canceled_selection: false,
+            canceled_state: false,
 
             key_tree: KeyTree::default(),
 
@@ -374,11 +378,11 @@ impl StrokeStore {
 
     /// set the active state for the cancelled selection
     pub fn set_cancelled_state(&mut self, state: bool) {
-        self.canceled_selection = state
+        self.canceled_state = state
     }
 
     /// get the active state for the cancelled selection
     pub fn get_cancelled_state(&self) -> bool {
-        self.canceled_selection
+        self.canceled_state
     }
 }

--- a/crates/rnote-engine/src/store/mod.rs
+++ b/crates/rnote-engine/src/store/mod.rs
@@ -91,6 +91,8 @@ pub struct StrokeStore {
     /// The index of the current live document in the history stack.
     #[serde(skip)]
     live_index: usize,
+    #[serde(skip)]
+    canceled_selection: bool,
     /// An rtree backed by the slotmap store, for faster spatial queries.
     ///
     /// Needs to be updated with `update_with_key()` when strokes changed their geometry or position!
@@ -110,6 +112,7 @@ impl Default for StrokeStore {
             // Start off with state in the history
             history: VecDeque::from(vec![HistoryEntry::default()]),
             live_index: 0,
+            canceled_selection: false,
 
             key_tree: KeyTree::default(),
 
@@ -367,5 +370,15 @@ impl StrokeStore {
         self.key_tree.clear();
 
         widget_flags
+    }
+
+    /// set the active state for the cancelled selection
+    pub fn set_cancelled_state(&mut self, state: bool) {
+        self.canceled_selection = state
+    }
+
+    /// get the active state for the cancelled selection
+    pub fn get_cancelled_state(&self) -> bool {
+        self.canceled_selection
     }
 }

--- a/crates/rnote-ui/src/appwindow/actions.rs
+++ b/crates/rnote-ui/src/appwindow/actions.rs
@@ -496,7 +496,8 @@ impl RnAppWindow {
                 // check if we have a selector as a temporary tool and need to change the pen
                 let cancel_selection = canvas.engine_ref().cancel_selection_temporary_pen();
                 let widget_flags = if cancel_selection {
-                    // trigger an event for a KeyboardPress::Delete
+                    // trigger an event for a KeyboardPress::Delete : this both deletes the selection
+                    // and resets the pen back to its previous mode
                     let (_, widget_flags) = canvas.engine_mut().handle_pen_event(
                         rnote_compose::PenEvent::KeyPressed {
                             keyboard_key: KeyboardKey::Delete,

--- a/crates/rnote-ui/src/appwindow/actions.rs
+++ b/crates/rnote-ui/src/appwindow/actions.rs
@@ -11,7 +11,7 @@ use gtk4::{
 use p2d::bounding_volume::BoundingVolume;
 use p2d::math::Vector2;
 use rnote_compose::SplitOrder;
-use rnote_compose::penevent::ShortcutKey;
+use rnote_compose::penevent::{KeyboardKey, ShortcutKey};
 use rnote_engine::document::format::MeasureUnit;
 use rnote_engine::engine::StrokeContent;
 use rnote_engine::ext::GraphenePointExt;
@@ -19,6 +19,7 @@ use rnote_engine::pens::PenStyle;
 use rnote_engine::strokes::resize::{ImageSizeOption, Resize};
 use rnote_engine::strokes::textstroke::TextAttribute;
 use rnote_engine::{Camera, Engine};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Instant;
@@ -492,7 +493,22 @@ impl RnAppWindow {
                 let Some(canvas) = appwindow.active_tab_canvas() else {
                     return;
                 };
-                let widget_flags = canvas.engine_mut().trash_selection();
+                // check if we have a selector as a temporary tool and need to change the pen
+                let cancel_selection = canvas.engine_ref().cancel_selection_temporary_pen();
+                let widget_flags = if cancel_selection {
+                    // trigger an event for a KeyboardPress::Delete
+                    let (_, widget_flags) = canvas.engine_mut().handle_pen_event(
+                        rnote_compose::PenEvent::KeyPressed {
+                            keyboard_key: KeyboardKey::Delete,
+                            modifier_keys: HashSet::new(),
+                        },
+                        None,
+                        Instant::now(),
+                    );
+                    widget_flags
+                } else {
+                    canvas.engine_mut().trash_selection()
+                };
                 appwindow.handle_widget_flags(widget_flags, &canvas);
             }
         ));


### PR DESCRIPTION
Fixes #414
Fixes #888 

- This fixes the small dots that appears on selection cancellation with the pen (whilst allowing for strokes to still be written if they're larger than small dots)

A couple remarks : 
- ~~shapes need an additional up/down cycle : we could change it to follow the same logic as the brush but this could also be done by not changing the logic of the shape part and only disallowing shapes to be too small (in that case we can create shapes that aren't even visible but are still part of the document)~~
- the eraser and typewriter both need an additional pen up/down to activate
- tools aren't affected (they won't change anything if they're activated on such a short pen down/up cycle)
- ~~This does not change behavior when a selection is deleted.~~

Rebase of the previous PR #1139 with the new clone! syntax


> I've added a condition to only create shapes if they're large enough. As things like arrows would still appear on a single pen event, I'll leave the current behavior for shapes after a selection cancellation (that is we need an extra up/down cycle)

> I've added the cancellation of the selection tool upon deleting a selection when the selection tool is temporary

> Putting back in draft as this needs a little work before it can be merged. I'm wondering if the condition can be slightly modified to include time delay as well. It will cancel a dot after a selection but sometimes this dot can be large enough to stay (if the pen slides a bit instead of a clean hit)


