### PR TITLE
feat: add callback to tabview `connect_create_window` to make detaching tab works

### DIFF
--- a/crates/rnote-ui/data/ui/overlays.ui
+++ b/crates/rnote-ui/data/ui/overlays.ui
@@ -109,6 +109,12 @@
                       <attribute name="action">win.active-tab-close</attribute>
                     </item>
                   </section>
+                  <section>
+                    <item>
+                      <attribute name="label" translatable="yes">_Move to New Window</attribute>
+                      <attribute name="action">win.active-tab-move-to-new-window</attribute>
+                    </item>
+                  </section>
                 </menu>
               </object>
             </property>

--- a/crates/rnote-ui/src/app/mod.rs
+++ b/crates/rnote-ui/src/app/mod.rs
@@ -154,7 +154,7 @@ mod imp {
             }
         }
 
-        pub(crate) fn new_appwindow_init_return_tab(&self)->adw::TabView{
+        pub(crate) fn new_appwindow_init_return_tab(&self) -> adw::TabView {
             let appwindow = RnAppWindow::new(self.obj().upcast_ref::<gtk4::Application>());
             appwindow.init(false);
 
@@ -166,9 +166,7 @@ mod imp {
             window_group.add_window(&appwindow);
 
             appwindow.present();
-            // this isn't enough
-            // (rnote:11838): Gtk-CRITICAL **: 14:08:17.296: New application windows must be added after the GApplication::startup signal has been emitted.
-            return appwindow.overlays().tabview()
+            return appwindow.overlays().tabview();
         }
     }
 }
@@ -208,5 +206,9 @@ impl RnApp {
 
     pub(crate) fn new_appwindow_init_show(&self) {
         self.imp().new_appwindow_init_show(None);
+    }
+
+    pub(crate) fn new_appwindow_init_return_tab(&self) -> adw::TabView {
+        self.imp().new_appwindow_init_return_tab()
     }
 }

--- a/crates/rnote-ui/src/app/mod.rs
+++ b/crates/rnote-ui/src/app/mod.rs
@@ -132,7 +132,7 @@ mod imp {
         /// Initializes and shows a new app window
         pub(crate) fn new_appwindow_init_show(&self, input_file: Option<gio::File>) {
             let appwindow = RnAppWindow::new(self.obj().upcast_ref::<gtk4::Application>());
-            appwindow.init();
+            appwindow.init(true);
             // create a window group for each app window
             // to make modals only impact the current app
             // window.
@@ -152,6 +152,23 @@ mod imp {
                     }
                 ));
             }
+        }
+
+        pub(crate) fn new_appwindow_init_return_tab(&self)->adw::TabView{
+            let appwindow = RnAppWindow::new(self.obj().upcast_ref::<gtk4::Application>());
+            appwindow.init(false);
+
+            // create a window group for each app window
+            // to make modals only impact the current app
+            // window.
+            // See issue #1461
+            let window_group = WindowGroup::new();
+            window_group.add_window(&appwindow);
+
+            appwindow.present();
+            // this isn't enough
+            // (rnote:11838): Gtk-CRITICAL **: 14:08:17.296: New application windows must be added after the GApplication::startup signal has been emitted.
+            return appwindow.overlays().tabview()
         }
     }
 }

--- a/crates/rnote-ui/src/app/mod.rs
+++ b/crates/rnote-ui/src/app/mod.rs
@@ -136,7 +136,7 @@ mod imp {
             // create a window group for each app window
             // to make modals only impact the current app
             // window.
-            // See issue #1461
+            // See issue: https://github.com/flxzt/rnote/issues/1461
             let window_group = WindowGroup::new();
             window_group.add_window(&appwindow);
 
@@ -161,7 +161,7 @@ mod imp {
             // create a window group for each app window
             // to make modals only impact the current app
             // window.
-            // See issue #1461
+            // See issue: https://github.com/flxzt/rnote/issues/1461
             let window_group = WindowGroup::new();
             window_group.add_window(&appwindow);
 

--- a/crates/rnote-ui/src/appwindow/actions.rs
+++ b/crates/rnote-ui/src/appwindow/actions.rs
@@ -131,6 +131,9 @@ impl RnAppWindow {
         self.add_action(&action_active_tab_move_right);
         let action_active_tab_close = gio::SimpleAction::new("active-tab-close", None);
         self.add_action(&action_active_tab_close);
+        let action_active_tab_move_window =
+            gio::SimpleAction::new("active-tab-move-to-new-window", None);
+        self.add_action(&action_active_tab_move_window);
         let action_drawing_pad_pressed_button_0 =
             gio::SimpleAction::new("drawing-pad-pressed-button-0", None);
         self.add_action(&action_drawing_pad_pressed_button_0);
@@ -379,6 +382,21 @@ impl RnAppWindow {
                     appwindow.close();
                 } else {
                     appwindow.close_tab_request(&active_tab_page);
+                }
+            }
+        ));
+
+        action_active_tab_move_window.connect_activate(clone!(
+            #[weak(rename_to=appwindow)]
+            self,
+            move |_, _| {
+                use crate::RnApp;
+                if let Some(active_tab_page) = appwindow.active_tab_page() {
+                    if let Some(rn_app_out) = appwindow.application() {
+                        let rnapp = rn_app_out.downcast::<RnApp>().unwrap();
+                        let tab_view = rnapp.new_appwindow_init_return_tab();
+                        appwindow.transfer_page(&active_tab_page, &tab_view, 0);
+                    }
                 }
             }
         ));

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -205,7 +205,7 @@ impl RnAppWindow {
     }
 
     /// Must be called after application is associated with the window else the init will panic
