### PR TITLE
refactor: canvas widget adjustments

### DIFF
--- a/crates/rnote-engine/src/camera.rs
+++ b/crates/rnote-engine/src/camera.rs
@@ -117,7 +117,6 @@ impl Camera {
         ];
 
         widget_flags.view_modified = true;
-        widget_flags.resize = true;
         widget_flags
     }
 
@@ -276,7 +275,6 @@ impl Camera {
         let mut widget_flags = WidgetFlags::default();
         self.offset = center * self.total_zoom() - self.size * 0.5;
         widget_flags.view_modified = true;
-        widget_flags.resize = true;
         widget_flags
     }
 

--- a/crates/rnote-engine/src/camera.rs
+++ b/crates/rnote-engine/src/camera.rs
@@ -104,10 +104,16 @@ impl Camera {
 
     pub fn set_offset(&mut self, offset: na::Vector2<f64>, doc: &Document) -> WidgetFlags {
         let mut widget_flags = WidgetFlags::default();
-        let (lower, upper) = self.offset_lower_upper(doc);
+
+        let (mins, maxs) = self.surface_mins_maxs(doc);
+        let offset_maxs = na::vector![
+            (maxs.x - self.size.x).max(mins.x),
+            (maxs.y - self.size.y).max(mins.y)
+        ];
+
         self.offset = na::vector![
-            offset[0].clamp(lower[0], upper[0]),
-            offset[1].clamp(lower[1], upper[1])
+            offset.x.clamp(mins.x, offset_maxs.x),
+            offset.y.clamp(mins.y, offset_maxs.y)
         ];
 
         widget_flags.view_modified = true;
@@ -115,8 +121,8 @@ impl Camera {
         widget_flags
     }
 
-    /// The offset minimum and maximum values in surface coordinate space.
-    pub fn offset_lower_upper(&self, doc: &Document) -> (na::Vector2<f64>, na::Vector2<f64>) {
+    /// The minimum and maximum surface bounds (document including overshoot) in surface coordinate space.
+    pub fn surface_mins_maxs(&self, doc: &Document) -> (na::Vector2<f64>, na::Vector2<f64>) {
         let total_zoom = self.total_zoom();
 
         let (h_lower, h_upper) = match doc.config.layout {

--- a/crates/rnote-engine/src/document/mod.rs
+++ b/crates/rnote-engine/src/document/mod.rs
@@ -9,6 +9,7 @@ pub use background::Background;
 pub use config::DocumentConfig;
 pub use format::Format;
 pub use layout::Layout;
+use na::SimdPartialOrd;
 
 // Imports
 use self::background::PatternStyle;
@@ -251,20 +252,26 @@ impl Document {
     ) -> bool {
         let padding_horizontal = self.config.format.width() * 2.0;
         let padding_vertical = self.config.format.height() * 2.0;
+        let padding = na::vector![padding_horizontal, padding_vertical];
 
-        let mut new_bounds = self.bounds().merged(
-            &viewport.extend_right_and_bottom_by(na::vector![padding_horizontal, padding_vertical]),
-        );
+        let mut new_bounds = self.bounds();
+        let mut minimum_bounds = viewport.extend_right_and_bottom_by(padding);
+        minimum_bounds.mins = minimum_bounds.mins.simd_max(new_bounds.mins);
+
+        if !new_bounds.contains(&minimum_bounds) {
+            // Extend the bounds further than necessary, so that we don't trigger
+            // a resize again immediately when the viewport is slightly moved
+            new_bounds.merge(&minimum_bounds.extend_right_and_bottom_by(padding));
+        }
 
         if include_content {
             let keys = store.stroke_keys_as_rendered();
             let content_bounds = if let Some(content_bounds) = store.bounds_for_strokes(&keys) {
-                content_bounds
-                    .extend_right_and_bottom_by(na::vector![padding_horizontal, padding_vertical])
+                content_bounds.extend_right_and_bottom_by(padding)
             } else {
                 // If doc is empty, resize to one page with the format size
                 Aabb::new(na::point![0.0, 0.0], self.config.format.size().into())
-                    .extend_right_and_bottom_by(na::vector![padding_horizontal, padding_vertical])
+                    .extend_right_and_bottom_by(padding)
             };
             new_bounds.merge(&content_bounds);
         }
@@ -296,19 +303,24 @@ impl Document {
     ) -> bool {
         let padding_horizontal = self.config.format.width() * 2.0;
         let padding_vertical = self.config.format.height() * 2.0;
+        let padding = na::vector![padding_horizontal, padding_vertical];
 
-        let mut new_bounds = self
-            .bounds()
-            .merged(&viewport.extend_by(na::vector![padding_horizontal, padding_vertical]));
+        let mut new_bounds = self.bounds();
+        let minimum_bounds = viewport.extend_by(padding);
+
+        if !new_bounds.contains(&minimum_bounds) {
+            // Extend the bounds further than necessary, so that we don't trigger
+            // a resize again immediately when the viewport is slightly moved
+            new_bounds.merge(&minimum_bounds.extend_by(padding));
+        }
 
         if include_content {
             let keys = store.stroke_keys_as_rendered();
             let content_bounds = if let Some(content_bounds) = store.bounds_for_strokes(&keys) {
-                content_bounds.extend_by(na::vector![padding_horizontal, padding_vertical])
+                content_bounds.extend_by(padding)
             } else {
                 // If doc is empty, resize to one page with the format size
-                Aabb::new(na::point![0.0, 0.0], self.config.format.size().into())
-                    .extend_by(na::vector![padding_horizontal, padding_vertical])
+                Aabb::new(na::point![0.0, 0.0], self.config.format.size().into()).extend_by(padding)
             };
             new_bounds.merge(&content_bounds);
         }

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -704,11 +704,9 @@ impl Engine {
         self.camera.set_size(size)
     }
 
-    /// Update the viewport size of the camera.
-    ///
-    /// Background and content rendering then need to be updated.
-    pub fn camera_offset_mins_maxs(&self) -> (na::Vector2<f64>, na::Vector2<f64>) {
-        self.camera.offset_lower_upper(&self.document)
+    /// The minimum and maximum surface bounds (document including overshoot) in surface coordinate space.
+    pub fn camera_surface_mins_maxs(&self) -> (na::Vector2<f64>, na::Vector2<f64>) {
+        self.camera.surface_mins_maxs(&self.document)
     }
 
     /// Update the current pen with the current engine state.

--- a/crates/rnote-ui/src/appwindow/actions.rs
+++ b/crates/rnote-ui/src/appwindow/actions.rs
@@ -607,9 +607,14 @@ impl RnAppWindow {
             #[weak(rename_to=appwindow)]
             self,
             move |_, _| {
-                let Some(canvas) = appwindow.active_tab_canvas() else {
+                let Some(wrapper) = appwindow.active_tab_wrapper() else {
                     return;
                 };
+
+                // workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/187
+                wrapper.workaround_cancel_kinetic_scrolling_for_zoom();
+
+                let canvas = wrapper.canvas();
                 let viewport_center = canvas.engine_ref().camera.viewport_center();
                 let new_zoom = Camera::ZOOM_DEFAULT;
                 let mut widget_flags = canvas.engine_mut().zoom_w_timeout(new_zoom);
@@ -629,6 +634,10 @@ impl RnAppWindow {
                 let Some(wrapper) = appwindow.active_tab_wrapper() else {
                     return;
                 };
+
+                // workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/187
+                wrapper.workaround_cancel_kinetic_scrolling_for_zoom();
+
                 let canvas = wrapper.canvas();
                 let viewport_center = canvas.engine_ref().camera.viewport_center();
                 let new_zoom = f64::from(wrapper.scroller().width())
@@ -648,9 +657,14 @@ impl RnAppWindow {
             #[weak(rename_to=appwindow)]
             self,
             move |_, _| {
-                let Some(canvas) = appwindow.active_tab_canvas() else {
+                let Some(wrapper) = appwindow.active_tab_wrapper() else {
                     return;
                 };
+
+                // workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/187
+                wrapper.workaround_cancel_kinetic_scrolling_for_zoom();
+
+                let canvas = wrapper.canvas();
                 let viewport_center = canvas.engine_ref().camera.viewport_center();
                 let new_zoom =
                     canvas.engine_ref().camera.total_zoom() * (1.0 + RnCanvas::ZOOM_SCROLL_STEP);
@@ -668,9 +682,14 @@ impl RnAppWindow {
             #[weak(rename_to=appwindow)]
             self,
             move |_, _| {
-                let Some(canvas) = appwindow.active_tab_canvas() else {
+                let Some(wrapper) = appwindow.active_tab_wrapper() else {
                     return;
                 };
+
+                // workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/187
+                wrapper.workaround_cancel_kinetic_scrolling_for_zoom();
+
+                let canvas = wrapper.canvas();
                 let viewport_center = canvas.engine_ref().camera.viewport_center();
                 let new_zoom = canvas.engine_ref().camera.total_zoom()
                     * (1.0 / (1.0 + RnCanvas::ZOOM_SCROLL_STEP));

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -293,11 +293,11 @@ impl RnAppWindow {
         }
         if widget_flags.view_modified {
             let offset = canvas.engine_ref().camera.offset();
-            let (offset_mins, offset_maxs) = canvas.engine_ref().camera_offset_mins_maxs();
-            
+            let (surface_mins, surface_maxs) = canvas.engine_ref().camera_surface_mins_maxs();
+
             let widget_size = canvas.widget_size();
-            let adjustment_maxs = RnCanvas::offset_to_adjustment(offset_maxs, offset_mins);
-            let adjustment_value = RnCanvas::offset_to_adjustment(offset, offset_mins);
+            let adjustment_maxs = RnCanvas::surface_to_adjustment(surface_maxs, surface_mins);
+            let adjustment_value = RnCanvas::surface_to_adjustment(offset, surface_mins);
 
             // Keep the adjustments configuration in sync
             canvas.configure_adjustments(widget_size, adjustment_maxs, adjustment_value);

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -292,16 +292,7 @@ impl RnAppWindow {
             canvas.set_empty(false);
         }
         if widget_flags.view_modified {
-            let offset = canvas.engine_ref().camera.offset();
-            let (surface_mins, surface_maxs) = canvas.engine_ref().camera_surface_mins_maxs();
-
-            let widget_size = canvas.widget_size();
-            let adjustment_maxs = RnCanvas::surface_to_adjustment(surface_maxs, surface_mins);
-            let adjustment_value = RnCanvas::surface_to_adjustment(offset, surface_mins);
-
-            // Keep the adjustments configuration in sync
-            canvas.configure_adjustments(widget_size, adjustment_maxs, adjustment_value);
-            canvas.queue_resize();
+            canvas.queue_allocate();
         }
         if widget_flags.zoomed_temporarily {
             let total_zoom = canvas.engine_ref().camera.total_zoom();

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -292,11 +292,15 @@ impl RnAppWindow {
             canvas.set_empty(false);
         }
         if widget_flags.view_modified {
-            let widget_size = canvas.widget_size();
-            let offset_mins_maxs = canvas.engine_ref().camera_offset_mins_maxs();
             let offset = canvas.engine_ref().camera.offset();
+            let (offset_mins, offset_maxs) = canvas.engine_ref().camera_offset_mins_maxs();
+            
+            let widget_size = canvas.widget_size();
+            let adjustment_maxs = RnCanvas::offset_to_adjustment(offset_maxs, offset_mins);
+            let adjustment_value = RnCanvas::offset_to_adjustment(offset, offset_mins);
+
             // Keep the adjustments configuration in sync
-            canvas.configure_adjustments(widget_size, offset_mins_maxs, offset);
+            canvas.configure_adjustments(widget_size, adjustment_maxs, adjustment_value);
             canvas.queue_resize();
         }
         if widget_flags.zoomed_temporarily {

--- a/crates/rnote-ui/src/canvas/canvaslayout.rs
+++ b/crates/rnote-ui/src/canvas/canvaslayout.rs
@@ -5,7 +5,7 @@ use gtk4::{
 };
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use rnote_compose::ext::AabbExt;
-use rnote_engine::{Camera, image};
+use rnote_engine::image;
 use std::cell::Cell;
 
 mod imp {

--- a/crates/rnote-ui/src/canvas/canvaslayout.rs
+++ b/crates/rnote-ui/src/canvas/canvaslayout.rs
@@ -64,21 +64,18 @@ mod imp {
 
         fn allocate(&self, widget: &Widget, width: i32, height: i32, _baseline: i32) {
             let canvas = widget.downcast_ref::<RnCanvas>().unwrap();
-            let hadj = canvas.hadjustment().unwrap();
-            let vadj = canvas.vadjustment().unwrap();
-            let hadj_value = hadj.value();
-            let vadj_value = vadj.value();
-            
-            let (offset_mins, offset_maxs) = canvas.engine_ref().camera_offset_mins_maxs();
-            let adjustment_maxs = RnCanvas::offset_to_adjustment(offset_maxs, offset_mins);
-            let adjustment_value = na::vector![hadj_value, vadj_value];
             
             let new_size = na::vector![width as f64, height as f64];
-            let new_offset = RnCanvas::adjustment_to_offset(adjustment_value, offset_mins);
-
-            canvas.configure_adjustments(new_size, adjustment_maxs, adjustment_value);
-            let _ = canvas.engine_mut().camera_set_offset(new_offset);
             let _ = canvas.engine_mut().camera_set_size(new_size);
+            
+            // Configure adjustments using new size
+            let (offset_mins, offset_maxs) = canvas.engine_ref().camera_offset_mins_maxs();
+            let offset = canvas.engine_ref().camera.offset();
+            
+            let adjustment_maxs = RnCanvas::offset_to_adjustment(offset_maxs, offset_mins);
+            let adjustment_value = RnCanvas::offset_to_adjustment(offset, offset_mins);
+            
+            canvas.configure_adjustments(new_size, adjustment_maxs, adjustment_value);
 
             // Calculate new viewport from the updated camera state
             let old_viewport = self.old_viewport.get();

--- a/crates/rnote-ui/src/canvas/canvaslayout.rs
+++ b/crates/rnote-ui/src/canvas/canvaslayout.rs
@@ -68,17 +68,21 @@ mod imp {
             let vadj = canvas.vadjustment().unwrap();
             let hadj_value = hadj.value();
             let vadj_value = vadj.value();
+            
+            let (offset_mins, offset_maxs) = canvas.engine_ref().camera_offset_mins_maxs();
+            let adjustment_maxs = RnCanvas::offset_to_adjustment(offset_maxs, offset_mins);
+            let adjustment_value = na::vector![hadj_value, vadj_value];
+            
             let new_size = na::vector![width as f64, height as f64];
-            let offset_mins_maxs = canvas.engine_ref().camera_offset_mins_maxs();
-            let new_offset = na::vector![hadj_value, vadj_value];
-            let old_viewport = self.old_viewport.get();
-            let new_viewport = canvas.engine_ref().camera.viewport();
+            let new_offset = RnCanvas::adjustment_to_offset(adjustment_value, offset_mins);
 
-            canvas.configure_adjustments(new_size, offset_mins_maxs, new_offset);
-
-            // Update the camera
+            canvas.configure_adjustments(new_size, adjustment_maxs, adjustment_value);
             let _ = canvas.engine_mut().camera_set_offset(new_offset);
             let _ = canvas.engine_mut().camera_set_size(new_size);
+
+            // Calculate new viewport from the updated camera state
+            let old_viewport = self.old_viewport.get();
+            let new_viewport = canvas.engine_ref().camera.viewport();
 
             // We only extend the viewport by a (tweakable) fraction of the margin, because we want to trigger rendering
             // before we reach it. This has two advantages: Strokes that might take longer to render have a head start

--- a/crates/rnote-ui/src/canvas/canvaslayout.rs
+++ b/crates/rnote-ui/src/canvas/canvaslayout.rs
@@ -64,17 +64,17 @@ mod imp {
 
         fn allocate(&self, widget: &Widget, width: i32, height: i32, _baseline: i32) {
             let canvas = widget.downcast_ref::<RnCanvas>().unwrap();
-            
+
             let new_size = na::vector![width as f64, height as f64];
             let _ = canvas.engine_mut().camera_set_size(new_size);
-            
+
             // Configure adjustments using new size
-            let (offset_mins, offset_maxs) = canvas.engine_ref().camera_offset_mins_maxs();
+            let (surface_mins, surface_maxs) = canvas.engine_ref().camera_surface_mins_maxs();
             let offset = canvas.engine_ref().camera.offset();
-            
-            let adjustment_maxs = RnCanvas::offset_to_adjustment(offset_maxs, offset_mins);
-            let adjustment_value = RnCanvas::offset_to_adjustment(offset, offset_mins);
-            
+
+            let adjustment_maxs = RnCanvas::surface_to_adjustment(surface_maxs, surface_mins);
+            let adjustment_value = RnCanvas::surface_to_adjustment(offset, surface_mins);
+
             canvas.configure_adjustments(new_size, adjustment_maxs, adjustment_value);
 
             // Calculate new viewport from the updated camera state

--- a/crates/rnote-ui/src/canvas/canvaslayout.rs
+++ b/crates/rnote-ui/src/canvas/canvaslayout.rs
@@ -45,19 +45,15 @@ mod imp {
             _for_size: i32,
         ) -> (i32, i32, i32, i32) {
             let canvas = widget.downcast_ref::<RnCanvas>().unwrap();
-            let total_zoom = canvas.engine_ref().camera.total_zoom();
-            let document = canvas.engine_ref().document.clone();
+
+            let (surface_mins, surface_maxs) = canvas.engine_ref().camera_surface_mins_maxs();
+            let surface_size = surface_maxs - surface_mins;
 
             if orientation == Orientation::Horizontal {
-                let natural_width = (document.width * total_zoom
-                    + 2.0 * Camera::OVERSHOOT_HORIZONTAL)
-                    .ceil() as i32;
-
+                let natural_width = surface_size.x.ceil() as i32;
                 (0, natural_width, -1, -1)
             } else {
-                let natural_height =
-                    (document.height * total_zoom + 2.0 * Camera::OVERSHOOT_VERTICAL).ceil() as i32;
-
+                let natural_height = surface_size.y.ceil() as i32;
                 (0, natural_height, -1, -1)
             }
         }

--- a/crates/rnote-ui/src/canvas/canvaslayout.rs
+++ b/crates/rnote-ui/src/canvas/canvaslayout.rs
@@ -62,16 +62,19 @@ mod imp {
             let canvas = widget.downcast_ref::<RnCanvas>().unwrap();
 
             let new_size = na::vector![width as f64, height as f64];
-            let _ = canvas.engine_mut().camera_set_size(new_size);
+            let offset = canvas.engine_ref().camera.offset();
 
             // Configure adjustments using new size
             let (surface_mins, surface_maxs) = canvas.engine_ref().camera_surface_mins_maxs();
-            let offset = canvas.engine_ref().camera.offset();
 
             let adjustment_maxs = RnCanvas::surface_to_adjustment(surface_maxs, surface_mins);
             let adjustment_value = RnCanvas::surface_to_adjustment(offset, surface_mins);
 
             canvas.configure_adjustments(new_size, adjustment_maxs, adjustment_value);
+
+            // Update the camera size and re-clamp the offset to the new size
+            let _ = canvas.engine_mut().camera_set_size(new_size);
+            let _ = canvas.engine_mut().camera_set_offset(offset);
 
             // Calculate new viewport from the updated camera state
             let old_viewport = self.old_viewport.get();

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -568,22 +568,19 @@ mod imp {
                     obj,
                     move |hadj_signal| {
                         // Apply scroll input from adjustment to camera
-                        let (offset_mins, _) = canvas.engine_ref().camera_surface_mins_maxs();
+                        let (surface_mins, _) = canvas.engine_ref().camera_surface_mins_maxs();
                         let offset = canvas.engine_ref().camera.offset();
 
                         let new_offset = na::vector![
                             super::RnCanvas::adjustment_to_surface(
                                 hadj_signal.value(),
-                                offset_mins.x
+                                surface_mins.x
                             ),
                             offset.y
                         ];
 
-                        let _ = canvas.engine_mut().camera_set_offset_expand(new_offset);
-
-                        // this triggers a canvaslayout allocate() call,
-                        // where the camera and content rendering is updated based on some conditions
-                        canvas.queue_resize();
+                        let widget_flags = canvas.engine_mut().camera_set_offset_expand(new_offset);
+                        canvas.emit_handle_widget_flags(widget_flags);
                     }
                 ));
 
@@ -615,22 +612,19 @@ mod imp {
                     obj,
                     move |vadj_signal| {
                         // Apply scroll input from adjustment to camera
-                        let (offset_mins, _) = canvas.engine_ref().camera_surface_mins_maxs();
+                        let (surface_mins, _) = canvas.engine_ref().camera_surface_mins_maxs();
                         let offset = canvas.engine_ref().camera.offset();
 
                         let new_offset = na::vector![
                             offset.x,
                             super::RnCanvas::adjustment_to_surface(
                                 vadj_signal.value(),
-                                offset_mins.y
+                                surface_mins.y
                             )
                         ];
 
-                        let _ = canvas.engine_mut().camera_set_offset_expand(new_offset);
-
-                        // this triggers a canvaslayout allocate() call,
-                        // where the camera and content rendering is updated based on some conditions
-                        canvas.queue_resize();
+                        let widget_flags = canvas.engine_mut().camera_set_offset_expand(new_offset);
+                        canvas.emit_handle_widget_flags(widget_flags);
                     }
                 ));
 

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -24,7 +24,6 @@ use once_cell::sync::Lazy;
 use p2d::bounding_volume::Aabb;
 use rnote_compose::ext::AabbExt;
 use rnote_compose::penevent::PenState;
-use rnote_engine::Camera;
 use rnote_engine::ext::GraphenePointExt;
 use rnote_engine::ext::GrapheneRectExt;
 use rnote_engine::{Engine, WidgetFlags};
@@ -556,15 +555,17 @@ mod imp {
                 .borrow()
                 .as_ref()
                 .map(|adj| adj.value())
-                .unwrap_or(-Camera::OVERSHOOT_HORIZONTAL);
+                .unwrap_or(0.0);
             let vadj_value = self
                 .vadjustment
                 .borrow()
                 .as_ref()
                 .map(|adj| adj.value())
-                .unwrap_or(-Camera::OVERSHOOT_VERTICAL);
+                .unwrap_or(0.0);
             let widget_size = obj.widget_size();
-            let offset_mins_maxs = obj.engine_ref().camera_offset_mins_maxs();
+
+            let (offset_mins, offset_maxs) = obj.engine_ref().camera_offset_mins_maxs();
+            let adjustment_maxs = super::RnCanvas::offset_to_adjustment(offset_maxs, offset_mins);
 
             if let Some(signal_id) = self.connections.borrow_mut().hadjustment.take() {
                 let old_adj = self.hadjustment.borrow().as_ref().unwrap().clone();
@@ -588,7 +589,7 @@ mod imp {
 
             obj.configure_adjustments(
                 widget_size,
-                offset_mins_maxs,
+                adjustment_maxs,
                 na::vector![hadj_value, vadj_value],
             );
         }
@@ -601,15 +602,17 @@ mod imp {
                 .borrow()
                 .as_ref()
                 .map(|adj| adj.value())
-                .unwrap_or(-Camera::OVERSHOOT_HORIZONTAL);
+                .unwrap_or(0.0);
             let vadj_value = self
                 .vadjustment
                 .borrow()
                 .as_ref()
                 .map(|adj| adj.value())
-                .unwrap_or(-Camera::OVERSHOOT_VERTICAL);
+                .unwrap_or(0.0);
             let widget_size = obj.widget_size();
-            let offset_mins_maxs = obj.engine_ref().camera_offset_mins_maxs();
+
+            let (offset_mins, offset_maxs) = obj.engine_ref().camera_offset_mins_maxs();
+            let adjustment_maxs = super::RnCanvas::offset_to_adjustment(offset_maxs, offset_mins);
 
             if let Some(signal_id) = self.connections.borrow_mut().vadjustment.take() {
                 let old_adj = self.vadjustment.borrow().as_ref().unwrap().clone();
@@ -633,7 +636,7 @@ mod imp {
 
             obj.configure_adjustments(
                 widget_size,
-                offset_mins_maxs,
+                adjustment_maxs,
                 na::vector![hadj_value, vadj_value],
             );
         }
@@ -794,20 +797,34 @@ impl RnCanvas {
             .unwrap()
     }
 
+    #[inline]
+    pub(crate) fn offset_to_adjustment(
+        offset: na::Vector2<f64>,
+        offset_mins: na::Vector2<f64>,
+    ) -> na::Vector2<f64> {
+        offset - offset_mins
+    }
+
+    #[inline]
+    pub(crate) fn adjustment_to_offset(
+        offset: na::Vector2<f64>,
+        offset_mins: na::Vector2<f64>,
+    ) -> na::Vector2<f64> {
+        offset + offset_mins
+    }
+
     pub(crate) fn configure_adjustments(
         &self,
         widget_size: na::Vector2<f64>,
-        offset_mins_maxs: (na::Vector2<f64>, na::Vector2<f64>),
-        offset: na::Vector2<f64>,
+        adjustment_upper: na::Vector2<f64>,
+        adjustment_value: na::Vector2<f64>,
     ) {
-        let (offset_mins, offset_maxs) = offset_mins_maxs;
-
         if let Some(hadj) = self.hadjustment() {
             hadj.configure(
                 // This gets clamped to the lower and upper values
-                offset[0],
-                offset_mins[0],
-                offset_maxs[0],
+                adjustment_value[0],
+                0.0,
+                adjustment_upper[0].max(widget_size[0]),
                 0.1 * widget_size[0],
                 0.9 * widget_size[0],
                 widget_size[0],
@@ -817,9 +834,9 @@ impl RnCanvas {
         if let Some(vadj) = self.vadjustment() {
             vadj.configure(
                 // This gets clamped to the lower and upper values
-                offset[1],
-                offset_mins[1],
-                offset_maxs[1],
+                adjustment_value[1],
+                0.0,
+                adjustment_upper[1].max(widget_size[1]),
                 0.1 * widget_size[1],
                 0.9 * widget_size[1],
                 widget_size[1],

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -549,23 +549,12 @@ mod imp {
 
         fn set_hadjustment_prop(&self, hadj: Option<Adjustment>) {
             let obj = self.obj();
-
-            let hadj_value = self
-                .hadjustment
-                .borrow()
-                .as_ref()
-                .map(|adj| adj.value())
-                .unwrap_or(0.0);
-            let vadj_value = self
-                .vadjustment
-                .borrow()
-                .as_ref()
-                .map(|adj| adj.value())
-                .unwrap_or(0.0);
             let widget_size = obj.widget_size();
+            let offset = obj.engine_ref().camera.offset();
 
             let (offset_mins, offset_maxs) = obj.engine_ref().camera_offset_mins_maxs();
             let adjustment_maxs = super::RnCanvas::offset_to_adjustment(offset_maxs, offset_mins);
+            let adjustment_value = super::RnCanvas::offset_to_adjustment(offset, offset_mins);
 
             if let Some(signal_id) = self.connections.borrow_mut().hadjustment.take() {
                 let old_adj = self.hadjustment.borrow().as_ref().unwrap().clone();
@@ -576,7 +565,21 @@ mod imp {
                 let signal_id = hadj.connect_value_changed(clone!(
                     #[weak(rename_to=canvas)]
                     obj,
-                    move |_| {
+                    move |hadj_signal| {
+                        // Apply scroll input from adjustment to camera
+                        let (offset_mins, _) = canvas.engine_ref().camera_offset_mins_maxs();
+                        let offset = canvas.engine_ref().camera.offset();
+
+                        let new_offset = na::vector![
+                            super::RnCanvas::adjustment_to_offset(
+                                hadj_signal.value(),
+                                offset_mins.x
+                            ),
+                            offset.y
+                        ];
+
+                        let _ = canvas.engine_mut().camera_set_offset_expand(new_offset);
+
                         // this triggers a canvaslayout allocate() call,
                         // where the camera and content rendering is updated based on some conditions
                         canvas.queue_resize();
@@ -587,32 +590,17 @@ mod imp {
             }
             self.hadjustment.replace(hadj);
 
-            obj.configure_adjustments(
-                widget_size,
-                adjustment_maxs,
-                na::vector![hadj_value, vadj_value],
-            );
+            obj.configure_adjustments(widget_size, adjustment_maxs, adjustment_value);
         }
 
         fn set_vadjustment_prop(&self, vadj: Option<Adjustment>) {
             let obj = self.obj();
-
-            let hadj_value = self
-                .hadjustment
-                .borrow()
-                .as_ref()
-                .map(|adj| adj.value())
-                .unwrap_or(0.0);
-            let vadj_value = self
-                .vadjustment
-                .borrow()
-                .as_ref()
-                .map(|adj| adj.value())
-                .unwrap_or(0.0);
             let widget_size = obj.widget_size();
+            let offset = obj.engine_ref().camera.offset();
 
             let (offset_mins, offset_maxs) = obj.engine_ref().camera_offset_mins_maxs();
             let adjustment_maxs = super::RnCanvas::offset_to_adjustment(offset_maxs, offset_mins);
+            let adjustment_value = super::RnCanvas::offset_to_adjustment(offset, offset_mins);
 
             if let Some(signal_id) = self.connections.borrow_mut().vadjustment.take() {
                 let old_adj = self.vadjustment.borrow().as_ref().unwrap().clone();
@@ -623,7 +611,21 @@ mod imp {
                 let signal_id = vadj.connect_value_changed(clone!(
                     #[weak(rename_to=canvas)]
                     obj,
-                    move |_| {
+                    move |vadj_signal| {
+                        // Apply scroll input from adjustment to camera
+                        let (offset_mins, _) = canvas.engine_ref().camera_offset_mins_maxs();
+                        let offset = canvas.engine_ref().camera.offset();
+
+                        let new_offset = na::vector![
+                            offset.x,
+                            super::RnCanvas::adjustment_to_offset(
+                                offset_mins.y,
+                                vadj_signal.value()
+                            )
+                        ];
+
+                        let _ = canvas.engine_mut().camera_set_offset_expand(new_offset);
+
                         // this triggers a canvaslayout allocate() call,
                         // where the camera and content rendering is updated based on some conditions
                         canvas.queue_resize();
@@ -634,11 +636,7 @@ mod imp {
             }
             self.vadjustment.replace(vadj);
 
-            obj.configure_adjustments(
-                widget_size,
-                adjustment_maxs,
-                na::vector![hadj_value, vadj_value],
-            );
+            obj.configure_adjustments(widget_size, adjustment_maxs, adjustment_value);
         }
     }
 }
@@ -798,18 +796,18 @@ impl RnCanvas {
     }
 
     #[inline]
-    pub(crate) fn offset_to_adjustment(
-        offset: na::Vector2<f64>,
-        offset_mins: na::Vector2<f64>,
-    ) -> na::Vector2<f64> {
+    pub(crate) fn offset_to_adjustment<T>(offset: T, offset_mins: T) -> T
+    where
+        T: std::ops::Sub<Output = T>,
+    {
         offset - offset_mins
     }
 
     #[inline]
-    pub(crate) fn adjustment_to_offset(
-        offset: na::Vector2<f64>,
-        offset_mins: na::Vector2<f64>,
-    ) -> na::Vector2<f64> {
+    pub(crate) fn adjustment_to_offset<T>(offset: T, offset_mins: T) -> T
+    where
+        T: std::ops::Add<Output = T>,
+    {
         offset + offset_mins
     }
 

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -14,8 +14,8 @@ use futures::StreamExt;
 use gettextrs::gettext;
 use gtk4::{
     Adjustment, DropTarget, EventControllerKey, EventControllerLegacy, IMMulticontext,
-    PropagationPhase, Scrollable, ScrollablePolicy, Widget, gdk, gio, glib, glib::clone, graphene,
-    prelude::*, subclass::prelude::*,
+    PropagationPhase, Scrollable, ScrollablePolicy, ScrolledWindow, Widget, gdk, gio, glib,
+    glib::clone, graphene, prelude::*, subclass::prelude::*,
 };
 use notify::EventKind;
 use notify::event::{AccessKind, AccessMode, ModifyKind, RenameMode};
@@ -36,6 +36,8 @@ use tracing::{debug, error, warn};
 struct Connections {
     hadjustment: Option<glib::SignalHandlerId>,
     vadjustment: Option<glib::SignalHandlerId>,
+    hadjustment_upper: Option<glib::SignalHandlerId>,
+    vadjustment_upper: Option<glib::SignalHandlerId>,
     tab_page_output_file: Option<glib::Binding>,
     tab_page_unsaved_changes: Option<glib::Binding>,
     tab_page_invalidate_thumbnail: Option<glib::SignalHandlerId>,
@@ -59,6 +61,7 @@ mod imp {
         pub(super) connections: RefCell<Connections>,
         pub(crate) hadjustment: RefCell<Option<Adjustment>>,
         pub(crate) vadjustment: RefCell<Option<Adjustment>>,
+        pub(crate) workaround_kinetic_scrolling_pending: Cell<bool>,
         pub(crate) hscroll_policy: Cell<ScrollablePolicy>,
         pub(crate) vscroll_policy: Cell<ScrollablePolicy>,
         pub(crate) regular_cursor_icon_name: RefCell<String>,
@@ -153,6 +156,7 @@ mod imp {
 
                 hadjustment: RefCell::new(None),
                 vadjustment: RefCell::new(None),
+                workaround_kinetic_scrolling_pending: Cell::new(false),
                 hscroll_policy: Cell::new(ScrollablePolicy::Minimum),
                 vscroll_policy: Cell::new(ScrollablePolicy::Minimum),
                 regular_cursor: RefCell::new(regular_cursor),
@@ -549,6 +553,10 @@ mod imp {
 
         fn set_hadjustment_prop(&self, hadj: Option<Adjustment>) {
             let obj = self.obj();
+            let scroller = obj
+                .parent()
+                .and_then(|parent| parent.downcast::<ScrolledWindow>().ok());
+
             let widget_size = obj.widget_size();
             let offset = obj.engine_ref().camera.offset();
 
@@ -561,11 +569,32 @@ mod imp {
                 let old_adj = self.hadjustment.borrow().as_ref().unwrap().clone();
                 old_adj.disconnect(signal_id);
             }
+            if let Some(signal_id) = self.connections.borrow_mut().hadjustment_upper.take() {
+                let old_adj = self.hadjustment.borrow().as_ref().unwrap().clone();
+                old_adj.disconnect(signal_id);
+            }
 
             if let Some(ref hadj) = hadj {
+                let upper_signal_id = hadj.connect_notify_local(
+                    Some("upper"),
+                    clone!(
+                        #[weak(rename_to=canvas)]
+                        obj,
+                        #[strong]
+                        scroller,
+                        move |_adj: &Adjustment, _| {
+                            // restore kinetic scrolling after the canvas has been resized,
+                            // workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/1494
+                            canvas.workaround_restore_kinetic_scrolling(scroller.as_ref());
+                        }
+                    ),
+                );
+
                 let signal_id = hadj.connect_value_changed(clone!(
                     #[weak(rename_to=canvas)]
                     obj,
+                    #[strong]
+                    scroller,
                     move |hadj_signal| {
                         // Apply scroll input from adjustment to camera
                         let (surface_mins, _) = canvas.engine_ref().camera_surface_mins_maxs();
@@ -580,11 +609,22 @@ mod imp {
                         ];
 
                         let widget_flags = canvas.engine_mut().camera_set_offset_expand(new_offset);
+
+                        if widget_flags.resize {
+                            // disable kinetic scrolling when the canvas is about to resize (i.e. when it was expanded),
+                            // workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/1494
+                            canvas.workaround_disable_kinetic_scrolling(scroller.as_ref());
+                        }
+
                         canvas.emit_handle_widget_flags(widget_flags);
                     }
                 ));
 
                 self.connections.borrow_mut().hadjustment.replace(signal_id);
+                self.connections
+                    .borrow_mut()
+                    .hadjustment_upper
+                    .replace(upper_signal_id);
             }
             self.hadjustment.replace(hadj);
 
@@ -593,6 +633,10 @@ mod imp {
 
         fn set_vadjustment_prop(&self, vadj: Option<Adjustment>) {
             let obj = self.obj();
+            let scroller = obj
+                .parent()
+                .and_then(|parent| parent.downcast::<ScrolledWindow>().ok());
+
             let widget_size = obj.widget_size();
             let offset = obj.engine_ref().camera.offset();
 
@@ -605,11 +649,32 @@ mod imp {
                 let old_adj = self.vadjustment.borrow().as_ref().unwrap().clone();
                 old_adj.disconnect(signal_id);
             }
+            if let Some(signal_id) = self.connections.borrow_mut().vadjustment_upper.take() {
+                let old_adj = self.vadjustment.borrow().as_ref().unwrap().clone();
+                old_adj.disconnect(signal_id);
+            }
 
             if let Some(ref vadj) = vadj {
+                let upper_signal_id = vadj.connect_notify_local(
+                    Some("upper"),
+                    clone!(
+                        #[weak(rename_to=canvas)]
+                        obj,
+                        #[strong]
+                        scroller,
+                        move |_adj: &Adjustment, _| {
+                            // restore kinetic scrolling after the canvas has been resized,
+                            // workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/1494
+                            canvas.workaround_restore_kinetic_scrolling(scroller.as_ref());
+                        }
+                    ),
+                );
+
                 let signal_id = vadj.connect_value_changed(clone!(
                     #[weak(rename_to=canvas)]
                     obj,
+                    #[strong]
+                    scroller,
                     move |vadj_signal| {
                         // Apply scroll input from adjustment to camera
                         let (surface_mins, _) = canvas.engine_ref().camera_surface_mins_maxs();
@@ -624,11 +689,22 @@ mod imp {
                         ];
 
                         let widget_flags = canvas.engine_mut().camera_set_offset_expand(new_offset);
+
+                        if widget_flags.resize {
+                            // disable kinetic scrolling when the canvas is about to resize (i.e. when it was expanded),
+                            // workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/1494
+                            canvas.workaround_disable_kinetic_scrolling(scroller.as_ref());
+                        }
+
                         canvas.emit_handle_widget_flags(widget_flags);
                     }
                 ));
 
                 self.connections.borrow_mut().vadjustment.replace(signal_id);
+                self.connections
+                    .borrow_mut()
+                    .vadjustment_upper
+                    .replace(upper_signal_id);
             }
             self.vadjustment.replace(vadj);
 
@@ -838,6 +914,29 @@ impl RnCanvas {
         }
 
         self.queue_resize();
+    }
+
+    fn workaround_disable_kinetic_scrolling(&self, scroller: Option<&ScrolledWindow>) {
+        if let Some(scroller) = scroller
+            && scroller.is_kinetic_scrolling()
+        {
+            scroller.set_kinetic_scrolling(false);
+            self.imp().workaround_kinetic_scrolling_pending.set(true);
+        }
+    }
+
+    fn workaround_restore_kinetic_scrolling(&self, scroller: Option<&ScrolledWindow>) {
+        if !self
+            .imp()
+            .workaround_kinetic_scrolling_pending
+            .replace(false)
+        {
+            return;
+        }
+
+        if let Some(scroller) = scroller {
+            scroller.set_kinetic_scrolling(true);
+        }
     }
 
     pub(crate) fn widget_size(&self) -> na::Vector2<f64> {

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -552,9 +552,10 @@ mod imp {
             let widget_size = obj.widget_size();
             let offset = obj.engine_ref().camera.offset();
 
-            let (offset_mins, offset_maxs) = obj.engine_ref().camera_offset_mins_maxs();
-            let adjustment_maxs = super::RnCanvas::offset_to_adjustment(offset_maxs, offset_mins);
-            let adjustment_value = super::RnCanvas::offset_to_adjustment(offset, offset_mins);
+            let (surface_mins, surface_maxs) = obj.engine_ref().camera_surface_mins_maxs();
+            let adjustment_maxs =
+                super::RnCanvas::surface_to_adjustment(surface_maxs, surface_mins);
+            let adjustment_value = super::RnCanvas::surface_to_adjustment(offset, surface_mins);
 
             if let Some(signal_id) = self.connections.borrow_mut().hadjustment.take() {
                 let old_adj = self.hadjustment.borrow().as_ref().unwrap().clone();
@@ -567,11 +568,11 @@ mod imp {
                     obj,
                     move |hadj_signal| {
                         // Apply scroll input from adjustment to camera
-                        let (offset_mins, _) = canvas.engine_ref().camera_offset_mins_maxs();
+                        let (offset_mins, _) = canvas.engine_ref().camera_surface_mins_maxs();
                         let offset = canvas.engine_ref().camera.offset();
 
                         let new_offset = na::vector![
-                            super::RnCanvas::adjustment_to_offset(
+                            super::RnCanvas::adjustment_to_surface(
                                 hadj_signal.value(),
                                 offset_mins.x
                             ),
@@ -598,9 +599,10 @@ mod imp {
             let widget_size = obj.widget_size();
             let offset = obj.engine_ref().camera.offset();
 
-            let (offset_mins, offset_maxs) = obj.engine_ref().camera_offset_mins_maxs();
-            let adjustment_maxs = super::RnCanvas::offset_to_adjustment(offset_maxs, offset_mins);
-            let adjustment_value = super::RnCanvas::offset_to_adjustment(offset, offset_mins);
+            let (surface_mins, surface_maxs) = obj.engine_ref().camera_surface_mins_maxs();
+            let adjustment_maxs =
+                super::RnCanvas::surface_to_adjustment(surface_maxs, surface_mins);
+            let adjustment_value = super::RnCanvas::surface_to_adjustment(offset, surface_mins);
 
             if let Some(signal_id) = self.connections.borrow_mut().vadjustment.take() {
                 let old_adj = self.vadjustment.borrow().as_ref().unwrap().clone();
@@ -613,14 +615,14 @@ mod imp {
                     obj,
                     move |vadj_signal| {
                         // Apply scroll input from adjustment to camera
-                        let (offset_mins, _) = canvas.engine_ref().camera_offset_mins_maxs();
+                        let (offset_mins, _) = canvas.engine_ref().camera_surface_mins_maxs();
                         let offset = canvas.engine_ref().camera.offset();
 
                         let new_offset = na::vector![
                             offset.x,
-                            super::RnCanvas::adjustment_to_offset(
-                                offset_mins.y,
-                                vadj_signal.value()
+                            super::RnCanvas::adjustment_to_surface(
+                                vadj_signal.value(),
+                                offset_mins.y
                             )
                         ];
 
@@ -796,19 +798,19 @@ impl RnCanvas {
     }
 
     #[inline]
-    pub(crate) fn offset_to_adjustment<T>(offset: T, offset_mins: T) -> T
+    pub(crate) fn surface_to_adjustment<T>(offset: T, surface_min: T) -> T
     where
         T: std::ops::Sub<Output = T>,
     {
-        offset - offset_mins
+        offset - surface_min
     }
 
     #[inline]
-    pub(crate) fn adjustment_to_offset<T>(offset: T, offset_mins: T) -> T
+    pub(crate) fn adjustment_to_surface<T>(offset: T, surface_min: T) -> T
     where
         T: std::ops::Add<Output = T>,
     {
-        offset + offset_mins
+        offset + surface_min
     }
 
     pub(crate) fn configure_adjustments(

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -916,7 +916,7 @@ impl RnCanvas {
         self.queue_resize();
     }
 
-    fn workaround_disable_kinetic_scrolling(&self, scroller: Option<&ScrolledWindow>) {
+    pub(crate) fn workaround_disable_kinetic_scrolling(&self, scroller: Option<&ScrolledWindow>) {
         if let Some(scroller) = scroller
             && scroller.is_kinetic_scrolling()
         {
@@ -925,7 +925,7 @@ impl RnCanvas {
         }
     }
 
-    fn workaround_restore_kinetic_scrolling(&self, scroller: Option<&ScrolledWindow>) {
+    pub(crate) fn workaround_restore_kinetic_scrolling(&self, scroller: Option<&ScrolledWindow>) {
         if !self
             .imp()
             .workaround_kinetic_scrolling_pending

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -917,6 +917,8 @@ impl RnCanvas {
     }
 
     pub(crate) fn workaround_disable_kinetic_scrolling(&self, scroller: Option<&ScrolledWindow>) {
+        // Only intervene when kinetic scrolling is currently enabled.
+        // If we disable it here, record that this workaround changed the state using the pending flag.
         if let Some(scroller) = scroller
             && scroller.is_kinetic_scrolling()
         {
@@ -926,16 +928,13 @@ impl RnCanvas {
     }
 
     pub(crate) fn workaround_restore_kinetic_scrolling(&self, scroller: Option<&ScrolledWindow>) {
-        if !self
-            .imp()
-            .workaround_kinetic_scrolling_pending
-            .replace(false)
+        // The pending flag is set to true only if we disabled kinetic scrolling before.
+        // This avoids forcing kinetic scrolling on for scrollers that started with it being disabled.
+        if self.imp().workaround_kinetic_scrolling_pending.get()
+            && let Some(scroller) = scroller
         {
-            return;
-        }
-
-        if let Some(scroller) = scroller {
             scroller.set_kinetic_scrolling(true);
+            self.imp().workaround_kinetic_scrolling_pending.set(false);
         }
     }
 

--- a/crates/rnote-ui/src/canvaswrapper.rs
+++ b/crates/rnote-ui/src/canvaswrapper.rs
@@ -332,20 +332,6 @@ mod imp {
                 ));
             }
 
-            // Actions when moving view with controls provided by the scroller ScrolledWindow.
-            // e.g. touch scrolling when inertial-scrolling is enabled.
-            {
-                self.scroller.connect_edge_overshot(clone!(
-                    #[weak(rename_to=canvaswrapper)]
-                    obj,
-                    move |_, _| {
-                        let canvas = canvaswrapper.canvas();
-                        let widget_flags = canvas.engine_mut().doc_expand_autoexpand();
-                        canvas.emit_handle_widget_flags(widget_flags);
-                    }
-                ));
-            }
-
             // zoom scrolling with <ctrl> + scroll
             {
                 self.canvas_zoom_scroll_controller.connect_scroll(clone!(

--- a/crates/rnote-ui/src/canvaswrapper.rs
+++ b/crates/rnote-ui/src/canvaswrapper.rs
@@ -411,10 +411,7 @@ mod imp {
                         // We don't claim the sequence, because we we want to allow touch zooming.
                         // When the zoom gesture is recognized, it claims it and denies this touch drag gesture.
 
-                        touch_drag_start.set(na::vector![
-                            canvaswrapper.canvas().hadjustment().unwrap().value(),
-                            canvaswrapper.canvas().vadjustment().unwrap().value()
-                        ]);
+                        touch_drag_start.set(canvaswrapper.canvas().engine_ref().camera.offset());
                     }
                 ));
                 self.canvas_drag_gesture.connect_drag_update(clone!(

--- a/crates/rnote-ui/src/canvaswrapper.rs
+++ b/crates/rnote-ui/src/canvaswrapper.rs
@@ -311,6 +311,23 @@ mod imp {
             );
         }
 
+        fn workaround_disable_kinetic_scrolling(&self) {
+            let scroller = self.scroller.get();
+            self.canvas
+                .workaround_disable_kinetic_scrolling(Some(&scroller));
+        }
+
+        fn workaround_restore_kinetic_scrolling(&self) {
+            let scroller = self.scroller.get();
+            self.canvas
+                .workaround_restore_kinetic_scrolling(Some(&scroller));
+        }
+
+        pub(super) fn workaround_cancel_kinetic_scrolling_for_zoom(&self) {
+            self.workaround_disable_kinetic_scrolling();
+            self.workaround_restore_kinetic_scrolling();
+        }
+
         fn setup_input(&self) {
             let obj = self.obj();
 
@@ -345,6 +362,11 @@ mod imp {
                         if !modifiers.contains(gdk::ModifierType::CONTROL_MASK) {
                             return glib::Propagation::Proceed;
                         }
+
+                        // workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/187
+                        canvaswrapper
+                            .imp()
+                            .workaround_cancel_kinetic_scrolling_for_zoom();
 
                         let canvas = canvaswrapper.canvas();
                         let old_zoom = canvas.engine_ref().camera.total_zoom();
@@ -495,15 +517,10 @@ mod imp {
                     obj,
                     move |gesture, _| {
                         gesture.set_state(EventSequenceState::Claimed);
-                        // Workaround for a GTK bug where kinetic scroll deceleration continues
-                        // with stale values during a pinch-to-zoom, causing sudden position jumps.
-                        // Toggling kinetic scrolling off/on cancels any active deceleration.
-                        // See: https://gitlab.gnome.org/GNOME/gtk/-/issues/187
-                        let scroller = canvaswrapper.scroller();
-                        if scroller.is_kinetic_scrolling() {
-                            scroller.set_kinetic_scrolling(false);
-                            scroller.set_kinetic_scrolling(true);
-                        }
+
+                        // workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/187
+                        canvaswrapper.imp().workaround_disable_kinetic_scrolling();
+
                         let current_zoom = canvaswrapper.canvas().engine_ref().camera.total_zoom();
 
                         zoom_begin.set(current_zoom);
@@ -571,6 +588,9 @@ mod imp {
                     #[weak(rename_to=canvaswrapper)]
                     obj,
                     move |_gesture, _event_sequence| {
+                        // workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/187
+                        canvaswrapper.imp().workaround_restore_kinetic_scrolling();
+
                         let widget_flags = canvaswrapper
                             .canvas()
                             .engine_mut()
@@ -586,6 +606,10 @@ mod imp {
                     obj,
                     move |gesture, _event_sequence| {
                         gesture.set_state(EventSequenceState::Denied);
+
+                        // workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/187
+                        canvaswrapper.imp().workaround_restore_kinetic_scrolling();
+
                         let widget_flags = canvaswrapper
                             .canvas()
                             .engine_mut()
@@ -702,6 +726,10 @@ mod imp {
                                 gdk::ModifierType::SHIFT_MASK | gdk::ModifierType::ALT_MASK,
                             ) {
                                 gesture.set_state(EventSequenceState::Claimed);
+
+                                // workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/187
+                                canvaswrapper.imp().workaround_disable_kinetic_scrolling();
+
                                 let current_zoom =
                                     canvaswrapper.canvas().engine_ref().camera.total_zoom();
                                 zoom_begin.set(current_zoom);
@@ -749,6 +777,9 @@ mod imp {
                     #[weak(rename_to=canvaswrapper)]
                     obj,
                     move |_, _, _| {
+                        // workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/187
+                        canvaswrapper.imp().workaround_restore_kinetic_scrolling();
+
                         let widget_flags = canvaswrapper
                             .canvas()
                             .engine_mut()
@@ -858,6 +889,10 @@ impl RnCanvasWrapper {
 
     pub(crate) fn scroller(&self) -> ScrolledWindow {
         self.imp().scroller.get()
+    }
+
+    pub(crate) fn workaround_cancel_kinetic_scrolling_for_zoom(&self) {
+        self.imp().workaround_cancel_kinetic_scrolling_for_zoom();
     }
 
     pub(crate) fn canvas(&self) -> RnCanvas {


### PR DESCRIPTION
- Fixes #1720.
- Fixes #1738.
- Fixes #1394.
- Applies the workaround from #1733 to all other zoom gestures and actions.
- Fixes "known issue" described in #1712.
- Fixes `gtk_adjustment_configure: assertion 'lower + page_size <= upper' failed` log spam by ensuring that the bounds are at least as big as the widget.

---

- Transforms the camera offset into an absolute range for configuring the adjustments of the canvas widget.
- Updates camera offset as soon as adjustments emit a value changed signal, instead of during layout (re-)allocation.
- Autoexpands the canvas when an adjustment changes (like all other gestures/actions), making the autoexpand on edge overshoot redundant. As a preparation for #1712, we cannot rely on edge overshoot callbacks, because when the document is rotated, we have to expand it *before* reaching the ScrolledWindow edge.
- Because of the above, we hit a [GTK bug](https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/395) related to kinetic scrolling. https://github.com/flxzt/rnote/pull/1719/changes/53af354b4de3cb3e1e2cdf4bbac5931b58c3618b works around this bug by temporarily disabling kinetic scrolling when the document is about to be expanded.

---

### TODO
- [x] It seems we hit this old GTK bug https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/395. I'm currently trying to implement the workaround used in other apps...