### PR TITLE
feat: expand brush style menu, fix inconsistencies

### DIFF
--- a/crates/rnote-ui/data/ui/penssidebar/brushpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/brushpage.ui
@@ -12,16 +12,44 @@
     <child>
       <object class="GtkBox">
         <property name="orientation">vertical</property>
+        <property name="spacing">3</property>
         <child>
-          <object class="GtkMenuButton" id="brushstyle_menubutton">
-            <property name="direction">left</property>
-            <property name="tooltip_text" translatable="yes">Brush Style</property>
-            <property name="popover">brushstyle_popover</property>
-            <property name="icon-name">pen-brush-style-solid-symbolic</property>
+          <object class="GtkBox" id="brushstyle_togglebox">
+            <property name="orientation">vertical</property>
+            <property name="homogeneous">true</property>
+            <property name="vexpand">false</property>
             <style>
-              <class name="flat" />
-              <class name="sidebar_action_button" />
+              <class name="linked" />
             </style>
+            <child>
+              <object class="GtkToggleButton" id="brushstyle_marker_toggle">
+                <property name="tooltip_text" translatable="yes">Marker</property>
+                <property name="icon-name">pen-brush-style-marker-symbolic</property>
+                <style>
+                  <class name="sidebar_action_button" />
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkToggleButton" id="brushstyle_solid_toggle">
+                <property name="group">brushstyle_marker_toggle</property>
+                <property name="tooltip_text" translatable="yes">Solid</property>
+                <property name="icon-name">pen-brush-style-solid-symbolic</property>
+                <style>
+                  <class name="sidebar_action_button" />
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkToggleButton" id="brushstyle_textured_toggle">
+                <property name="group">brushstyle_marker_toggle</property>
+                <property name="tooltip_text" translatable="yes">Textured</property>
+                <property name="icon-name">pen-brush-style-textured-symbolic</property>
+                <style>
+                  <class name="sidebar_action_button" />
+                </style>
+              </object>
+            </child>
           </object>
         </child>
         <child>
@@ -48,90 +76,6 @@
       <object class="RnStrokeWidthPicker" id="stroke_width_picker">
       </object>
     </child>
-
-    <!-- Brush style -->
-    <object class="GtkPopover" id="brushstyle_popover">
-      <child>
-        <object class="GtkBox">
-          <property name="orientation">vertical</property>
-          <property name="margin-top">6</property>
-          <property name="margin-bottom">6</property>
-          <property name="margin-start">6</property>
-          <property name="margin-end">6</property>
-          <property name="spacing">12</property>
-          <child>
-            <object class="GtkBox">
-              <child>
-                <object class="GtkLabel">
-                  <property name="label" translatable="yes">Brush Styles</property>
-                  <property name="hexpand">true</property>
-                  <property name="halign">center</property>
-                  <style>
-                    <class name="title-3" />
-                  </style>
-                </object>
-              </child>
-              <child>
-                <object class="GtkButton" id="brushstyle_popover_close_button">
-                  <property name="icon-name">window-close-symbolic</property>
-                  <style>
-                    <class name="flat" />
-                    <class name="circular" />
-                  </style>
-                </object>
-              </child>
-            </object>
-          </child>
-          <child>
-            <object class="GtkListBox" id="brushstyle_listbox">
-              <property name="width-request">300</property>
-              <property name="selection-mode">browse</property>
-              <style>
-                <class name="content" />
-                <class name="large" />
-              </style>
-              <child>
-                <object class="AdwActionRow" id="brushstyle_marker_row">
-                  <property name="title" translatable="yes">Marker</property>
-                  <property name="subtitle" translatable="yes">Mark underneath other strokes</property>
-                  <child type="prefix">
-                    <object class="GtkImage">
-                      <property name="icon-name">pen-brush-style-marker-symbolic</property>
-                      <property name="icon-size">large</property>
-                    </object>
-                  </child>
-                </object>
-              </child>
-              <child>
-                <object class="AdwActionRow" id="brushstyle_solid_row">
-                  <property name="title" translatable="yes">Solid</property>
-                  <property name="subtitle" translatable="yes">Draw solid color strokes</property>
-                  <child type="prefix">
-                    <object class="GtkImage">
-                      <property name="icon-name">pen-brush-style-solid-symbolic</property>
-                      <property name="icon-size">large</property>
-                    </object>
-                  </child>
-                </object>
-              </child>
-              <child>
-                <object class="AdwActionRow" id="brushstyle_textured_row">
-                  <property name="title" translatable="yes">Textured</property>
-                  <property name="subtitle" translatable="yes">Draw textured strokes</property>
-                  <child type="prefix">
-                    <object class="GtkImage">
-                      <property name="icon-name">pen-brush-style-textured-symbolic</property>
-                      <property name="icon-size">large</property>
-                    </object>
-                  </child>
-                </object>
-              </child>
-            </object>
-          </child>
-        </object>
-      </child>
-    </object>
-
     <!-- Brush config -->
     <object class="GtkPopover" id="brushconfig_popover">
       <child>

