### PR TITLE
feat: Enable editing width of existing strokes

### DIFF
--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -539,6 +539,28 @@ impl Engine {
         widget_flags
     }
 
+    /// Get the width of the thinnest stroke in the selection.
+    pub fn get_selection_stroke_width(&self) -> Option<f64> {
+        let keys = self.store.selection_keys_as_rendered();
+        self.store.min_stroke_width(&keys)
+    }
+
+    /// Change the width of all selected strokes.
+    pub fn change_selection_stroke_width(&mut self, width: f64) -> WidgetFlags {
+        let keys = self.store.selection_keys_as_rendered();
+        if keys.is_empty() {
+            return WidgetFlags::default();
+        }
+
+        let widget_flags = self.store.set_stroke_widths(&keys, width);
+
+        widget_flags
+            | self.current_pen_update_state()
+            | self.doc_resize_autoexpand()
+            | self.record(Instant::now())
+            | self.update_rendering_current_viewport()
+    }
+
     /// Generate bounds for each page on the document which contains content.
     pub fn pages_bounds_w_content(&self, split_order: SplitOrder) -> Vec<Aabb> {
         let doc_bounds = self.document.bounds();

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -102,6 +102,50 @@ impl StrokeStore {
             .collect::<Vec<Stroke>>()
     }
 
+    /// The width of the thinnest stroke from the given keys.
+    pub(crate) fn min_stroke_width(&self, keys: &[StrokeKey]) -> Option<f64> {
+        let strokes = self.get_strokes_ref(keys);
+
+        strokes
+            .iter()
+            .filter_map(|stroke| match stroke {
+                Stroke::BrushStroke(brush_stroke) => Some(brush_stroke.style.stroke_width()),
+                Stroke::ShapeStroke(shape_stroke) => Some(shape_stroke.style.stroke_width()),
+                _ => None,
+            })
+            .reduce(f64::min)
+    }
+
+    /// Change the width of the strokes for the given keys.
+    pub(crate) fn set_stroke_widths(&mut self, keys: &[StrokeKey], width: f64) -> WidgetFlags {
+        let mut widget_flags = WidgetFlags::default();
+
+        if keys.is_empty() {
+            return widget_flags;
+        }
+
+        for &key in keys {
+            if let Some(stroke) = self.get_stroke_mut(key) {
+                match stroke {
+                    Stroke::BrushStroke(brush_stroke) => {
+                        brush_stroke.style.set_stroke_width(width);
+                    }
+                    Stroke::ShapeStroke(shape_stroke) => {
+                        shape_stroke.style.set_stroke_width(width);
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        self.update_geometry_for_strokes(keys);
+
+        widget_flags.redraw = true;
+        widget_flags.store_modified = true;
+
+        widget_flags
+    }
+
     /// Updates the stroke geometry.
     ///
     /// The stroke then needs to update its rendering.

--- a/crates/rnote-ui/data/ui/penssidebar/selectorpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/selectorpage.ui
@@ -106,6 +106,18 @@
           </object>
         </child>
         <child>
+          <object class="GtkMenuButton" id="strokewidth_menubutton">
+            <property name="direction">left</property>
+            <property name="tooltip_text" translatable="yes">Change Width of Selected Strokes</property>
+            <property name="popover">strokewidth_popover</property>
+            <property name="icon-name">pen-brush-style-solid-symbolic</property>
+            <style>
+              <class name="flat" />
+              <class name="sidebar_action_button" />
+            </style>
+          </object>
+        </child>
+        <child>
           <object class="GtkButton" id="selection_delete_button">
             <property name="tooltip_text" translatable="yes">Delete Selection</property>
             <property name="action-name">win.selection-trash</property>
@@ -119,4 +131,49 @@
       </object>
     </child>
   </template>
+
+    <!-- Stroke Width Menu -->
+    <object class="GtkPopover" id="strokewidth_popover">
+        <child>
+        <object class="GtkBox">
+            <property name="orientation">vertical</property>
+            <property name="margin-top">6</property>
+            <property name="margin-bottom">6</property>
+            <property name="margin-start">6</property>
+            <property name="margin-end">6</property>
+            <property name="spacing">12</property>
+            <property name="width-request">100</property> <!-- todo: change this value -->
+            <child>
+            <object class="GtkBox">
+                <child>
+                <object class="GtkLabel">
+                    <property name="label" translatable="yes">Stroke Width</property>
+                    <property name="hexpand">true</property>
+                    <property name="halign">center</property>
+                    <style>
+                    <class name="title-3" />
+                    </style>
+                </object>
+                </child>
+                <child>
+                <object class="GtkButton" id="strokewidth_popover_close_button">
+                    <property name="icon-name">window-close-symbolic</property>
+                    <style>
+                    <class name="flat" />
+                    <class name="circular" />
+                    </style>
+                </object>
+                </child>
+            </object>
+            </child>
+            <child>
+                <object class="RnStrokeWidthPicker" id="stroke_width_picker">
+                    <property name="halign">center</property>
+                    <property name="position">top</property>
+                </object>
+            </child>
+        </object>
+        </child>
+    </object>
+
 </interface>

--- a/crates/rnote-ui/src/appwindow/imp.rs
+++ b/crates/rnote-ui/src/appwindow/imp.rs
@@ -730,6 +730,11 @@ impl RnAppWindow {
                 .set_position(PositionType::Left);
             obj.overlays()
                 .penssidebar()
+                .selector_page()
+                .strokewidth_menubutton()
+                .set_direction(ArrowType::Right);
+            obj.overlays()
+                .penssidebar()
                 .tools_page()
                 .verticalspace_menubutton()
                 .set_direction(ArrowType::Right);
@@ -845,6 +850,11 @@ impl RnAppWindow {
                 .eraser_page()
                 .stroke_width_picker()
                 .set_position(PositionType::Right);
+            obj.overlays()
+                .penssidebar()
+                .selector_page()
+                .strokewidth_menubutton()
+                .set_direction(ArrowType::Left);
             obj.overlays()
                 .penssidebar()
                 .tools_page()

--- a/crates/rnote-ui/src/penssidebar/selectorpage.rs
+++ b/crates/rnote-ui/src/penssidebar/selectorpage.rs
@@ -1,14 +1,20 @@
 // Imports
 use crate::RnAppWindow;
+use crate::RnStrokeWidthPicker;
 use gtk4::{
-    CompositeTemplate, ToggleButton, Widget, glib, glib::clone, prelude::*, subclass::prelude::*,
+    Button, CompositeTemplate, MenuButton, Popover, ToggleButton, Widget, glib, glib::clone,
+    prelude::*, subclass::prelude::*,
 };
+use rnote_engine::pens::pensconfig::BrushConfig;
+use rnote_engine::pens::pensconfig::brushconfig::SolidOptions;
 use rnote_engine::pens::pensconfig::selectorconfig::SelectorStyle;
+use std::cell::Cell;
+use std::str;
 
 mod imp {
     use super::*;
 
-    #[derive(Default, Debug, CompositeTemplate)]
+    #[derive(Debug, CompositeTemplate)]
     #[template(resource = "/com/github/flxzt/rnote/ui/penssidebar/selectorpage.ui")]
     pub(crate) struct RnSelectorPage {
         #[template_child]
@@ -21,6 +27,34 @@ mod imp {
         pub(crate) selectorstyle_intersectingpath_toggle: TemplateChild<ToggleButton>,
         #[template_child]
         pub(crate) resize_lock_aspectratio_togglebutton: TemplateChild<ToggleButton>,
+        #[template_child]
+        pub(crate) strokewidth_menubutton: TemplateChild<MenuButton>,
+        #[template_child]
+        pub(crate) strokewidth_popover: TemplateChild<Popover>,
+        #[template_child]
+        pub(crate) strokewidth_popover_close_button: TemplateChild<Button>,
+        #[template_child]
+        pub(crate) stroke_width_picker: TemplateChild<RnStrokeWidthPicker>,
+
+        pub(crate) allow_stroke_width_changes: Cell<bool>, // Used to stop the stroke width changing immediately when the popup is opened
+    }
+
+    impl Default for RnSelectorPage {
+        fn default() -> Self {
+            Self {
+                selectorstyle_polygon_toggle: TemplateChild::default(),
+                selectorstyle_rect_toggle: TemplateChild::default(),
+                selectorstyle_single_toggle: TemplateChild::default(),
+                selectorstyle_intersectingpath_toggle: TemplateChild::default(),
+                resize_lock_aspectratio_togglebutton: TemplateChild::default(),
+                strokewidth_menubutton: TemplateChild::default(),
+                strokewidth_popover: TemplateChild::default(),
+                strokewidth_popover_close_button: TemplateChild::default(),
+                stroke_width_picker: TemplateChild::default(),
+
+                allow_stroke_width_changes: Cell::new(true),
+            }
+        }
     }
 
     #[glib::object_subclass]
@@ -71,6 +105,10 @@ impl RnSelectorPage {
         glib::Object::new()
     }
 
+    pub(crate) fn strokewidth_menubutton(&self) -> MenuButton {
+        self.imp().strokewidth_menubutton.get()
+    }
+
     #[allow(unused)]
     pub(crate) fn selector_style(&self) -> Option<SelectorStyle> {
         if self.imp().selectorstyle_polygon_toggle.is_active() {
@@ -97,6 +135,10 @@ impl RnSelectorPage {
                 .selectorstyle_intersectingpath_toggle
                 .set_active(true),
         }
+    }
+
+    pub(crate) fn stroke_width_picker(&self) -> RnStrokeWidthPicker {
+        self.imp().stroke_width_picker.get()
     }
 
     pub(crate) fn init(&self, appwindow: &RnAppWindow) {
@@ -180,6 +222,92 @@ impl RnSelectorPage {
                         .resize_lock_aspectratio = toggle.is_active();
                 }
             ));
+
+        // Stroke width
+
+        // Close popup when close button clicked
+        let strokewidth_popover = imp.strokewidth_popover.get();
+        imp.strokewidth_popover_close_button.connect_clicked(clone!(
+            #[weak]
+            strokewidth_popover,
+            move |_| {
+                strokewidth_popover.popdown();
+            }
+        ));
+
+        // Deselect setters when popup closed
+        imp.strokewidth_popover.connect_closed(clone!(
+            #[weak(rename_to=selectorpage)]
+            self,
+            move |_| {
+                selectorpage.stroke_width_picker().deselect_setters();
+                // TODO: Stop deselect animation from showing when popup opened again
+            }
+        ));
+
+        // Set width picker to selected stroke width when popup opened
+        imp.strokewidth_menubutton.connect_active_notify(clone!(
+            #[weak]
+            imp,
+            #[weak]
+            appwindow,
+            move |btn| {
+                if !btn.is_active() {
+                    return;
+                }
+
+                let Some(canvas) = appwindow.active_tab_canvas() else {
+                    return;
+                };
+                let stroke_width = canvas
+                    .engine_ref()
+                    .get_selection_stroke_width()
+                    .unwrap_or(2.0); // Default to width of 2 if no valid strokes selected
+
+                imp.allow_stroke_width_changes.set(false); // Stop the new picker width from applying immediately
+                imp.stroke_width_picker
+                    .set_stroke_width(stroke_width + 0.001); // A small value is added to allow the user to apply a width equal to 'stroke width'
+            }
+        ));
+
+        imp.stroke_width_picker
+            .spinbutton()
+            .set_range(BrushConfig::STROKE_WIDTH_MIN, BrushConfig::STROKE_WIDTH_MAX);
+        // set value after the range!
+        imp.stroke_width_picker
+            .set_stroke_width(SolidOptions::default().stroke_width);
+
+        // Set stroke width when picker width changed
+        imp.stroke_width_picker.connect_notify_local(
+            Some("stroke-width"),
+            clone!(
+                #[weak]
+                imp,
+                #[weak]
+                appwindow,
+                move |picker, _| {
+                    let stroke_width = picker.stroke_width();
+
+                    // Return if no canvas found
+                    let Some(canvas) = appwindow.active_tab_canvas() else {
+                        return;
+                    };
+
+                    // Return if the popup has just been opened
+                    if !imp.allow_stroke_width_changes.get() {
+                        imp.allow_stroke_width_changes.set(true);
+                        return;
+                    }
+
+                    // Change the width of the selected strokes
+                    let widget_flags = canvas
+                        .engine_mut()
+                        .change_selection_stroke_width(stroke_width);
+
+                    appwindow.handle_widget_flags(widget_flags, &canvas);
+                }
+            ),
+        );
     }
 
     pub(crate) fn refresh_ui(&self, appwindow: &RnAppWindow) {


### PR DESCRIPTION
This merge request adds a popup menu to the selection sidebar, which allows the width of the selected strokes to be edited. The widths of selected brush and shape strokes are changed, while other stroke types are unaffected.

Resolves #1039.
Partially resolves #1626 , by allowing the width to be manually changed back after an object is scaled.

## Demo:

https://github.com/user-attachments/assets/c268c3bc-1637-4122-99e8-0f3d440ac925


## Todo:

- [ ] Use a more suitable icon for the menu button.
- [ ] Add keyboard shortcuts to open/close the menu.

Additionally, there are 2 problems I've not yet been able to resolve:

The 3 width selector buttons are deselected when the popup is closed to allow them to be clicked again next time it is opened. The issue is that the deselect animation only starts when the popup is next opened, and I don't know how to stop this animation from playing:

https://github.com/user-attachments/assets/bd19de56-2986-4fa3-970b-bc7aa9d9ddb8

Also, I'd like to save the size of the selector buttons between application restarts, like in the other width selectors, but I haven't been able to figure out how to do this yet.

Any advice on these issues would be greatly appreciated. I would also like to confirm whether the implementation so far looks suitable, or if there are any changes needed.

Thanks for making such a great app!