### PR TITLE
Performance fixes for larger files

### DIFF
--- a/crates/rnote-compose/src/ext.rs
+++ b/crates/rnote-compose/src/ext.rs
@@ -151,8 +151,6 @@ where
     /// splits a aabb into multiple which have a maximum of the given size. Their union is the given aabb.
     /// the split bounds are exactly fitted to not overlap, or extend the given bounds
     fn split(self, split_size: Vector2) -> Vec<Self>;
-    /// get the top patch for a given split size
-    fn get_origin(self, split_size: Vector2, split_order: SplitOrder) -> Self;
     /// splits a aabb into multiple of the given size. Their union contains the given aabb.
     /// The boxes on the edges most likely extend beyond the given aabb.
     fn split_extended(self, split_size: Vector2) -> Vec<Self>;
@@ -164,6 +162,9 @@ where
         split_size: Vector2,
         split_order: SplitOrder,
     ) -> Vec<Self>;
+    /// Gives an aabb of size split_size, snapped to a multiple of split_size
+    /// This returns the first element of a call to `split_extended_origin_aligned`
+    fn split_first_origin_aligned(self, split_size: Vector2) -> Self;
     /// Converts a Aabb to a kurbo Rectangle
     fn to_kurbo_rect(&self) -> kurbo::Rect;
     /// Converts a kurbo Rectangle to Aabb
@@ -362,22 +363,10 @@ impl AabbExt for Aabb {
         split_aabbs
     }
 
-    fn get_origin(self, split_size: Vector2, split_order: SplitOrder) -> Self {
-        let (outer_idx, inner_idx) = match split_order {
-            SplitOrder::RowMajor => (1, 0),
-            SplitOrder::ColumnMajor => (0, 1),
-        };
-
-        let offset_outer =
-            (self.mins[outer_idx] / split_size[outer_idx]).floor() * split_size[outer_idx];
-
-        let offset_inner =
-            (self.mins[inner_idx] / split_size[inner_idx]).floor() * split_size[inner_idx];
-
-        let mins = match split_order {
-            SplitOrder::RowMajor => Vector2::new(offset_inner, offset_outer),
-            SplitOrder::ColumnMajor => Vector2::new(offset_outer, offset_inner),
-        };
+    fn split_first_origin_aligned(self, split_size: Vector2) -> Self {
+        let offset_outer = (self.mins[1] / split_size[1]).floor() * split_size[1];
+        let offset_inner = (self.mins[0] / split_size[0]).floor() * split_size[0];
+        let mins = Vector2::new(offset_inner, offset_outer);
         Aabb::new(mins, mins + split_size)
     }
 

--- a/crates/rnote-compose/src/ext.rs
+++ b/crates/rnote-compose/src/ext.rs
@@ -151,6 +151,8 @@ where
     /// splits a aabb into multiple which have a maximum of the given size. Their union is the given aabb.
     /// the split bounds are exactly fitted to not overlap, or extend the given bounds
     fn split(self, split_size: Vector2) -> Vec<Self>;
+    /// get the top patch for a given split size
+    fn get_origin(self, split_size: Vector2, split_order: SplitOrder) -> Self;
     /// splits a aabb into multiple of the given size. Their union contains the given aabb.
     /// The boxes on the edges most likely extend beyond the given aabb.
     fn split_extended(self, split_size: Vector2) -> Vec<Self>;
@@ -358,6 +360,25 @@ impl AabbExt for Aabb {
         }
 
         split_aabbs
+    }
+
+    fn get_origin(self, split_size: Vector2, split_order: SplitOrder) -> Self {
+        let (outer_idx, inner_idx) = match split_order {
+            SplitOrder::RowMajor => (1, 0),
+            SplitOrder::ColumnMajor => (0, 1),
+        };
+
+        let offset_outer =
+            (self.mins[outer_idx] / split_size[outer_idx]).floor() * split_size[outer_idx];
+
+        let offset_inner =
+            (self.mins[inner_idx] / split_size[inner_idx]).floor() * split_size[inner_idx];
+
+        let mins = match split_order {
+            SplitOrder::RowMajor => Vector2::new(offset_inner, offset_outer),
+            SplitOrder::ColumnMajor => Vector2::new(offset_outer, offset_inner),
+        };
+        Aabb::new(mins, mins + split_size)
     }
 
     fn split_extended_origin_aligned(

--- a/crates/rnote-engine/src/document/mod.rs
+++ b/crates/rnote-engine/src/document/mod.rs
@@ -271,9 +271,7 @@ impl Document {
                 Aabb::new(Vector2::ZERO, self.config.format.size())
                     .extend_right_and_bottom_by(padding)
             } else {
-                store
-                    .get_bounds()
-                    .extend_right_and_bottom_by(padding)
+                store.get_bounds().extend_right_and_bottom_by(padding)
             };
             new_bounds.merge(&content_bounds);
         }
