### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/crates/rnote-engine/src/drawable.rs
+++ b/crates/rnote-engine/src/drawable.rs
@@ -7,7 +7,7 @@ use piet::RenderContext;
 pub trait Drawable {
     /// Draw itself.
     ///
-    /// The implementors are expected to save/restore the drawing context.
+    /// The implementers are expected to save/restore the drawing context.
     ///
     /// `image_scale` is the scale-factor of generated images within the type.
     /// The content should not be zoomed by it!
@@ -30,7 +30,7 @@ pub trait DrawableOnDoc {
 
     /// Draw itself on the document.
     ///
-    /// The implementors are expected to save/restore the drawing context.
+    /// The implementers are expected to save/restore the drawing context.
     fn draw_on_doc(
         &self,
         cx: &mut piet_cairo::CairoRenderContext,

--- a/crates/rnote-engine/src/strokes/content.rs
+++ b/crates/rnote-engine/src/strokes/content.rs
@@ -7,7 +7,7 @@ use rnote_compose::{color, shapes::Shapeable};
 #[derive(Debug, Clone)]
 /// Generated content images.
 ///
-/// Some `Content` trait implementors only support generating image(s) for the entire content (Full).
+/// Some `Content` trait implementers only support generating image(s) for the entire content (Full).
 pub enum GeneratedContentImages {
     /// Only part of the content was rendered (for example when part of it is out of the current viewport).
     Partial {
@@ -71,7 +71,7 @@ where
 
     /// Draw the content highlight. Used when indicating a selection.
     ///
-    /// The implementors are expected to save/restore the drawing context.
+    /// The implementers are expected to save/restore the drawing context.
     ///
     /// `total_zoom` is the zoom-factor of the surface that the highlight gets drawn on.
     fn draw_highlight(

--- a/crates/rnote-engine/src/strokes/textstroke.rs
+++ b/crates/rnote-engine/src/strokes/textstroke.rs
@@ -885,12 +885,12 @@ impl TextStroke {
     }
 
     pub fn move_cursor_back(&self, cursor: &mut GraphemeCursor) {
-        // Cant fail, we are providing the entire text
+        // Can't fail, we are providing the entire text
         cursor.prev_boundary(&self.text, 0).unwrap();
     }
 
     pub fn move_cursor_forward(&self, cursor: &mut GraphemeCursor) {
-        // Cant fail, we are providing the entire text
+        // Can't fail, we are providing the entire text
         cursor.next_boundary(&self.text, 0).unwrap();
     }
 

--- a/crates/rnote-engine/src/strokes/vectorimage.rs
+++ b/crates/rnote-engine/src/strokes/vectorimage.rs
@@ -171,7 +171,7 @@ impl VectorImage {
         let mut transform = Transform::default();
         let rectangle = match size_option {
             ImageSizeOption::RespectOriginalSize => {
-                // Size not given : use the intrisic size
+                // Size not given : use the intrinsic size
                 transform.append_translation_mut(pos + intrinsic_size * 0.5);
                 Rectangle {
                     cuboid: p2d::shape::Cuboid::new(intrinsic_size * 0.5),

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -611,7 +611,7 @@ impl RnAppWindow {
                             {
                                 (true, self.new_canvas_wrapper())
                             }
-                            // Re-use the existing empty tab otherwise
+                            // Reuse the existing empty tab otherwise
                             (true, Some(active_wrapper)) => (false, active_wrapper),
                             (false, None) => (true, self.new_canvas_wrapper()),
                             (false, Some(active_wrapper)) => (false, active_wrapper),

--- a/crates/rnote-ui/src/workspacebrowser/workspaceactions/createfolder.rs
+++ b/crates/rnote-ui/src/workspacebrowser/workspaceactions/createfolder.rs
@@ -65,7 +65,7 @@ pub(crate) fn create_folder(
                                 .overlays()
                                 .dispatch_toast_error("Can't create folder that already exists.");
                             debug!(
-                                "Couldn't create new folder wit name `{}`, it already exists.",
+                                "Couldn't create new folder with name `{}`, it already exists.",
                                 folder_name_entry.text().as_str()
                             );
                         } else {


### PR DESCRIPTION
% `codespell --skip="*.po" --write-changes`
* https://pypi.org/project/codespell