### PR TITLE
fix: unicode segmentation for inital selection when renaming file

### DIFF
--- a/crates/rnote-ui/src/workspacebrowser/filerow/actions/rename.rs
+++ b/crates/rnote-ui/src/workspacebrowser/filerow/actions/rename.rs
@@ -5,6 +5,7 @@ use gettextrs::gettext;
 use gtk4::{Align, Entry, Label, gio, glib, glib::clone, pango, prelude::*};
 use std::path::Path;
 use tracing::{debug, error};
+use unicode_segmentation::UnicodeSegmentation;
 
 /// Create a new `rename` action.
 pub(crate) fn rename(filerow: &RnFileRow, appwindow: &RnAppWindow) -> gio::SimpleAction {
@@ -112,7 +113,13 @@ fn create_entry(current_path: impl AsRef<Path>) -> Entry {
 
 fn entry_text_select_stem(entry: &Entry) {
     let entry_text = entry.text();
-    let stem_end = entry_text.match_indices('.').map(|(i, _)| i).next_back();
+
+    let stem_end = entry_text
+        .graphemes(true)
+        .enumerate()
+        .filter(|(_, g)| *g == ".")
+        .last()
+        .map(|(i, _)| i);
 
     // Select entire text first
     entry.grab_focus();


### PR DESCRIPTION
Changes the stem selection logic when renaming files to use unicode segmentation, since GTK expects character instead of byte indices.

|Previously|Now|
|---|---|
|![grafik](https://github.com/user-attachments/assets/e2e1deac-9b18-4f77-80d4-3f366d2b94d6)|![grafik](https://github.com/user-attachments/assets/a105b74d-608f-488e-a326-f5771eaccef0)|