### PR TITLE
Add a `WindowGroup` for each `appwindow`

### DIFF
--- a/crates/rnote-ui/src/app/mod.rs
+++ b/crates/rnote-ui/src/app/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     workspacebrowser::RnWorkspacesBar, workspacebrowser::workspacesbar::RnWorkspaceRow,
 };
 use adw::subclass::prelude::AdwApplicationImpl;
-use gtk4::{gio, glib, glib::clone, prelude::*, subclass::prelude::*};
+use gtk4::{WindowGroup, gio, glib, glib::clone, prelude::*, subclass::prelude::*};
 
 mod imp {
     use super::*;
@@ -133,6 +133,13 @@ mod imp {
         pub(crate) fn new_appwindow_init_show(&self, input_file: Option<gio::File>) {
             let appwindow = RnAppWindow::new(self.obj().upcast_ref::<gtk4::Application>());
             appwindow.init();
+            // create a window group for each app window
+            // to make modals only impact the current app
+            // window.
+            // See issue #1461
+            let window_group = WindowGroup::new();
+            window_group.add_window(&appwindow);
+
             appwindow.present();
 
             // Loading in input file in the first tab, if Some


### PR DESCRIPTION
This restricts the `modal` nature of dialogs to each `appwindow` instead of being applied to all instances of opened rnote windows. This would result in weird behavior (if a modal is opened in one instance, a new freshly launched instance would have all inputs frozen)

Fixes #1461