### PR TITLE
fix: alt shift drag gesture regression

### DIFF
--- a/crates/rnote-ui/src/canvaswrapper.rs
+++ b/crates/rnote-ui/src/canvaswrapper.rs
@@ -627,7 +627,9 @@ mod imp {
                         let modifiers = gesture.current_event_state();
 
                         // At the start BUTTON1_MASK is not included
-                        if modifiers.contains(gdk::ModifierType::ALT_MASK) {
+                        if modifiers.contains(gdk::ModifierType::ALT_MASK)
+                            && !modifiers.contains(gdk::ModifierType::SHIFT_MASK)
+                        {
                             gesture.set_state(EventSequenceState::Claimed);
                             offset_start.set(canvaswrapper.canvas().engine_ref().camera.offset());
                         } else {
@@ -715,9 +717,9 @@ mod imp {
                             let modifiers = gesture.current_event_state();
 
                             // At the start BUTTON1_MASK is not included
-                            if modifiers.contains(
-                                gdk::ModifierType::SHIFT_MASK | gdk::ModifierType::ALT_MASK,
-                            ) {
+                            if modifiers.contains(gdk::ModifierType::ALT_MASK)
+                                && modifiers.contains(gdk::ModifierType::SHIFT_MASK)
+                            {
                                 gesture.set_state(EventSequenceState::Claimed);
                                 let current_zoom =
                                     canvaswrapper.canvas().engine_ref().camera.total_zoom();


### PR DESCRIPTION
- Fixes a regression caused by #1724 that prevents the <kbd>ALT</kbd> + <kbd>SHIFT</kbd> + Drag gesture from working (because the <kbd>ALT</kbd> + Drag gesture always claims the event).