### PR TITLE
Xopp text import

### DIFF
--- a/crates/rnote-engine/src/engine/snapshot.rs
+++ b/crates/rnote-engine/src/engine/snapshot.rs
@@ -183,6 +183,20 @@ impl EngineSnapshot {
                                 }
                             }
                         }
+
+                        for new_xopptext in layers.texts.into_iter() {
+                            match Stroke::from_xopptext(new_xopptext, offset, xopp_import_prefs.dpi)
+                            {
+                                Ok(new_text) => {
+                                    engine.store.insert_stroke(new_text, None);
+                                }
+                                Err(e) => {
+                                    error!(
+                                        "Creating Stroke from XoppText failed while loading Xopp bytes, Err: {e:?}",
+                                    );
+                                }
+                            }
+                        }
                     }
 
                     // Only add to y offset, results in vertical pages

--- a/crates/rnote-engine/src/strokes/stroke.rs
+++ b/crates/rnote-engine/src/strokes/stroke.rs
@@ -520,6 +520,12 @@ impl Stroke {
                 ))
             }
             Stroke::ShapeStroke(shapestroke) => {
+                // Remark
+                // We can transform shapes to a xopp brushstroke
+                // under the following conditions
+                // - if the stroke color is not none
+                // - if the fill color is transparent
+                // - if the style is not rough
                 let png_data = match shapestroke.export_to_bitmap_image_bytes(
                     image::ImageFormat::Png,
                     Engine::STROKE_EXPORT_IMAGE_SCALE,
@@ -564,6 +570,14 @@ impl Stroke {
             Stroke::TextStroke(textstroke) => {
                 // Xournal++ text strokes do not support affine transformations, so we have to convert on best effort here.
                 // The best solution for now seems to be to export them as a bitmap image.
+                //
+                // We _could_ try to retain the text more but
+                // the hard part is a xopp text element is
+                // - a single font
+                // - a single emphasis mode (bold,italic ...) on all text
+                // - a single color
+                // So we'd have to cut the text into smaller xopp text elements
+                // to retain it ...
                 let png_data = match textstroke.export_to_bitmap_image_bytes(
                     image::ImageFormat::Png,
                     Engine::STROKE_EXPORT_IMAGE_SCALE,
@@ -606,6 +620,7 @@ impl Stroke {
                 ))
             }
             Stroke::VectorImage(vectorimage) => {
+                // no svg support in xournalpp
                 let png_data = match vectorimage.export_to_bitmap_image_bytes(
                     image::ImageFormat::Png,
                     Engine::STROKE_EXPORT_IMAGE_SCALE,


### PR DESCRIPTION
Text import from xournal files.

Now the actual text is a little bit larger in rnote. Should I increase the font weight to compensate ? Or maybe it is spaces that are larger ?

<img width="2409" height="447" alt="image" src="https://github.com/user-attachments/assets/6120d754-54bc-4139-9588-2f30dc67a058" />

Also added some notes for the export.

From #1320 there's a way to retain shapes by converting them to brushstrokes, but under some conditions. Maybe I can add a `can_convert_to_brush` method to test these conditions and create a common code path for both conversions ?