### PR TITLE
fix: transparent stroke rendering

### DIFF
--- a/crates/rnote-compose/src/color.rs
+++ b/crates/rnote-compose/src/color.rs
@@ -130,18 +130,6 @@ impl Color {
         0.2126 * self.r + 0.7152 * self.g + 0.0722 * self.b
     }
 
-    /// Mix the color with a background color, resulting in a new opaque color.
-    pub fn with_background_color(self, background_color: Self) -> Self {
-        let a = self.a;
-
-        Self::new(
-            self.r * a + background_color.r * (1.0 - a),
-            self.g * a + background_color.g * (1.0 - a),
-            self.b * a + background_color.b * (1.0 - a),
-            1.0,
-        )
-    }
-
     /// Invert the perceived brightness of the color.
     pub fn to_inverted_brightness_color(self) -> Self {
         let mut hwba_color: palette::Okhwba<f64> = self.into_color();

--- a/crates/rnote-compose/src/color.rs
+++ b/crates/rnote-compose/src/color.rs
@@ -130,6 +130,18 @@ impl Color {
         0.2126 * self.r + 0.7152 * self.g + 0.0722 * self.b
     }
 
+    /// Mix the color with a background color, resulting in a new opaque color.
+    pub fn with_background_color(self, background_color: Self) -> Self {
+        let a = self.a;
+
+        Self::new(
+            self.r * a + background_color.r * (1.0 - a),
+            self.g * a + background_color.g * (1.0 - a),
+            self.b * a + background_color.b * (1.0 - a),
+            1.0,
+        )
+    }
+
     /// Invert the perceived brightness of the color.
     pub fn to_inverted_brightness_color(self) -> Self {
         let mut hwba_color: palette::Okhwba<f64> = self.into_color();

--- a/crates/rnote-compose/src/style/smooth/mod.rs
+++ b/crates/rnote-compose/src/style/smooth/mod.rs
@@ -250,6 +250,8 @@ impl Composer<SmoothOptions> for PenPath {
         let Some(color) = options.stroke_color else {
             return;
         };
+
+        let mut full_path = kurbo::BezPath::new();
         let mut single_pos = true;
         let mut prev = self.start;
 
@@ -347,8 +349,10 @@ impl Composer<SmoothOptions> for PenPath {
             //let stroke_brush = cx.solid_brush(piet::Color::RED);
             //cx.stroke(bez_path.clone(), &stroke_brush, 0.2);
 
-            cx.fill(bez_path, &Into::<piet::Color>::into(color));
+            full_path.extend(bez_path);
         }
+
+        cx.fill(full_path, &Into::<piet::Color>::into(color));
 
         // Single element/position strokes need special treatment to be rendered
         if single_pos {

--- a/crates/rnote-compose/src/style/textured/mod.rs
+++ b/crates/rnote-compose/src/style/textured/mod.rs
@@ -22,76 +22,12 @@ impl Composer<TexturedOptions> for Line {
     }
 
     fn draw_composed(&self, cx: &mut impl piet::RenderContext, options: &TexturedOptions) {
-        cx.save().unwrap();
-        let bez_path = {
-            // Return early if line has no length, else Uniform::new() will panic for range with low >= high
-            if (self.end - self.start).magnitude() <= 0.0 {
-                return;
-            };
-
-            let mut rng = crate::utils::new_rng_default_pcg64(options.seed);
-
-            let line_vec = self.end - self.start;
-            let line_rect = self.line_w_width_to_rect(options.stroke_width);
-
-            let area = 4.0 * line_rect.cuboid.half_extents[0] * line_rect.cuboid.half_extents[1];
-
-            // Radii scale with the stroke width, with a weight.
-            let dots_radii = TexturedOptions::DOTS_RADII_DEFAULT
-                * (1.0 + options.stroke_width * TexturedOptions::STROKE_WIDTH_RADII_WEIGHT);
-
-            // Ranges for randomization
-            let range_x = -line_rect.cuboid.half_extents[0]..line_rect.cuboid.half_extents[0];
-            let range_y = -line_rect.cuboid.half_extents[1]..line_rect.cuboid.half_extents[1];
-            let range_dots_rot = -std::f64::consts::FRAC_PI_8..std::f64::consts::FRAC_PI_8;
-            let range_dots_rx = dots_radii[0] * 0.8..dots_radii[0] * 1.25;
-            let range_dots_ry = dots_radii[1] * 0.8..dots_radii[1] * 1.25;
-
-            let distr_x = Uniform::try_from(range_x).unwrap();
-            let distr_dots_rot = Uniform::try_from(range_dots_rot).unwrap();
-            let distr_dots_rx = Uniform::try_from(range_dots_rx).unwrap();
-            let distr_dots_ry = Uniform::try_from(range_dots_ry).unwrap();
-
-            let n_dots = (area * 0.1 * options.density).round() as i32;
-
-            let mut bez_path = kurbo::BezPath::new();
-
-            for _ in 0..n_dots {
-                let x_pos = distr_x.sample(&mut rng);
-                let y_pos = options
-                    .distribution
-                    .sample_for_range_symmetrical_clipped(&mut rng, range_y.clone());
-
-                let pos = line_rect.transform.affine * na::point![x_pos, y_pos];
-
-                let rotation_angle = na::Rotation2::rotation_between(&na::Vector2::x(), &line_vec)
-                    .angle()
-                    + distr_dots_rot.sample(&mut rng);
-                let radii = na::vector![
-                    distr_dots_rx.sample(&mut rng),
-                    distr_dots_ry.sample(&mut rng)
-                ];
-
-                let ellipse = kurbo::Ellipse::new(
-                    kurbo::Point {
-                        x: pos[0],
-                        y: pos[1],
-                    },
-                    radii.to_kurbo_vec(),
-                    rotation_angle,
-                );
-
-                bez_path.extend(ellipse.to_path(0.1));
-            }
-
-            bez_path
-        };
+        let bez_path = compose_textured_line_path(self, options);
 
         if let Some(fill_color) = options.stroke_color {
             let fill_brush = cx.solid_brush(fill_color.into());
             cx.fill(bez_path, &fill_brush);
         }
-        cx.restore().unwrap();
     }
 }
 
@@ -101,10 +37,13 @@ impl Composer<TexturedOptions> for PenPath {
     }
 
     fn draw_composed(&self, cx: &mut impl piet::RenderContext, options: &TexturedOptions) {
+        let Some(color) = options.stroke_color else {
+            return;
+        };
+
+        let mut full_path = kurbo::BezPath::new();
         let mut options = options.clone();
         let mut prev = self.start;
-
-        cx.save().unwrap();
 
         for seg in self.segments.iter() {
             if seg.end().pos == self.start.pos {
@@ -112,7 +51,7 @@ impl Composer<TexturedOptions> for PenPath {
                 continue;
             }
 
-            match seg {
+            let bez_path = match seg {
                 Segment::LineTo { end } => {
                     let line = Line {
                         start: prev.pos,
@@ -125,8 +64,9 @@ impl Composer<TexturedOptions> for PenPath {
                         .pressure_curve
                         .apply(options.stroke_width, (prev.pressure + end.pressure) * 0.5);
 
-                    line.draw_composed(cx, &options);
+                    let bez_path = compose_textured_line_path(&line, &options);
                     prev = *end;
+                    bez_path
                 }
                 Segment::QuadBezTo { end, .. } => {
                     let line = Line {
@@ -140,8 +80,9 @@ impl Composer<TexturedOptions> for PenPath {
                         .pressure_curve
                         .apply(options.stroke_width, (prev.pressure + end.pressure) * 0.5);
 
-                    line.draw_composed(cx, &options);
+                    let bez_path = compose_textured_line_path(&line, &options);
                     prev = *end;
+                    bez_path
                 }
                 Segment::CubBezTo { end, .. } => {
                     let line = Line {
@@ -155,14 +96,79 @@ impl Composer<TexturedOptions> for PenPath {
                         .pressure_curve
                         .apply(options.stroke_width, (prev.pressure + end.pressure) * 0.5);
 
-                    line.draw_composed(cx, &options);
+                    let bez_path = compose_textured_line_path(&line, &options);
                     prev = *end;
+                    bez_path
                 }
-            }
+            };
 
+            full_path.extend(bez_path);
             options.advance_seed();
         }
 
-        cx.restore().unwrap();
+        cx.fill(full_path, &Into::<piet::Color>::into(color));
     }
+}
+
+fn compose_textured_line_path(line: &Line, options: &TexturedOptions) -> kurbo::BezPath {
+    // Return early if line has no length, else Uniform::new() will panic for range with low >= high
+    if (line.end - line.start).magnitude() <= 0.0 {
+        return kurbo::BezPath::new();
+    }
+
+    let mut rng = crate::utils::new_rng_default_pcg64(options.seed);
+
+    let line_vec = line.end - line.start;
+    let line_rect = line.line_w_width_to_rect(options.stroke_width);
+
+    let area = 4.0 * line_rect.cuboid.half_extents[0] * line_rect.cuboid.half_extents[1];
+
+    // Radii scale with the stroke width, with a weight.
+    let dots_radii = TexturedOptions::DOTS_RADII_DEFAULT
+        * (1.0 + options.stroke_width * TexturedOptions::STROKE_WIDTH_RADII_WEIGHT);
+
+    // Ranges for randomization
+    let range_x = -line_rect.cuboid.half_extents[0]..line_rect.cuboid.half_extents[0];
+    let range_y = -line_rect.cuboid.half_extents[1]..line_rect.cuboid.half_extents[1];
+    let range_dots_rot = -std::f64::consts::FRAC_PI_8..std::f64::consts::FRAC_PI_8;
+    let range_dots_rx = dots_radii[0] * 0.8..dots_radii[0] * 1.25;
+    let range_dots_ry = dots_radii[1] * 0.8..dots_radii[1] * 1.25;
+
+    let distr_x = Uniform::try_from(range_x).unwrap();
+    let distr_dots_rot = Uniform::try_from(range_dots_rot).unwrap();
+    let distr_dots_rx = Uniform::try_from(range_dots_rx).unwrap();
+    let distr_dots_ry = Uniform::try_from(range_dots_ry).unwrap();
+
+    let n_dots = (area * 0.1 * options.density).round() as i32;
+
+    let mut bez_path = kurbo::BezPath::new();
+
+    for _ in 0..n_dots {
+        let x_pos = distr_x.sample(&mut rng);
+        let y_pos = options
+            .distribution
+            .sample_for_range_symmetrical_clipped(&mut rng, range_y.clone());
+
+        let pos = line_rect.transform.affine * na::point![x_pos, y_pos];
+
+        let rotation_angle = na::Rotation2::rotation_between(&na::Vector2::x(), &line_vec).angle()
+            + distr_dots_rot.sample(&mut rng);
+        let radii = na::vector![
+            distr_dots_rx.sample(&mut rng),
+            distr_dots_ry.sample(&mut rng)
+        ];
+
+        let ellipse = kurbo::Ellipse::new(
+            kurbo::Point {
+                x: pos[0],
+                y: pos[1],
+            },
+            radii.to_kurbo_vec(),
+            rotation_angle,
+        );
+
+        bez_path.extend(ellipse.to_path(0.1));
+    }
+
+    bez_path
 }

--- a/crates/rnote-engine/src/pens/brush.rs
+++ b/crates/rnote-engine/src/pens/brush.rs
@@ -10,6 +10,7 @@ use crate::{DrawableOnDoc, WidgetFlags};
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use piet::RenderContext;
 use rnote_compose::Constraints;
+use rnote_compose::Style;
 use rnote_compose::builders::buildable::{Buildable, BuilderCreator, BuilderProgress};
 use rnote_compose::builders::{
     PenPathBuilderType, PenPathCurvedBuilder, PenPathModeledBuilder, PenPathSimpleBuilder,
@@ -25,6 +26,7 @@ enum BrushState {
     Drawing {
         path_builder: Box<dyn Buildable<Emit = Segment>>,
         current_stroke_key: StrokeKey,
+        preview_style: Style,
     },
 }
 
@@ -89,14 +91,10 @@ impl PenBehaviour for Brush {
                         .brush_config
                         .new_style_seeds();
 
-                    let brushstroke = Stroke::BrushStroke(BrushStroke::new(
-                        element,
-                        engine_view
-                            .config
-                            .pens_config
-                            .brush_config
-                            .style_for_current_options(),
-                    ));
+                    let preview_style = Self::get_preview_style(&engine_view.as_im());
+                    let brushstroke =
+                        Stroke::BrushStroke(BrushStroke::new(element, preview_style.clone()));
+
                     let current_stroke_key = engine_view.store.insert_stroke(
                         brushstroke,
                         Some(
@@ -121,6 +119,7 @@ impl PenBehaviour for Brush {
                             now,
                         ),
                         current_stroke_key,
+                        preview_style,
                     };
 
                     EventResult {
@@ -147,6 +146,16 @@ impl PenBehaviour for Brush {
                 },
                 PenEvent::Cancel,
             ) => {
+                if let Some(Stroke::BrushStroke(brushstroke)) =
+                    engine_view.store.get_stroke_mut(*current_stroke_key)
+                {
+                    brushstroke.style = engine_view
+                        .config
+                        .pens_config
+                        .brush_config
+                        .style_for_current_options();
+                }
+
                 // Finish up the last stroke
                 engine_view
                     .store
@@ -176,6 +185,7 @@ impl PenBehaviour for Brush {
                 BrushState::Drawing {
                     path_builder,
                     current_stroke_key,
+                    ..
                 },
                 pen_event,
             ) => {
@@ -248,6 +258,16 @@ impl PenBehaviour for Brush {
                             );
                         }
 
+                        if let Some(Stroke::BrushStroke(brushstroke)) =
+                            engine_view.store.get_stroke_mut(*current_stroke_key)
+                        {
+                            brushstroke.style = engine_view
+                                .config
+                                .pens_config
+                                .brush_config
+                                .style_for_current_options();
+                        }
+
                         // Finish up the last stroke
                         engine_view
                             .store
@@ -308,18 +328,21 @@ impl DrawableOnDoc for Brush {
 
         match &self.state {
             BrushState::Idle => {}
-            BrushState::Drawing { path_builder, .. } => {
+            BrushState::Drawing {
+                path_builder,
+                preview_style,
+                ..
+            } => {
                 match engine_view.config.pens_config.brush_config.style {
                     BrushStyle::Marker => {
                         // Don't draw the marker, as the pen would render on top of other strokes, while the stroke itself would render underneath them.
                     }
                     BrushStyle::Solid | BrushStyle::Textured => {
-                        let style = engine_view
-                            .config
-                            .pens_config
-                            .brush_config
-                            .style_for_current_options();
-                        path_builder.draw_styled(cx, &style, engine_view.camera.total_zoom());
+                        path_builder.draw_styled(
+                            cx,
+                            preview_style,
+                            engine_view.camera.total_zoom(),
+                        );
                     }
                 }
             }
@@ -332,6 +355,25 @@ impl DrawableOnDoc for Brush {
 
 impl Brush {
     const INPUT_OVERSHOOT: f64 = 30.0;
+
+    fn get_preview_style(engine_view: &EngineView) -> Style {
+        let mut style = engine_view
+            .config
+            .pens_config
+            .brush_config
+            .style_for_current_options();
+
+        if let Some(stroke_color) = style.stroke_color()
+            && stroke_color.a < 1.0
+        {
+            let mixed_opaque =
+                stroke_color.with_background_color(engine_view.document.config.background.color);
+
+            style.set_stroke_color(mixed_opaque);
+        }
+
+        style
+    }
 }
 
 #[cfg(feature = "ui")]

--- a/crates/rnote-engine/src/pens/brush.rs
+++ b/crates/rnote-engine/src/pens/brush.rs
@@ -363,13 +363,9 @@ impl Brush {
             .brush_config
             .style_for_current_options();
 
-        if let Some(stroke_color) = style.stroke_color()
-            && stroke_color.a < 1.0
-        {
-            let mixed_opaque =
-                stroke_color.with_background_color(engine_view.document.config.background.color);
-
-            style.set_stroke_color(mixed_opaque);
+        if let Some(mut stroke_color) = style.stroke_color() {
+            stroke_color.a = 1.0;
+            style.set_stroke_color(stroke_color);
         }
 
         style

--- a/crates/rnote-engine/src/strokes/brushstroke.rs
+++ b/crates/rnote-engine/src/strokes/brushstroke.rs
@@ -56,8 +56,10 @@ impl Content for BrushStroke {
             > IMAGES_STROKE_WIDTH_BOUNDS_THRESHOLD * bounds_extents[0]
             || self.style.stroke_width() > IMAGES_STROKE_WIDTH_BOUNDS_THRESHOLD * bounds_extents[1];
 
+        let stroke_opacity_condition = self.style.stroke_color().is_some_and(|color| color.a < 1.0);
+
         // if these conditions evaluate true the stroke is rendered as a single image
-        let images = if image_size_condition || stroke_width_condition {
+        let images = if image_size_condition || stroke_width_condition || stroke_opacity_condition {
             // generate a single image when bounds are smaller than threshold
             match &self.style {
                 Style::Smooth(options) => {


### PR DESCRIPTION
- Fixes #891.
- Addresses #449.

---

- All stroke elements are collected into a single bezier path before being submitted to cairo. This fixes the blending issue when individual line caps overlap.
- When transparent strokes are being drawn/in progress, they are rendered opaque. This prevents having to regenerate the whole stroke on every input, which would cause serious performance problems when drawing long strokes. It looks a bit weird, but this is the best solution I could think of.

[Bildschirmaufnahme_20260407_172404.webm](https://github.com/user-attachments/assets/6d045c2f-e17c-4ae0-91d9-fded9a20c020)
