### PR TITLE
fix: rnote thumbnailer execution

### DIFF
--- a/crates/rnote-ui/data/rnote.thumbnailer
+++ b/crates/rnote-ui/data/rnote.thumbnailer
@@ -1,4 +1,4 @@
 [Thumbnailer Entry]
-TryExec=rnote-cli thumbnail
+TryExec=rnote-cli
 Exec=rnote-cli thumbnail %i %o -s %s
 MimeType=application/rnote


### PR DESCRIPTION
The TryExec statement attempts to execute a command
to quickly see if the thumbnailer is present.
Only passing rnote-cli without a argument is enough to check
whether the CLI is available and able to generate thumbnails.