@@ -319,11 +317,7 @@ impl Document {
             let rendered_bounds = store.get_bounds();
 
             let content_bounds = if rendered_bounds.volume() > 0.0 {
-                Aabb::new(
-                    Vector2::new(rendered_bounds.mins[0], rendered_bounds.mins[1]),
-                    Vector2::new(rendered_bounds.maxs[0], rendered_bounds.maxs[1]),
-                )
-                .extend_by(padding)
+                rendered_bounds.extend_right_and_bottom_by(padding)
             } else {
                 // If doc is empty, resize to one page with the format size
                 Aabb::new(Vector2::ZERO, self.config.format.size()).extend_by(padding)

--- a/crates/rnote-engine/src/document/mod.rs
+++ b/crates/rnote-engine/src/document/mod.rs
@@ -271,12 +271,9 @@ impl Document {
                 Aabb::new(Vector2::ZERO, self.config.format.size())
                     .extend_right_and_bottom_by(padding)
             } else {
-                let rendered_bounds = store.get_bounds();
-
-                Aabb::new(
-                    Vector2::new(rendered_bounds.lower()[0], rendered_bounds.lower()[1]),
-                    Vector2::new(rendered_bounds.upper()[0], rendered_bounds.upper()[1]),
-                ).extend_right_and_bottom_by(padding)
+                store
+                    .get_bounds()
+                    .extend_right_and_bottom_by(padding)
             };
             new_bounds.merge(&content_bounds);
         }
@@ -321,10 +318,10 @@ impl Document {
         if include_content {
             let rendered_bounds = store.get_bounds();
 
-            let content_bounds = if rendered_bounds.area() > 0.0 {
+            let content_bounds = if rendered_bounds.volume() > 0.0 {
                 Aabb::new(
-                    Vector2::new(rendered_bounds.lower()[0], rendered_bounds.lower()[1]),
-                    Vector2::new(rendered_bounds.upper()[0], rendered_bounds.upper()[1]),
+                    Vector2::new(rendered_bounds.mins[0], rendered_bounds.mins[1]),
+                    Vector2::new(rendered_bounds.maxs[0], rendered_bounds.maxs[1]),
                 )
                 .extend_by(padding)
             } else {

--- a/crates/rnote-engine/src/document/mod.rs
+++ b/crates/rnote-engine/src/document/mod.rs
@@ -9,7 +9,6 @@ pub use background::Background;
 pub use config::DocumentConfig;
 pub use format::Format;
 pub use layout::Layout;
-use rstar::Envelope;
 
 // Imports
 use self::background::PatternStyle;
@@ -271,7 +270,9 @@ impl Document {
                 Aabb::new(Vector2::ZERO, self.config.format.size())
                     .extend_right_and_bottom_by(padding)
             } else {
-                store.get_bounds().extend_right_and_bottom_by(padding)
+                store
+                    .get_bounds_non_trashed()
+                    .extend_right_and_bottom_by(padding)
             };
             new_bounds.merge(&content_bounds);
         }
@@ -314,7 +315,7 @@ impl Document {
         }
 
         if include_content {
-            let rendered_bounds = store.get_bounds();
+            let rendered_bounds = store.get_bounds_non_trashed();
 
             let content_bounds = if rendered_bounds.volume() > 0.0 {
                 rendered_bounds.extend_right_and_bottom_by(padding)

--- a/crates/rnote-engine/src/document/mod.rs
+++ b/crates/rnote-engine/src/document/mod.rs
@@ -266,7 +266,7 @@ impl Document {
         }
 
         if include_content {
-            let rendered_bounds = store.key_tree.get_bounds();
+            let rendered_bounds = store.get_bounds();
 
             let content_bounds = if rendered_bounds.area() > 0.0 {
                 Aabb::new(
@@ -320,7 +320,7 @@ impl Document {
         }
 
         if include_content {
-            let rendered_bounds = store.key_tree.get_bounds();
+            let rendered_bounds = store.get_bounds();
 
             let content_bounds = if rendered_bounds.area() > 0.0 {
                 Aabb::new(

--- a/crates/rnote-engine/src/document/mod.rs
+++ b/crates/rnote-engine/src/document/mod.rs
@@ -266,18 +266,17 @@ impl Document {
         }
 
         if include_content {
-            let rendered_bounds = store.get_bounds();
-
-            let content_bounds = if rendered_bounds.area() > 0.0 {
-                Aabb::new(
-                    Vector2::new(rendered_bounds.lower()[0], rendered_bounds.lower()[1]),
-                    Vector2::new(rendered_bounds.upper()[0], rendered_bounds.upper()[1]),
-                )
-                .extend_right_and_bottom_by(padding)
-            } else {
+            let content_bounds = if store.keytree_is_empty() {
                 // If doc is empty, resize to one page with the format size
                 Aabb::new(Vector2::ZERO, self.config.format.size())
                     .extend_right_and_bottom_by(padding)
+            } else {
+                let rendered_bounds = store.get_bounds();
+
+                Aabb::new(
+                    Vector2::new(rendered_bounds.lower()[0], rendered_bounds.lower()[1]),
+                    Vector2::new(rendered_bounds.upper()[0], rendered_bounds.upper()[1]),
+                ).extend_right_and_bottom_by(padding)
             };
             new_bounds.merge(&content_bounds);
         }

--- a/crates/rnote-engine/src/document/mod.rs
+++ b/crates/rnote-engine/src/document/mod.rs
@@ -9,6 +9,7 @@ pub use background::Background;
 pub use config::DocumentConfig;
 pub use format::Format;
 pub use layout::Layout;
+use rstar::Envelope;
 
 // Imports
 use self::background::PatternStyle;
@@ -265,9 +266,14 @@ impl Document {
         }
 
         if include_content {
-            let keys = store.stroke_keys_as_rendered();
-            let content_bounds = if let Some(content_bounds) = store.bounds_for_strokes(&keys) {
-                content_bounds.extend_right_and_bottom_by(padding)
+            let rendered_bounds = store.key_tree.get_bounds();
+
+            let content_bounds = if rendered_bounds.area() > 0.0 {
+                Aabb::new(
+                    Vector2::new(rendered_bounds.lower()[0], rendered_bounds.lower()[1]),
+                    Vector2::new(rendered_bounds.upper()[0], rendered_bounds.upper()[1]),
+                )
+                .extend_right_and_bottom_by(padding)
             } else {
                 // If doc is empty, resize to one page with the format size
                 Aabb::new(Vector2::ZERO, self.config.format.size())
@@ -314,9 +320,14 @@ impl Document {
         }
 
         if include_content {
-            let keys = store.stroke_keys_as_rendered();
-            let content_bounds = if let Some(content_bounds) = store.bounds_for_strokes(&keys) {
-                content_bounds.extend_by(padding)
+            let rendered_bounds = store.key_tree.get_bounds();
+
+            let content_bounds = if rendered_bounds.area() > 0.0 {
+                Aabb::new(
+                    Vector2::new(rendered_bounds.lower()[0], rendered_bounds.lower()[1]),
+                    Vector2::new(rendered_bounds.upper()[0], rendered_bounds.upper()[1]),
+                )
+                .extend_by(padding)
             } else {
                 // If doc is empty, resize to one page with the format size
                 Aabb::new(Vector2::ZERO, self.config.format.size()).extend_by(padding)

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -207,7 +207,8 @@ pub struct Engine {
     background_tile_image: Option<Image>,
     #[cfg(feature = "ui")]
     #[serde(skip)]
-    background_rendernodes: Vec<gtk4::gsk::RenderNode>,
+    background_rendernode: Option<gtk4::gsk::RenderNode>,
+    origin_background_rendernode: Option<Aabb>,
     // Origin indicator rendering
     #[serde(skip)]
     origin_indicator_image: Option<Image>,
@@ -234,7 +235,8 @@ impl Default for Engine {
             tasks_rx: Some(EngineTaskReceiver(tasks_rx)),
             background_tile_image: None,
             #[cfg(feature = "ui")]
-            background_rendernodes: Vec::default(),
+            background_rendernode: None,
+            origin_background_rendernode: None,
             origin_indicator_image: None,
             #[cfg(feature = "ui")]
             origin_indicator_rendernode: None,

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -208,7 +208,6 @@ pub struct Engine {
     #[cfg(feature = "ui")]
     #[serde(skip)]
     background_rendernode: Option<gtk4::gsk::RenderNode>,
-    origin_background_rendernode: Option<Aabb>,
     // Origin indicator rendering
     #[serde(skip)]
     origin_indicator_image: Option<Image>,
@@ -236,7 +235,6 @@ impl Default for Engine {
             background_tile_image: None,
             #[cfg(feature = "ui")]
             background_rendernode: None,
-            origin_background_rendernode: None,
             origin_indicator_image: None,
             #[cfg(feature = "ui")]
             origin_indicator_rendernode: None,

--- a/crates/rnote-engine/src/engine/rendering.rs
+++ b/crates/rnote-engine/src/engine/rendering.rs
@@ -47,7 +47,6 @@ impl Engine {
                     )
                     .upcast(),
                 );
-                self.origin_background_rendernode = Some(origin_aabb);
             }
         }
 
@@ -116,7 +115,6 @@ impl Engine {
         #[cfg(feature = "ui")]
         {
             self.background_rendernode = None;
-            self.origin_background_rendernode = None;
             self.origin_indicator_rendernode.take();
         }
         widget_flags.redraw = true;
@@ -256,14 +254,8 @@ impl Engine {
         );
         snapshot.pop();
 
-        if let (Some(bounds), Some(render_node)) = (
-            self.origin_background_rendernode,
-            self.background_rendernode.clone(),
-        ) {
-            snapshot.push_repeat(
-                &graphene::Rect::from_p2d_aabb(doc_bounds),
-                Some(&graphene::Rect::from_p2d_aabb(bounds)),
-            );
+        if let Some(render_node) = &self.background_rendernode {
+            snapshot.push_repeat(&graphene::Rect::from_p2d_aabb(doc_bounds), None);
             snapshot.append_node(render_node);
             snapshot.pop();
         }

--- a/crates/rnote-engine/src/engine/rendering.rs
+++ b/crates/rnote-engine/src/engine/rendering.rs
@@ -18,7 +18,6 @@ impl Engine {
         {
             use crate::ext::GrapheneRectExt;
             use gtk4::{graphene, gsk, prelude::*};
-            use rnote_compose::SplitOrder;
             use rnote_compose::ext::AabbExt;
 
             let viewport = self.camera.viewport();
@@ -35,10 +34,8 @@ impl Engine {
                     }
                 };
 
-                let origin_aabb = viewport.get_origin(
-                    self.document.config.background.tile_size(),
-                    SplitOrder::default(),
-                );
+                let origin_aabb = viewport
+                    .split_first_origin_aligned(self.document.config.background.tile_size());
 
                 self.background_rendernode = Some(
                     gsk::TextureNode::new(

--- a/crates/rnote-engine/src/engine/rendering.rs
+++ b/crates/rnote-engine/src/engine/rendering.rs
@@ -22,7 +22,6 @@ impl Engine {
             use rnote_compose::ext::AabbExt;
 
             let viewport = self.camera.viewport();
-            let mut rendernodes: Vec<gsk::RenderNode> = vec![];
 
             if let Some(image) = &self.background_tile_image {
                 // Only create the texture once, it is expensive
@@ -36,21 +35,20 @@ impl Engine {
                     }
                 };
 
-                for split_bounds in viewport.split_extended_origin_aligned(
+                let origin_aabb = viewport.get_origin(
                     self.document.config.background.tile_size(),
                     SplitOrder::default(),
-                ) {
-                    rendernodes.push(
-                        gsk::TextureNode::new(
-                            &new_texture,
-                            &graphene::Rect::from_p2d_aabb(split_bounds),
-                        )
-                        .upcast(),
-                    );
-                }
-            }
+                );
 
-            self.background_rendernodes = rendernodes;
+                self.background_rendernode = Some(
+                    gsk::TextureNode::new(
+                        &new_texture,
+                        &graphene::Rect::from_p2d_aabb(origin_aabb),
+                    )
+                    .upcast(),
+                );
+                self.origin_background_rendernode = Some(origin_aabb);
+            }
         }
 
         #[cfg(feature = "ui")]
@@ -117,7 +115,8 @@ impl Engine {
         self.origin_indicator_image.take();
         #[cfg(feature = "ui")]
         {
-            self.background_rendernodes.clear();
+            self.background_rendernode = None;
+            self.origin_background_rendernode = None;
             self.origin_indicator_rendernode.take();
         }
         widget_flags.redraw = true;
@@ -251,17 +250,23 @@ impl Engine {
         snapshot.append_node(
             gsk::ColorNode::new(
                 &gdk::RGBA::from_compose_color(self.document.config.background.color),
-                //&gdk::RGBA::RED,
                 &graphene::Rect::from_p2d_aabb(doc_bounds),
             )
             .upcast(),
         );
-
-        for r in self.background_rendernodes.iter() {
-            snapshot.append_node(r);
-        }
-
         snapshot.pop();
+
+        if let (Some(bounds), Some(render_node)) = (
+            self.origin_background_rendernode,
+            self.background_rendernode.clone(),
+        ) {
+            snapshot.push_repeat(
+                &graphene::Rect::from_p2d_aabb(doc_bounds),
+                Some(&graphene::Rect::from_p2d_aabb(bounds)),
+            );
+            snapshot.append_node(render_node);
+            snapshot.pop();
+        }
         Ok(())
     }
 

--- a/crates/rnote-engine/src/store/chrono_comp.rs
+++ b/crates/rnote-engine/src/store/chrono_comp.rs
@@ -107,6 +107,33 @@ impl StrokeStore {
         keys
     }
 
+    pub(crate) fn keys_bounds_sorted_chrono_intersecting_bounds(
+        &self,
+        bounds: Aabb,
+    ) -> Vec<(StrokeKey, Aabb)> {
+        let chrono_components = &self.chrono_components;
+
+        let mut keys = self.key_tree.keys_bounds_intersecting_bounds(bounds);
+
+        keys.par_sort_unstable_by(|&(first, ..), &(second, ..)| {
+            if let (Some(first_chrono), Some(second_chrono)) =
+                (chrono_components.get(first), chrono_components.get(second))
+            {
+                let layer_order = first_chrono.layer.cmp(&second_chrono.layer);
+
+                if layer_order != std::cmp::Ordering::Equal {
+                    layer_order
+                } else {
+                    first_chrono.t.cmp(&second_chrono.t)
+                }
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        });
+
+        keys
+    }
+
     pub(crate) fn keys_sorted_chrono_in_bounds(&self, bounds: Aabb) -> Vec<StrokeKey> {
         let mut keys = self.key_tree.keys_in_bounds(bounds);
         self.sort_keys_chrono(&mut keys);

--- a/crates/rnote-engine/src/store/keytree.rs
+++ b/crates/rnote-engine/src/store/keytree.rs
@@ -1,9 +1,9 @@
 // Imports
 use super::StrokeKey;
 use p2d::bounding_volume::Aabb;
+use p2d::math::Vector2;
 use rstar::primitives::GeomWithData;
 use std::collections::HashMap;
-use p2d::math::Vector2;
 
 
 /// The rtree object that holds the bounds and [StrokeKey].
@@ -22,10 +22,12 @@ impl KeyTree {
     }
 
     /// Removes the [KeyTreeObject] for the given key.
-    pub(crate) fn remove_with_key(&mut self, key: StrokeKey) -> Option<KeyTreeObject> {
+    pub(crate) fn remove_with_key(&mut self, key: StrokeKey) -> Option<(StrokeKey, Aabb)> {
         let object_to_remove = self.0.iter().find(|&object| object.data == key)?.to_owned();
 
-        self.0.remove(&object_to_remove)
+        self.0
+            .remove(&object_to_remove)
+            .and_then(|key_object| Some(keytree_to_store(key_object)))
     }
 
     /// Update the Tree with new bounds for the given key.
@@ -120,5 +122,15 @@ fn new_keytree_object(key: StrokeKey, bounds: Aabb) -> KeyTreeObject {
             [bounds.maxs[0], bounds.maxs[1]],
         ),
         key,
+    )
+}
+
+fn keytree_to_store(key_object: KeyTreeObject) -> (StrokeKey, Aabb) {
+    (
+        key_object.data,
+        Aabb::new(
+            Vector2::new(key_object.geom().lower()[0], key_object.geom().lower()[1]),
+            Vector2::new(key_object.geom().upper()[0], key_object.geom().upper()[1]),
+        ),
     )
 }

--- a/crates/rnote-engine/src/store/keytree.rs
+++ b/crates/rnote-engine/src/store/keytree.rs
@@ -1,10 +1,10 @@
 // Imports
 use super::StrokeKey;
 use p2d::bounding_volume::Aabb;
-use p2d::math::Vector2;
-use rstar::AABB;
 use rstar::primitives::GeomWithData;
 use std::collections::HashMap;
+use p2d::math::Vector2;
+
 
 /// The rtree object that holds the bounds and [StrokeKey].
 type KeyTreeObject = GeomWithData<rstar::primitives::Rectangle<[f64; 2]>, StrokeKey>;
@@ -100,8 +100,12 @@ impl KeyTree {
         *self = Self::default()
     }
 
-    pub fn get_bounds(&self) -> AABB<[f64; 2]> {
-        self.0.root().envelope()
+    pub fn get_bounds(&self) -> Aabb {
+        let aabb_enveloppe = self.0.root().envelope();
+        Aabb::new(
+            Vector2::new(aabb_enveloppe.lower()[0], aabb_enveloppe.lower()[1]),
+            Vector2::new(aabb_enveloppe.upper()[0], aabb_enveloppe.upper()[1]),
+        )
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/crates/rnote-engine/src/store/keytree.rs
+++ b/crates/rnote-engine/src/store/keytree.rs
@@ -27,7 +27,7 @@ impl KeyTree {
 
         self.0
             .remove(&object_to_remove)
-            .and_then(|key_object| Some(keytree_to_store(key_object)))
+            .and_then(|key_object| Some(keytree_to_store(&key_object)))
     }
 
     /// Update the Tree with new bounds for the given key.
@@ -46,6 +46,17 @@ impl KeyTree {
                 [bounds.maxs[0], bounds.maxs[1]],
             ))
             .map(|object| object.data)
+            .collect()
+    }
+
+    /// Return the keys + bounds that intersect with the given bounds.
+    pub(crate) fn keys_bounds_intersecting_bounds(&self, bounds: Aabb) -> Vec<(StrokeKey, Aabb)> {
+        self.0
+            .locate_in_envelope_intersecting(&rstar::AABB::from_corners(
+                [bounds.mins[0], bounds.mins[1]],
+                [bounds.maxs[0], bounds.maxs[1]],
+            ))
+            .map(|object| keytree_to_store(&object))
             .collect()
     }
 
@@ -125,7 +136,7 @@ fn new_keytree_object(key: StrokeKey, bounds: Aabb) -> KeyTreeObject {
     )
 }
 
-fn keytree_to_store(key_object: KeyTreeObject) -> (StrokeKey, Aabb) {
+fn keytree_to_store(key_object: &KeyTreeObject) -> (StrokeKey, Aabb) {
     (
         key_object.data,
         Aabb::new(

--- a/crates/rnote-engine/src/store/keytree.rs
+++ b/crates/rnote-engine/src/store/keytree.rs
@@ -100,10 +100,6 @@ impl KeyTree {
         *self = Self::default()
     }
 
-    pub(crate) fn get_tree(&self) -> &rstar::RTree<KeyTreeObject, rstar::DefaultParams> {
-        &self.0
-    }
-
     pub fn get_bounds(&self) -> AABB<[f64; 2]> {
         self.0.root().envelope()
     }

--- a/crates/rnote-engine/src/store/keytree.rs
+++ b/crates/rnote-engine/src/store/keytree.rs
@@ -4,6 +4,7 @@ use p2d::bounding_volume::Aabb;
 use p2d::math::Vector2;
 use rstar::AABB;
 use rstar::primitives::GeomWithData;
+use std::collections::HashMap;
 
 /// The rtree object that holds the bounds and [StrokeKey].
 type KeyTreeObject = GeomWithData<rstar::primitives::Rectangle<[f64; 2]>, StrokeKey>;
@@ -43,6 +44,17 @@ impl KeyTree {
                 [bounds.maxs[0], bounds.maxs[1]],
             ))
             .map(|object| object.data)
+            .collect()
+    }
+
+    /// Return the keys that intersect with the given bounds.
+    pub(crate) fn keys_intersecting_bounds_hashset(&self, bounds: Aabb) -> HashMap<StrokeKey, ()> {
+        self.0
+            .locate_in_envelope_intersecting(&rstar::AABB::from_corners(
+                [bounds.mins[0], bounds.mins[1]],
+                [bounds.maxs[0], bounds.maxs[1]],
+            ))
+            .map(|object| (object.data, ()))
             .collect()
     }
 

--- a/crates/rnote-engine/src/store/keytree.rs
+++ b/crates/rnote-engine/src/store/keytree.rs
@@ -95,6 +95,10 @@ impl KeyTree {
     pub fn get_bounds(&self) -> AABB<[f64; 2]> {
         self.0.root().envelope()
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.size() == 0
+    }
 }
 
 fn new_keytree_object(key: StrokeKey, bounds: Aabb) -> KeyTreeObject {

--- a/crates/rnote-engine/src/store/keytree.rs
+++ b/crates/rnote-engine/src/store/keytree.rs
@@ -2,16 +2,17 @@
 use super::StrokeKey;
 use p2d::bounding_volume::Aabb;
 use p2d::math::Vector2;
+use rstar::AABB;
 use rstar::primitives::GeomWithData;
 
 /// The rtree object that holds the bounds and [StrokeKey].
-type KeyTreeObject = GeomWithData<rstar::primitives::Rectangle<[f64; 2]>, StrokeKey>;
+pub(crate) type KeyTreeObject = GeomWithData<rstar::primitives::Rectangle<[f64; 2]>, StrokeKey>;
 
 #[derive(Debug, Default)]
 /// A Rtree with [StrokeKey]'s as associated data.
 ///
 /// Used for faster spatial queries.
-pub(super) struct KeyTree(rstar::RTree<KeyTreeObject, rstar::DefaultParams>);
+pub(crate) struct KeyTree(rstar::RTree<KeyTreeObject, rstar::DefaultParams>);
 
 impl KeyTree {
     /// Insert a new tree object with the given [StrokeKey] and bounds.
@@ -89,6 +90,10 @@ impl KeyTree {
 
     pub(crate) fn get_tree(&self) -> &rstar::RTree<KeyTreeObject, rstar::DefaultParams> {
         &self.0
+    }
+
+    pub fn get_bounds(&self) -> AABB<[f64; 2]> {
+        self.0.root().envelope()
     }
 }
 

--- a/crates/rnote-engine/src/store/keytree.rs
+++ b/crates/rnote-engine/src/store/keytree.rs
@@ -5,7 +5,6 @@ use p2d::math::Vector2;
 use rstar::primitives::GeomWithData;
 use std::collections::HashMap;
 
-
 /// The rtree object that holds the bounds and [StrokeKey].
 type KeyTreeObject = GeomWithData<rstar::primitives::Rectangle<[f64; 2]>, StrokeKey>;
 
@@ -27,7 +26,7 @@ impl KeyTree {
 
         self.0
             .remove(&object_to_remove)
-            .and_then(|key_object| Some(keytree_to_store(&key_object)))
+            .map(|key_object| keytree_to_store(&key_object))
     }
 
     /// Update the Tree with new bounds for the given key.
@@ -56,7 +55,7 @@ impl KeyTree {
                 [bounds.mins[0], bounds.mins[1]],
                 [bounds.maxs[0], bounds.maxs[1]],
             ))
-            .map(|object| keytree_to_store(&object))
+            .map(keytree_to_store)
             .collect()
     }
 

--- a/crates/rnote-engine/src/store/keytree.rs
+++ b/crates/rnote-engine/src/store/keytree.rs
@@ -86,6 +86,10 @@ impl KeyTree {
     pub(crate) fn clear(&mut self) {
         *self = Self::default()
     }
+
+    pub(crate) fn get_tree(&self) -> &rstar::RTree<KeyTreeObject, rstar::DefaultParams> {
+        &self.0
+    }
 }
 
 fn new_keytree_object(key: StrokeKey, bounds: Aabb) -> KeyTreeObject {

--- a/crates/rnote-engine/src/store/keytree.rs
+++ b/crates/rnote-engine/src/store/keytree.rs
@@ -6,13 +6,13 @@ use rstar::AABB;
 use rstar::primitives::GeomWithData;
 
 /// The rtree object that holds the bounds and [StrokeKey].
-pub(crate) type KeyTreeObject = GeomWithData<rstar::primitives::Rectangle<[f64; 2]>, StrokeKey>;
+type KeyTreeObject = GeomWithData<rstar::primitives::Rectangle<[f64; 2]>, StrokeKey>;
 
 #[derive(Debug, Default)]
 /// A Rtree with [StrokeKey]'s as associated data.
 ///
 /// Used for faster spatial queries.
-pub(crate) struct KeyTree(rstar::RTree<KeyTreeObject, rstar::DefaultParams>);
+pub(super) struct KeyTree(rstar::RTree<KeyTreeObject, rstar::DefaultParams>);
 
 impl KeyTree {
     /// Insert a new tree object with the given [StrokeKey] and bounds.

--- a/crates/rnote-engine/src/store/mod.rs
+++ b/crates/rnote-engine/src/store/mod.rs
@@ -95,7 +95,7 @@ pub struct StrokeStore {
     ///
     /// Needs to be updated with `update_with_key()` when strokes changed their geometry or position!
     #[serde(skip)]
-    key_tree: KeyTree,
+    pub(crate) key_tree: KeyTree,
 }
 
 impl Default for StrokeStore {

--- a/crates/rnote-engine/src/store/mod.rs
+++ b/crates/rnote-engine/src/store/mod.rs
@@ -10,6 +10,7 @@ pub mod trash_comp;
 pub use chrono_comp::ChronoComponent;
 use keytree::KeyTree;
 pub use render_comp::RenderComponent;
+use rstar::AABB;
 pub use selection_comp::SelectionComponent;
 pub use trash_comp::TrashComponent;
 
@@ -95,7 +96,7 @@ pub struct StrokeStore {
     ///
     /// Needs to be updated with `update_with_key()` when strokes changed their geometry or position!
     #[serde(skip)]
-    pub(crate) key_tree: KeyTree,
+    key_tree: KeyTree,
 }
 
 impl Default for StrokeStore {
@@ -368,5 +369,9 @@ impl StrokeStore {
         self.key_tree.clear();
 
         widget_flags
+    }
+
+    pub(super) fn get_bounds(&self) -> AABB<[f64; 2]> {
+        self.key_tree.get_bounds()
     }
 }

--- a/crates/rnote-engine/src/store/mod.rs
+++ b/crates/rnote-engine/src/store/mod.rs
@@ -9,8 +9,8 @@ pub mod trash_comp;
 // Re-exports
 pub use chrono_comp::ChronoComponent;
 use keytree::KeyTree;
+use p2d::bounding_volume::Aabb;
 pub use render_comp::RenderComponent;
-use rstar::AABB;
 pub use selection_comp::SelectionComponent;
 pub use trash_comp::TrashComponent;
 
@@ -371,7 +371,7 @@ impl StrokeStore {
         widget_flags
     }
 
-    pub(super) fn get_bounds(&self) -> AABB<[f64; 2]> {
+    pub(super) fn get_bounds(&self) -> Aabb {
         self.key_tree.get_bounds()
     }
 

--- a/crates/rnote-engine/src/store/mod.rs
+++ b/crates/rnote-engine/src/store/mod.rs
@@ -147,6 +147,7 @@ impl StrokeStore {
         let tree_objects = self
             .stroke_components
             .iter()
+            .filter(|(key, _stroke)| self.trashed(*key).is_some_and(|x| !x))
             .map(|(key, stroke)| (key, stroke.bounds()))
             .collect();
         self.key_tree.rebuild_from_vec(tree_objects);

--- a/crates/rnote-engine/src/store/mod.rs
+++ b/crates/rnote-engine/src/store/mod.rs
@@ -95,8 +95,14 @@ pub struct StrokeStore {
     /// An rtree backed by the slotmap store, for faster spatial queries.
     ///
     /// Needs to be updated with `update_with_key()` when strokes changed their geometry or position!
+    /// Only holds non trashed keys
     #[serde(skip)]
     key_tree: KeyTree,
+    /// Same principle but only for trashed keys
+    /// This allows operations on non trashed strokes to
+    /// be faster (as they don't incur filtering after the fact)
+    #[serde(skip)]
+    trashed_key_tree: KeyTree,
 }
 
 impl Default for StrokeStore {
@@ -113,6 +119,7 @@ impl Default for StrokeStore {
             live_index: 0,
 
             key_tree: KeyTree::default(),
+            trashed_key_tree: KeyTree::default(),
 
             chrono_counter: 0,
         }
@@ -145,13 +152,13 @@ impl StrokeStore {
 
     /// Rebuild the rtree with the current stored strokes keys and bounds.
     fn rebuild_rtree(&mut self) {
-        let tree_objects = self
+        let (tree_objects, trashed_tree_objects) = self
             .stroke_components
             .iter()
-            .filter(|(key, _stroke)| self.trashed(*key).is_some_and(|x| !x))
             .map(|(key, stroke)| (key, stroke.bounds()))
-            .collect();
+            .partition(|(key, _bounds)| self.trashed(*key).is_some_and(|x| !x));
         self.key_tree.rebuild_from_vec(tree_objects);
+        self.trashed_key_tree.rebuild_from_vec(trashed_tree_objects);
     }
 
     /// Checks the equality of current state to all fields of the given history entry,
@@ -350,6 +357,7 @@ impl StrokeStore {
         self.render_components.remove(key);
 
         self.key_tree.remove_with_key(key);
+        self.trashed_key_tree.remove_with_key(key);
         Arc::make_mut(&mut self.stroke_components)
             .remove(key)
             .map(|stroke| (*stroke).clone())
@@ -367,11 +375,12 @@ impl StrokeStore {
 
         self.render_components.clear();
         self.key_tree.clear();
+        self.trashed_key_tree.clear();
 
         widget_flags
     }
 
-    pub(super) fn get_bounds(&self) -> Aabb {
+    pub(super) fn get_bounds_non_trashed(&self) -> Aabb {
         self.key_tree.get_bounds()
     }
 

--- a/crates/rnote-engine/src/store/mod.rs
+++ b/crates/rnote-engine/src/store/mod.rs
@@ -374,4 +374,8 @@ impl StrokeStore {
     pub(super) fn get_bounds(&self) -> AABB<[f64; 2]> {
         self.key_tree.get_bounds()
     }
+
+    pub(super) fn keytree_is_empty(&self) -> bool {
+        self.key_tree.is_empty()
+    }
 }

--- a/crates/rnote-engine/src/store/render_comp.rs
+++ b/crates/rnote-engine/src/store/render_comp.rs
@@ -244,9 +244,6 @@ impl StrokeStore {
         viewport: Aabb,
         image_scale: f64,
     ) {
-        // use the rtree to reduce the number of keys to search through
-        // for now we are using directly the tree because we want to iter without actually
-        // collecting elements
         let viewport_extended =
             viewport.extend_by(viewport.extents() * image::VIEWPORT_EXTENTS_MARGIN_FACTOR);
 
@@ -254,26 +251,29 @@ impl StrokeStore {
         // rtree but also get from this the keys that are not in here
         // for that also create a slotmap of keys that are in the viewport
         // so that we can iterate a second time on keys and filter on elements not in the slotmap
-        let mut hashmap_in_viewport: HashMap<StrokeKey, ()> = HashMap::new();
-
-        let keys_in_viewport = self
+        let mut keys_in_viewport_hash = self
             .key_tree
-            .get_tree()
-            .locate_in_envelope_intersecting(&rstar::AABB::from_corners(
-                [viewport_extended.mins[0], viewport_extended.mins[1]],
-                [viewport_extended.maxs[0], viewport_extended.maxs[1]],
-            ))
-            .map(|object| {
-                let key = object.data;
-                hashmap_in_viewport.insert(key, ());
-                key
-            })
-            .into_iter()
-            .collect::<Vec<StrokeKey>>();
+            .keys_intersecting_bounds_hashset(viewport_extended);
 
-        for key in keys_in_viewport {
+        // remove stroke keys that we know are not in
+        // the viewport
+        // This way we can skip calculating their bounds
+        for (_key, render_comp) in self
+            .render_components
+            .iter_mut()
+            .filter(|x| !keys_in_viewport_hash.contains_key(&x.0))
+        {
+            #[cfg(feature = "ui")]
+            {
+                render_comp.rendernodes = vec![];
+            }
+            render_comp.images = vec![];
+            render_comp.state = RenderCompState::Dirty;
+        }
+
+        for (key, _) in keys_in_viewport_hash {
             if let Some(stroke) = self.stroke_components.get(key)
-                && let Some(render_comp) = self.render_components.get_mut(key)
+            && let Some(render_comp) = self.render_components.get_mut(key)
             {
                 let tasks_tx = tasks_tx.clone();
 
@@ -325,22 +325,6 @@ impl StrokeStore {
                     },
                 );
             }
-        }
-
-        // iterate a second time on stroke keys that we know are not in
-        // the viewport
-        // This way we can skip calculating their bounds
-        for (_key, render_comp) in self
-            .render_components
-            .iter_mut()
-            .filter(|x| !hashmap_in_viewport.contains_key(&x.0))
-        {
-            #[cfg(feature = "ui")]
-            {
-                render_comp.rendernodes = vec![];
-            }
-            render_comp.images = vec![];
-            render_comp.state = RenderCompState::Dirty;
         }
     }
 

--- a/crates/rnote-engine/src/store/render_comp.rs
+++ b/crates/rnote-engine/src/store/render_comp.rs
@@ -269,7 +269,7 @@ impl StrokeStore {
 
         for (key, _) in keys_in_viewport_hash {
             if let Some(stroke) = self.stroke_components.get(key)
-            && let Some(render_comp) = self.render_components.get_mut(key)
+                && let Some(render_comp) = self.render_components.get_mut(key)
             {
                 let tasks_tx = tasks_tx.clone();
 

--- a/crates/rnote-engine/src/store/render_comp.rs
+++ b/crates/rnote-engine/src/store/render_comp.rs
@@ -329,7 +329,7 @@ impl StrokeStore {
 
         // iterate a second time on stroke keys that we know are not in
         // the viewport
-        // This way we can skip calculting their bounds
+        // This way we can skip calculating their bounds
         for (_key, render_comp) in self
             .render_components
             .iter_mut()

--- a/crates/rnote-engine/src/store/render_comp.rs
+++ b/crates/rnote-engine/src/store/render_comp.rs
@@ -7,7 +7,6 @@ use crate::strokes::content::GeneratedContentImages;
 use crate::{Drawable, image};
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use rnote_compose::ext::AabbExt;
-use std::collections::HashMap;
 use tracing::error;
 
 #[cfg(feature = "ui")]
@@ -251,7 +250,7 @@ impl StrokeStore {
         // rtree but also get from this the keys that are not in here
         // for that also create a slotmap of keys that are in the viewport
         // so that we can iterate a second time on keys and filter on elements not in the slotmap
-        let mut keys_in_viewport_hash = self
+        let keys_in_viewport_hash = self
             .key_tree
             .keys_intersecting_bounds_hashset(viewport_extended);
 

--- a/crates/rnote-engine/src/store/render_comp.rs
+++ b/crates/rnote-engine/src/store/render_comp.rs
@@ -9,9 +9,6 @@ use p2d::bounding_volume::{Aabb, BoundingVolume};
 use rnote_compose::ext::AabbExt;
 use tracing::error;
 
-#[cfg(feature = "ui")]
-use rnote_compose::shapes::Shapeable;
-
 /// The tolerance where check between scale-factors are considered "equal".
 pub(crate) const RENDER_IMAGE_SCALE_TOLERANCE: f64 = 0.01;
 
@@ -505,6 +502,7 @@ impl StrokeStore {
         use crate::ext::{GdkRGBAExt, GrapheneRectExt};
         use gtk4::{gdk, graphene, prelude::*};
         use rnote_compose::color;
+        use rnote_compose::shapes::Shapeable;
 
         snapshot.push_clip(&graphene::Rect::from_p2d_aabb(doc_bounds));
 
@@ -584,6 +582,7 @@ impl StrokeStore {
     ) -> anyhow::Result<()> {
         use crate::engine::visual_debug;
         use gtk4::prelude::*;
+        use rnote_compose::shapes::Shapeable;
 
         let border_widths = 1.0 / engine.camera.total_zoom();
 

--- a/crates/rnote-engine/src/store/render_comp.rs
+++ b/crates/rnote-engine/src/store/render_comp.rs
@@ -7,8 +7,11 @@ use crate::strokes::content::GeneratedContentImages;
 use crate::{Drawable, image};
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use rnote_compose::ext::AabbExt;
-use rnote_compose::shapes::Shapeable;
+use std::collections::HashMap;
 use tracing::error;
+
+#[cfg(feature = "ui")]
+use rnote_compose::shapes::Shapeable;
 
 /// The tolerance where check between scale-factors are considered "equal".
 pub(crate) const RENDER_IMAGE_SCALE_TOLERANCE: f64 = 0.01;
@@ -241,27 +244,38 @@ impl StrokeStore {
         viewport: Aabb,
         image_scale: f64,
     ) {
-        let keys = self.render_components.keys().collect::<Vec<StrokeKey>>();
+        // use the rtree to reduce the number of keys to search through
+        // for now we are using directly the tree because we want to iter without actually
+        // collecting elements
+        let viewport_extended =
+            viewport.extend_by(viewport.extents() * image::VIEWPORT_EXTENTS_MARGIN_FACTOR);
 
-        for key in keys {
+        // we want to iterate on the keys that are in the viewport using the
+        // rtree but also get from this the keys that are not in here
+        // for that also create a slotmap of keys that are in the viewport
+        // so that we can iterate a second time on keys and filter on elements not in the slotmap
+        let mut hashmap_in_viewport: HashMap<StrokeKey, ()> = HashMap::new();
+
+        let keys_in_viewport = self
+            .key_tree
+            .get_tree()
+            .locate_in_envelope_intersecting(&rstar::AABB::from_corners(
+                [viewport_extended.mins[0], viewport_extended.mins[1]],
+                [viewport_extended.maxs[0], viewport_extended.maxs[1]],
+            ))
+            .map(|object| {
+                let key = object.data;
+                hashmap_in_viewport.insert(key, ());
+                key
+            })
+            .into_iter()
+            .collect::<Vec<StrokeKey>>();
+
+        for key in keys_in_viewport {
             if let Some(stroke) = self.stroke_components.get(key)
                 && let Some(render_comp) = self.render_components.get_mut(key)
             {
                 let tasks_tx = tasks_tx.clone();
-                let stroke_bounds = stroke.bounds();
-                let viewport_extended =
-                    viewport.extend_by(viewport.extents() * image::VIEWPORT_EXTENTS_MARGIN_FACTOR);
-
-                // skip and clear image buffer if stroke is not in viewport
-                if !viewport_extended.intersects(&stroke_bounds) {
-                    #[cfg(feature = "ui")]
-                    {
-                        render_comp.rendernodes = vec![];
-                    }
-                    render_comp.images = vec![];
-                    render_comp.state = RenderCompState::Dirty;
-                    continue;
-                }
 
                 // only check if rerendering is not forced
                 if !force_regenerate {
@@ -311,6 +325,22 @@ impl StrokeStore {
                     },
                 );
             }
+        }
+
+        // iterate a second time on stroke keys that we know are not in
+        // the viewport
+        // This way we can skip calculting their bounds
+        for (_key, render_comp) in self
+            .render_components
+            .iter_mut()
+            .filter(|x| !hashmap_in_viewport.contains_key(&x.0))
+        {
+            #[cfg(feature = "ui")]
+            {
+                render_comp.rendernodes = vec![];
+            }
+            render_comp.images = vec![];
+            render_comp.state = RenderCompState::Dirty;
         }
     }
 

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -68,7 +68,7 @@ impl StrokeStore {
             .collect()
     }
 
-    /// Storke keys in the order that they should be rendered.
+    /// Stroke keys in the order that they should be rendered.
     pub(crate) fn stroke_keys_as_rendered(&self) -> Vec<StrokeKey> {
         self.keys_sorted_chrono()
             .into_iter()

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -128,7 +128,7 @@ impl StrokeStore {
 
     /// Calculate the height needed to fit all strokes.
     pub(crate) fn calc_height(&self) -> f64 {
-        let bounds = self.key_tree.get_tree().root().envelope();
+        let bounds = self.key_tree.get_bounds();
         bounds.upper()[1] - bounds.lower()[1]
     }
 

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -132,7 +132,7 @@ impl StrokeStore {
             return 0.0;
         } else {
             let bounds = self.key_tree.get_bounds();
-            bounds.upper()[1] - bounds.lower()[1]
+            bounds.maxs[1] - bounds.mins[1]
         }
     }
 

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -128,8 +128,12 @@ impl StrokeStore {
 
     /// Calculate the height needed to fit all strokes.
     pub(crate) fn calc_height(&self) -> f64 {
-        let bounds = self.key_tree.get_bounds();
-        bounds.upper()[1] - bounds.lower()[1]
+        if self.keytree_is_empty() {
+            return 0.0;
+        } else {
+            let bounds = self.key_tree.get_bounds();
+            bounds.upper()[1] - bounds.lower()[1]
+        }
     }
 
     /// Calculate the width needed to fit all strokes.

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -145,7 +145,7 @@ impl StrokeStore {
     /// Calculate the height needed to fit all (non trashed) strokes.
     pub(crate) fn calc_height(&self) -> f64 {
         if self.keytree_is_empty() {
-            return 0.0;
+            0.0
         } else {
             let bounds = self.key_tree.get_bounds();
             bounds.maxs[1] - bounds.mins[1]

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -88,6 +88,16 @@ impl StrokeStore {
             .collect::<Vec<StrokeKey>>()
     }
 
+    /// Stroke keys + bounds intersecting the given bounds, in the order that they should be rendered
+    pub(crate) fn stroke_keys_and_bounds_as_rendered_intersecting_bounds(
+        &self,
+        bounds: Aabb,
+    ) -> Vec<(StrokeKey, Aabb)> {
+        self.keys_bounds_sorted_chrono_intersecting_bounds(bounds)
+            .into_iter()
+            .collect()
+    }
+
     /// Stroke keys contained in the given bounds, in the order that they should be rendered.
     pub(crate) fn stroke_keys_as_rendered_in_bounds(&self, bounds: Aabb) -> Vec<StrokeKey> {
         self.keys_sorted_chrono_in_bounds(bounds)

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -57,7 +57,9 @@ impl StrokeStore {
 
     #[allow(unused)]
     pub(crate) fn keys_unordered_intersecting_bounds(&self, bounds: Aabb) -> Vec<StrokeKey> {
-        self.key_tree.keys_intersecting_bounds(bounds)
+        let mut keys_collect = self.key_tree.keys_intersecting_bounds(bounds);
+        keys_collect.extend_from_slice(&self.trashed_key_tree.keys_intersecting_bounds(bounds));
+        keys_collect
     }
 
     /// All stroke keys that are not trashed, unordered.
@@ -83,7 +85,6 @@ impl StrokeStore {
     ) -> Vec<StrokeKey> {
         self.keys_sorted_chrono_intersecting_bounds(bounds)
             .into_iter()
-            .filter(|&key| !(self.trashed(key).unwrap_or(false)))
             .collect::<Vec<StrokeKey>>()
     }
 
@@ -91,7 +92,6 @@ impl StrokeStore {
     pub(crate) fn stroke_keys_as_rendered_in_bounds(&self, bounds: Aabb) -> Vec<StrokeKey> {
         self.keys_sorted_chrono_in_bounds(bounds)
             .into_iter()
-            .filter(|&key| !(self.trashed(key).unwrap_or(false)))
             .collect::<Vec<StrokeKey>>()
     }
 
@@ -107,12 +107,18 @@ impl StrokeStore {
     ///
     /// The stroke then needs to update its rendering.
     pub(crate) fn update_geometry_for_stroke(&mut self, key: StrokeKey) {
+        let is_trashed = self.trashed(key).is_some_and(|x| x);
+
         if let Some(stroke) = Arc::make_mut(&mut self.stroke_components)
             .get_mut(key)
             .map(Arc::make_mut)
         {
             stroke.update_geometry();
-            self.key_tree.update_with_key(key, stroke.bounds());
+            if is_trashed {
+                self.trashed_key_tree.update_with_key(key, stroke.bounds());
+            } else {
+                self.key_tree.update_with_key(key, stroke.bounds());
+            }
             self.set_rendering_dirty(key);
         }
     }
@@ -126,7 +132,7 @@ impl StrokeStore {
         });
     }
 
-    /// Calculate the height needed to fit all strokes.
+    /// Calculate the height needed to fit all (non trashed) strokes.
     pub(crate) fn calc_height(&self) -> f64 {
         if self.keytree_is_empty() {
             return 0.0;
@@ -190,6 +196,7 @@ impl StrokeStore {
     /// The strokes then need to update their geometry and rendering.
     pub(crate) fn translate_strokes(&mut self, keys: &[StrokeKey], offset: Vector2) {
         keys.iter().for_each(|&key| {
+            let is_trashed = self.trashed(key).is_some_and(|x| x);
             if let Some(stroke) = Arc::make_mut(&mut self.stroke_components)
                 .get_mut(key)
                 .map(Arc::make_mut)
@@ -197,7 +204,11 @@ impl StrokeStore {
                 {
                     // translate the stroke geometry
                     stroke.translate(offset);
-                    self.key_tree.update_with_key(key, stroke.bounds());
+                    if is_trashed {
+                        self.trashed_key_tree.update_with_key(key, stroke.bounds());
+                    } else {
+                        self.key_tree.update_with_key(key, stroke.bounds());
+                    }
                 }
             }
         });
@@ -231,6 +242,7 @@ impl StrokeStore {
     /// Strokes then need to update their rendering.
     pub(crate) fn rotate_strokes(&mut self, keys: &[StrokeKey], angle: f64, center: Vector2) {
         keys.iter().for_each(|&key| {
+            let is_trashed = self.trashed(key).is_some_and(|x| x);
             if let Some(stroke) = Arc::make_mut(&mut self.stroke_components)
                 .get_mut(key)
                 .map(Arc::make_mut)
@@ -238,7 +250,11 @@ impl StrokeStore {
                 {
                     // rotate the stroke geometry
                     stroke.rotate(angle, center);
-                    self.key_tree.update_with_key(key, stroke.bounds());
+                    if is_trashed {
+                        self.trashed_key_tree.update_with_key(key, stroke.bounds());
+                    } else {
+                        self.key_tree.update_with_key(key, stroke.bounds());
+                    }
                 }
             }
         });
@@ -386,6 +402,7 @@ impl StrokeStore {
     /// The strokes then need to update their rendering.
     pub(crate) fn scale_strokes(&mut self, keys: &[StrokeKey], scale: Vector2) {
         keys.iter().for_each(|&key| {
+            let is_trashed = self.trashed(key).is_some_and(|x| x);
             if let Some(stroke) = Arc::make_mut(&mut self.stroke_components)
                 .get_mut(key)
                 .map(Arc::make_mut)
@@ -393,7 +410,11 @@ impl StrokeStore {
                 {
                     // rotate the stroke geometry
                     stroke.scale(scale);
-                    self.key_tree.update_with_key(key, stroke.bounds());
+                    if is_trashed {
+                        self.trashed_key_tree.update_with_key(key, stroke.bounds());
+                    } else {
+                        self.key_tree.update_with_key(key, stroke.bounds());
+                    }
                 }
             }
         });
@@ -478,11 +499,6 @@ impl StrokeStore {
         self.keys_sorted_chrono_intersecting_bounds(bounds)
             .into_iter()
             .filter_map(|key| {
-                // skip if stroke is trashed
-                if self.trashed(key)? {
-                    return None;
-                }
-
                 let stroke = self.stroke_components.get(key)?;
                 let stroke_bounds = stroke.bounds();
 
@@ -533,11 +549,6 @@ impl StrokeStore {
         self.keys_sorted_chrono_intersecting_bounds(bounds)
             .into_iter()
             .filter_map(|key| {
-                // skip if stroke is trashed
-                if self.trashed(key)? {
-                    return None;
-                }
-
                 let stroke = self.stroke_components.get(key)?;
                 let stroke_bounds = stroke.bounds();
 
@@ -566,11 +577,6 @@ impl StrokeStore {
         self.keys_sorted_chrono_intersecting_bounds(viewport.merged(&aabb))
             .into_iter()
             .filter_map(|key| {
-                // skip if stroke is trashed
-                if self.trashed(key)? {
-                    return None;
-                }
-
                 let stroke = self.stroke_components.get(key)?;
                 let stroke_bounds = stroke.bounds();
 
@@ -637,7 +643,7 @@ impl StrokeStore {
         limit_movement_vertical_border: bool,
         limit_movement_horizontal_border: bool,
     ) -> Vec<StrokeKey> {
-        self.key_tree.keys_intersecting_bounds(Aabb::new(
+        let bounds = Aabb::new(
             Vector2::new(
                 if limit_movement_vertical_border {
                     x_lims.0
@@ -658,7 +664,14 @@ impl StrokeStore {
                     f64::INFINITY
                 },
             ),
-        ))
+        );
+        let mut collector = self.key_tree.keys_intersecting_bounds(bounds);
+        collector.extend(
+            self.trashed_key_tree
+                .keys_intersecting_bounds(bounds)
+                .iter(),
+        );
+        collector
     }
 
     pub(crate) fn filter_keys_intersecting_bounds<'a, I: IntoIterator<Item = &'a StrokeKey>>(

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -128,17 +128,8 @@ impl StrokeStore {
 
     /// Calculate the height needed to fit all strokes.
     pub(crate) fn calc_height(&self) -> f64 {
-        let strokes_iter = self
-            .stroke_keys_unordered()
-            .into_iter()
-            .filter_map(|key| self.stroke_components.get(key));
-
-        let strokes_min_y = strokes_iter
-            .clone()
-            .fold(0.0, |acc, stroke| stroke.bounds().mins[1].min(acc));
-        let strokes_max_y = strokes_iter.fold(0.0, |acc, stroke| stroke.bounds().maxs[1].max(acc));
-
-        strokes_max_y - strokes_min_y
+        let bounds = self.key_tree.get_tree().root().envelope();
+        bounds.upper()[1] - bounds.lower()[1]
     }
 
     /// Calculate the width needed to fit all strokes.

--- a/crates/rnote-engine/src/store/trash_comp.rs
+++ b/crates/rnote-engine/src/store/trash_comp.rs
@@ -49,6 +49,18 @@ impl StrokeStore {
             .map(Arc::make_mut)
         {
             trash_comp.trashed = trash;
+            // remove the key from the rtree (so that the rtree holds information
+            // only for non trashed strokes)
+            if trash {
+                self.key_tree.remove_with_key(key);
+            } else {
+                if let Some(stroke) = Arc::make_mut(&mut self.stroke_components)
+                    .get_mut(key)
+                    .map(Arc::make_mut)
+                {
+                    self.key_tree.update_with_key(key, stroke.bounds());
+                }
+            }
             self.update_chrono_to_last(key);
         }
     }

--- a/crates/rnote-engine/src/store/trash_comp.rs
+++ b/crates/rnote-engine/src/store/trash_comp.rs
@@ -51,6 +51,8 @@ impl StrokeStore {
             trash_comp.trashed = trash;
             // remove the key from the rtree (so that the rtree holds information
             // only for non trashed strokes)
+            // Remark : the corresponding stroke will hold onto its rendernodes and image
+            // until `regenerate_rendering_in_viewport_threaded` is called again
             if trash {
                 self.key_tree.remove_with_key(key);
             } else {

--- a/crates/rnote-engine/src/store/trash_comp.rs
+++ b/crates/rnote-engine/src/store/trash_comp.rs
@@ -98,16 +98,16 @@ impl StrokeStore {
     ) -> WidgetFlags {
         let mut widget_flags = WidgetFlags::default();
 
-        self.stroke_keys_as_rendered_intersecting_bounds(viewport)
+        self.stroke_keys_and_bounds_as_rendered_intersecting_bounds(viewport)
             .into_iter()
-            .for_each(|key| {
+            .for_each(|(key, bounds)| {
                 let mut trash_current_stroke = false;
 
                 if let Some(stroke) = self.stroke_components.get(key) {
                     match stroke.as_ref() {
                         Stroke::BrushStroke(_) | Stroke::ShapeStroke(_) => {
                             // First check if eraser even intersects stroke bounds, avoiding unnecessary work
-                            if eraser_bounds.intersects(&stroke.bounds()) {
+                            if eraser_bounds.intersects(&bounds) {
                                 for hitbox in stroke.hitboxes().into_iter() {
                                     if eraser_bounds.intersects(&hitbox) {
                                         trash_current_stroke = true;

--- a/crates/rnote-engine/src/store/trash_comp.rs
+++ b/crates/rnote-engine/src/store/trash_comp.rs
@@ -57,10 +57,8 @@ impl StrokeStore {
                 if let Some((key, bounds)) = self.key_tree.remove_with_key(key) {
                     self.trashed_key_tree.insert_with_key(key, bounds);
                 }
-            } else {
-                if let Some((key, bounds)) = self.trashed_key_tree.remove_with_key(key) {
-                    self.key_tree.insert_with_key(key, bounds);
-                }
+            } else if let Some((key, bounds)) = self.trashed_key_tree.remove_with_key(key) {
+                self.key_tree.insert_with_key(key, bounds);
             }
             self.update_chrono_to_last(key);
         }


### PR DESCRIPTION
Fixes #1436 
(and maybe #1438, waiting on a response)

- use `push_repeat` for background nodes : This seems to reduce RAM usage and buffer uploads to the gpu so there's more headroom for the rest of the nodes
- use the rtree to speed up `regenerate_rendering_in_viewport_threaded` : We use the rtree to get the strokes in the viewport without recalculating any stroke bounds, and get the ones not in the view by iterating on keys and using a hashmap to filter out the previously selected ones

On that subject, it seems we could use a https://docs.rs/slotmap/1.0.7/slotmap/sparse_secondary/struct.SparseSecondaryMap.html for the render components and/or be smarter on clearing the `render_comp` components of strokes (we know there's no work to do if we have x strokes in view that we just initialized the rendering components and x strokes in the rendering component slot)

I've updated the rtree to only keep bounds for visible strokes (so trashed strokes are removed from the tree)

- [use rtree for update_content_rendering_current_viewport calculations](https://github.com/flxzt/rnote/commit/e75519864ef25c03b0560c06f6044736ccae817e) Once again, using the rtree to calculate document bounds is much faster

I've also added to the visual debug mode a way to see the envelope of the whole rtree (marked by orange bounds)