### PR TITLE
fix: fix blocking on "open in default app" actions

### DIFF
--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -324,7 +324,7 @@ pub(crate) async fn dialog_export_doc_w_prefs(appwindow: &RnAppWindow, canvas: &
                             return;
                     };
 
-                    if let Err(e) = open::that(&folder_path_string) {
+                    if let Err(e) = open::that_detached(&folder_path_string) {
                         error!("Opening the parent folder '{folder_path_string}' in the file manager failed, Err: {e:?}");
                         appwindow.overlays().dispatch_toast_error(&gettext("Failed to view the file in the file manager"));
                     }
@@ -747,7 +747,7 @@ pub(crate) async fn dialog_export_doc_pages_w_prefs(appwindow: &RnAppWindow, can
                         return;
                     };
 
-                    if let Err(e) = open::that(&folder_path_string) {
+                    if let Err(e) = open::that_detached(&folder_path_string) {
                         error!("Opening the parent folder '{folder_path_string}' in the file manager failed, Err: {e:?}");
                         appwindow.overlays().dispatch_toast_error(&gettext("Failed to view the file in the file manager"));
                     }
@@ -1112,7 +1112,7 @@ pub(crate) async fn dialog_export_selection_w_prefs(appwindow: &RnAppWindow, can
                             return;
                     };
 
-                    if let Err(e) = open::that(&folder_path_string) {
+                    if let Err(e) = open::that_detached(&folder_path_string) {
                         error!("Opening the parent folder '{folder_path_string}' in the file manager failed, Err: {e:?}");
                         appwindow.overlays().dispatch_toast_error(&gettext("Failed to view the file in the file manager"));
                     }

--- a/crates/rnote-ui/src/workspacebrowser/filerow/actions/open_in_default_app.rs
+++ b/crates/rnote-ui/src/workspacebrowser/filerow/actions/open_in_default_app.rs
@@ -20,7 +20,7 @@ pub(crate) fn open_in_default_app(
             let Some(current_file) = filerow.current_file() else {
                 return;
             };
-            if let Err(e) = open::that(current_file.uri()) {
+            if let Err(e) = open::that_detached(current_file.uri()) {
                 appwindow
                     .overlays()
                     .dispatch_toast_error(&gettext("Open the file in the default app failed"));

--- a/crates/rnote-ui/src/workspacebrowser/workspaceactions/openfolder.rs
+++ b/crates/rnote-ui/src/workspacebrowser/workspaceactions/openfolder.rs
@@ -15,7 +15,7 @@ pub(crate) fn open_folder(
         appwindow,
         move |_, _| {
         if let Some(parent_path) = workspacebrowser.dir_list_file().and_then(|f| f.path()) {
-            if let Err(e) = open::that(&parent_path) {
+            if let Err(e) = open::that_detached(&parent_path) {
                 let path_string =   &parent_path.into_os_string().into_string().ok().unwrap_or(String::from("Failed to get the path of the workspace folder"));
                 tracing::error!("Opening the parent folder '{path_string}' in the file manager failed, Err: {e:?}");
                 appwindow.overlays().dispatch_toast_error(&gettext("Failed to open the file in the file manager"));


### PR DESCRIPTION
Rnote blocks while an app opened via "open in default app" or "open workspace folder" is running.

Replacing `open::that` with `open::that_detached` fixes this.