### PR TITLE
feat: UI redesign

### DIFF
--- a/crates/rnote-compose/src/style/indicators.rs
+++ b/crates/rnote-compose/src/style/indicators.rs
@@ -229,6 +229,49 @@ pub fn draw_circular_node(
     }
 }
 
+/// Draw a circular delete node.
+pub fn draw_circular_delete_node(
+    cx: &mut impl RenderContext,
+    node_state: PenState,
+    bounding_sphere: BoundingSphere,
+    zoom: f64,
+) {
+    const OUTLINE_COLOR: piet::Color = color::GNOME_REDS[4];
+    const FILL_STATE_PROXIMITY: piet::Color = color::GNOME_REDS[0].with_a8(77);
+    const FILL_STATE_DOWN: piet::Color = color::GNOME_REDS[2].with_a8(128);
+
+    let circular_node = circular_node_shape(node_state, bounding_sphere, zoom);
+
+    match node_state {
+        PenState::Up => {}
+        PenState::Proximity => {
+            cx.fill(circular_node.clone(), &FILL_STATE_PROXIMITY);
+        }
+        PenState::Down => {
+            cx.fill(circular_node.clone(), &FILL_STATE_DOWN);
+        }
+    }
+
+    cx.stroke(
+        circular_node,
+        &OUTLINE_COLOR,
+        CIRCULAR_NODE_OUTLINE_WIDTH / zoom,
+    );
+
+    // Draw "X" icon
+    let center = bounding_sphere.center().coords;
+    let half = bounding_sphere.radius() * 0.45; // size of X relative to node radius
+    let x_stroke_width = (CIRCULAR_NODE_OUTLINE_WIDTH * 0.9) / zoom;
+
+    let mut x_path = kurbo::BezPath::new();
+    x_path.move_to((center + na::vector![-half, -half]).to_kurbo_point());
+    x_path.line_to((center + na::vector![ half,  half]).to_kurbo_point());
+    x_path.move_to((center + na::vector![-half,  half]).to_kurbo_point());
+    x_path.line_to((center + na::vector![ half, -half]).to_kurbo_point());
+
+    cx.stroke(x_path, &OUTLINE_COLOR, x_stroke_width);
+}
+
 // Triangular down node
 
 /// Triangular node outline width.

