### PR TITLE
Corrections in the docs to prevent errors

### DIFF
--- a/misc/building/rnote-windows-build.md
+++ b/misc/building/rnote-windows-build.md
@@ -26,7 +26,7 @@ pacman -S --noconfirm \
 Add the Rust binary directory to the MSYS2 `PATH` by adding the following line to `~/.bashrc`.
 
 ```bash
-export PATH=$PATH:/c/Users/<user>/.cargo/bin
+export PATH="$PATH:/c/Users/<user>/.cargo/bin"
 ```
 
 If you installed Inno Setup, append `:/c/Program Files (x86)/Inno Setup 6` to the path as well.
@@ -45,6 +45,7 @@ Finally, clone the repository somewhere and initialize the submodules.
 
 ```bash
 git clone -c core.symlinks=true https://github.com/flxzt/rnote
+cd rnote/
 git submodule update --init --recursive
 ```
 


### PR DESCRIPTION
Small changes that help avoid confusion when following the instructions.
Quote marks are needed when specifying Inno Setup path because of the parenthesis.