-    pub(crate) fn init(&self, add_initial_tab:bool) {
+    pub(crate) fn init(&self, add_initial_tab: bool) {
         let imp = self.imp();
 
         imp.overlays.get().init(self);
@@ -337,6 +337,18 @@ impl RnAppWindow {
     /// Get the active (selected) tab page.
     pub(crate) fn active_tab_page(&self) -> Option<adw::TabPage> {
         self.imp().overlays.tabview().selected_page()
+    }
+
+    pub(crate) fn transfer_page(
+        &self,
+        page: &adw::TabPage,
+        other_view: &adw::TabView,
+        position: i32,
+    ) {
+        self.imp()
+            .overlays
+            .tabview()
+            .transfer_page(page, other_view, position);
     }
 
     pub(crate) fn n_tabs_open(&self) -> usize {

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -205,7 +205,7 @@ impl RnAppWindow {
     }
 
     /// Must be called after application is associated with the window else the init will panic
-    pub(crate) fn init(&self) {
+    pub(crate) fn init(&self, add_initial_tab:bool) {
         let imp = self.imp();
 
         imp.overlays.get().init(self);
@@ -235,7 +235,9 @@ impl RnAppWindow {
         }
 
         // An initial tab (canvas).
-        self.add_initial_tab();
+        if add_initial_tab {
+            self.add_initial_tab();
+        }
 
         // Anything that needs to be done right before showing the appwindow
 

--- a/crates/rnote-ui/src/overlays.rs
+++ b/crates/rnote-ui/src/overlays.rs
@@ -330,6 +330,13 @@ impl RnOverlays {
                 }
             }
         ));
+
+        imp.tabview.connect_create_window(clone!( 
+            move |_tab| {
+            use crate::RnApp;
+            let app = RnApp::new();
+            Some(app.imp().new_appwindow_init_return_tab())
+        }));
     }
 
     pub(crate) fn progressbar_start_pulsing(&self) {

--- a/crates/rnote-ui/src/overlays.rs
+++ b/crates/rnote-ui/src/overlays.rs
@@ -319,6 +319,11 @@ impl RnOverlays {
                         .unwrap()
                         .downcast::<gio::SimpleAction>()
                         .unwrap();
+                    let action_active_tab_move_window = appwindow
+                        .lookup_action("active-tab-move-to-new-window")
+                        .unwrap()
+                        .downcast::<gio::SimpleAction>()
+                        .unwrap();
 
                     tabview.set_selected_page(page);
 
@@ -327,6 +332,7 @@ impl RnOverlays {
                     action_active_tab_move_left.set_enabled(pos > 0);
                     action_active_tab_move_right.set_enabled(pos + 1 < n_pages);
                     action_active_tab_close.set_enabled(n_pages > 1);
+                    action_active_tab_move_window.set_enabled(n_pages > 1);
                 }
             }
         ));

--- a/crates/rnote-ui/src/overlays.rs
+++ b/crates/rnote-ui/src/overlays.rs
@@ -331,12 +331,20 @@ impl RnOverlays {
             }
         ));
 
-        imp.tabview.connect_create_window(clone!( 
+        imp.tabview.connect_create_window(clone!(
+            #[weak]
+            appwindow,
+            #[upgrade_or_default]
             move |_tab| {
-            use crate::RnApp;
-            let app = RnApp::new();
-            Some(app.imp().new_appwindow_init_return_tab())
-        }));
+                use crate::RnApp;
+                if let Some(rn_app_out) = appwindow.application() {
+                    let rnapp = rn_app_out.downcast::<RnApp>().unwrap();
+                    Some(rnapp.new_appwindow_init_return_tab())
+                } else {
+                    None
+                }
+            }
+        ));
     }
 
     pub(crate) fn progressbar_start_pulsing(&self) {


### PR DESCRIPTION
There was a missing implementation for 
```rs
imp.tabview.connect_create_window
```
(see https://docs.rs/libadwaita/latest/libadwaita/struct.TabView.html#method.connect_create_window)
that should create a new window and return its tabview (where the dragged tab will be inserted)

This prevented tabs from detaching from the main window with the error message
```
AdwTabView::create-window handler must not return NULL
```

Now, there is still another error message
```
(rnote:17037): Gtk-CRITICAL **: 15:50:17.281: New application windows must be added after the GApplication::startup signal has been emitted.
```
but dragging tabs out create a new window.

Demo : 

[Screen Recording 2026-05-14 at 16.14.42.webm](https://github.com/user-attachments/assets/f7f92d7a-b93d-4dde-ba1a-8e67e9b51c96)


Though there are still some things to fix
- [x] ~~The current method doesn't really work~~
   - ~I create a new `RnApp` so I'm not 100 % sure that the full setup done in `main()` in addition to the creating of the `RnApp` is propagated to the new child window.~
   - ~This also doesn't fully work as closing the first window closes the second one.  Ideally I'd have an `RnApp` reference accessible from the `imp.tabview.connect_create_window` call~
   - ~Not sure how to call from the appwindow the creating of a new window and also get the tabview back in the callback (with a signal a new window can be created but not sure I can get the tab view back ?)~
- [x] Find why /fix the new error message 
- [x] Maybe it's worth adding a right click `Move to new window` like the adwaita demo 

<img width="405" height="280" alt="image" src="https://github.com/user-attachments/assets/9d2e2056-372f-4dc3-b4a9-79dce578300a" />



Related : #1766 