### PR TITLE
fix: correct modifier check in gestures

### DIFF
--- a/crates/rnote-ui/src/canvaswrapper.rs
+++ b/crates/rnote-ui/src/canvaswrapper.rs
@@ -354,9 +354,12 @@ mod imp {
                     #[upgrade_or]
                     glib::Propagation::Proceed,
                     move |controller, _, dy| {
-                        if controller.current_event_state() != gdk::ModifierType::CONTROL_MASK {
+                        let modifiers = controller.current_event_state();
+
+                        if !modifiers.contains(gdk::ModifierType::CONTROL_MASK) {
                             return glib::Propagation::Proceed;
                         }
+
                         let canvas = canvaswrapper.canvas();
                         let old_zoom = canvas.engine_ref().camera.total_zoom();
                         let new_zoom = if dy < 0.0 {
@@ -615,7 +618,7 @@ mod imp {
                         let modifiers = gesture.current_event_state();
 
                         // At the start BUTTON1_MASK is not included
-                        if modifiers == gdk::ModifierType::ALT_MASK {
+                        if modifiers.contains(gdk::ModifierType::ALT_MASK) {
                             gesture.set_state(EventSequenceState::Claimed);
                             offset_start.set(canvaswrapper.canvas().engine_ref().camera.offset());
                         } else {
@@ -703,9 +706,9 @@ mod imp {
                             let modifiers = gesture.current_event_state();
 
                             // At the start BUTTON1_MASK is not included
-                            if modifiers
-                                == (gdk::ModifierType::SHIFT_MASK | gdk::ModifierType::ALT_MASK)
-                            {
+                            if modifiers.contains(
+                                gdk::ModifierType::SHIFT_MASK | gdk::ModifierType::ALT_MASK,
+                            ) {
                                 gesture.set_state(EventSequenceState::Claimed);
                                 let current_zoom =
                                     canvaswrapper.canvas().engine_ref().camera.total_zoom();


### PR DESCRIPTION
- Fixes #1617.
- Switches to `.contains` instead of strict equality for gesture modifiers.