### PR TITLE
Fix: make pen sounds work on windows

### DIFF
--- a/build-aux/rnote_inno.iss.in
+++ b/build-aux/rnote_inno.iss.in
@@ -82,6 +82,7 @@ Source: "{#meson_source_root}\crates\rnote-engine\data\sounds\brush\*"; DestDir:
 Source: "{#meson_source_root}\crates\rnote-engine\data\sounds\marker\*"; DestDir: "{app}\share\rnote\sounds"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#meson_source_root}\crates\rnote-engine\data\sounds\originals\*"; DestDir: "{app}\share\rnote\sounds"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#meson_source_root}\crates\rnote-engine\data\sounds\typewriter\*"; DestDir: "{app}\share\rnote\sounds"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#meson_source_root}\crates\rnote-engine\data\sounds\LICENSES.md"; DestDir: "{app}\share\rnote\"; Flags: ignoreversion
 
 ; Binary
 Source: "{#meson_build_root}\{#MyAppExeName}"; DestDir: "{app}\bin\"; Flags: ignoreversion

--- a/build-aux/rnote_inno.iss.in
+++ b/build-aux/rnote_inno.iss.in
@@ -78,7 +78,11 @@ Source: "{#meson_source_root}\crates\rnote-engine\data\fonts\OpenDyslexic-Regula
 Source: "{#meson_source_root}\crates\rnote-engine\data\fonts\TT2020Base-Regular.ttf"; DestDir: "{autofonts}"; FontInstall: "TT2020Base"; Flags: onlyifdoesntexist uninsneveruninstall
 Source: "{#meson_source_root}\crates\rnote-engine\data\fonts\Virgil.ttf"; DestDir: "{autofonts}"; FontInstall: "Virgil"; Flags: onlyifdoesntexist uninsneveruninstall
 ; Data that is installed to pkg-data-dir
-Source: "{#meson_source_root}\crates\rnote-engine\data\sounds\*"; DestDir: "{app}\share\rnote\sounds"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#meson_source_root}\crates\rnote-engine\data\sounds\brush\*"; DestDir: "{app}\share\rnote\sounds"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#meson_source_root}\crates\rnote-engine\data\sounds\marker\*"; DestDir: "{app}\share\rnote\sounds"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#meson_source_root}\crates\rnote-engine\data\sounds\originals\*"; DestDir: "{app}\share\rnote\sounds"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#meson_source_root}\crates\rnote-engine\data\sounds\typewriter\*"; DestDir: "{app}\share\rnote\sounds"; Flags: ignoreversion recursesubdirs createallsubdirs
+
 ; Binary
 Source: "{#meson_build_root}\{#MyAppExeName}"; DestDir: "{app}\bin\"; Flags: ignoreversion
 


### PR DESCRIPTION
Make pen sounds work on windows by changing the inno file because the data structure wasn't the one expected in the code.

This was the reason for lag on windows with the sounds activated (which would repeatedly try to setup the pen sounds handlers and fail on a tool change).

Fixes #1523