### PR TITLE
update windows ci to 2025 version

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -9,7 +9,7 @@ name: Release Windows
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: windows-2025
     permissions:
       # needed for uploading release artifact
       contents: write
@@ -17,6 +17,12 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
+      - name: Install Inno 6
+        id: install_inno
+        shell: pwsh
+        run: |
+           Invoke-WebRequest -Uri https://jrsoftware.org/download.php/is.exe -OutFile D:\\is.exe
+           Start-Process -FilePath D:\\is.exe -ArgumentList "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-" -Wait
 
       - name: Set installer name
         id: set_installer_name

--- a/justfile
+++ b/justfile
@@ -123,7 +123,7 @@ setup-win-installer installer_name="rnote-win-installer":
     meson setup \
         --prefix={{ mingw64_prefix_path }} \
         -Dprofile=default \
-        -Dcli=false \
+        -Dcli=true \
         -Dwin-installer-name={{ installer_name }} \
         -Dci={{ ci }} \
         {{ build_folder }}


### PR DESCRIPTION
- update windows to 2025 version
- install inno (done manually as this isn't part of the image otherwise)
- set `cli=true` for window ci (fails otherwise, because refers to a `cargo_build` target only defined if the cli is set to true)

This makes it possible to use the 2025 version for compiling on the CI.

TODO
- [ ] fix the inno version (set to a specific version)
- [ ] checksum and validation (checksum on the exe + verify signature before launching)
- [ ] changing how the cli parameter is setup ?