### PR TITLE
refactor: use `snapshot` for `RnColorSetter` and `RnColorPad` instead of css

### DIFF
--- a/crates/rnote-ui/data/ui/style.css
+++ b/crates/rnote-ui/data/ui/style.css
@@ -54,9 +54,6 @@
     padding: 0px;
     margin: 0px;
     background-blend-mode: screen;
-    background-image:
-        linear-gradient(45deg, #0f0f0f55 25%, transparent 25%, transparent 75%, #0f0f0f55 75%, #0f0f0f55),
-        linear-gradient(45deg, #0f0f0f55 25%, transparent 25%, transparent 75%, #0f0f0f55 75%, #0f0f0f55);
     background-color: @colorpad_color;
     color: @colorpad_fg_color;
     background-size: 18px 18px;

--- a/crates/rnote-ui/data/ui/style.css
+++ b/crates/rnote-ui/data/ui/style.css
@@ -88,26 +88,14 @@
     padding: 0px;
     margin: 0px;
     background-blend-mode: screen;
-    background-image:
-        linear-gradient(45deg, #0f0f0f55 25%, transparent 25%, transparent 75%, #0f0f0f55 75%, #0f0f0f55),
-        linear-gradient(45deg, #0f0f0f55 25%, transparent 25%, transparent 75%, #0f0f0f55 75%, #0f0f0f55);
-    background-color: @colorsetter_color;
     color: @colorsetter_fg_color;
     background-size: 18px 18px;
     background-position: 0px 0px, 9px 9px;
     border: 1px solid @borders;
-    filter: brightness(100%);
-    border-radius: 2px;
+    border-radius: 2px; 
     transition: all 0.15s ease-out;
 }
 
-.colorsetter:hover {
-    filter: brightness(93%);
-}
-
-.colorsetter:active {
-    filter: brightness(86%);
-}
 
 .colorsetter:checked {
     filter: brightness(100%);

--- a/crates/rnote-ui/data/ui/style.css
+++ b/crates/rnote-ui/data/ui/style.css
@@ -88,7 +88,7 @@
     color: @colorsetter_fg_color;
     background-size: 18px 18px;
     background-position: 0px 0px, 9px 9px;
-    border: 1px solid @borders;
+    border: 1px solid gray;
     border-radius: 2px; 
     transition: all 0.15s ease-out;
 }

--- a/crates/rnote-ui/src/colorpicker/colorpad.rs
+++ b/crates/rnote-ui/src/colorpicker/colorpad.rs
@@ -1,18 +1,34 @@
 // Imports
+use adw::prelude::AnimationExt;
 use gtk4::{
-    Align, Button, CssProvider, ToggleButton, Widget, gdk, glib, prelude::*, subclass::prelude::*,
+    Align, Button, CssProvider, ToggleButton, Widget, gdk, glib, glib::clone, graphene, prelude::*,
+    subclass::prelude::*,
 };
 use once_cell::sync::Lazy;
 use rnote_compose::{Color, color};
 use rnote_engine::ext::GdkRGBAExt;
-use std::cell::Cell;
+use std::cell::{Cell, OnceCell};
 
 mod imp {
+    const BOTTOM_BAR_PROPORTION: f32 = 0.15;
+    const BRIGHTNESS_HOVER: f32 = 0.93;
+    const BRIGHTNESS_ACTIVE: f32 = 0.86;
+    const REPEAT_RATIO: f32 = 1.8;
+    const OFFSET_RATIO: f32 = 0.0;
+    const ANIMATION_TIME_MS: u32 = 150;
+    // to keep synchronized with style.css.colorpad.border-radius
+    const BORDER_RADIUS: f32 = 4.0;
+
     use super::*;
 
     #[derive(Debug)]
     pub(crate) struct RnColorPad {
         pub(crate) color: Cell<gdk::RGBA>,
+        pub(crate) previous_color: Cell<gdk::RGBA>,
+        pub(super) animation_toggle_active: OnceCell<adw::TimedAnimation>,
+        pub(super) display_progress: Cell<f64>,
+        pub(super) animation_color_change: OnceCell<adw::TimedAnimation>,
+        pub(super) color_change_progress: Cell<f64>,
     }
 
     #[glib::object_subclass]
@@ -28,6 +44,13 @@ mod imp {
                 color: Cell::new(gdk::RGBA::from_compose_color(
                     super::RnColorPad::COLOR_DEFAULT,
                 )),
+                previous_color: Cell::new(gdk::RGBA::from_compose_color(
+                    super::RnColorPad::COLOR_DEFAULT,
+                )),
+                animation_toggle_active: OnceCell::new(),
+                display_progress: Cell::new(0.0),
+                animation_color_change: OnceCell::new(),
+                color_change_progress: Cell::new(0.0),
             }
         }
     }
@@ -46,6 +69,60 @@ mod imp {
             obj.set_css_classes(&["colorpad"]);
 
             self.update_appearance(super::RnColorPad::COLOR_DEFAULT);
+
+            let animation_target = adw::CallbackAnimationTarget::new(clone!(
+                #[weak]
+                obj,
+                move |value| {
+                    let imp = obj.imp();
+                    imp.display_progress.set(value);
+                    obj.queue_draw();
+                }
+            ));
+            let anim = adw::TimedAnimation::builder()
+                .widget(&*obj)
+                .duration(ANIMATION_TIME_MS)
+                .target(&animation_target)
+                .build();
+            anim.set_easing(adw::Easing::EaseInOutSine);
+            let _ = self.animation_toggle_active.set(anim);
+
+            obj.connect_toggled(clone!(
+                #[weak(rename_to=colorsetter)]
+                self,
+                move |button| {
+                    use adw::prelude::AnimationExt;
+                    if let Some(animation) = colorsetter.animation_toggle_active.get() {
+                        if button.is_active() {
+                            animation.set_value_from(0.0);
+                            animation.set_value_to(1.0);
+                        } else {
+                            animation.set_value_from(1.0);
+                            animation.set_value_to(0.0);
+                        }
+                        animation.play();
+                    }
+                }
+            ));
+
+            let animation_color_target = adw::CallbackAnimationTarget::new(clone!(
+                #[weak]
+                obj,
+                move |value| {
+                    let imp = obj.imp();
+                    imp.color_change_progress.set(value);
+                    obj.queue_draw();
+                }
+            ));
+            let anim_color_change = adw::TimedAnimation::builder()
+                .widget(&*obj)
+                .duration(ANIMATION_TIME_MS)
+                .target(&animation_color_target)
+                .build();
+            anim_color_change.set_easing(adw::Easing::EaseInOutSine);
+            anim_color_change.set_value_from(0.0);
+            anim_color_change.set_value_to(1.0);
+            let _ = self.animation_color_change.set(anim_color_change);
         }
 
         fn properties() -> &'static [glib::ParamSpec] {
@@ -60,9 +137,15 @@ mod imp {
                     let color = value
                         .get::<gdk::RGBA>()
                         .expect("value not of type `gdk::RGBA`");
+                    self.previous_color.set(self.color.get());
                     self.color.set(color);
 
+                    // trigger the color change animation
+                    if let Some(animation_color) = self.animation_color_change.get() {
+                        animation_color.play();
+                    }
                     self.update_appearance(color.into_compose_color());
+                    self.obj().queue_draw();
                 }
                 _ => panic!("invalid property name"),
             }
@@ -76,15 +159,157 @@ mod imp {
         }
     }
 