--- a/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
@@ -12,6 +12,7 @@
     <child>
       <object class="GtkBox">
         <property name="orientation">vertical</property>
+        <property name="spacing">3</property>
         <property name="vexpand">false</property>
         <child>
           <object class="GtkMenuButton" id="shapebuildertype_menubutton">
@@ -54,11 +55,6 @@
     </child>
     <child>
       <object class="RnStrokeWidthPicker" id="stroke_width_picker">
-      </object>
-    </child>
-    <child>
-      <object class="GtkSeparator">
-        <property name="orientation">vertical</property>
       </object>
     </child>
 

--- a/crates/rnote-ui/data/ui/penssidebar/toolspage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/toolspage.ui
@@ -16,6 +16,7 @@
         <child>
           <object class="GtkBox">
             <property name="orientation">vertical</property>
+            <property name="spacing">3</property>
             <child>
               <object class="GtkToggleButton" id="toolstyle_verticalspace_toggle">
                 <property name="tooltip_text" translatable="yes">Insert Vertical Space</property>

--- a/crates/rnote-ui/src/appwindow/imp.rs
+++ b/crates/rnote-ui/src/appwindow/imp.rs
@@ -696,11 +696,6 @@ impl RnAppWindow {
             obj.overlays()
                 .penssidebar()
                 .brush_page()
-                .brushstyle_menubutton()
-                .set_direction(ArrowType::Right);
-            obj.overlays()
-                .penssidebar()
-                .brush_page()
                 .stroke_width_picker()
                 .set_position(PositionType::Left);
             obj.overlays()
@@ -809,11 +804,6 @@ impl RnAppWindow {
                 .penssidebar()
                 .brush_page()
                 .brushconfig_menubutton()
-                .set_direction(ArrowType::Left);
-            obj.overlays()
-                .penssidebar()
-                .brush_page()
-                .brushstyle_menubutton()
                 .set_direction(ArrowType::Left);
             obj.overlays()
                 .penssidebar()

--- a/crates/rnote-ui/src/penssidebar/brushpage.rs
+++ b/crates/rnote-ui/src/penssidebar/brushpage.rs
@@ -2,8 +2,8 @@
 use crate::{RnAppWindow, RnStrokeWidthPicker};
 use adw::prelude::*;
 use gtk4::{
-    Button, CompositeTemplate, ListBox, MenuButton, Popover, Widget, glib, glib::clone,
-    subclass::prelude::*,
+    Button, CompositeTemplate, ListBox, MenuButton, Popover, ToggleButton, Widget, glib,
+    glib::clone, subclass::prelude::*,
 };
 use num_traits::cast::ToPrimitive;
 use rnote_compose::builders::PenPathBuilderType;
@@ -19,19 +19,11 @@ mod imp {
     #[template(resource = "/com/github/flxzt/rnote/ui/penssidebar/brushpage.ui")]
     pub(crate) struct RnBrushPage {
         #[template_child]
-        pub(crate) brushstyle_menubutton: TemplateChild<MenuButton>,
+        pub(crate) brushstyle_marker_toggle: TemplateChild<ToggleButton>,
         #[template_child]
-        pub(crate) brushstyle_popover: TemplateChild<Popover>,
+        pub(crate) brushstyle_solid_toggle: TemplateChild<ToggleButton>,
         #[template_child]
-        pub(crate) brushstyle_popover_close_button: TemplateChild<Button>,
-        #[template_child]
-        pub(crate) brushstyle_listbox: TemplateChild<ListBox>,
-        #[template_child]
-        pub(crate) brushstyle_marker_row: TemplateChild<adw::ActionRow>,
-        #[template_child]
-        pub(crate) brushstyle_solid_row: TemplateChild<adw::ActionRow>,
-        #[template_child]
-        pub(crate) brushstyle_textured_row: TemplateChild<adw::ActionRow>,
+        pub(crate) brushstyle_textured_toggle: TemplateChild<ToggleButton>,
         #[template_child]
         pub(crate) brushconfig_menubutton: TemplateChild<MenuButton>,
         #[template_child]
@@ -104,32 +96,76 @@ impl RnBrushPage {
         glib::Object::new()
     }
 
-    pub(crate) fn brushstyle_menubutton(&self) -> MenuButton {
-        self.imp().brushstyle_menubutton.get()
-    }
-
     pub(crate) fn brushconfig_menubutton(&self) -> MenuButton {
         self.imp().brushconfig_menubutton.get()
     }
 
     pub(crate) fn brush_style(&self) -> Option<BrushStyle> {
-        BrushStyle::try_from(self.imp().brushstyle_listbox.selected_row()?.index() as u32).ok()
+        if self.imp().brushstyle_marker_toggle.is_active() {
+            Some(BrushStyle::Marker)
+        } else if self.imp().brushstyle_solid_toggle.is_active() {
+            Some(BrushStyle::Solid)
+        } else if self.imp().brushstyle_textured_toggle.is_active() {
+            Some(BrushStyle::Textured)
+        } else {
+            None
+        }
     }
 
     pub(crate) fn set_brush_style(&self, brush_style: BrushStyle) {
         match brush_style {
-            BrushStyle::Marker => self
-                .imp()
-                .brushstyle_listbox
-                .select_row(Some(&*self.imp().brushstyle_marker_row)),
-            BrushStyle::Solid => self
-                .imp()
-                .brushstyle_listbox
-                .select_row(Some(&*self.imp().brushstyle_solid_row)),
-            BrushStyle::Textured => self
-                .imp()
-                .brushstyle_listbox
-                .select_row(Some(&*self.imp().brushstyle_textured_row)),
+            BrushStyle::Marker => self.imp().brushstyle_marker_toggle.set_active(true),
+            BrushStyle::Solid => self.imp().brushstyle_solid_toggle.set_active(true),
+            BrushStyle::Textured => self.imp().brushstyle_textured_toggle.set_active(true),
+        }
+    }
+
+    fn apply_brush_style_selection(&self, appwindow: &RnAppWindow, brush_style: BrushStyle) {
+        appwindow
+            .engine_config()
+            .write()
+            .pens_config
+            .brush_config
+            .style = brush_style;
+        self.stroke_width_picker().deselect_setters();
+
+        match brush_style {
+            BrushStyle::Marker => {
+                let stroke_width = appwindow
+                    .engine_config()
+                    .read()
+                    .pens_config
+                    .brush_config
+                    .marker_options
+                    .stroke_width;
+                self.imp()
+                    .stroke_width_picker
+                    .set_stroke_width(stroke_width);
+            }
+            BrushStyle::Solid => {
+                let stroke_width = appwindow
+                    .engine_config()
+                    .read()
+                    .pens_config
+                    .brush_config
+                    .solid_options
+                    .stroke_width;
+                self.imp()
+                    .stroke_width_picker
+                    .set_stroke_width(stroke_width);
+            }
+            BrushStyle::Textured => {
+                let stroke_width = appwindow
+                    .engine_config()
+                    .read()
+                    .pens_config
+                    .brush_config
+                    .textured_options
+                    .stroke_width;
+                self.imp()
+                    .stroke_width_picker
+                    .set_stroke_width(stroke_width);
+            }
         }
     }
 
@@ -195,17 +231,9 @@ impl RnBrushPage {
 
     pub(crate) fn init(&self, appwindow: &RnAppWindow) {
         let imp = self.imp();
-        let brushstyle_popover = imp.brushstyle_popover.get();
         let brushconfig_popover = imp.brushconfig_popover.get();
 
         // Popovers
-        imp.brushstyle_popover_close_button.connect_clicked(clone!(
-            #[weak]
-            brushstyle_popover,
-            move |_| {
-                brushstyle_popover.popdown();
-            }
-        ));
         imp.brushconfig_popover_close_button.connect_clicked(clone!(
             #[weak]
             brushconfig_popover,
@@ -270,77 +298,57 @@ impl RnBrushPage {
         );
 
         // Style
-        imp.brushstyle_listbox.connect_row_selected(clone!(
+        imp.brushstyle_marker_toggle.connect_toggled(clone!(
             #[weak(rename_to=brushpage)]
             self,
             #[weak]
             appwindow,
-            move |_, _| {
+            move |toggle| {
+                if !toggle.is_active() {
+                    return;
+                }
+
                 let Some(brush_style) = brushpage.brush_style() else {
                     return;
                 };
 
-                appwindow
-                    .engine_config()
-                    .write()
-                    .pens_config
-                    .brush_config
-                    .style = brush_style;
-                brushpage.stroke_width_picker().deselect_setters();
+                brushpage.apply_brush_style_selection(&appwindow, brush_style);
+            }
+        ));
 
-                match brush_style {
-                    BrushStyle::Marker => {
-                        let stroke_width = appwindow
-                            .engine_config()
-                            .read()
-                            .pens_config
-                            .brush_config
-                            .marker_options
-                            .stroke_width;
-                        brushpage
-                            .imp()
-                            .stroke_width_picker
-                            .set_stroke_width(stroke_width);
-                        brushpage
-                            .imp()
-                            .brushstyle_menubutton
-                            .set_icon_name("pen-brush-style-marker-symbolic");
-                    }
-                    BrushStyle::Solid => {
-                        let stroke_width = appwindow
-                            .engine_config()
-                            .read()
-                            .pens_config
-                            .brush_config
-                            .solid_options
-                            .stroke_width;
-                        brushpage
-                            .imp()
-                            .stroke_width_picker
-                            .set_stroke_width(stroke_width);
-                        brushpage
-                            .imp()
-                            .brushstyle_menubutton
-                            .set_icon_name("pen-brush-style-solid-symbolic");
-                    }
-                    BrushStyle::Textured => {
-                        let stroke_width = appwindow
-                            .engine_config()
-                            .read()
-                            .pens_config
-                            .brush_config
-                            .textured_options
-                            .stroke_width;
-                        brushpage
-                            .imp()
-                            .stroke_width_picker
-                            .set_stroke_width(stroke_width);
-                        brushpage
-                            .imp()
-                            .brushstyle_menubutton
-                            .set_icon_name("pen-brush-style-textured-symbolic");
-                    }
+        imp.brushstyle_solid_toggle.connect_toggled(clone!(
+            #[weak(rename_to=brushpage)]
+            self,
+            #[weak]
+            appwindow,
+            move |toggle| {
+                if !toggle.is_active() {
+                    return;
                 }
+
+                let Some(brush_style) = brushpage.brush_style() else {
+                    return;
+                };
+
+                brushpage.apply_brush_style_selection(&appwindow, brush_style);
+            }
+        ));
+
+        imp.brushstyle_textured_toggle.connect_toggled(clone!(
+            #[weak(rename_to=brushpage)]
+            self,
+            #[weak]
+            appwindow,
+            move |toggle| {
+                if !toggle.is_active() {
+                    return;
+                }
+
+                let Some(brush_style) = brushpage.brush_style() else {
+                    return;
+                };
+
+                brushpage.apply_brush_style_selection(&appwindow, brush_style);
             }
         ));
 


### PR DESCRIPTION
- Should be merged alongside #1730.
- Alternative to #1602.
- Fixes some inconsistent margins and separators.

There has been some discussion in #1602 on if the highlighter/marker brush style should be split off into a separate pen in the bottom sidebar. As I've explained there, I think that this is a compromise that makes the highlighter easily accessible while not duplicating parts of the UI and engine.

<img width="125" height="569" alt="grafik" src="https://github.com/user-attachments/assets/3adea250-c665-4484-9f00-8aebd3b63e16" />