### PR TITLE
Add `StartupWMClass` to the desktop file

### DIFF
--- a/crates/rnote-ui/data/app.desktop.in.in
+++ b/crates/rnote-ui/data/app.desktop.in.in
@@ -4,6 +4,7 @@ Name=@DESKTOP_FILE_NAME_ENTRY@
 Comment=Sketch and take handwritten notes
 # Translators: Do NOT translate or transliterate this text, this is an icon file name!
 Icon=@APP_ID@
+StartupWMClass=@APP_ID@
 #DBusActivatable=true
 Exec=@APP_NAME@ %f
 Terminal=false


### PR DESCRIPTION
This should resolve any edge-cases where icon is not shown in Gnome's dash or in other desktop environments, in case there is a regression in compositor recognizing `wmclass` through the desktop filename.

It also respects XDG desktop standards:  
https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html