### PR TITLE
feat: multiplicative marker blending

### DIFF
--- a/crates/rnote-engine/src/engine/export.rs
+++ b/crates/rnote-engine/src/engine/export.rs
@@ -339,33 +339,36 @@ impl Engine {
         oneshot_receiver
     }
 
-    pub fn extract_document_content(&self) -> StrokeContent {
+    fn stroke_content_from_sorted_keys(
+        &self,
+        mut keys: Vec<crate::store::StrokeKey>,
+    ) -> StrokeContent {
+        let highlighter_keys = self.store.split_off_highlighter_keys(&mut keys);
+
         StrokeContent::default()
-            .with_strokes(
-                self.store
-                    .get_strokes_arc(&self.store.stroke_keys_as_rendered()),
-            )
+            .with_strokes(self.store.get_strokes_arc(&keys))
+            .with_highlighter_strokes(self.store.get_strokes_arc(&highlighter_keys))
+            .with_background(self.document.config.background)
+    }
+
+    pub fn extract_document_content(&self) -> StrokeContent {
+        self
+            .stroke_content_from_sorted_keys(self.store.stroke_keys_as_rendered())
             .with_bounds(
                 self.bounds_w_content_extended()
                     .unwrap_or(self.document.bounds()),
             )
-            .with_background(self.document.config.background)
     }
 
     pub fn extract_pages_content(&self, page_order: SplitOrder) -> Vec<StrokeContent> {
         self.pages_bounds_w_content(page_order)
             .into_iter()
             .map(|bounds| {
-                StrokeContent::default()
-                    .with_strokes(
-                        self.store.get_strokes_arc(
-                            &self
-                                .store
-                                .stroke_keys_as_rendered_intersecting_bounds(bounds),
-                        ),
-                    )
-                    .with_bounds(bounds)
-                    .with_background(self.document.config.background)
+                let keys = self
+                    .store
+                    .stroke_keys_as_rendered_intersecting_bounds(bounds);
+
+                self.stroke_content_from_sorted_keys(keys).with_bounds(bounds)
             })
             .collect()
     }
@@ -375,11 +378,7 @@ impl Engine {
         if selection_keys.is_empty() {
             return None;
         }
-        Some(
-            StrokeContent::default()
-                .with_strokes(self.store.get_strokes_arc(&selection_keys))
-                .with_background(self.document.config.background),
-        )
+        Some(self.stroke_content_from_sorted_keys(selection_keys))
     }
 
     /// Extract thumbnail content.
@@ -390,10 +389,7 @@ impl Engine {
         let scale_factor = self.camera.scale_factor();
         let (keys, bounds) = self.store.thumbnail_keys_as_rendered(size * scale_factor);
         let bounds = bounds.unwrap_or_else(|| self.document.bounds());
-        StrokeContent::default()
-            .with_strokes(self.store.get_strokes_arc(&keys))
-            .with_bounds(bounds)
-            .with_background(self.document.config.background)
+        self.stroke_content_from_sorted_keys(keys).with_bounds(bounds)
     }
 
     /// Export the entire engine state as Json string.
@@ -572,6 +568,7 @@ impl Engine {
                         let xopp_strokestyles = page_content
                             .strokes
                             .into_iter()
+                            .chain(page_content.highlighter_strokes.into_iter())
                             .filter_map(|mut stroke| {
                                 let mut stroke = Arc::make_mut(&mut stroke).clone();
                                 stroke.translate(-page_bounds.mins.coords);

--- a/crates/rnote-engine/src/engine/export.rs
+++ b/crates/rnote-engine/src/engine/export.rs
@@ -352,8 +352,7 @@ impl Engine {
     }
 
     pub fn extract_document_content(&self) -> StrokeContent {
-        self
-            .stroke_content_from_sorted_keys(self.store.stroke_keys_as_rendered())
+        self.stroke_content_from_sorted_keys(self.store.stroke_keys_as_rendered())
             .with_bounds(
                 self.bounds_w_content_extended()
                     .unwrap_or(self.document.bounds()),
@@ -368,7 +367,8 @@ impl Engine {
                     .store
                     .stroke_keys_as_rendered_intersecting_bounds(bounds);
 
-                self.stroke_content_from_sorted_keys(keys).with_bounds(bounds)
+                self.stroke_content_from_sorted_keys(keys)
+                    .with_bounds(bounds)
             })
             .collect()
     }
@@ -389,7 +389,8 @@ impl Engine {
         let scale_factor = self.camera.scale_factor();
         let (keys, bounds) = self.store.thumbnail_keys_as_rendered(size * scale_factor);
         let bounds = bounds.unwrap_or_else(|| self.document.bounds());
-        self.stroke_content_from_sorted_keys(keys).with_bounds(bounds)
+        self.stroke_content_from_sorted_keys(keys)
+            .with_bounds(bounds)
     }
 
     /// Export the entire engine state as Json string.

--- a/crates/rnote-engine/src/engine/export.rs
+++ b/crates/rnote-engine/src/engine/export.rs
@@ -339,15 +339,9 @@ impl Engine {
         oneshot_receiver
     }
 
-    fn stroke_content_from_sorted_keys(
-        &self,
-        mut keys: Vec<crate::store::StrokeKey>,
-    ) -> StrokeContent {
-        let highlighter_keys = self.store.split_off_highlighter_keys(&mut keys);
-
-        StrokeContent::default()
-            .with_strokes(self.store.get_strokes_arc(&keys))
-            .with_highlighter_strokes(self.store.get_strokes_arc(&highlighter_keys))
+    fn stroke_content_from_sorted_keys(&self, keys: Vec<crate::store::StrokeKey>) -> StrokeContent {
+        self.store
+            .fetch_stroke_content(&keys)
             .with_background(self.document.config.background)
     }
 
@@ -569,9 +563,9 @@ impl Engine {
                         let xopp_strokestyles = page_content
                             .strokes
                             .into_iter()
-                            .chain(page_content.highlighter_strokes.into_iter())
-                            .filter_map(|mut stroke| {
-                                let mut stroke = Arc::make_mut(&mut stroke).clone();
+                            .filter_map(|mut stroke_content_stroke| {
+                                let mut stroke =
+                                    Arc::make_mut(&mut stroke_content_stroke.stroke).clone();
                                 stroke.translate(-page_bounds.mins.coords);
                                 stroke.into_xopp(document.config.format.dpi())
                             })

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -15,7 +15,7 @@ pub use config::EngineConfigShared;
 pub use export::ExportPrefs;
 pub use import::ImportPrefs;
 pub use snapshot::EngineSnapshot;
-pub use strokecontent::StrokeContent;
+pub use strokecontent::{LayeredStroke, StrokeContent};
 
 // Imports
 use crate::Image;

--- a/crates/rnote-engine/src/engine/rendering.rs
+++ b/crates/rnote-engine/src/engine/rendering.rs
@@ -163,10 +163,10 @@ impl Engine {
         snapshot: &gtk4::Snapshot,
         surface_bounds: p2d::bounding_volume::Aabb,
     ) -> anyhow::Result<()> {
-        use crate::drawable::DrawableOnDoc;
         use crate::engine::visual_debug;
         use crate::engine_view;
-        use gtk4::prelude::*;
+        use crate::{drawable::DrawableOnDoc, ext::GrapheneRectExt};
+        use gtk4::{graphene, prelude::*};
 
         let doc_bounds = self.document.bounds();
         let viewport = self.camera.viewport();
@@ -174,12 +174,48 @@ impl Engine {
 
         snapshot.save();
         snapshot.transform(Some(&camera_transform));
+
         self.draw_document_shadow_to_gtk_snapshot(snapshot);
+
+        let mut non_highlighter_keys = self
+            .store
+            .stroke_keys_as_rendered_intersecting_bounds(viewport);
+        let highlighter_keys = self
+            .store
+            .split_off_highlighter_keys(&mut non_highlighter_keys);
+
+        // push clip
+        snapshot.push_clip(&graphene::Rect::from_p2d_aabb(doc_bounds));
+
+        // push blend mode for each highlighter stroke
+        for _ in highlighter_keys.iter() {
+            snapshot.push_blend(gtk4::gsk::BlendMode::Multiply);
+        }
+
         self.draw_background_to_gtk_snapshot(snapshot)?;
         self.draw_format_borders_to_gtk_snapshot(snapshot)?;
+
+        // bottom image in blend (regular content)
+        for &key in non_highlighter_keys.iter() {
+            self.store.draw_stroke_key_to_gtk_snapshot(snapshot, key);
+        }
+
+        // top image in blend (highlighter layer)
+        for &key in highlighter_keys.iter() {
+            // pop blend bottom image
+            snapshot.pop();
+
+            self.store.draw_stroke_key_to_gtk_snapshot(snapshot, key);
+
+            // pop blend top image
+            snapshot.pop();
+        }
+
+        // pop clip
+        snapshot.pop();
+
         self.draw_origin_indicator_to_gtk_snapshot(snapshot)?;
-        self.store
-            .draw_strokes_to_gtk_snapshot(snapshot, doc_bounds, viewport);
+
         snapshot.restore();
         /*
                let cairo_cx = snapshot.append_cairo(&graphene::Rect::from_p2d_aabb(surface_bounds));

--- a/crates/rnote-engine/src/engine/rendering.rs
+++ b/crates/rnote-engine/src/engine/rendering.rs
@@ -165,6 +165,7 @@ impl Engine {
     ) -> anyhow::Result<()> {
         use crate::engine::visual_debug;
         use crate::engine_view;
+        use crate::store::chrono_comp::StrokeLayer;
         use crate::{drawable::DrawableOnDoc, ext::GrapheneRectExt};
         use gtk4::{graphene, prelude::*};
 
@@ -177,12 +178,11 @@ impl Engine {
 
         self.draw_document_shadow_to_gtk_snapshot(snapshot);
 
-        let mut non_highlighter_keys = self
+        let (non_highlighter_keys, highlighter_keys): (Vec<_>, Vec<_>) = self
             .store
-            .stroke_keys_as_rendered_intersecting_bounds(viewport);
-        let highlighter_keys = self
-            .store
-            .split_off_highlighter_keys(&mut non_highlighter_keys);
+            .stroke_keys_as_rendered_intersecting_bounds(viewport)
+            .iter()
+            .partition(|key| self.store.get_chrono_layer(**key) != StrokeLayer::Highlighter);
 
         // push clip
         snapshot.push_clip(&graphene::Rect::from_p2d_aabb(doc_bounds));

--- a/crates/rnote-engine/src/engine/strokecontent.rs
+++ b/crates/rnote-engine/src/engine/strokecontent.rs
@@ -17,6 +17,8 @@ use tracing::warn;
 pub struct StrokeContent {
     #[serde(rename = "strokes")]
     pub strokes: Vec<Arc<Stroke>>,
+    #[serde(default, rename = "highlighter_strokes")]
+    pub highlighter_strokes: Vec<Arc<Stroke>>,
     #[serde(rename = "bounds")]
     pub bounds: Option<Aabb>,
     #[serde(rename = "background")]
@@ -37,6 +39,11 @@ impl StrokeContent {
         self
     }
 
+    pub fn with_highlighter_strokes(mut self, highlighter_strokes: Vec<Arc<Stroke>>) -> Self {
+        self.highlighter_strokes = highlighter_strokes;
+        self
+    }
+
     pub fn with_background(mut self, background: Background) -> Self {
         self.background = Some(background);
         self
@@ -46,12 +53,13 @@ impl StrokeContent {
         if self.bounds.is_some() {
             return self.bounds;
         }
-        if self.strokes.is_empty() {
+        if self.strokes.is_empty() && self.highlighter_strokes.is_empty() {
             return None;
         }
         Some(
             self.strokes
                 .iter()
+                .chain(self.highlighter_strokes.iter())
                 .map(|s| s.bounds())
                 .fold(Aabb::new_invalid(), |acc, x| acc.merged(&x)),
         )
@@ -136,6 +144,7 @@ impl StrokeContent {
         let image_bounds = self
             .strokes
             .iter()
+            .chain(self.highlighter_strokes.iter())
             .filter_map(|stroke| match stroke.as_ref() {
                 Stroke::BitmapImage(image) => Some(image.rectangle.bounds()),
                 Stroke::VectorImage(image) => Some(image.rectangle.bounds()),
@@ -143,7 +152,7 @@ impl StrokeContent {
             })
             .collect::<Vec<Aabb>>();
 
-        for stroke in self.strokes.iter() {
+        let draw_stroke = |stroke: &Arc<Stroke>, cairo_cx: &cairo::Context| -> anyhow::Result<()> {
             let stroke_bounds = stroke.bounds();
 
             if optimize_printing
@@ -157,10 +166,23 @@ impl StrokeContent {
                 let mut darkest_color_stroke = stroke.as_ref().clone();
                 darkest_color_stroke.set_to_darkest_color();
 
-                darkest_color_stroke.draw_to_cairo(cairo_cx, image_scale)?;
+                darkest_color_stroke.draw_to_cairo(cairo_cx, image_scale)
             } else {
-                stroke.draw_to_cairo(cairo_cx, image_scale)?;
+                stroke.draw_to_cairo(cairo_cx, image_scale)
             }
+        };
+
+        for stroke in self.strokes.iter() {
+            draw_stroke(stroke, cairo_cx)?;
+        }
+
+        if !self.highlighter_strokes.is_empty() {
+            cairo_cx.save()?;
+            cairo_cx.set_operator(cairo::Operator::Multiply);
+            for stroke in self.highlighter_strokes.iter() {
+                draw_stroke(stroke, cairo_cx)?;
+            }
+            cairo_cx.restore()?;
         }
 
         cairo_cx.restore()?;

--- a/crates/rnote-engine/src/engine/strokecontent.rs
+++ b/crates/rnote-engine/src/engine/strokecontent.rs
@@ -2,12 +2,22 @@
 use crate::Drawable;
 use crate::Svg;
 use crate::document::Background;
+use crate::store::chrono_comp::StrokeLayer;
 use crate::strokes::Stroke;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use rnote_compose::shapes::Shapeable;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::warn;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename = "layered_stroke")]
+pub struct LayeredStroke {
+    #[serde(rename = "stroke")]
+    pub stroke: Arc<Stroke>,
+    #[serde(rename = "layer")]
+    pub layer: StrokeLayer,
+}
 
 /// Stroke content.
 ///
@@ -16,15 +26,12 @@ use tracing::warn;
 #[serde(default, rename = "stroke_content")]
 pub struct StrokeContent {
     #[serde(rename = "strokes")]
-    pub strokes: Vec<Arc<Stroke>>,
-    #[serde(default, rename = "highlighter_strokes")]
-    pub highlighter_strokes: Vec<Arc<Stroke>>,
+    pub strokes: Vec<LayeredStroke>,
     #[serde(rename = "bounds")]
     pub bounds: Option<Aabb>,
     #[serde(rename = "background")]
     pub background: Option<Background>,
 }
-
 impl StrokeContent {
     pub const MIME_TYPE: &'static str = "application/rnote-stroke-content";
     pub const CLIPBOARD_EXPORT_MARGIN: f64 = 6.0;
@@ -34,13 +41,8 @@ impl StrokeContent {
         self
     }
 
-    pub fn with_strokes(mut self, strokes: Vec<Arc<Stroke>>) -> Self {
+    pub fn with_strokes(mut self, strokes: Vec<LayeredStroke>) -> Self {
         self.strokes = strokes;
-        self
-    }
-
-    pub fn with_highlighter_strokes(mut self, highlighter_strokes: Vec<Arc<Stroke>>) -> Self {
-        self.highlighter_strokes = highlighter_strokes;
         self
     }
 
@@ -53,14 +55,13 @@ impl StrokeContent {
         if self.bounds.is_some() {
             return self.bounds;
         }
-        if self.strokes.is_empty() && self.highlighter_strokes.is_empty() {
+        if self.strokes.is_empty() {
             return None;
         }
         Some(
             self.strokes
                 .iter()
-                .chain(self.highlighter_strokes.iter())
-                .map(|s| s.bounds())
+                .map(|stroke_content_stroke| stroke_content_stroke.stroke.bounds())
                 .fold(Aabb::new_invalid(), |acc, x| acc.merged(&x)),
         )
     }
@@ -144,16 +145,19 @@ impl StrokeContent {
         let image_bounds = self
             .strokes
             .iter()
-            .chain(self.highlighter_strokes.iter())
-            .filter_map(|stroke| match stroke.as_ref() {
-                Stroke::BitmapImage(image) => Some(image.rectangle.bounds()),
-                Stroke::VectorImage(image) => Some(image.rectangle.bounds()),
-                _ => None,
-            })
+            .filter_map(
+                |stroke_content_stroke| match stroke_content_stroke.stroke.as_ref() {
+                    Stroke::BitmapImage(image) => Some(image.rectangle.bounds()),
+                    Stroke::VectorImage(image) => Some(image.rectangle.bounds()),
+                    _ => None,
+                },
+            )
             .collect::<Vec<Aabb>>();
 
-        let draw_stroke = |stroke: &Arc<Stroke>, cairo_cx: &cairo::Context| -> anyhow::Result<()> {
-            let stroke_bounds = stroke.bounds();
+        let draw_stroke = |stroke_content_stroke: &LayeredStroke,
+                           cairo_cx: &cairo::Context|
+         -> anyhow::Result<()> {
+            let stroke_bounds = stroke_content_stroke.stroke.bounds();
 
             if optimize_printing
                 && image_bounds
@@ -163,25 +167,34 @@ impl StrokeContent {
                 // Using the stroke's bounds instead of hitboxes works for inclusion.
                 // If this is changed to intersection, all hitboxes must be checked individually.
 
-                let mut darkest_color_stroke = stroke.as_ref().clone();
+                let mut darkest_color_stroke = stroke_content_stroke.stroke.as_ref().clone();
                 darkest_color_stroke.set_to_darkest_color();
 
                 darkest_color_stroke.draw_to_cairo(cairo_cx, image_scale)
             } else {
-                stroke.draw_to_cairo(cairo_cx, image_scale)
+                stroke_content_stroke
+                    .stroke
+                    .draw_to_cairo(cairo_cx, image_scale)
             }
         };
 
-        for stroke in self.strokes.iter() {
+        let (non_highlighter_strokes, highlighter_strokes): (Vec<_>, Vec<_>) = self
+            .strokes
+            .iter()
+            .partition(|stroke| stroke.layer != StrokeLayer::Highlighter);
+
+        for stroke in non_highlighter_strokes {
             draw_stroke(stroke, cairo_cx)?;
         }
 
-        if !self.highlighter_strokes.is_empty() {
+        if !highlighter_strokes.is_empty() {
             cairo_cx.save()?;
             cairo_cx.set_operator(cairo::Operator::Multiply);
-            for stroke in self.highlighter_strokes.iter() {
+
+            for stroke in highlighter_strokes {
                 draw_stroke(stroke, cairo_cx)?;
             }
+
             cairo_cx.restore()?;
         }
 

--- a/crates/rnote-engine/src/store/chrono_comp.rs
+++ b/crates/rnote-engine/src/store/chrono_comp.rs
@@ -42,22 +42,14 @@ impl PartialOrd for StrokeLayer {
 
 impl Ord for StrokeLayer {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        match (self, other) {
-            (StrokeLayer::UserLayer(this_ul), StrokeLayer::UserLayer(other_ul)) => {
-                this_ul.cmp(other_ul)
-            }
-            (StrokeLayer::UserLayer(_), _) => Ordering::Greater,
-            (StrokeLayer::Highlighter, StrokeLayer::UserLayer(_)) => Ordering::Less,
-            (StrokeLayer::Highlighter, StrokeLayer::Highlighter) => Ordering::Equal,
-            (StrokeLayer::Highlighter, _) => Ordering::Greater,
-            (StrokeLayer::Image, StrokeLayer::UserLayer(_) | StrokeLayer::Highlighter) => {
-                Ordering::Less
-            }
-            (StrokeLayer::Image, StrokeLayer::Image) => Ordering::Equal,
-            (StrokeLayer::Image, StrokeLayer::Document) => Ordering::Greater,
-            (StrokeLayer::Document, StrokeLayer::Document) => Ordering::Equal,
-            (StrokeLayer::Document, _) => Ordering::Less,
-        }
+        let key = |layer: &StrokeLayer| match layer {
+            StrokeLayer::Document => (0_u8, 0_u32),
+            StrokeLayer::Image => (1_u8, 0_u32),
+            StrokeLayer::UserLayer(layer_no) => (2_u8, *layer_no),
+            StrokeLayer::Highlighter => (3_u8, 0_u32),
+        };
+
+        key(self).cmp(&key(other))
     }
 }
 
@@ -87,6 +79,17 @@ impl ChronoComponent {
 
 /// Systems that are related to their chronological ordering.
 impl StrokeStore {
+    pub(crate) fn split_off_highlighter_keys(&self, keys: &mut Vec<StrokeKey>) -> Vec<StrokeKey> {
+        let split_index = keys.partition_point(|&key| {
+            self.chrono_components
+                .get(key)
+                .map(|chrono_comp| chrono_comp.layer != StrokeLayer::Highlighter)
+                .unwrap_or(true)
+        });
+
+        keys.split_off(split_index)
+    }
+
     pub(crate) fn update_chrono_to_last(&mut self, key: StrokeKey) {
         if let Some(chrono_comp) = Arc::make_mut(&mut self.chrono_components).get_mut(key) {
             self.chrono_counter += 1;

--- a/crates/rnote-engine/src/store/chrono_comp.rs
+++ b/crates/rnote-engine/src/store/chrono_comp.rs
@@ -79,15 +79,11 @@ impl ChronoComponent {
 
 /// Systems that are related to their chronological ordering.
 impl StrokeStore {
-    pub(crate) fn split_off_highlighter_keys(&self, keys: &mut Vec<StrokeKey>) -> Vec<StrokeKey> {
-        let split_index = keys.partition_point(|&key| {
-            self.chrono_components
-                .get(key)
-                .map(|chrono_comp| chrono_comp.layer != StrokeLayer::Highlighter)
-                .unwrap_or(true)
-        });
-
-        keys.split_off(split_index)
+    pub(crate) fn get_chrono_layer(&self, key: StrokeKey) -> StrokeLayer {
+        self.chrono_components
+            .get(key)
+            .map(|chrono_comp| chrono_comp.layer)
+            .unwrap_or_default()
     }
 
     pub(crate) fn update_chrono_to_last(&mut self, key: StrokeKey) {

--- a/crates/rnote-engine/src/store/render_comp.rs
+++ b/crates/rnote-engine/src/store/render_comp.rs
@@ -483,73 +483,36 @@ impl StrokeStore {
 
     /// Draw all strokes on the gtk snapshot.
     #[cfg(feature = "ui")]
-    pub(crate) fn draw_strokes_to_gtk_snapshot(
+    pub(crate) fn draw_stroke_key_to_gtk_snapshot(
         &self,
         snapshot: &gtk4::Snapshot,
-        doc_bounds: Aabb,
-        viewport: Aabb,
+        key: StrokeKey,
     ) {
         use crate::ext::{GdkRGBAExt, GrapheneRectExt};
         use gtk4::{gdk, graphene, prelude::*};
         use rnote_compose::color;
 
-        // push clip
-        snapshot.push_clip(&graphene::Rect::from_p2d_aabb(doc_bounds));
-
-        let mut non_highlighter_keys = self.stroke_keys_as_rendered_intersecting_bounds(viewport);
-        let highlighter_keys = self.split_off_highlighter_keys(&mut non_highlighter_keys);
-
-        let draw_key = |key: StrokeKey, snapshot: &gtk4::Snapshot| {
-            if let Some(stroke) = self.stroke_components.get(key)
-                && let Some(render_comp) = self.render_components.get(key)
+        if let Some(stroke) = self.stroke_components.get(key)
+            && let Some(render_comp) = self.render_components.get(key)
+        {
+            // if the stroke currently does not have a rendering and is will create one,
+            // draw a placeholder filled rect
+            if render_comp.rendernodes.is_empty()
+                && matches!(
+                    render_comp.state,
+                    RenderCompState::Dirty | RenderCompState::BusyRenderingInTask
+                )
             {
-                // if the stroke currently does not have a rendering and is will create one,
-                // draw a placeholder filled rect
-                if render_comp.rendernodes.is_empty()
-                    && matches!(
-                        render_comp.state,
-                        RenderCompState::Dirty | RenderCompState::BusyRenderingInTask
-                    )
-                {
-                    snapshot.append_color(
-                        &gdk::RGBA::from_piet_color(color::GNOME_BRIGHTS[1].with_alpha(0.13)),
-                        &graphene::Rect::from_p2d_aabb(stroke.bounds()),
-                    );
-                }
-
-                for rendernode in render_comp.rendernodes.iter() {
-                    snapshot.append_node(rendernode);
-                }
-            }
-        };
-
-        if highlighter_keys.is_empty() {
-            for &key in non_highlighter_keys.iter() {
-                draw_key(key, snapshot);
-            }
-        } else {
-            // push blend
-            snapshot.push_blend(gtk4::gsk::BlendMode::Multiply);
-
-            // bottom image in blend (regular content)
-            for &key in non_highlighter_keys.iter() {
-                draw_key(key, snapshot);
+                snapshot.append_color(
+                    &gdk::RGBA::from_piet_color(color::GNOME_BRIGHTS[1].with_alpha(0.13)),
+                    &graphene::Rect::from_p2d_aabb(stroke.bounds()),
+                );
             }
 
-            // pop blend bottom image
-            snapshot.pop();
-
-            // top image in blend (highlighter layer)
-            for &key in highlighter_keys.iter() {
-                draw_key(key, snapshot);
+            for rendernode in render_comp.rendernodes.iter() {
+                snapshot.append_node(rendernode);
             }
-
-            // pop blend top image
-            snapshot.pop();
         }
-
-        // pop clip
-        snapshot.pop();
     }
 
     /// Draw the strokes for the given keys on the [piet::RenderContext].

--- a/crates/rnote-engine/src/store/render_comp.rs
+++ b/crates/rnote-engine/src/store/render_comp.rs
@@ -493,9 +493,13 @@ impl StrokeStore {
         use gtk4::{gdk, graphene, prelude::*};
         use rnote_compose::color;
 
+        // push clip
         snapshot.push_clip(&graphene::Rect::from_p2d_aabb(doc_bounds));
 
-        for key in self.stroke_keys_as_rendered_intersecting_bounds(viewport) {
+        let mut non_highlighter_keys = self.stroke_keys_as_rendered_intersecting_bounds(viewport);
+        let highlighter_keys = self.split_off_highlighter_keys(&mut non_highlighter_keys);
+
+        let draw_key = |key: StrokeKey, snapshot: &gtk4::Snapshot| {
             if let Some(stroke) = self.stroke_components.get(key)
                 && let Some(render_comp) = self.render_components.get(key)
             {
@@ -517,8 +521,34 @@ impl StrokeStore {
                     snapshot.append_node(rendernode);
                 }
             }
+        };
+
+        if highlighter_keys.is_empty() {
+            for &key in non_highlighter_keys.iter() {
+                draw_key(key, snapshot);
+            }
+        } else {
+            // push blend
+            snapshot.push_blend(gtk4::gsk::BlendMode::Multiply);
+
+            // bottom image in blend (regular content)
+            for &key in non_highlighter_keys.iter() {
+                draw_key(key, snapshot);
+            }
+
+            // pop blend bottom image
+            snapshot.pop();
+
+            // top image in blend (highlighter layer)
+            for &key in highlighter_keys.iter() {
+                draw_key(key, snapshot);
+            }
+
+            // pop blend top image
+            snapshot.pop();
         }
 
+        // pop clip
         snapshot.pop();
     }
 

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -1,5 +1,6 @@
 // Imports
 use super::StrokeKey;
+use super::chrono_comp::StrokeLayer;
 use super::render_comp::RenderCompState;
 use crate::engine::StrokeContent;
 use crate::strokes::{Content, Stroke};
@@ -688,26 +689,45 @@ impl StrokeStore {
     }
 
     pub(crate) fn fetch_stroke_content(&self, keys: &[StrokeKey]) -> StrokeContent {
-        let strokes = keys
+        let mut non_highlighter_keys = keys.to_vec();
+        let highlighter_keys = self.split_off_highlighter_keys(&mut non_highlighter_keys);
+
+        let strokes = non_highlighter_keys
+            .iter()
+            .filter_map(|k| self.stroke_components.get(*k).cloned())
+            .collect();
+        let highlighter_strokes = highlighter_keys
             .iter()
             .filter_map(|k| self.stroke_components.get(*k).cloned())
             .collect();
 
-        StrokeContent::default().with_strokes(strokes)
+        StrokeContent::default()
+            .with_strokes(strokes)
+            .with_highlighter_strokes(highlighter_strokes)
     }
 
     /// Cut the strokes for the given keys and return them as stroke content.
     pub(crate) fn cut_stroke_content(&mut self, keys: &[StrokeKey]) -> StrokeContent {
-        let strokes = keys
+        for &key in keys {
+            self.set_selected(key, false);
+            self.set_trashed(key, true);
+        }
+
+        let mut non_highlighter_keys = keys.to_vec();
+        let highlighter_keys = self.split_off_highlighter_keys(&mut non_highlighter_keys);
+
+        let strokes = non_highlighter_keys
             .iter()
-            .filter_map(|k| {
-                self.set_selected(*k, false);
-                self.set_trashed(*k, true);
-                self.stroke_components.get(*k).cloned()
-            })
+            .filter_map(|k| self.stroke_components.get(*k).cloned())
+            .collect();
+        let highlighter_strokes = highlighter_keys
+            .iter()
+            .filter_map(|k| self.stroke_components.get(*k).cloned())
             .collect();
 
-        StrokeContent::default().with_strokes(strokes)
+        StrokeContent::default()
+            .with_strokes(strokes)
+            .with_highlighter_strokes(highlighter_strokes)
     }
 
     /// Paste the clipboard content as a selection.
@@ -721,32 +741,50 @@ impl StrokeStore {
         ratio: f64,
         pos: na::Vector2<f64>,
     ) -> Vec<StrokeKey> {
-        if clipboard_content.strokes.is_empty() {
+        if clipboard_content.strokes.is_empty() && clipboard_content.highlighter_strokes.is_empty() {
             return vec![];
         }
+
         let clipboard_bounds = clipboard_content
             .strokes
             .iter()
+            .chain(clipboard_content.highlighter_strokes.iter())
             .fold(Aabb::new_invalid(), |acc, s| acc.merged(&s.bounds()));
 
-        clipboard_content
-            .strokes
-            .into_iter()
-            .map(|s| {
-                let offset = s.bounds().mins.coords - clipboard_bounds.mins.coords;
-                let key = self.insert_stroke((*s).clone(), None);
-                // position strokes without resizing
-                self.set_stroke_pos(key, pos);
-                self.translate_strokes(&[key], offset);
+        let StrokeContent {
+            strokes,
+            highlighter_strokes,
+            ..
+        } = clipboard_content;
 
-                // apply a rescale around a pivot
-                self.scale_strokes_with_pivot(&[key], na::Vector2::new(ratio, ratio), pos);
-                self.scale_strokes_images_with_pivot(&[key], na::Vector2::new(ratio, ratio), pos);
+        let mut insert_group =
+            |strokes: Vec<Arc<Stroke>>, layer: Option<StrokeLayer>| -> Vec<StrokeKey> {
+                strokes
+                    .into_iter()
+                    .map(|s| {
+                        let offset = s.bounds().mins.coords - clipboard_bounds.mins.coords;
+                        let key = self.insert_stroke((*s).clone(), layer);
+                        // position strokes without resizing
+                        self.set_stroke_pos(key, pos);
+                        self.translate_strokes(&[key], offset);
 
-                // select keys
-                self.set_selected(key, true);
-                key
-            })
-            .collect()
+                        // apply a rescale around a pivot
+                        self.scale_strokes_with_pivot(&[key], na::Vector2::new(ratio, ratio), pos);
+                        self.scale_strokes_images_with_pivot(
+                            &[key],
+                            na::Vector2::new(ratio, ratio),
+                            pos,
+                        );
+
+                        // select keys
+                        self.set_selected(key, true);
+                        key
+                    })
+                    .collect()
+            };
+
+        let mut inserted_keys = insert_group(strokes, None);
+        inserted_keys.extend(insert_group(highlighter_strokes, Some(StrokeLayer::Highlighter)));
+        inserted_keys
     }
 }

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -741,7 +741,8 @@ impl StrokeStore {
         ratio: f64,
         pos: na::Vector2<f64>,
     ) -> Vec<StrokeKey> {
-        if clipboard_content.strokes.is_empty() && clipboard_content.highlighter_strokes.is_empty() {
+        if clipboard_content.strokes.is_empty() && clipboard_content.highlighter_strokes.is_empty()
+        {
             return vec![];
         }
 
@@ -784,7 +785,11 @@ impl StrokeStore {
             };
 
         let mut inserted_keys = insert_group(strokes, None);
-        inserted_keys.extend(insert_group(highlighter_strokes, Some(StrokeLayer::Highlighter)));
+        inserted_keys.extend(insert_group(
+            highlighter_strokes,
+            Some(StrokeLayer::Highlighter),
+        ));
+
         inserted_keys
     }
 }

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -1,8 +1,7 @@
 // Imports
 use super::StrokeKey;
-use super::chrono_comp::StrokeLayer;
 use super::render_comp::RenderCompState;
-use crate::engine::StrokeContent;
+use crate::engine::{LayeredStroke, StrokeContent};
 use crate::strokes::{Content, Stroke};
 use crate::{StrokeStore, WidgetFlags};
 use geo::intersects::Intersects;
@@ -44,6 +43,7 @@ impl StrokeStore {
     }
 
     /// Gets the strokes by cloning the Arc's that are wrapped around them.
+    #[allow(unused)]
     pub(crate) fn get_strokes_arc(&self, keys: &[StrokeKey]) -> Vec<Arc<Stroke>> {
         keys.iter()
             .filter_map(|&key| self.stroke_components.get(key).cloned())
@@ -689,21 +689,21 @@ impl StrokeStore {
     }
 
     pub(crate) fn fetch_stroke_content(&self, keys: &[StrokeKey]) -> StrokeContent {
-        let mut non_highlighter_keys = keys.to_vec();
-        let highlighter_keys = self.split_off_highlighter_keys(&mut non_highlighter_keys);
-
-        let strokes = non_highlighter_keys
+        let strokes = keys
             .iter()
-            .filter_map(|k| self.stroke_components.get(*k).cloned())
-            .collect();
-        let highlighter_strokes = highlighter_keys
-            .iter()
-            .filter_map(|k| self.stroke_components.get(*k).cloned())
-            .collect();
+            .filter_map(|&key| {
+                let stroke = self.stroke_components.get(key).cloned()?;
+                let layer = self
+                    .chrono_components
+                    .get(key)
+                    .map(|chrono_comp| chrono_comp.layer)
+                    .unwrap_or_else(|| stroke.extract_default_layer());
 
-        StrokeContent::default()
-            .with_strokes(strokes)
-            .with_highlighter_strokes(highlighter_strokes)
+                Some(LayeredStroke { stroke, layer })
+            })
+            .collect::<Vec<LayeredStroke>>();
+
+        StrokeContent::default().with_strokes(strokes)
     }
 
     /// Cut the strokes for the given keys and return them as stroke content.
@@ -713,21 +713,21 @@ impl StrokeStore {
             self.set_trashed(key, true);
         }
 
-        let mut non_highlighter_keys = keys.to_vec();
-        let highlighter_keys = self.split_off_highlighter_keys(&mut non_highlighter_keys);
-
-        let strokes = non_highlighter_keys
+        let strokes = keys
             .iter()
-            .filter_map(|k| self.stroke_components.get(*k).cloned())
-            .collect();
-        let highlighter_strokes = highlighter_keys
-            .iter()
-            .filter_map(|k| self.stroke_components.get(*k).cloned())
-            .collect();
+            .filter_map(|&key| {
+                let stroke = self.stroke_components.get(key).cloned()?;
+                let layer = self
+                    .chrono_components
+                    .get(key)
+                    .map(|chrono_comp| chrono_comp.layer)
+                    .unwrap_or_else(|| stroke.extract_default_layer());
 
-        StrokeContent::default()
-            .with_strokes(strokes)
-            .with_highlighter_strokes(highlighter_strokes)
+                Some(LayeredStroke { stroke, layer })
+            })
+            .collect::<Vec<LayeredStroke>>();
+
+        StrokeContent::default().with_strokes(strokes)
     }
 
     /// Paste the clipboard content as a selection.
@@ -741,55 +741,35 @@ impl StrokeStore {
         ratio: f64,
         pos: na::Vector2<f64>,
     ) -> Vec<StrokeKey> {
-        if clipboard_content.strokes.is_empty() && clipboard_content.highlighter_strokes.is_empty()
-        {
+        if clipboard_content.strokes.is_empty() {
             return vec![];
         }
 
         let clipboard_bounds = clipboard_content
             .strokes
             .iter()
-            .chain(clipboard_content.highlighter_strokes.iter())
-            .fold(Aabb::new_invalid(), |acc, s| acc.merged(&s.bounds()));
+            .fold(Aabb::new_invalid(), |acc, s| acc.merged(&s.stroke.bounds()));
 
-        let StrokeContent {
-            strokes,
-            highlighter_strokes,
-            ..
-        } = clipboard_content;
+        clipboard_content
+            .strokes
+            .into_iter()
+            .map(|stroke_content_stroke| {
+                let LayeredStroke { stroke, layer } = stroke_content_stroke;
+                let offset = stroke.bounds().mins.coords - clipboard_bounds.mins.coords;
+                let key = self.insert_stroke((*stroke).clone(), Some(layer));
 
-        let mut insert_group =
-            |strokes: Vec<Arc<Stroke>>, layer: Option<StrokeLayer>| -> Vec<StrokeKey> {
-                strokes
-                    .into_iter()
-                    .map(|s| {
-                        let offset = s.bounds().mins.coords - clipboard_bounds.mins.coords;
-                        let key = self.insert_stroke((*s).clone(), layer);
-                        // position strokes without resizing
-                        self.set_stroke_pos(key, pos);
-                        self.translate_strokes(&[key], offset);
+                // position strokes without resizing
+                self.set_stroke_pos(key, pos);
+                self.translate_strokes(&[key], offset);
 
-                        // apply a rescale around a pivot
-                        self.scale_strokes_with_pivot(&[key], na::Vector2::new(ratio, ratio), pos);
-                        self.scale_strokes_images_with_pivot(
-                            &[key],
-                            na::Vector2::new(ratio, ratio),
-                            pos,
-                        );
+                // apply a rescale around a pivot
+                self.scale_strokes_with_pivot(&[key], na::Vector2::new(ratio, ratio), pos);
+                self.scale_strokes_images_with_pivot(&[key], na::Vector2::new(ratio, ratio), pos);
 
-                        // select keys
-                        self.set_selected(key, true);
-                        key
-                    })
-                    .collect()
-            };
-
-        let mut inserted_keys = insert_group(strokes, None);
-        inserted_keys.extend(insert_group(
-            highlighter_strokes,
-            Some(StrokeLayer::Highlighter),
-        ));
-
-        inserted_keys
+                // select keys
+                self.set_selected(key, true);
+                key
+            })
+            .collect()
     }
 }


### PR DESCRIPTION
- Depends on #1729.
- Closes #449.
- Alternative to #1602.

---

- Adds multiplicative blending to the "Marker" pen.
- Moves the highlighter stroke layer to the top.
- Preserves layer information when copy-pasting strokes.

[Bildschirmaufnahme_20260407_171820.webm](https://github.com/user-attachments/assets/28cc68c3-7e3c-4a04-8708-e450f7a4bec9)

---

### TODO

The SVGs that Cairo produces when multiplicative blending is involved seem to be very weird. Simplifying them using `usvg` breaks them, making them fully blank or black in all applications. 

When skipping the simplification, the only applications I have that were able to correctly render them were a Chromium browser, GIMP and Inkscape (didn't work in LibreOffice, Gwenview, Firefox and Rnote). This also fixed Rnote PNG exports, so I guess `librsvg` can do it... *sometimes*?

Any help on this would be appreciated. Below is an example SVG (without simplification). I believe that this could be a dealbreaker for this PR as it seems like a Cairo bug, and Cairo is pretty much maintenance-only.

<img width="309" height="160" alt="test" src="https://github.com/user-attachments/assets/f4cea6ac-07df-457e-9457-88d64811dcb1" />