-    impl WidgetImpl for RnColorPad {}
+    impl WidgetImpl for RnColorPad {
+        fn snapshot(&self, snapshot: &gtk4::Snapshot) {
+            snapshot.save();
+
+            let width = self.obj().width();
+            let height = self.obj().height();
+
+            let bounds = graphene::Rect::new(0.0, 0.0, width as f32, height as f32);
+            let bounds_clipped = gtk4::gsk::RoundedRect::new(
+                bounds,
+                graphene::Size::new(BORDER_RADIUS, BORDER_RADIUS),
+                graphene::Size::new(BORDER_RADIUS, BORDER_RADIUS),
+                graphene::Size::new(BORDER_RADIUS, BORDER_RADIUS),
+                graphene::Size::new(BORDER_RADIUS, BORDER_RADIUS),
+            );
+            snapshot.push_rounded_clip(&bounds_clipped);
+
+            let previous_color = self.previous_color.get();
+            let next_color = self.color.get();
+            let progress = self.color_change_progress.get() as f32;
+
+            let colorpad_color = self.color.get();
+
+            let mut color = gdk::RGBA::new(
+                progress * next_color.red() + (1.0 - progress) * previous_color.red(),
+                progress * next_color.green() + (1.0 - progress) * previous_color.green(),
+                progress * next_color.blue() + (1.0 - progress) * previous_color.blue(),
+                progress * next_color.alpha() + (1.0 - progress) * previous_color.alpha(),
+            );
+
+            if colorpad_color.alpha() != 0.0 {
+                if self
+                    .obj()
+                    .state_flags()
+                    .contains(gtk4::StateFlags::PRELIGHT)
+                {
+                    // colorsetter:hover
+                    color.set_red(color.red() * BRIGHTNESS_HOVER);
+                    color.set_green(color.green() * BRIGHTNESS_HOVER);
+                    color.set_blue(color.blue() * BRIGHTNESS_HOVER);
+                }
+                if self.obj().state_flags().contains(gtk4::StateFlags::ACTIVE)
+                    && !self.obj().is_active()
+                {
+                    // colorsetter:active
+                    color.set_red(color.red() * BRIGHTNESS_ACTIVE);
+                    color.set_green(color.green() * BRIGHTNESS_ACTIVE);
+                    color.set_blue(color.blue() * BRIGHTNESS_ACTIVE);
+                }
+            }
+            // background image (checkboard pattern)
+            if colorpad_color.alpha() != 1.0 {
+                let checkboard_bounds = graphene::Rect::new(
+                    OFFSET_RATIO * (width as f32),
+                    OFFSET_RATIO * (height as f32),
+                    width as f32 / (2.0 * REPEAT_RATIO),
+                    height as f32 / (2.0 * REPEAT_RATIO),
+                );
+                let checkboard_repeat = graphene::Rect::new(
+                    OFFSET_RATIO * (width as f32),
+                    OFFSET_RATIO * (height as f32),
+                    width as f32 / (REPEAT_RATIO),
+                    height as f32 / (REPEAT_RATIO),
+                );
+
+                snapshot.push_repeat(&bounds, Some(&checkboard_repeat));
+                snapshot.append_color(&gdk::RGBA::BLACK.with_alpha(0.75), &checkboard_bounds);
+                snapshot.append_color(
+                    &gdk::RGBA::BLACK.with_alpha(0.75),
+                    &checkboard_bounds.offset_r(
+                        width as f32 / (2.0 * REPEAT_RATIO),
+                        height as f32 / (2.0 * REPEAT_RATIO),
+                    ),
+                );
+
+                snapshot.pop();
+            }
+
+            snapshot.append_color(&color, &bounds);
+
+            // bottom bar
+            let current_foreground_color = if colorpad_color.alpha() == 0.0 {
+                // accessing colors through the style context is deprecated,
+                // but this needs new color API to fetch theme colors.
+                // TODO: where is this set ? any way around this ?
+                #[allow(deprecated)]
+                self.obj()
+                    .style_context()
+                    .lookup_color("window_fg_color")
+                    .unwrap_or(gdk::RGBA::BLACK)
+            } else if colorpad_color.into_compose_color().luma() < color::FG_LUMINANCE_THRESHOLD {
+                gdk::RGBA::WHITE
+            } else {
+                gdk::RGBA::BLACK
+            };
+            let foreground_color = if progress > 0.0 || progress < 1.0 {
+                let previous_foreground_color = if previous_color.alpha() == 0.0 {
+                    // accessing colors through the style context is deprecated,
+                    // but this needs new color API to fetch theme colors.
+                    // TODO: where is this set ? any way around this ?
+                    #[allow(deprecated)]
+                    self.obj()
+                        .style_context()
+                        .lookup_color("window_fg_color")
+                        .unwrap_or(gdk::RGBA::BLACK)
+                } else if colorpad_color.into_compose_color().luma() < color::FG_LUMINANCE_THRESHOLD
+                {
+                    gdk::RGBA::WHITE
+                } else {
+                    gdk::RGBA::BLACK
+                };
+                gdk::RGBA::new(
+                    progress * current_foreground_color.red()
+                        + (1.0 - progress) * previous_foreground_color.red(),
+                    progress * current_foreground_color.green()
+                        + (1.0 - progress) * previous_foreground_color.green(),
+                    progress * current_foreground_color.blue()
+                        + (1.0 - progress) * previous_foreground_color.blue(),
+                    progress * current_foreground_color.alpha()
+                        + (1.0 - progress) * previous_foreground_color.alpha(),
+                )
+            } else {
+                current_foreground_color
+            };
+
+            let bounds_active = graphene::Rect::new(
+                0.0,
+                (1.0 - BOTTOM_BAR_PROPORTION * (self.display_progress.get() as f32))
+                    * (height as f32),
+                width as f32,
+                BOTTOM_BAR_PROPORTION * (self.display_progress.get() as f32) * (height as f32),
+            );
+            snapshot.append_color(&foreground_color, &bounds_active);
+            snapshot.pop();
+
+            snapshot.restore();
+
+            // 2. Default button rendering (icon/text) on top
+            self.parent_snapshot(snapshot);
+
+            self.obj().queue_draw();
+        }
+    }
     impl ButtonImpl for RnColorPad {}
     impl ToggleButtonImpl for RnColorPad {}
 
     impl RnColorPad {
         fn update_appearance(&self, color: Color) {
+            // we still rely on the CSS to switch the icon light/dark mode
             let css = CssProvider::new();
 
-            let colorpad_color = color.to_css_color_attr();
             let colorpad_fg_color = if color.a == 0.0 {
                 String::from("@window_fg_color")
             } else if color.luma() < color::FG_LUMINANCE_THRESHOLD {
@@ -93,9 +318,7 @@ mod imp {
                 String::from("@dark_5")
             };
 
-            let custom_css = format!(
-                "@define-color colorpad_color {colorpad_color}; @define-color colorpad_fg_color {colorpad_fg_color};",
-            );
+            let custom_css = format!("@define-color colorpad_fg_color {colorpad_fg_color};",);
             css.load_from_string(&custom_css);
 
             // adding custom css is deprecated.

--- a/crates/rnote-ui/src/colorpicker/colorpad.rs
+++ b/crates/rnote-ui/src/colorpicker/colorpad.rs
@@ -241,14 +241,9 @@ mod imp {
 
             // bottom bar
             let current_foreground_color = if colorpad_color.alpha() == 0.0 {
-                // accessing colors through the style context is deprecated,
-                // but this needs new color API to fetch theme colors.
-                // TODO: where is this set ? any way around this ?
-                #[allow(deprecated)]
-                self.obj()
-                    .style_context()
-                    .lookup_color("window_fg_color")
-                    .unwrap_or(gdk::RGBA::BLACK)
+                // see https://gtk-rs.org/gtk4-rs/stable/latest/docs/gtk4/prelude/trait.WidgetExt.html#method.color
+                // Returns the foreground color for custom snapshot implementation
+                WidgetExt::color(&self.obj().clone().upcast::<Widget>())
             } else if colorpad_color.into_compose_color().luma() < color::FG_LUMINANCE_THRESHOLD {
                 gdk::RGBA::WHITE
             } else {
@@ -256,14 +251,7 @@ mod imp {
             };
             let foreground_color = if progress > 0.0 || progress < 1.0 {
                 let previous_foreground_color = if previous_color.alpha() == 0.0 {
-                    // accessing colors through the style context is deprecated,
-                    // but this needs new color API to fetch theme colors.
-                    // TODO: where is this set ? any way around this ?
-                    #[allow(deprecated)]
-                    self.obj()
-                        .style_context()
-                        .lookup_color("window_fg_color")
-                        .unwrap_or(gdk::RGBA::BLACK)
+                    WidgetExt::color(&self.obj().clone().upcast::<Widget>())
                 } else if colorpad_color.into_compose_color().luma() < color::FG_LUMINANCE_THRESHOLD
                 {
                     gdk::RGBA::WHITE

--- a/crates/rnote-ui/src/colorpicker/colorpad.rs
+++ b/crates/rnote-ui/src/colorpicker/colorpad.rs
@@ -16,8 +16,8 @@ mod imp {
     const REPEAT_RATIO: f32 = 1.8;
     const OFFSET_RATIO: f32 = 0.0;
     const ANIMATION_TIME_MS: u32 = 150;
-    // to keep synchronized with style.css.colorpad.border-radius
-    const BORDER_RADIUS: f32 = 4.0;
+    // to keep synchronized with style.css.colorpad.border-radius -1 
+    const BORDER_RADIUS: f32 = 3.0;
 
     use super::*;
 

--- a/crates/rnote-ui/src/colorpicker/colorpad.rs
+++ b/crates/rnote-ui/src/colorpicker/colorpad.rs
@@ -225,9 +225,15 @@ mod imp {
                 );
 
                 snapshot.push_repeat(&bounds, Some(&checkboard_repeat));
-                snapshot.append_color(&gdk::RGBA::BLACK.with_alpha(0.75), &checkboard_bounds);
+
+                let checkboard_color = if adw::StyleManager::default().is_dark() {
+                    gdk::RGBA::BLACK.with_alpha(0.75)
+                } else {
+                    gdk::RGBA::BLACK.with_alpha(0.25)
+                };
+                snapshot.append_color(&checkboard_color, &checkboard_bounds);
                 snapshot.append_color(
-                    &gdk::RGBA::BLACK.with_alpha(0.75),
+                    &checkboard_color,
                     &checkboard_bounds.offset_r(
                         width as f32 / (2.0 * REPEAT_RATIO),
                         height as f32 / (2.0 * REPEAT_RATIO),

--- a/crates/rnote-ui/src/colorpicker/colorsetter.rs
+++ b/crates/rnote-ui/src/colorpicker/colorsetter.rs
@@ -14,6 +14,7 @@ mod imp {
     const BRIGHTNESS_ACTIVE: f32 = 0.86;
     const REPEAT_RATIO: f32 = 1.8;
     const OFFSET_RATIO: f32 = 0.0;
+    const ANIMATION_TIME_MS: u32 = 150;
 
     use super::*;
 
@@ -69,26 +70,27 @@ mod imp {
             ));
             let anim = adw::TimedAnimation::builder()
                 .widget(&*obj)
-                .duration(200)
+                .duration(ANIMATION_TIME_MS)
                 .target(&animation_target)
                 .build();
             anim.set_easing(adw::Easing::EaseInOutSine);
-            self.animation.set(anim).unwrap();
+            let _ = self.animation.set(anim);
 
             obj.connect_toggled(clone!(
                 #[weak(rename_to=colorsetter)]
                 self,
                 move |button| {
                     use adw::prelude::AnimationExt;
-                    let animation = colorsetter.animation.get().unwrap();
-                    if button.is_active() {
-                        animation.set_value_from(0.0);
-                        animation.set_value_to(1.0);
-                    } else {
-                        animation.set_value_from(1.0);
-                        animation.set_value_to(0.0);
+                    if let Some(animation) = colorsetter.animation.get() {
+                        if button.is_active() {
+                            animation.set_value_from(0.0);
+                            animation.set_value_to(1.0);
+                        } else {
+                            animation.set_value_from(1.0);
+                            animation.set_value_to(0.0);
+                        }
+                        animation.play();
                     }
-                    animation.play();
                 }
             ));
 

--- a/crates/rnote-ui/src/colorpicker/colorsetter.rs
+++ b/crates/rnote-ui/src/colorpicker/colorsetter.rs
@@ -1,7 +1,7 @@
 // Imports
 use gtk4::{
-    Align, Button, PositionType, ToggleButton, Widget, gdk, glib, prelude::*, subclass::prelude::*,
-    glib::clone, graphene
+    Align, Button, PositionType, ToggleButton, Widget, gdk, glib, glib::clone, graphene,
+    prelude::*, subclass::prelude::*,
 };
 use once_cell::sync::Lazy;
 use rnote_compose::{Color, color};

--- a/crates/rnote-ui/src/colorpicker/colorsetter.rs
+++ b/crates/rnote-ui/src/colorpicker/colorsetter.rs
@@ -15,6 +15,7 @@ mod imp {
     const REPEAT_RATIO: f32 = 1.8;
     const OFFSET_RATIO: f32 = 0.0;
     const ANIMATION_TIME_MS: u32 = 150;
+    const BORDER_SIZE: f32 = 0.5;
 
     use super::*;
 
@@ -226,6 +227,25 @@ mod imp {
                 BOTTOM_BAR_PROPORTION * (self.display_progress.get() as f32) * (height as f32),
             );
             snapshot.append_color(&foreground_color, &bounds_active);
+
+            // gray borders for visibility
+            let border_bounds = gtk4::gsk::RoundedRect::new(
+                bounds,
+                graphene::Size::zero(),
+                graphene::Size::zero(),
+                graphene::Size::zero(),
+                graphene::Size::zero(),
+            );
+            snapshot.append_border(
+                &border_bounds,
+                &[BORDER_SIZE, BORDER_SIZE, BORDER_SIZE, BORDER_SIZE],
+                &[
+                    gdk::RGBA::BLACK,
+                    gdk::RGBA::BLACK,
+                    gdk::RGBA::BLACK,
+                    gdk::RGBA::BLACK,
+                ],
+            );
 
             self.obj().queue_draw();
         }

--- a/crates/rnote-ui/src/colorpicker/colorsetter.rs
+++ b/crates/rnote-ui/src/colorpicker/colorsetter.rs
@@ -95,6 +95,15 @@ mod imp {
                 }
             ));
 
+            adw::StyleManager::default().connect_dark_notify(clone!(
+                #[weak]
+                obj,
+                move |_| {
+                    // force a redraw when the light/dark mode changes
+                    obj.queue_draw();
+                }
+            ));
+
             obj.queue_draw();
         }
 

--- a/crates/rnote-ui/src/colorpicker/colorsetter.rs
+++ b/crates/rnote-ui/src/colorpicker/colorsetter.rs
@@ -188,10 +188,15 @@ mod imp {
                     height as f32 / (REPEAT_RATIO),
                 );
 
+                let checkboard_color = if adw::StyleManager::default().is_dark() {
+                    gdk::RGBA::BLACK.with_alpha(0.75)
+                } else {
+                    gdk::RGBA::BLACK.with_alpha(0.25)
+                };
                 snapshot.push_repeat(&bounds, Some(&checkboard_repeat));
-                snapshot.append_color(&gdk::RGBA::BLACK.with_alpha(0.75), &checkboard_bounds);
+                snapshot.append_color(&checkboard_color, &checkboard_bounds);
                 snapshot.append_color(
-                    &gdk::RGBA::BLACK.with_alpha(0.75),
+                    &checkboard_color,
                     &checkboard_bounds.offset_r(
                         width as f32 / (2.0 * REPEAT_RATIO),
                         height as f32 / (2.0 * REPEAT_RATIO),

--- a/crates/rnote-ui/src/colorpicker/colorsetter.rs
+++ b/crates/rnote-ui/src/colorpicker/colorsetter.rs
@@ -15,7 +15,6 @@ mod imp {
     const REPEAT_RATIO: f32 = 1.8;
     const OFFSET_RATIO: f32 = 0.0;
     const ANIMATION_TIME_MS: u32 = 150;
-    const BORDER_SIZE: f32 = 0.5;
 
     use super::*;
 
@@ -241,26 +240,7 @@ mod imp {
                 BOTTOM_BAR_PROPORTION * (self.display_progress.get() as f32) * (height as f32),
             );
             snapshot.append_color(&foreground_color, &bounds_active);
-
-            // gray borders for visibility
-            let border_bounds = gtk4::gsk::RoundedRect::new(
-                bounds,
-                graphene::Size::zero(),
-                graphene::Size::zero(),
-                graphene::Size::zero(),
-                graphene::Size::zero(),
-            );
-            snapshot.append_border(
-                &border_bounds,
-                &[BORDER_SIZE, BORDER_SIZE, BORDER_SIZE, BORDER_SIZE],
-                &[
-                    gdk::RGBA::BLACK,
-                    gdk::RGBA::BLACK,
-                    gdk::RGBA::BLACK,
-                    gdk::RGBA::BLACK,
-                ],
-            );
-
+            
             self.obj().queue_draw();
         }
     }

--- a/crates/rnote-ui/src/colorpicker/colorsetter.rs
+++ b/crates/rnote-ui/src/colorpicker/colorsetter.rs
@@ -218,14 +218,7 @@ mod imp {
 
             // bottom bar
             let foreground_color = if color_stroke.alpha() == 0.0 {
-                // accessing colors through the style context is deprecated,
-                // but this needs new color API to fetch theme colors.
-                // TODO: where is this set ? any way around this ?
-                #[allow(deprecated)]
-                self.obj()
-                    .style_context()
-                    .lookup_color("window_fg_color")
-                    .unwrap_or(gdk::RGBA::BLACK)
+                WidgetExt::color(&self.obj().clone().upcast::<Widget>())
             } else if color_stroke.into_compose_color().luma() < color::FG_LUMINANCE_THRESHOLD {
                 gdk::RGBA::WHITE
             } else {

--- a/crates/rnote-ui/src/colorpicker/colorsetter.rs
+++ b/crates/rnote-ui/src/colorpicker/colorsetter.rs
@@ -15,6 +15,8 @@ mod imp {
     const REPEAT_RATIO: f32 = 1.8;
     const OFFSET_RATIO: f32 = 0.0;
     const ANIMATION_TIME_MS: u32 = 150;
+    // to keep synchronized with style.css.colorsetter.border-radius -1 
+    const BORDER_RADIUS: f32 = 1.0;
 
     use super::*;
 
@@ -156,6 +158,14 @@ mod imp {
             let height = self.obj().height();
 
             let bounds = graphene::Rect::new(0.0, 0.0, width as f32, height as f32);
+            let bounds_clipped = gtk4::gsk::RoundedRect::new(
+                bounds,
+                graphene::Size::new(BORDER_RADIUS, BORDER_RADIUS),
+                graphene::Size::new(BORDER_RADIUS, BORDER_RADIUS),
+                graphene::Size::new(BORDER_RADIUS, BORDER_RADIUS),
+                graphene::Size::new(BORDER_RADIUS, BORDER_RADIUS),
+            );
+            snapshot.push_rounded_clip(&bounds_clipped);
 
             let color_stroke = self.color.get();
             let mut color = self.color.get().clone();
@@ -233,7 +243,8 @@ mod imp {
                 BOTTOM_BAR_PROPORTION * (self.display_progress.get() as f32) * (height as f32),
             );
             snapshot.append_color(&foreground_color, &bounds_active);
-            
+            snapshot.pop();
+
             self.obj().queue_draw();
         }
     }


### PR DESCRIPTION

![Screencast_20260120_202024](https://github.com/user-attachments/assets/1defa3e0-c6e1-43c9-b0c2-a184ea916250)


Uses only `snapshot` to render the colorsetter (or at least reduces the amount of css and makes the color render through a `snapshot` call, not a css color variable)

The animation is implemented with a `TimedAnimation`

For the colorpad, there is still some `css` left because of the icon light/dark mode switch (that I don't really know how to toggle programatically here)