### PR TITLE
Fix Pinch-to-Zoom With GTK Workaround

### DIFF
--- a/crates/rnote-ui/src/canvaswrapper.rs
+++ b/crates/rnote-ui/src/canvaswrapper.rs
@@ -509,6 +509,15 @@ mod imp {
                     obj,
                     move |gesture, _| {
                         gesture.set_state(EventSequenceState::Claimed);
+                        // Workaround for a GTK bug where kinetic scroll deceleration continues
+                        // with stale values during a pinch-to-zoom, causing sudden position jumps.
+                        // Toggling kinetic scrolling off/on cancels any active deceleration.
+                        // See: https://gitlab.gnome.org/GNOME/gtk/-/issues/187
+                        let scroller = canvaswrapper.scroller();
+                        if scroller.is_kinetic_scrolling() {
+                            scroller.set_kinetic_scrolling(false);
+                            scroller.set_kinetic_scrolling(true);
+                        }
                         let current_zoom = canvaswrapper.canvas().engine_ref().camera.total_zoom();
 
                         zoom_begin.set(current_zoom);


### PR DESCRIPTION
This is a workaround for the GTK bug, where kinetic scrolling doesn't correctly cancel during pinch-to-zoom, causing sudden jumps in the document position. This was heavily inspired by https://gitlab.gnome.org/GNOME/papers/-/merge_requests/751. Given the sporadic nature of the bug, I can't guarantee, that this fixes all instances but at least on my system I can't seem to trigger it any more.

Closes: #885 