### PR TITLE
fix: grid snapping for all pattern styles

### DIFF
--- a/crates/rnote-engine/src/document/mod.rs
+++ b/crates/rnote-engine/src/document/mod.rs
@@ -11,6 +11,7 @@ pub use format::Format;
 pub use layout::Layout;
 
 // Imports
+use self::background::PatternStyle;
 use crate::engine::EngineConfig;
 use crate::engine::snapshot::Snapshotable;
 use crate::{Camera, StrokeStore, WidgetFlags};
@@ -335,18 +336,21 @@ impl Document {
         const DOCUMENT_SNAP_DIST: f64 = 10.;
         let doc_format_size = self.config.format.size();
         let pattern_size = self.config.background.pattern_size;
+        let pattern_style = self.config.background.pattern;
 
         if !config.snap_positions {
             return pos;
         }
 
-        let snap_to_grid = |pos: na::Vector2<f64>, grid_size: na::Vector2<f64>| {
-            let grid_pos = pos.component_div(&grid_size);
-            grid_size.component_mul(&grid_pos.round())
-        };
-
-        let pos_snapped_pattern = snap_to_grid(pos, pattern_size);
         let pos_snapped_document = snap_to_grid(pos, doc_format_size);
+        let pos_snapped_pattern = match pattern_style {
+            PatternStyle::None => pos,
+            PatternStyle::Lines => snap_to_line(pos, pattern_size[1]),
+            PatternStyle::Grid | PatternStyle::Dots => snap_to_grid(pos, pattern_size),
+            PatternStyle::IsometricGrid | PatternStyle::IsometricDots => {
+                snap_to_isometric_pattern(pos, pattern_size[1])
+            }
+        };
 
         let mut pos_snapped = pos_snapped_pattern;
 
@@ -360,6 +364,51 @@ impl Document {
 
         pos_snapped
     }
+}
+
+fn snap_to_grid(pos: na::Vector2<f64>, grid_size: na::Vector2<f64>) -> na::Vector2<f64> {
+    let grid_pos = pos.component_div(&grid_size);
+    grid_size.component_mul(&grid_pos.round())
+}
+
+fn snap_to_line(pos: na::Vector2<f64>, line_spacing: f64) -> na::Vector2<f64> {
+    let line_pos = pos[1] / line_spacing;
+    na::vector![pos[0], line_spacing * line_pos.round()]
+}
+
+fn snap_to_isometric_pattern(pos: na::Vector2<f64>, spacing: f64) -> na::Vector2<f64> {
+    const SQRT_THREE: f64 = 1.7320508075688772;
+
+    let column_width = spacing * SQRT_THREE;
+    let row_height = spacing * 0.5;
+
+    // convert the cartesian coordinates to cube coordinates
+    let q = pos[0] / column_width + pos[1] / spacing;
+    let r = pos[0] / column_width - pos[1] / spacing;
+    let s = -q - r;
+
+    // cube coordinate rounding
+    // https://www.redblobgames.com/grids/hexagons/#rounding
+    let mut rounded_q = q.round();
+    let mut rounded_r = r.round();
+    let rounded_s = s.round();
+
+    let q_diff = (rounded_q - q).abs();
+    let r_diff = (rounded_r - r).abs();
+    let s_diff = (rounded_s - s).abs();
+
+    // we can omit the s coordinate case, because we can compute it from q and r and don't need it in the conversion below
+    if q_diff > r_diff && q_diff > s_diff {
+        rounded_q = -rounded_r - rounded_s;
+    } else if r_diff > s_diff {
+        rounded_r = -rounded_q - rounded_s;
+    }
+
+    // convert the rounded cube coordinates back to cartesian coordinates
+    na::vector![
+        (rounded_q + rounded_r) * column_width * 0.5,
+        (rounded_q - rounded_r) * row_height,
+    ]
 }
 
 #[must_use = "Determines if the resize flag should be set"]


### PR DESCRIPTION
- This PR adds proper grid snapping for every pattern style. Previously, the positions would always snap to a grid.
- Fixes #1685.