--- a/crates/rnote-engine/src/pens/selector/mod.rs
+++ b/crates/rnote-engine/src/pens/selector/mod.rs
@@ -36,6 +36,7 @@ pub(super) enum ResizeCorner {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(super) enum ModifyState {
     Idle,
+    Delete,
     Translate {
         start_pos: na::Vector2<f64>,
         current_pos: na::Vector2<f64>,
@@ -539,6 +540,15 @@ impl Selector {
         BoundingSphere::new(pos, Self::ROTATE_NODE_DIAMETER * 0.5 / total_zoom)
     }
 
+    fn delete_node_sphere(selection_bounds: Aabb, camera: &Camera) -> BoundingSphere {
+        let total_zoom = camera.total_zoom();
+        let pos = na::point![
+            (selection_bounds.maxs[0] + selection_bounds.mins[0]) * 0.5,
+            selection_bounds.mins[1] - Self::RESIZE_NODE_SIZE[1] / (2.0 * total_zoom)
+        ];
+        BoundingSphere::new(pos, Self::ROTATE_NODE_DIAMETER * 0.5 / total_zoom)
+    }
+
     fn draw_selection_overlay(
         piet_cx: &mut impl RenderContext,
         selection_bounds: Aabb,
@@ -554,6 +564,19 @@ impl Selector {
             PenState::Down
         } else if let Some(pos) = pos {
             if rotate_node_sphere.contains_local_point(&pos.into()) {
+                PenState::Proximity
+            } else {
+                PenState::Up
+            }
+        } else {
+            PenState::Up
+        };
+
+        let delete_node_sphere = Self::delete_node_sphere(selection_bounds, camera);
+        let delete_node_state = if matches!(modify_state, ModifyState::Delete) {
+            PenState::Down
+        } else if let Some(pos) = pos {
+            if delete_node_sphere.contains_local_point(&pos.into()) {
                 PenState::Proximity
             } else {
                 PenState::Up
@@ -710,6 +733,14 @@ impl Selector {
 
         // Rotate Node
         indicators::draw_circular_node(piet_cx, rotate_node_state, rotate_node_sphere, total_zoom);
+
+        // Delete Node
+        indicators::draw_circular_delete_node(
+            piet_cx,
+            delete_node_state,
+            delete_node_sphere,
+            total_zoom,
+        );
 
         // Resize Nodes
         indicators::draw_rectangular_node(

--- a/crates/rnote-engine/src/pens/selector/penevents.rs
+++ b/crates/rnote-engine/src/pens/selector/penevents.rs
@@ -103,6 +103,10 @@ impl Selector {
                             {
                                 *selection_bounds = new_bounds;
                             }
+                        } else if Self::delete_node_sphere(*selection_bounds, engine_view.camera)
+                            .contains_local_point(&element.pos.into())
+                        {
+                            *modify_state = ModifyState::Delete;
                         } else if Self::rotate_node_sphere(*selection_bounds, engine_view.camera)
                             .contains_local_point(&element.pos.into())
                         {
@@ -203,6 +207,9 @@ impl Selector {
 
                             progress = PenProgress::Finished;
                         }
+                    }
+                    ModifyState::Delete => {
+                        // nothing on repeated down/move while pressed; wait for Up to execute delete
                     }
                     ModifyState::Translate {
                         start_pos: _,
@@ -526,6 +533,20 @@ impl Selector {
 
                         widget_flags |= engine_view.store.record(Instant::now());
                         widget_flags.store_modified = true;
+                    }
+                    ModifyState::Delete => {
+                        engine_view.store.set_trashed_keys(selection, true);
+                        widget_flags |= super::cancel_selection(selection, engine_view);
+                        self.state = SelectorState::Idle;
+
+                        return (
+                            EventResult {
+                                handled: true,
+                                propagate: EventPropagation::Stop,
+                                progress: PenProgress::Finished,
+                            },
+                            widget_flags,
+                        );
                     }
                     _ => {}
                 }

--- a/crates/rnote-ui/data/ui/colorpicker.ui
+++ b/crates/rnote-ui/data/ui/colorpicker.ui
@@ -34,60 +34,55 @@
           </object>
         </child>
         <child>
-          <object class="GtkSeparator"></object>
-        </child>
-        <child>
-          <object class="GtkBox" id="setter_box">
-            <property name="orientation">horizontal</property>
-            <property name="homogeneous">true</property>
-            <property name="spacing">6</property>
+          <object class="GtkMenuButton" id="color_dropdown_button">
+            <property name="icon-name">pan-down-symbolic</property>
+            <property name="tooltip-text" translatable="yes">More Colors</property>
             <style>
-              <class name="linked" />
+              <class name="flat"/>
             </style>
-            <child>
-              <object class="RnColorSetter" id="setter_1">
+            <property name="popover">
+              <object class="GtkPopover" id="color_popover">
+                <child>
+                  <object class="GtkBox">
+                    <property name="orientation">horizontal</property>
+                    <property name="spacing">6</property>
+                    <property name="margin-top">6</property>
+                    <property name="margin-bottom">6</property>
+                    <property name="margin-start">6</property>
+                    <property name="margin-end">6</property>
+
+                    <child>
+                      <object class="GtkBox" id="setter_box">
+                        <property name="orientation">horizontal</property>
+                        <property name="homogeneous">true</property>
+                        <property name="spacing">6</property>
+                        <style>
+                          <class name="linked"/>
+                        </style>
+                        <child><object class="RnColorSetter" id="setter_1"/></child>
+                        <child><object class="RnColorSetter" id="setter_2"/></child>
+                        <child><object class="RnColorSetter" id="setter_3"/></child>
+                        <child><object class="RnColorSetter" id="setter_4"/></child>
+                        <child><object class="RnColorSetter" id="setter_5"/></child>
+                        <child><object class="RnColorSetter" id="setter_6"/></child>
+                        <child><object class="RnColorSetter" id="setter_7"/></child>
+                        <child><object class="RnColorSetter" id="setter_8"/></child>
+                        <child><object class="RnColorSetter" id="setter_9"/></child>
+                      </object>
+                    </child>
+
+                    <child>
+                      <object class="GtkButton" id="colordialog_button">
+                        <property name="icon-name">preferences-color-symbolic</property>
+                        <style>
+                          <class name="flat"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
-            </child>
-            <child>
-              <object class="RnColorSetter" id="setter_2">
-              </object>
-            </child>
-            <child>
-              <object class="RnColorSetter" id="setter_3">
-              </object>
-            </child>
-            <child>
-              <object class="RnColorSetter" id="setter_4">
-              </object>
-            </child>
-            <child>
-              <object class="RnColorSetter" id="setter_5">
-              </object>
-            </child>
-            <child>
-              <object class="RnColorSetter" id="setter_6">
-              </object>
-            </child>
-            <child>
-              <object class="RnColorSetter" id="setter_7">
-              </object>
-            </child>
-            <child>
-              <object class="RnColorSetter" id="setter_8">
-              </object>
-            </child>
-            <child>
-              <object class="RnColorSetter" id="setter_9">
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkButton" id="colordialog_button">
-            <property name="icon-name">preferences-color-symbolic</property>
-            <style>
-              <class name="flat" />
-            </style>
+            </property>
           </object>
         </child>
       </object>

--- a/crates/rnote-ui/data/ui/mainheader.ui
+++ b/crates/rnote-ui/data/ui/mainheader.ui
@@ -11,18 +11,18 @@
         <property name="vexpand">false</property>
         <property name="title-widget">
           <object class="GtkBox">
+            <property name="spacing">6</property>
             <child>
-              <object class="GtkLabel" id="main_title_unsaved_indicator">
-                <property name="label">•</property>
-                <property name="visible">false</property>
+              <object class="RnColorPicker" id="colorpicker">
+                <style>
+                  <class name="flat"/>
+                </style>
               </object>
             </child>
             <child>
-              <object class="AdwWindowTitle" id="main_title">
-                <property name="title" translatable="yes">New Document</property>
-                <property name="subtitle" translatable="yes">Draft</property>
+              <object class="RnPenPicker" id="penpicker">
                 <style>
-                  <class name="main_title" />
+                  <class name="flat"/>
                 </style>
               </object>
             </child>

--- a/crates/rnote-ui/data/ui/overlays.ui
+++ b/crates/rnote-ui/data/ui/overlays.ui
@@ -22,36 +22,6 @@
           </object>
         </child>
         <child type="overlay">
-          <object class="RnPenPicker" id="penpicker">
-            <property name="hexpand">false</property>
-            <property name="vexpand">false</property>
-            <property name="halign">center</property>
-            <property name="valign">end</property>
-            <property name="margin-top">6</property>
-            <property name="margin-bottom">18</property>
-            <property name="margin-start">6</property>
-            <property name="margin-end">6</property>
-            <style>
-              <class name="overlay_toolbar" />
-            </style>
-          </object>
-        </child>
-        <child type="overlay">
-          <object class="RnColorPicker" id="colorpicker">
-            <property name="hexpand">false</property>
-            <property name="vexpand">false</property>
-            <property name="halign">center</property>
-            <property name="valign">start</property>
-            <property name="margin-top">18</property>
-            <property name="margin-bottom">6</property>
-            <property name="margin-start">18</property>
-            <property name="margin-end">18</property>
-            <style>
-              <class name="overlay_toolbar" />
-            </style>
-          </object>
-        </child>
-        <child type="overlay">
           <object class="GtkBox" id="sidebar_box">
             <property name="hexpand">false</property>
             <property name="vexpand">false</property>

--- a/crates/rnote-ui/src/appwindow/appsettings.rs
+++ b/crates/rnote-ui/src/appwindow/appsettings.rs
@@ -156,7 +156,7 @@ impl RnAppWindow {
         app_settings
             .bind(
                 "active-stroke-color",
-                &self.overlays().colorpicker(),
+                &self.main_header().colorpicker(),
                 "stroke-color",
             )
             .mapping(gdk_color_mapping)
@@ -166,7 +166,7 @@ impl RnAppWindow {
         app_settings
             .bind(
                 "active-fill-color",
-                &self.overlays().colorpicker(),
+                &self.main_header().colorpicker(),
                 "fill-color",
             )
             .mapping(gdk_color_mapping)
@@ -176,7 +176,7 @@ impl RnAppWindow {
         app_settings
             .bind(
                 "colorpicker-color-1",
-                &self.overlays().colorpicker().setter_1(),
+                &self.main_header().colorpicker().setter_1(),
                 "color",
             )
             .mapping(gdk_color_mapping)
@@ -186,7 +186,7 @@ impl RnAppWindow {
         app_settings
             .bind(
                 "colorpicker-color-2",
-                &self.overlays().colorpicker().setter_2(),
+                &self.main_header().colorpicker().setter_2(),
                 "color",
             )
             .mapping(gdk_color_mapping)
@@ -196,7 +196,7 @@ impl RnAppWindow {
         app_settings
             .bind(
                 "colorpicker-color-3",
-                &self.overlays().colorpicker().setter_3(),
+                &self.main_header().colorpicker().setter_3(),
                 "color",
             )
             .mapping(gdk_color_mapping)
@@ -206,7 +206,7 @@ impl RnAppWindow {
         app_settings
             .bind(
                 "colorpicker-color-4",
-                &self.overlays().colorpicker().setter_4(),
+                &self.main_header().colorpicker().setter_4(),
                 "color",
             )
             .mapping(gdk_color_mapping)
@@ -216,7 +216,7 @@ impl RnAppWindow {
         app_settings
             .bind(
                 "colorpicker-color-5",
-                &self.overlays().colorpicker().setter_5(),
+                &self.main_header().colorpicker().setter_5(),
                 "color",
             )
             .mapping(gdk_color_mapping)
@@ -226,7 +226,7 @@ impl RnAppWindow {
         app_settings
             .bind(
                 "colorpicker-color-6",
-                &self.overlays().colorpicker().setter_6(),
+                &self.main_header().colorpicker().setter_6(),
                 "color",
             )
             .mapping(gdk_color_mapping)
@@ -236,7 +236,7 @@ impl RnAppWindow {
         app_settings
             .bind(
                 "colorpicker-color-7",
-                &self.overlays().colorpicker().setter_7(),
+                &self.main_header().colorpicker().setter_7(),
                 "color",
             )
             .mapping(gdk_color_mapping)
@@ -246,7 +246,7 @@ impl RnAppWindow {
         app_settings
             .bind(
                 "colorpicker-color-8",
-                &self.overlays().colorpicker().setter_8(),
+                &self.main_header().colorpicker().setter_8(),
                 "color",
             )
             .mapping(gdk_color_mapping)
@@ -256,7 +256,7 @@ impl RnAppWindow {
         app_settings
             .bind(
                 "colorpicker-color-9",
-                &self.overlays().colorpicker().setter_9(),
+                &self.main_header().colorpicker().setter_9(),
                 "color",
             )
             .mapping(gdk_color_mapping)

--- a/crates/rnote-ui/src/appwindow/imp.rs
+++ b/crates/rnote-ui/src/appwindow/imp.rs
@@ -294,8 +294,6 @@ impl ObjectImpl for RnAppWindow {
                 let focus_mode: bool = value.get().expect("The value needs to be of type `bool`");
                 self.focus_mode.replace(focus_mode);
 
-                self.overlays.penpicker().set_visible(!focus_mode);
-                self.overlays.colorpicker().set_visible(!focus_mode);
                 self.overlays.sidebar_box().set_visible(!focus_mode);
             }
             "devel-mode" => {

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -318,16 +318,16 @@ impl RnAppWindow {
             canvas.queue_resize();
         }
         if widget_flags.deselect_color_setters {
-            self.overlays().colorpicker().deselect_setters();
+            self.main_header().colorpicker().deselect_setters();
         }
         if let Some(hide_undo) = widget_flags.hide_undo {
-            self.overlays()
+            self.main_header()
                 .penpicker()
                 .undo_button()
                 .set_sensitive(!hide_undo);
         }
         if let Some(hide_redo) = widget_flags.hide_redo {
-            self.overlays()
+            self.main_header()
                 .penpicker()
                 .redo_button()
                 .set_sensitive(!hide_redo);
@@ -530,22 +530,6 @@ impl RnAppWindow {
         self.set_title(Some(
             &(title.clone() + " - " + config::APP_NAME_CAPITALIZED),
         ));
-
-        self.main_header()
-            .main_title_unsaved_indicator()
-            .set_visible(canvas.unsaved_changes());
-        if canvas.unsaved_changes() {
-            self.main_header()
-                .main_title()
-                .add_css_class("unsaved_changes");
-        } else {
-            self.main_header()
-                .main_title()
-                .remove_css_class("unsaved_changes");
-        }
-
-        self.main_header().main_title().set_title(&title);
-        self.main_header().main_title().set_subtitle(&subtitle);
     }
 
     /// Open the file, with import dialogs when appropriate.
@@ -726,11 +710,11 @@ impl RnAppWindow {
             let can_redo = canvas.engine_ref().can_redo();
             let visual_debug = self.engine_config().read().visual_debug;
 
-            self.overlays()
+            self.main_header()
                 .penpicker()
                 .undo_button()
                 .set_sensitive(can_undo);
-            self.overlays()
+            self.main_header()
                 .penpicker()
                 .redo_button()
                 .set_sensitive(can_redo);
@@ -745,7 +729,7 @@ impl RnAppWindow {
             // Current pen
             match pen_style {
                 PenStyle::Brush => {
-                    self.overlays().penpicker().brush_toggle().set_active(true);
+                    self.main_header().penpicker().brush_toggle().set_active(true);
                     self.overlays()
                         .penssidebar()
                         .sidebar_stack()
@@ -770,10 +754,10 @@ impl RnAppWindow {
                                 .marker_options
                                 .fill_color
                                 .unwrap_or(Color::TRANSPARENT);
-                            self.overlays()
+                            self.main_header()
                                 .colorpicker()
                                 .set_stroke_color(gdk::RGBA::from_compose_color(stroke_color));
-                            self.overlays()
+                            self.main_header()
                                 .colorpicker()
                                 .set_fill_color(gdk::RGBA::from_compose_color(fill_color));
                         }
@@ -794,10 +778,10 @@ impl RnAppWindow {
                                 .solid_options
                                 .fill_color
                                 .unwrap_or(Color::TRANSPARENT);
-                            self.overlays()
+                            self.main_header()
                                 .colorpicker()
                                 .set_stroke_color(gdk::RGBA::from_compose_color(stroke_color));
-                            self.overlays()
+                            self.main_header()
                                 .colorpicker()
                                 .set_fill_color(gdk::RGBA::from_compose_color(fill_color));
                         }
@@ -810,14 +794,14 @@ impl RnAppWindow {
                                 .textured_options
                                 .stroke_color
                                 .unwrap_or(Color::TRANSPARENT);
-                            self.overlays()
+                            self.main_header()
                                 .colorpicker()
                                 .set_stroke_color(gdk::RGBA::from_compose_color(stroke_color));
                         }
                     }
                 }
                 PenStyle::Shaper => {
-                    self.overlays().penpicker().shaper_toggle().set_active(true);
+                    self.main_header().penpicker().shaper_toggle().set_active(true);
                     self.overlays()
                         .penssidebar()
                         .sidebar_stack()
@@ -842,10 +826,10 @@ impl RnAppWindow {
                                 .smooth_options
                                 .fill_color
                                 .unwrap_or(Color::TRANSPARENT);
-                            self.overlays()
+                            self.main_header()
                                 .colorpicker()
                                 .set_stroke_color(gdk::RGBA::from_compose_color(stroke_color));
-                            self.overlays()
+                            self.main_header()
                                 .colorpicker()
                                 .set_fill_color(gdk::RGBA::from_compose_color(fill_color));
                         }
@@ -866,17 +850,17 @@ impl RnAppWindow {
                                 .rough_options
                                 .fill_color
                                 .unwrap_or(Color::TRANSPARENT);
-                            self.overlays()
+                            self.main_header()
                                 .colorpicker()
                                 .set_stroke_color(gdk::RGBA::from_compose_color(stroke_color));
-                            self.overlays()
+                            self.main_header()
                                 .colorpicker()
                                 .set_fill_color(gdk::RGBA::from_compose_color(fill_color));
                         }
                     }
                 }
                 PenStyle::Typewriter => {
-                    self.overlays()
+                    self.main_header()
                         .penpicker()
                         .typewriter_toggle()
                         .set_active(true);
@@ -892,19 +876,19 @@ impl RnAppWindow {
                         .typewriter_config
                         .text_style
                         .color;
-                    self.overlays()
+                    self.main_header()
                         .colorpicker()
                         .set_stroke_color(gdk::RGBA::from_compose_color(text_color));
                 }
                 PenStyle::Eraser => {
-                    self.overlays().penpicker().eraser_toggle().set_active(true);
+                    self.main_header().penpicker().eraser_toggle().set_active(true);
                     self.overlays()
                         .penssidebar()
                         .sidebar_stack()
                         .set_visible_child_name("eraser_page");
                 }
                 PenStyle::Selector => {
-                    self.overlays()
+                    self.main_header()
                         .penpicker()
                         .selector_toggle()
                         .set_active(true);
@@ -914,7 +898,7 @@ impl RnAppWindow {
                         .set_visible_child_name("selector_page");
                 }
                 PenStyle::Tools => {
-                    self.overlays().penpicker().tools_toggle().set_active(true);
+                    self.main_header().penpicker().tools_toggle().set_active(true);
                     self.overlays()
                         .penssidebar()
                         .sidebar_stack()

--- a/crates/rnote-ui/src/mainheader.rs
+++ b/crates/rnote-ui/src/mainheader.rs
@@ -1,9 +1,14 @@
 // Imports
-use crate::{appmenu::RnAppMenu, appwindow::RnAppWindow, canvasmenu::RnCanvasMenu};
-use gtk4::{
-    Box, CompositeTemplate, EventControllerLegacy, Label, ToggleButton, Widget, glib, prelude::*,
-    subclass::prelude::*,
+use crate::{
+    RnColorPicker, RnPenPicker, appmenu::RnAppMenu, appwindow::RnAppWindow,
+    canvasmenu::RnCanvasMenu,
 };
+use gtk4::{
+    Box, CompositeTemplate, EventControllerLegacy, Label, ToggleButton, Widget, glib, glib::clone,
+    prelude::*, subclass::prelude::*,
+};
+use rnote_engine::ext::GdkRGBAExt;
+use rnote_engine::pens::PenStyle;
 
 mod imp {
     use super::*;
@@ -14,9 +19,9 @@ mod imp {
         #[template_child]
         pub(crate) headerbar: TemplateChild<adw::HeaderBar>,
         #[template_child]
-        pub(crate) main_title: TemplateChild<adw::WindowTitle>,
+        pub(crate) colorpicker: TemplateChild<RnColorPicker>,
         #[template_child]
-        pub(crate) main_title_unsaved_indicator: TemplateChild<Label>,
+        pub(crate) penpicker: TemplateChild<RnPenPicker>,
         #[template_child]
         pub(crate) left_sidebar_reveal_toggle: TemplateChild<ToggleButton>,
         #[template_child]
@@ -82,12 +87,12 @@ impl RnMainHeader {
         self.imp().headerbar.get()
     }
 
-    pub(crate) fn main_title(&self) -> adw::WindowTitle {
-        self.imp().main_title.get()
+    pub(crate) fn colorpicker(&self) -> RnColorPicker {
+        self.imp().colorpicker.get()
     }
 
-    pub(crate) fn main_title_unsaved_indicator(&self) -> Label {
-        self.imp().main_title_unsaved_indicator.get()
+    pub(crate) fn penpicker(&self) -> RnPenPicker {
+        self.imp().penpicker.get()
     }
 
     pub(crate) fn left_sidebar_reveal_toggle(&self) -> ToggleButton {
@@ -111,6 +116,10 @@ impl RnMainHeader {
 
         imp.canvasmenu.get().init(appwindow);
         imp.appmenu.get().init(appwindow);
+        imp.colorpicker.get().init(appwindow);
+        imp.penpicker.get().init(appwindow);
+
+        self.setup_colorpicker(appwindow);
 
         // add controllers to elements to prevent accidental resizes: left buttons
         let capture_left = EventControllerLegacy::builder()
@@ -129,5 +138,81 @@ impl RnMainHeader {
 
         capture_right.connect_event(|_, _| glib::Propagation::Stop);
         imp.right_buttons_box.add_controller(capture_right);
+    }
+
+    fn setup_colorpicker(&self, appwindow: &RnAppWindow) {
+        let imp = self.imp();
+
+        imp.colorpicker.connect_notify_local(
+            Some("stroke-color"),
+            clone!(
+                #[weak]
+                appwindow,
+                move |colorpicker, _paramspec| {
+                    let Some(canvas) = appwindow.active_tab_canvas() else {
+                        return;
+                    };
+                    let stroke_color = colorpicker.stroke_color().into_compose_color();
+                    let current_pen_style = canvas.engine_ref().current_pen_style_w_override();
+
+                    match current_pen_style {
+                        PenStyle::Typewriter => {
+                            let widget_flags = canvas.engine_mut().text_change_color(stroke_color);
+                            appwindow.handle_widget_flags(widget_flags, &canvas);
+                        }
+                        PenStyle::Selector => {
+                            let widget_flags = canvas
+                                .engine_mut()
+                                .change_selection_stroke_colors(stroke_color);
+                            appwindow.handle_widget_flags(widget_flags, &canvas);
+                        }
+                        PenStyle::Brush | PenStyle::Shaper | PenStyle::Eraser | PenStyle::Tools => {
+                        }
+                    }
+
+                    // We have a global colorpicker, so we apply it to all styles
+                    appwindow
+                        .engine_config()
+                        .write()
+                        .pens_config
+                        .set_all_stroke_colors(stroke_color);
+                }
+            ),
+        );
+
+        imp.colorpicker.connect_notify_local(
+            Some("fill-color"),
+            clone!(
+                #[weak]
+                appwindow,
+                move |colorpicker, _paramspec| {
+                    let Some(canvas) = appwindow.active_tab_canvas() else {
+                        return;
+                    };
+                    let fill_color = colorpicker.fill_color().into_compose_color();
+                    let stroke_style = canvas.engine_ref().current_pen_style_w_override();
+
+                    match stroke_style {
+                        PenStyle::Selector => {
+                            let widget_flags =
+                                canvas.engine_mut().change_selection_fill_colors(fill_color);
+                            appwindow.handle_widget_flags(widget_flags, &canvas);
+                        }
+                        PenStyle::Typewriter
+                        | PenStyle::Brush
+                        | PenStyle::Shaper
+                        | PenStyle::Eraser
+                        | PenStyle::Tools => {}
+                    }
+
+                    // We have a global colorpicker, so we apply it to all styles
+                    appwindow
+                        .engine_config()
+                        .write()
+                        .pens_config
+                        .set_all_fill_colors(fill_color);
+                }
+            ),
+        );
     }
 }

--- a/crates/rnote-ui/src/overlays.rs
+++ b/crates/rnote-ui/src/overlays.rs
@@ -1,14 +1,12 @@
 // Imports
 use crate::RnPensSideBar;
 use crate::canvaswrapper::RnCanvasWrapper;
-use crate::{RnAppWindow, RnColorPicker, RnPenPicker, dialogs};
+use crate::{RnAppWindow, dialogs};
 use core::time::Duration;
 use gtk4::{
     CompositeTemplate, Overlay, ProgressBar, ScrolledWindow, Widget, gio, glib, glib::clone,
     prelude::*, subclass::prelude::*,
 };
-use rnote_engine::ext::GdkRGBAExt;
-use rnote_engine::pens::PenStyle;
 use std::cell::{Cell, RefCell};
 use tracing::error;
 
@@ -27,10 +25,6 @@ mod imp {
         pub(crate) toast_overlay: TemplateChild<adw::ToastOverlay>,
         #[template_child]
         pub(crate) progressbar: TemplateChild<ProgressBar>,
-        #[template_child]
-        pub(crate) penpicker: TemplateChild<RnPenPicker>,
-        #[template_child]
-        pub(crate) colorpicker: TemplateChild<RnColorPicker>,
         #[template_child]
         pub(crate) tabview: TemplateChild<adw::TabView>,
         #[template_child]
@@ -75,10 +69,6 @@ mod imp {
     impl RnOverlays {
         fn setup_toolbar_overlay(&self) {
             self.toolbar_overlay
-                .set_measure_overlay(&*self.colorpicker, true);
-            self.toolbar_overlay
-                .set_measure_overlay(&*self.penpicker, true);
-            self.toolbar_overlay
                 .set_measure_overlay(&*self.sidebar_box, true);
         }
     }
@@ -102,14 +92,6 @@ impl Default for RnOverlays {
 impl RnOverlays {
     pub(crate) fn new() -> Self {
         glib::Object::new()
-    }
-
-    pub(crate) fn penpicker(&self) -> RnPenPicker {
-        self.imp().penpicker.get()
-    }
-
-    pub(crate) fn colorpicker(&self) -> RnColorPicker {
-        self.imp().colorpicker.get()
     }
 
     pub(crate) fn toast_overlay(&self) -> adw::ToastOverlay {
@@ -138,9 +120,7 @@ impl RnOverlays {
 
     pub(crate) fn init(&self, appwindow: &RnAppWindow) {
         let imp = self.imp();
-        imp.colorpicker.get().init(appwindow);
         imp.penssidebar.get().init(appwindow);
-        imp.penpicker.get().init(appwindow);
         imp.penssidebar.get().brush_page().init(appwindow);
         imp.penssidebar.get().shaper_page().init(appwindow);
         imp.penssidebar.get().typewriter_page().init(appwindow);
@@ -148,84 +128,7 @@ impl RnOverlays {
         imp.penssidebar.get().selector_page().init(appwindow);
         imp.penssidebar.get().tools_page().init(appwindow);
 
-        self.setup_colorpicker(appwindow);
         self.setup_tabview(appwindow);
-    }
-
-    fn setup_colorpicker(&self, appwindow: &RnAppWindow) {
-        let imp = self.imp();
-
-        imp.colorpicker.connect_notify_local(
-            Some("stroke-color"),
-            clone!(
-                #[weak]
-                appwindow,
-                move |colorpicker, _paramspec| {
-                    let Some(canvas) = appwindow.active_tab_canvas() else {
-                        return;
-                    };
-                    let stroke_color = colorpicker.stroke_color().into_compose_color();
-                    let current_pen_style = canvas.engine_ref().current_pen_style_w_override();
-
-                    match current_pen_style {
-                        PenStyle::Typewriter => {
-                            let widget_flags = canvas.engine_mut().text_change_color(stroke_color);
-                            appwindow.handle_widget_flags(widget_flags, &canvas);
-                        }
-                        PenStyle::Selector => {
-                            let widget_flags = canvas
-                                .engine_mut()
-                                .change_selection_stroke_colors(stroke_color);
-                            appwindow.handle_widget_flags(widget_flags, &canvas);
-                        }
-                        PenStyle::Brush | PenStyle::Shaper | PenStyle::Eraser | PenStyle::Tools => {
-                        }
-                    }
-
-                    // We have a global colorpicker, so we apply it to all styles
-                    appwindow
-                        .engine_config()
-                        .write()
-                        .pens_config
-                        .set_all_stroke_colors(stroke_color);
-                }
-            ),
-        );
-
-        imp.colorpicker.connect_notify_local(
-            Some("fill-color"),
-            clone!(
-                #[weak]
-                appwindow,
-                move |colorpicker, _paramspec| {
-                    let Some(canvas) = appwindow.active_tab_canvas() else {
-                        return;
-                    };
-                    let fill_color = colorpicker.fill_color().into_compose_color();
-                    let stroke_style = canvas.engine_ref().current_pen_style_w_override();
-
-                    match stroke_style {
-                        PenStyle::Selector => {
-                            let widget_flags =
-                                canvas.engine_mut().change_selection_fill_colors(fill_color);
-                            appwindow.handle_widget_flags(widget_flags, &canvas);
-                        }
-                        PenStyle::Typewriter
-                        | PenStyle::Brush
-                        | PenStyle::Shaper
-                        | PenStyle::Eraser
-                        | PenStyle::Tools => {}
-                    }
-
-                    // We have a global colorpicker, so we apply it to all styles
-                    appwindow
-                        .engine_config()
-                        .write()
-                        .pens_config
-                        .set_all_fill_colors(fill_color);
-                }
-            ),
-        );
     }
 
     fn setup_tabview(&self, appwindow: &RnAppWindow) {

--- a/crates/rnote-ui/src/settingspanel/mod.rs
+++ b/crates/rnote-ui/src/settingspanel/mod.rs
@@ -569,8 +569,6 @@ impl RnSettingsPanel {
 
         let set_overlays_margins = |appwindow: &RnAppWindow, row_active: bool| {
             let (m1, m2) = if row_active { (18, 72) } else { (9, 63) };
-            appwindow.overlays().colorpicker().set_margin_top(m1);
-            appwindow.overlays().penpicker().set_margin_bottom(m1);
             appwindow.overlays().sidebar_box().set_margin_start(m1);
             appwindow.overlays().sidebar_box().set_margin_end(m1);
             appwindow.overlays().sidebar_box().set_margin_top(m2);
@@ -591,7 +589,7 @@ impl RnSettingsPanel {
         imp.general_optimize_epd_row
             .bind_property(
                 "active",
-                &appwindow.overlays().colorpicker().active_color_label(),
+                &appwindow.main_header().colorpicker().active_color_label(),
                 "visible",
             )
             .sync_create()


### PR DESCRIPTION
- Move `colorpicker` and `penpicker` to `mainheader`.
- Add a delete node to selection overlay.

See also #367