### PR TITLE
fix: block signals modifying the store upon startup

### DIFF
--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -240,6 +240,7 @@ impl RnAppWindow {
         // Anything that needs to be done right before showing the appwindow
 
         self.refresh_ui();
+        imp.sidebar.get().activate_doc_settings_buttons();
     }
 
     fn setup_icon_theme(&self) {

--- a/crates/rnote-ui/src/settingspanel/mod.rs
+++ b/crates/rnote-ui/src/settingspanel/mod.rs
@@ -838,6 +838,7 @@ impl RnSettingsPanel {
             }
         ));
 
+        imp.doc_show_format_borders_row.set_sensitive(false);
         imp.doc_show_format_borders_row
             .connect_active_notify(clone!(
                 #[weak]
@@ -860,6 +861,7 @@ impl RnSettingsPanel {
             .sync_create()
             .build();
 
+        imp.doc_format_border_color_button.set_sensitive(false);
         imp.doc_format_border_color_button
             .connect_rgba_notify(clone!(
                 #[weak(rename_to=settingspanel)]
@@ -867,6 +869,9 @@ impl RnSettingsPanel {
                 #[weak]
                 appwindow,
                 move |button| {
+                    if !button.get_sensitive() {
+                        return;
+                    }
                     let format_border_color = button.rgba().into_compose_color();
                     let Some(canvas) = appwindow.active_tab_canvas() else {
                         return;
@@ -892,10 +897,14 @@ impl RnSettingsPanel {
                 }
             ));
 
+        imp.doc_background_color_button.set_sensitive(false);
         imp.doc_background_color_button.connect_rgba_notify(clone!(
             #[weak]
             appwindow,
             move |button| {
+                if !button.get_sensitive() {
+                    return;
+                }
                 let background_color = button.rgba().into_compose_color();
                 let Some(canvas) = appwindow.active_tab_canvas() else {
                     return;
@@ -917,6 +926,7 @@ impl RnSettingsPanel {
             }
         ));
 
+        imp.doc_document_layout_row.set_sensitive(false);
         imp.doc_document_layout_row
             .get()
             .connect_selected_item_notify(clone!(
@@ -924,7 +934,10 @@ impl RnSettingsPanel {
                 self,
                 #[weak]
                 appwindow,
-                move |_| {
+                move |row| {
+                    if !row.get_sensitive() {
+                        return;
+                    }
                     let document_layout = settings_panel.document_layout();
                     let Some(canvas) = appwindow.active_tab_canvas() else {
                         return;
@@ -944,6 +957,7 @@ impl RnSettingsPanel {
                 }
             ));
 
+        imp.doc_background_patterns_row.set_sensitive(false);
         imp.doc_background_patterns_row
             .get()
             .connect_selected_item_notify(clone!(
@@ -951,7 +965,10 @@ impl RnSettingsPanel {
                 self,
                 #[weak]
                 appwindow,
-                move |_| {
+                move |row| {
+                    if !row.get_sensitive() {
+                        return;
+                    }
                     let pattern = settings_panel.background_pattern();
                     let Some(canvas) = appwindow.active_tab_canvas() else {
                         return;
@@ -1030,11 +1047,15 @@ impl RnSettingsPanel {
                 }
             ));
 
+        imp.doc_background_pattern_color_button.set_sensitive(false);
         imp.doc_background_pattern_color_button
             .connect_rgba_notify(clone!(
                 #[weak]
                 appwindow,
                 move |button| {
+                    if !button.get_sensitive() {
+                        return;
+                    }
                     let Some(canvas) = appwindow.active_tab_canvas() else {
                         return;
                     };
@@ -1059,6 +1080,8 @@ impl RnSettingsPanel {
             ));
 
         imp.doc_background_pattern_width_unitentry
+            .set_sensitive(false);
+        imp.doc_background_pattern_width_unitentry
             .get()
             .connect_notify_local(
                 Some("value"),
@@ -1066,6 +1089,9 @@ impl RnSettingsPanel {
                     #[weak]
                     appwindow,
                     move |unit_entry, _| {
+                        if !unit_entry.get_sensitive() {
+                            return;
+                        }
                         let Some(canvas) = appwindow.active_tab_canvas() else {
                             return;
                         };
@@ -1093,6 +1119,8 @@ impl RnSettingsPanel {
             );
 
         imp.doc_background_pattern_height_unitentry
+            .set_sensitive(false);
+        imp.doc_background_pattern_height_unitentry
             .get()
             .connect_notify_local(
                 Some("value"),
@@ -1100,6 +1128,9 @@ impl RnSettingsPanel {
                     #[weak]
                     appwindow,
                     move |unit_entry, _| {
+                        if !unit_entry.get_sensitive() {
+                            return;
+                        }
                         let Some(canvas) = appwindow.active_tab_canvas() else {
                             return;
                         };
@@ -1145,11 +1176,16 @@ impl RnSettingsPanel {
             ));
 
         imp.background_pattern_invert_color_button
+            .set_sensitive(false);
+        imp.background_pattern_invert_color_button
             .get()
             .connect_clicked(clone!(
                 #[weak]
                 appwindow,
-                move |_| {
+                move |button| {
+                    if !button.get_sensitive() {
+                        return;
+                    }
                     let Some(canvas) = appwindow.active_tab_canvas() else {
                         return;
                     };
@@ -1182,6 +1218,26 @@ impl RnSettingsPanel {
                     appwindow.handle_widget_flags(widget_flags, &canvas);
                 }
             ));
+    }
+
+    // All relevant buttons are set as sensitive : false upon startup
+    // until the first tab is added. This way setting the correct values
+    // in the doc part of the settings won't send back a widget flag
+    // that modifies the store
+    pub fn activate_doc_settings_buttons(&self) {
+        let imp = self.imp();
+        imp.doc_show_format_borders_row.set_sensitive(true);
+        imp.doc_format_border_color_button.set_sensitive(true);
+        imp.doc_background_color_button.set_sensitive(true);
+        imp.doc_document_layout_row.set_sensitive(true);
+        imp.doc_background_patterns_row.set_sensitive(true);
+        imp.doc_background_pattern_color_button.set_sensitive(true);
+        imp.doc_background_pattern_width_unitentry
+            .set_sensitive(true);
+        imp.doc_background_pattern_height_unitentry
+            .set_sensitive(true);
+        imp.background_pattern_invert_color_button
+            .set_sensitive(true);
     }
 
     fn setup_shortcuts(&self, appwindow: &RnAppWindow) {

--- a/crates/rnote-ui/src/sidebar.rs
+++ b/crates/rnote-ui/src/sidebar.rs
@@ -124,4 +124,10 @@ impl RnSidebar {
             }
         ));
     }
+
+    pub(crate) fn activate_doc_settings_buttons(&self) {
+        let imp = self.imp();
+
+        imp.settings_panel.get().activate_doc_settings_buttons();
+    }
 }


### PR DESCRIPTION
Fixes #1258 

Now for now I'm blocking/unblocking signals upon startup.
- I'm not 100% sure if the unsaved indicator is coming from the `add_initial_tab` and widget flags from this call
- Not all signal handler are blocked for now

These one can also change the store and are not treated yet 
- [x] `doc_background_pattern_color_button`
- [x] `doc_background_color_button`
- [x] `set_document_layout` calling to  -> `doc_document_layout_row`

It also seems to me like we can either change the logic to set the initial values for the document section before the activation or setup of the handlers in `setup_doc` or change how the `SignalHandlerId` variables are held to only use them once (we probably don't need to reuse them later).

Seems like the unsaved indicator on startup is a little more common after the refactor on document settings as well