### PR TITLE
add the rnote cli to the windows inno build

### DIFF
--- a/build-aux/inno_build.py
+++ b/build-aux/inno_build.py
@@ -15,6 +15,7 @@ app_name_capitalized = sys.argv[5]
 app_id = sys.argv[6]
 ui_output = sys.argv[7]
 inno_script = sys.argv[8]
+define_cli_output = sys.argv[9]
 
 print(f"""
 ### executing Inno-Setup installer build script with arguments: ###
@@ -26,6 +27,7 @@ print(f"""
     app_id: {app_id}
     ui_output: {ui_output}
     inno_script: {inno_script}
+    (optional) define cli {define_cli_output}
 """, file=sys.stderr)
 
 def run_command(command, error_message):
@@ -138,7 +140,7 @@ for file in os.listdir(app_mo_dir):
 print("Running ISCC...", file=sys.stderr)
 
 run_command(
-    f"iscc {inno_script}",
+    f"iscc {inno_script} {define_cli_output}",
     "Running ISCC failed"
 )
 

--- a/build-aux/inno_build.py
+++ b/build-aux/inno_build.py
@@ -29,7 +29,7 @@ print(f"""
     app_id: {app_id}
     ui_output: {ui_output}
     inno_script: {inno_script}
-    (optional) define cli {cli_name}
+    cli_name: {cli_name} (empty if not packaged)
 """, file=sys.stderr)
 
 def run_command(command, error_message):

--- a/build-aux/inno_build.py
+++ b/build-aux/inno_build.py
@@ -5,6 +5,8 @@ import os
 import shutil
 import glob
 import itertools
+import subprocess
+from subprocess import CalledProcessError
 
 source_root = sys.argv[1]
 build_root = sys.argv[2]
@@ -15,7 +17,7 @@ app_name_capitalized = sys.argv[5]
 app_id = sys.argv[6]
 ui_output = sys.argv[7]
 inno_script = sys.argv[8]
-define_cli_output = sys.argv[9]
+cli_name = sys.argv[9]
 
 print(f"""
 ### executing Inno-Setup installer build script with arguments: ###
@@ -27,13 +29,14 @@ print(f"""
     app_id: {app_id}
     ui_output: {ui_output}
     inno_script: {inno_script}
-    (optional) define cli {define_cli_output}
+    (optional) define cli {cli_name}
 """, file=sys.stderr)
 
 def run_command(command, error_message):
-    res = os.system(command)
-    if res != 0:
-        print(f"{error_message}, code: {res}", file=sys.stderr)
+    try:
+        subprocess.run(command, shell=True, check=True)
+    except CalledProcessError as e:
+        print(f"{error_message}: {e}", file=sys.stderr)
         print(f"command: {command}", file=sys.stderr)
         sys.exit(1)
 
@@ -139,6 +142,13 @@ for file in os.listdir(app_mo_dir):
 # Build installer
 print("Running ISCC...", file=sys.stderr)
 
+# the inno script will package the cli if the variable MyAppCliExeName
+# is defined. This is done with an additional /DMyAppCliExeName=cli_name.exe
+# argument 
+define_cli_output = ""
+if cli_name:
+    define_cli_output = "/DMyAppCliExeName=" + \
+        cli_name + ".exe"
 run_command(
     f"iscc {inno_script} {define_cli_output}",
     "Running ISCC failed"

--- a/build-aux/rnote_inno.iss.in
+++ b/build-aux/rnote_inno.iss.in
@@ -5,7 +5,6 @@
 #define MyAppPublisher @APP_AUTHOR_NAME@
 #define MyAppURL @APP_WEBSITE@
 #define MyAppExeName @UI_OUTPUT@
-#define MyAppCliExeName @CLI_OUTPUT@
 #define MyAppAssocName MyAppName + " File"
 #define MyAppAssocExt ".rnote"
 #define MyAppAssocKey StringChange(MyAppAssocName, " ", "") + MyAppAssocExt
@@ -50,6 +49,9 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: checkedonce
+#if Defined(MyAppCliExeName)
+    Name: "addtopath"; Description: "Add rnote-cli to PATH (requires logging in again)"; Flags: checkedonce
+#endif
 
 [Files]
 ; DLLs
@@ -85,7 +87,9 @@ Source: "{#meson_source_root}\crates\rnote-engine\data\sounds\LICENSES.md"; Dest
 
 ; Binary
 Source: "{#meson_build_root}\{#MyAppExeName}"; DestDir: "{app}\bin\"; Flags: ignoreversion
-Source: "{#meson_build_root}\{#MyAppCliExeName}"; DestDir: "{app}\bin\"; Flags: ignoreversion
+#if Defined(MyAppCliExeName)
+    Source: "{#meson_build_root}\{#MyAppCliExeName}"; DestDir: "{app}\bin\"; Flags: ignoreversion
+#endif
 
 [Registry]
 Root: HKA; Subkey: "Software\Classes\{#MyAppAssocKey}"; ValueType: string; ValueName: ""; ValueData: "{#MyAppAssocName}"; Flags: uninsdeletekey
@@ -100,3 +104,65 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\bin\{#MyAppExeName}"; Tasks
 
 [Run]
 Filename: "{app}\bin\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+
+[Code]
+#if Defined(MyAppCliExeName)
+    procedure EnvAddPath(Path: string);
+    var
+        Paths: string;
+    begin
+        { Retrieve current path (use empty string if entry does not exists) }
+        { Taken from https://github.com/mentebinaria/retoolkit/blob/f86f5e608836b898da36a3787eb5135d2baef976/src/installer/retoolkit.iss }
+        if not RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', Paths)
+        then Paths := '';
+
+        { Skip if string already found in path }
+        if Pos(';' + Uppercase(Path) + ';', ';' + Uppercase(Paths) + ';') > 0 then exit;
+
+        { App string to the end of the path variable }
+        Paths := Paths + ';'+ Path //+';'
+
+        { Overwrite (or create if missing) path environment variable }
+        if RegWriteStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', Paths)
+        then Log(Format('The [%s] added to PATH: [%s]', [Path, Paths]))
+        else Log(Format('Error while adding the [%s] to PATH: [%s]', [Path, Paths]));
+    end;
+
+    procedure EnvRemovePath(Path: string);
+    var
+        Paths: string;
+        P: Integer;
+    begin
+        { Skip if registry entry not exists }
+        if not RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', Paths) then
+            exit;
+
+        { Skip if string not found in path }
+        P := Pos(';' + Uppercase(Path) + ';', ';' + Uppercase(Paths) + ';');
+        if P = 0 then exit;
+
+        { Update path variable }
+        Delete(Paths, P - 1, Length(Path) + 1);
+
+        { Overwrite path environment variable }
+        if RegWriteStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', Paths)
+        then Log(Format('The [%s] removed from PATH: [%s]', [Path, Paths]))
+        else Log(Format('Error while removing the [%s] from PATH: [%s]', [Path, Paths]));
+    end;
+
+    procedure CurStepChanged(CurStep: TSetupStep);
+    begin
+        if CurStep = ssPostInstall then
+        begin
+            if WizardIsTaskSelected('addtopath') then EnvAddPath(ExpandConstant('{app}\bin\'));
+        end
+    end;
+
+    procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+    begin
+        if CurUninstallStep = usPostUninstall then
+        begin
+            EnvRemovePath(ExpandConstant('{app}\bin\'));
+        end
+    end;
+#endif

--- a/build-aux/rnote_inno.iss.in
+++ b/build-aux/rnote_inno.iss.in
@@ -5,6 +5,7 @@
 #define MyAppPublisher @APP_AUTHOR_NAME@
 #define MyAppURL @APP_WEBSITE@
 #define MyAppExeName @UI_OUTPUT@
+#define MyAppCliExeName @CLI_OUTPUT@
 #define MyAppAssocName MyAppName + " File"
 #define MyAppAssocExt ".rnote"
 #define MyAppAssocKey StringChange(MyAppAssocName, " ", "") + MyAppAssocExt
@@ -84,6 +85,7 @@ Source: "{#meson_source_root}\crates\rnote-engine\data\sounds\LICENSES.md"; Dest
 
 ; Binary
 Source: "{#meson_build_root}\{#MyAppExeName}"; DestDir: "{app}\bin\"; Flags: ignoreversion
+Source: "{#meson_build_root}\{#MyAppCliExeName}"; DestDir: "{app}\bin\"; Flags: ignoreversion
 
 [Registry]
 Root: HKA; Subkey: "Software\Classes\{#MyAppAssocKey}"; ValueType: string; ValueName: ""; ValueData: "{#MyAppAssocName}"; Flags: uninsdeletekey
@@ -98,4 +100,3 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\bin\{#MyAppExeName}"; Tasks
 
 [Run]
 Filename: "{app}\bin\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
-

--- a/meson.build
+++ b/meson.build
@@ -261,10 +261,10 @@ if build_ui == true
         configuration: inno_script_conf,
     )
 
-    if build_cli and host_machine.system() == 'windows' 
+    if build_cli and host_machine.system() == 'windows'
         define_cli_output = '/DMyAppCliExeName=' + cli_name + '.exe'
     else
-        define_cli_output = ''    
+        define_cli_output = ''
     endif
 
     if host_machine.system() == 'windows'

--- a/meson.build
+++ b/meson.build
@@ -253,13 +253,6 @@ if build_ui == true
     inno_script_conf.set_quoted('APP_SUPPORT_URL', app_support_url)
     inno_script_conf.set_quoted('APP_DONATE_URL', app_donate_url)
     inno_script_conf.set_quoted('UI_OUTPUT', ui_output)
-
-    if host_machine.system() == 'windows'
-        cli_output = cli_name + '.exe'
-    else
-        cli_output = cli_name
-    endif
-    inno_script_conf.set_quoted('CLI_OUTPUT', cli_output)
     inno_script_conf.set_quoted('INSTALLER_NAME', win_installer_name)
 
     inno_script = configure_file(
@@ -267,6 +260,12 @@ if build_ui == true
         output: 'rnote_inno.iss',
         configuration: inno_script_conf,
     )
+
+    if build_cli and host_machine.system() == 'windows' 
+        define_cli_output = '/DMyAppCliExeName=' + cli_name + '.exe'
+    else
+        define_cli_output = ''    
+    endif
 
     if host_machine.system() == 'windows'
         # build installer
@@ -284,6 +283,7 @@ if build_ui == true
                 app_id,
                 ui_output,
                 meson.project_build_root() / '@INPUT@',
+                define_cli_output,
             ],
             build_by_default: false,
             depends: app_cargo_build,

--- a/meson.build
+++ b/meson.build
@@ -253,6 +253,13 @@ if build_ui == true
     inno_script_conf.set_quoted('APP_SUPPORT_URL', app_support_url)
     inno_script_conf.set_quoted('APP_DONATE_URL', app_donate_url)
     inno_script_conf.set_quoted('UI_OUTPUT', ui_output)
+
+    if host_machine.system() == 'windows'
+        cli_output = cli_name + '.exe'
+    else
+        cli_output = cli_name
+    endif
+    inno_script_conf.set_quoted('CLI_OUTPUT', cli_output)
     inno_script_conf.set_quoted('INSTALLER_NAME', win_installer_name)
 
     inno_script = configure_file(

--- a/meson.build
+++ b/meson.build
@@ -268,6 +268,15 @@ if build_ui == true
     endif
 
     if host_machine.system() == 'windows'
+        # the inno_build_script build script will
+        # package the cli if its name is provided
+        # so only give the name if the cli is
+        # actually built
+        if build_cli
+            package_cli_name = cli_name
+        else
+            package_cli_name = ''
+        endif
         # build installer
         custom_target(
             'build-installer',
@@ -283,7 +292,7 @@ if build_ui == true
                 app_id,
                 ui_output,
                 meson.project_build_root() / '@INPUT@',
-                define_cli_output,
+                package_cli_name,
             ],
             build_by_default: false,
             depends: app_cargo_build,


### PR DESCRIPTION
CI test on : https://github.com/Doublonmousse/rnote/actions/runs/25228946601

Fixes #1757 

TODO 
- [x] cleanup the script (does it work with `-Dcli=false`? I'm not sure whether it fails when failing to copy a file or how to adapt the script more cleanly for this)
- [x] add to path? For now this is in the bin folder, not in the window path