### PR TITLE
[Feature] Setting to enable automatic background color/pattern inversion for each document

### DIFF
--- a/crates/rnote-ui/data/ui/settingspanel.ui
+++ b/crates/rnote-ui/data/ui/settingspanel.ui
@@ -127,6 +127,21 @@ gets disabled.</property>
                         </child>
                       </object>
                     </child>
+                    <child>
+                      <object class="AdwComboRow" id="general_background_invert_mode_row">
+                        <property name="title" translatable="yes">Invert Background Brightness</property>
+                        <property name="subtitle" translatable="yes">Invert the brightness of the background and pattern colors</property>
+                        <property name="model">
+                          <object class="GtkStringList">
+                            <items>
+                              <item translatable="yes">Disabled</item>
+                              <item translatable="yes">Enabled</item>
+                              <item translatable="yes">Follow system</item>
+                            </items>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
                   </object>
                 </child>
                 <!-- Format Group -->
@@ -438,18 +453,6 @@ gets disabled.</property>
                       <object class="AdwSwitchRow" id="doc_show_origin_indicator_row">
                         <property name="title" translatable="yes">Show Origin Indicator</property>
                         <property name="subtitle" translatable="yes">Set whether the document origin indicator is shown</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="AdwActionRow" id="background_pattern_invert_color_row">
-                        <property name="title" translatable="yes">Invert Color Brightness</property>
-                        <property name="subtitle" translatable="yes">Invert the brightness of the background and pattern colors</property>
-                        <child type="suffix">
-                          <object class="GtkButton" id="background_pattern_invert_color_button">
-                            <property name="valign">center</property>
-                            <property name="label" translatable="yes">Invert</property>
-                          </object>
-                        </child>
                       </object>
                     </child>
                   </object>

--- a/crates/rnote-ui/src/settingspanel/mod.rs
+++ b/crates/rnote-ui/src/settingspanel/mod.rs
@@ -57,6 +57,8 @@ mod imp {
         #[template_child]
         pub(crate) general_drawing_cursor_picker_menubutton: TemplateChild<MenuButton>,
         #[template_child]
+        pub(crate) general_background_invert_mode_row: TemplateChild<adw::ComboRow>,
+        #[template_child]
         pub(crate) format_predefined_formats_row: TemplateChild<adw::ComboRow>,
         #[template_child]
         pub(crate) format_save_preset_button: TemplateChild<Button>,
@@ -108,8 +110,6 @@ mod imp {
         pub(crate) doc_background_pattern_height_unitentry: TemplateChild<RnUnitEntry>,
         #[template_child]
         pub(crate) doc_show_origin_indicator_row: TemplateChild<adw::SwitchRow>,
-        #[template_child]
-        pub(crate) background_pattern_invert_color_button: TemplateChild<Button>,
         #[template_child]
         pub(crate) penshortcut_stylus_button_primary_row: TemplateChild<RnPenShortcutRow>,
         #[template_child]
@@ -395,6 +395,16 @@ impl RnSettingsPanel {
 
     pub(crate) fn general_inertial_scrolling_row(&self) -> adw::SwitchRow {
         self.imp().general_inertial_scrolling_row.clone()
+    }
+
+    pub(crate) fn invert_mode(&self) -> u32 {
+        self.imp().general_background_invert_mode_row.selected()
+    }
+
+    pub(crate) fn set_background_pattern_invert_mode(&self, mode: u32) {
+        self.imp()
+            .general_background_invert_mode_row
+            .set_selected(mode);
     }
 
     pub(crate) fn document_layout(&self) -> Layout {
@@ -1144,43 +1154,14 @@ impl RnSettingsPanel {
                 }
             ));
 
-        imp.background_pattern_invert_color_button
+        imp.general_background_invert_mode_row
             .get()
-            .connect_clicked(clone!(
+            .connect_selected_item_notify(clone!(
+                #[weak(rename_to=settings_panel)]
+                self,
                 #[weak]
                 appwindow,
-                move |_| {
-                    let Some(canvas) = appwindow.active_tab_canvas() else {
-                        return;
-                    };
-
-                    let mut widget_flags = {
-                        let mut engine = canvas.engine_mut();
-                        engine.document.config.background.color = engine
-                            .document
-                            .config
-                            .background
-                            .color
-                            .to_inverted_brightness_color();
-                        engine.document.config.background.pattern_color = engine
-                            .document
-                            .config
-                            .background
-                            .pattern_color
-                            .to_inverted_brightness_color();
-                        engine.document.config.format.border_color = engine
-                            .document
-                            .config
-                            .format
-                            .border_color
-                            .to_inverted_brightness_color();
-                        engine.background_rendering_regenerate()
-                    };
-
-                    widget_flags.refresh_ui = true;
-                    widget_flags.store_modified = true;
-                    appwindow.handle_widget_flags(widget_flags, &canvas);
-                }
+                move |_| todo!()
             ));
     }
 


### PR DESCRIPTION
This PR aims to at least partially address #1293, specifically the dynamic dark-mode background (I'm thinking the stroke + palette inversion action might be its own feature)

Submitting early as WIP to open things up for discussion/feedback.

Here's a rough overview of where I'm at for anyone to follow along.

## Initial approach:

- Replace `background_pattern_invert_color_row` with a multi-select option:
  - _Enabled_, _Disabled_, and _Follow System_
- Apply background inversion based on setting at document load or on setting change

### Problem(s):

- Document settings are per-document, so this setting would have to be enabled for each document
- As someone who rarely saves what I draw (I mostly use Rnote as a one-off whiteboard/scratchpad), this didn't seem to align with my general use-case

## Revised approach (we are here, presently):

- Move `background_pattern_invert_color_row` to `general_background_invert_mode_row` under the general category as a more universal setting
- Apply background inversion on _any_ document load or setting change

### Problem(s):

- The background inversion operation modifies the document locally, meaning this could potentially be a destructive/undesirable operation for any opened document if the user isn't aware of how this option may impact them

--- 

I think what could make sense (if a little convoluted) could be some kind of hybrid between the local per-document setting and the global default where the local setting overrides the global default, but I'll keep considering more satisfactory ways to handle this. 

I'm open to any direction or feedback.