### PR TITLE
Changed accidental shortcut for clear-doc back to the original one

### DIFF
--- a/crates/rnote-ui/src/appwindow/actions.rs
+++ b/crates/rnote-ui/src/appwindow/actions.rs
@@ -1100,7 +1100,7 @@ impl RnAppWindow {
         app.set_accels_for_action("win.save-doc-as", &["<Ctrl><Shift>s"]);
         app.set_accels_for_action("win.new-tab", &["<Ctrl>t"]);
         app.set_accels_for_action("win.snap-positions", &["<Ctrl><Shift>p"]);
-        app.set_accels_for_action("win.clear-doc", &["<Ctrl><Shift>l"]);
+        app.set_accels_for_action("win.clear-doc", &["<Ctrl>l"]);
         app.set_accels_for_action("win.print-doc", &["<Ctrl>p"]);
         app.set_accels_for_action("win.add-page-to-doc", &["<Ctrl><Shift>a"]);
         app.set_accels_for_action("win.remove-page-from-doc", &["<Ctrl><Shift>r"]);


### PR DESCRIPTION
See commit: c7a85021147ba93bd96c5c4d7449f021772355d6