### PR TITLE
feat: brush stroke simplification

### DIFF
--- a/crates/rnote-compose/src/meson.build
+++ b/crates/rnote-compose/src/meson.build
@@ -27,6 +27,7 @@ rnote_compose_sources = files(
     'penpath/element.rs',
     'penpath/mod.rs',
     'penpath/segment.rs',
+    'penpath/simplification.rs',
     'serialize.rs',
     'shapes/arrow.rs',
     'shapes/cubbez.rs',

--- a/crates/rnote-compose/src/penpath/mod.rs
+++ b/crates/rnote-compose/src/penpath/mod.rs
@@ -301,61 +301,68 @@ pub(crate) fn no_subsegments_for_segment_len(len: f64) -> i32 {
     }
 }
 
+/// Squared distance from point p to the line segment ab.
+fn point_segment_distance_sq(p: na::Vector2<f64>, a: na::Vector2<f64>, b: na::Vector2<f64>) -> f64 {
+    let ab = b - a;
+    let ab_len_sq = ab.norm_squared();
+
+    if ab_len_sq == 0.0 {
+        return (p - a).norm_squared();
+    }
+
+    let t = ((p - a).dot(&ab) / ab_len_sq).clamp(0.0, 1.0);
+    (p - (a + ab * t)).norm_squared()
+}
+
 /// Ramer-Douglas-Peucker simplification for a slice of `Element`.
-/// 
+///
 /// https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
 fn ramer_douglas_peucker(points: &[Element], epsilon: f64) -> Vec<Element> {
     if points.len() < 3 {
         return points.to_vec();
     }
 
-    // shortest distance from point p to the line segment ab
-    fn point_segment_distance(
-        p: na::Vector2<f64>,
-        a: na::Vector2<f64>,
-        b: na::Vector2<f64>,
-    ) -> f64 {
-        let ab = b - a;
-        let len_sq = ab.norm_squared();
+    let epsilon_sq = epsilon * epsilon;
 
-        if len_sq == 0.0 {
-            return (p - a).norm();
+    // marks points that should be kept
+    let mut keep = vec![false; points.len()];
+    keep[0] = true;
+    keep[points.len() - 1] = true;
+
+    // stack of ranges [start, end]
+    let mut stack = vec![(0, points.len() - 1)];
+
+    while let Some((start_idx, end_idx)) = stack.pop() {
+        if end_idx <= start_idx + 1 {
+            continue;
         }
 
-        let t = ((p - a).dot(&ab) / len_sq).clamp(0.0, 1.0);
-        (p - (a + ab * t)).norm()
-    }
-
-    fn rdp_recursive(pts: &[Element], eps: f64, out: &mut Vec<Element>) {
-        if pts.len() < 3 {
-            out.extend_from_slice(pts);
-            return;
-        }
-
-        let start = pts.first().unwrap();
-        let end = pts.last().unwrap();
+        let start = points[start_idx].pos;
+        let end = points[end_idx].pos;
 
         let mut max_distance = 0.0;
         let mut max_distance_index = 0;
-        for i in 1..(pts.len() - 1) {
-            let d = point_segment_distance(pts[i].pos, start.pos, end.pos);
-            if d > max_distance {
-                max_distance = d;
+
+        for i in (start_idx + 1)..end_idx {
+            let distance = point_segment_distance_sq(points[i].pos, start, end);
+
+            if distance > max_distance {
+                max_distance = distance;
                 max_distance_index = i;
             }
         }
 
-        if max_distance > eps {
-            rdp_recursive(&pts[..=max_distance_index], eps, out);
-            out.pop(); // remove duplicated midpoint
-            rdp_recursive(&pts[max_distance_index..], eps, out);
-        } else {
-            out.push(*start);
-            out.push(*end);
+        if max_distance > epsilon_sq {
+            keep[max_distance_index] = true;
+
+            stack.push((start_idx, max_distance_index));
+            stack.push((max_distance_index, end_idx));
         }
     }
 
-    let mut out: Vec<Element> = Vec::with_capacity(points.len());
-    rdp_recursive(points, epsilon, &mut out);
-    out
+    points
+        .iter()
+        .zip(keep)
+        .filter_map(|(point, keep)| keep.then_some(*point))
+        .collect()
 }

--- a/crates/rnote-compose/src/penpath/mod.rs
+++ b/crates/rnote-compose/src/penpath/mod.rs
@@ -13,6 +13,7 @@ use crate::transform::Transformable;
 use kurbo::Shape;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename = "pen_path")]
@@ -118,10 +119,10 @@ impl PenPath {
     }
 
     /// extracts the elements from the path. the path shape will be lost, as only the actual input elements are returned.
-    pub fn into_elements(self) -> Vec<Element> {
+    pub fn as_elements(&self) -> Vec<Element> {
         let mut elements = vec![self.start];
 
-        elements.extend(self.segments.into_iter().map(|seg| match seg {
+        elements.extend(self.segments.iter().map(|seg| match seg {
             Segment::LineTo { end } => end,
             Segment::QuadBezTo { end, .. } => end,
             Segment::CubBezTo { end, .. } => end,
@@ -140,6 +141,22 @@ impl PenPath {
             .collect::<Vec<Segment>>();
 
         Some(Self { start, segments })
+    }
+
+    /// Simplify this path in place using Ramer-Douglas-Peucker.
+    pub fn simplify_rdp(&mut self, epsilon: f64) {
+        let elements = self.as_elements();
+        let simplified = ramer_douglas_peucker(&elements, epsilon);
+
+        debug!(
+            "simplified path from {} to {} elements",
+            elements.len(),
+            simplified.len()
+        );
+
+        if let Some(path) = Self::try_from_elements(simplified.into_iter()) {
+            *self = path;
+        }
     }
 
     /// Checks whether bounds collide with the path. If it does, it returns the indices of the colliding segments
@@ -282,4 +299,63 @@ pub(crate) fn no_subsegments_for_segment_len(len: f64) -> i32 {
         // avoiding huge amounts of hitboxes for large strokes that are drawn when zoomed out
         MAX_SUBSEGMENT_ELEMENTS
     }
+}
+
+/// Ramer-Douglas-Peucker simplification for a slice of `Element`.
+/// 
+/// https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
+fn ramer_douglas_peucker(points: &[Element], epsilon: f64) -> Vec<Element> {
+    if points.len() < 3 {
+        return points.to_vec();
+    }
+
+    // shortest distance from point p to the line segment ab
+    fn point_segment_distance(
+        p: na::Vector2<f64>,
+        a: na::Vector2<f64>,
+        b: na::Vector2<f64>,
+    ) -> f64 {
+        let ab = b - a;
+        let len_sq = ab.norm_squared();
+
+        if len_sq == 0.0 {
+            return (p - a).norm();
+        }
+
+        let t = ((p - a).dot(&ab) / len_sq).clamp(0.0, 1.0);
+        (p - (a + ab * t)).norm()
+    }
+
+    fn rdp_recursive(pts: &[Element], eps: f64, out: &mut Vec<Element>) {
+        if pts.len() < 3 {
+            out.extend_from_slice(pts);
+            return;
+        }
+
+        let start = pts.first().unwrap();
+        let end = pts.last().unwrap();
+
+        let mut max_distance = 0.0;
+        let mut max_distance_index = 0;
+        for i in 1..(pts.len() - 1) {
+            let d = point_segment_distance(pts[i].pos, start.pos, end.pos);
+            if d > max_distance {
+                max_distance = d;
+                max_distance_index = i;
+            }
+        }
+
+        if max_distance > eps {
+            rdp_recursive(&pts[..=max_distance_index], eps, out);
+            out.pop(); // remove duplicated midpoint
+            rdp_recursive(&pts[max_distance_index..], eps, out);
+        } else {
+            out.push(*start);
+            out.push(*end);
+        }
+    }
+
+    let mut out: Vec<Element> = Vec::with_capacity(points.len());
+    rdp_recursive(points, epsilon, &mut out);
+    out
 }

--- a/crates/rnote-compose/src/penpath/mod.rs
+++ b/crates/rnote-compose/src/penpath/mod.rs
@@ -1,6 +1,7 @@
 // Modules
 mod element;
 mod segment;
+mod simplification;
 
 // Re-exports
 pub use element::Element;
@@ -8,6 +9,7 @@ pub use segment::Segment;
 
 // Imports
 use crate::ext::{KurboShapeExt, Vector2Ext};
+use crate::penpath::simplification::{apply_mask_redistribute_pressure, ramer_douglas_peucker};
 use crate::shapes::{CubicBezier, Line, QuadraticBezier, Shapeable};
 use crate::transform::Transformable;
 use kurbo::Shape;
@@ -152,7 +154,7 @@ impl PenPath {
         }
 
         let keep_mask = ramer_douglas_peucker(&elements, geometry_epsilon, pressure_epsilon);
-        let simplified_elements = redistribute_pressure(&elements, &keep_mask);
+        let simplified_elements = apply_mask_redistribute_pressure(&elements, &keep_mask);
 
         debug!(
             "simplified path from {} to {} elements",
@@ -305,126 +307,4 @@ pub(crate) fn no_subsegments_for_segment_len(len: f64) -> i32 {
         // avoiding huge amounts of hitboxes for large strokes that are drawn when zoomed out
         MAX_SUBSEGMENT_ELEMENTS
     }
-}
-
-/// Projection parameter of point `p` onto segment `a..b`.
-fn segment_projection(p: na::Vector2<f64>, a: na::Vector2<f64>, b: na::Vector2<f64>) -> f64 {
-    let ab = b - a;
-    let ab_len_sq = ab.norm_squared();
-
-    if ab_len_sq == 0.0 {
-        // if a == b, interpret as midpoint (for pressure interpolation)
-        return 0.5; 
-    }
-
-    ((p - a).dot(&ab) / ab_len_sq).clamp(0.0, 1.0)
-}
-
-/// Modified Ramer-Douglas-Peucker simplification that additionally considers pressure.
-/// Returns a mask for which points to keep.
-///
-/// https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
-fn ramer_douglas_peucker(points: &[Element], geometry_epsilon: f64, pressure_epsilon: f64) -> Vec<bool> {
-    let geometry_epsilon_sq = geometry_epsilon * geometry_epsilon;
-
-    let mut keep_mask = vec![false; points.len()];
-    keep_mask[0] = true;
-    keep_mask[points.len() - 1] = true;
-
-    let mut ranges_stack = vec![(0, points.len() - 1)];
-
-    while let Some((start_index, end_index)) = ranges_stack.pop() {
-        if end_index <= start_index + 1 {
-            continue;
-        }
-
-        let start_point = &points[start_index];
-        let end_point = &points[end_index];
-
-        let mut max_score = 0.0;
-        let mut max_score_index = start_index;
-
-        for point_index in (start_index + 1)..end_index {
-            let current_point = &points[point_index];
-
-            let t = segment_projection(current_point.pos, start_point.pos, end_point.pos);
-            let projected_point = start_point.pos + t * (end_point.pos - start_point.pos);
-            let projected_point_pressure = start_point.pressure + t * (end_point.pressure - start_point.pressure);
-
-            // squared distance to the closest point on the segment
-            let geometry_score =
-                (current_point.pos - projected_point).norm_squared()
-                    / geometry_epsilon_sq;
-                    
-            // pressure deviation from the interpolated pressure of the closest point on the segment
-            let pressure_score =
-                (current_point.pressure - projected_point_pressure).abs()
-                    / pressure_epsilon;
-
-            let combined_score = geometry_score.max(pressure_score);
-
-            if combined_score > max_score {
-                max_score = combined_score;
-                max_score_index = point_index;
-            }
-        }
-
-        if max_score > 1.0 {
-            keep_mask[max_score_index] = true;
-            ranges_stack.push((start_index, max_score_index));
-            ranges_stack.push((max_score_index, end_index));
-        }
-    }
-
-    keep_mask
-}
-
-/// Redistribute pressure from removed points to their neighboring kept points.
-fn redistribute_pressure(points: &[Element], keep_mask: &[bool]) -> Vec<Element> {
-    // build ordered kept indices
-    let kept_indices: Vec<usize> = keep_mask
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, &keep)| keep.then_some(idx))
-        .collect();
-
-    let mut pressure_sums = vec![0.0; points.len()];
-    let mut pressure_weights = vec![0.0; points.len()];
-
-    let mut span_index = 0;
-    for point_index in 0..points.len() {
-        if keep_mask[point_index] {
-            continue;
-        }
-
-        while span_index + 1 < kept_indices.len() && point_index > kept_indices[span_index + 1] {
-            span_index += 1;
-        }
-
-        let left_index = kept_indices[span_index];
-        let right_index = kept_indices[span_index + 1];
-
-        let span_length = (right_index - left_index) as f64;
-        let t = (point_index - left_index) as f64 / span_length;
-        let left_weight = 1.0 - t;
-        let right_weight = t;
-
-        let pressure_value = points[point_index].pressure;
-        pressure_sums[left_index] += pressure_value * left_weight;
-        pressure_weights[left_index] += left_weight;
-        pressure_sums[right_index] += pressure_value * right_weight;
-        pressure_weights[right_index] += right_weight;
-    }
-
-    kept_indices
-        .into_iter()
-        .map(|index| {
-            let mut kept_point = points[index];
-            let weight = pressure_weights[index];
-            if weight > 0.0 {
-                kept_point.pressure = (pressure_sums[index] / weight).clamp(0.0, 1.0);
-            }
-            kept_point
-        })
-        .collect()
 }

--- a/crates/rnote-compose/src/penpath/mod.rs
+++ b/crates/rnote-compose/src/penpath/mod.rs
@@ -307,33 +307,20 @@ pub(crate) fn no_subsegments_for_segment_len(len: f64) -> i32 {
     }
 }
 
-/// Projection parameter t of point `p` onto segment `a..b`.
-fn projection_t(p: na::Vector2<f64>, a: na::Vector2<f64>, b: na::Vector2<f64>) -> f64 {
+/// Projection parameter of point `p` onto segment `a..b`.
+fn segment_projection(p: na::Vector2<f64>, a: na::Vector2<f64>, b: na::Vector2<f64>) -> f64 {
     let ab = b - a;
     let ab_len_sq = ab.norm_squared();
 
     if ab_len_sq == 0.0 {
-        return 0.5; // if a == b, use midpoint for pressure interpolation
+        // if a == b, interpret as midpoint (for pressure interpolation)
+        return 0.5; 
     }
 
     ((p - a).dot(&ab) / ab_len_sq).clamp(0.0, 1.0)
 }
 
-/// Squared distance from point `p` to the segment `a..b`.
-fn point_segment_distance_sq(p: na::Vector2<f64>, a: na::Vector2<f64>, b: na::Vector2<f64>) -> f64 {
-    let t = projection_t(p, a, b);
-    let projection = a + (b - a) * t;
-    (p - projection).norm_squared()
-}
-
-/// Absolute deviation of point `p`'s pressure from linear interpolation between the pressures of points `a` and `b` at the projection of `p` onto the segment `a..b`.
-fn pressure_deviation_on_segment(p: &Element, a: &Element, b: &Element) -> f64 {
-    let t = projection_t(p.pos, a.pos, b.pos);
-    let interpolated_pressure = a.pressure + (b.pressure - a.pressure) * t;
-    (p.pressure - interpolated_pressure).abs()
-}
-
-/// Modified Ramer-Douglas-Peucker simplification that additionally considerspressure.
+/// Modified Ramer-Douglas-Peucker simplification that additionally considers pressure.
 /// Returns a mask for which points to keep.
 ///
 /// https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
@@ -358,12 +345,20 @@ fn ramer_douglas_peucker(points: &[Element], geometry_epsilon: f64, pressure_eps
         let mut max_score_index = start_index;
 
         for point_index in (start_index + 1)..end_index {
-            let geometry_score =
-                point_segment_distance_sq(points[point_index].pos, start_point.pos, end_point.pos)
-                    / geometry_epsilon_sq;
+            let current_point = &points[point_index];
 
+            let t = segment_projection(current_point.pos, start_point.pos, end_point.pos);
+            let projected_point = start_point.pos + t * (end_point.pos - start_point.pos);
+            let projected_point_pressure = start_point.pressure + t * (end_point.pressure - start_point.pressure);
+
+            // squared distance to the closest point on the segment
+            let geometry_score =
+                (current_point.pos - projected_point).norm_squared()
+                    / geometry_epsilon_sq;
+                    
+            // pressure deviation from the interpolated pressure of the closest point on the segment
             let pressure_score =
-                pressure_deviation_on_segment(&points[point_index], start_point, end_point)
+                (current_point.pressure - projected_point_pressure).abs()
                     / pressure_epsilon;
 
             let combined_score = geometry_score.max(pressure_score);

--- a/crates/rnote-compose/src/penpath/mod.rs
+++ b/crates/rnote-compose/src/penpath/mod.rs
@@ -9,7 +9,7 @@ pub use segment::Segment;
 
 // Imports
 use crate::ext::{KurboShapeExt, Vector2Ext};
-use crate::penpath::simplification::{apply_mask_redistribute_pressure, ramer_douglas_peucker};
+use crate::penpath::simplification::ramer_douglas_peucker;
 use crate::shapes::{CubicBezier, Line, QuadraticBezier, Shapeable};
 use crate::transform::Transformable;
 use kurbo::Shape;
@@ -148,13 +148,8 @@ impl PenPath {
     /// Simplify this path in place as a polyline that approximates the original path.
     pub fn simplify_polyline(&mut self, geometry_epsilon: f64, pressure_epsilon: f64) {
         let elements = self.as_elements();
-
-        if elements.len() < 3 {
-            return;
-        }
-
-        let keep_mask = ramer_douglas_peucker(&elements, geometry_epsilon, pressure_epsilon);
-        let simplified_elements = apply_mask_redistribute_pressure(&elements, &keep_mask);
+        let simplified_elements =
+            ramer_douglas_peucker(&elements, geometry_epsilon, pressure_epsilon);
 
         debug!(
             "simplified path from {} to {} elements (polyline)",

--- a/crates/rnote-compose/src/penpath/mod.rs
+++ b/crates/rnote-compose/src/penpath/mod.rs
@@ -143,18 +143,24 @@ impl PenPath {
         Some(Self { start, segments })
     }
 
-    /// Simplify this path in place using Ramer-Douglas-Peucker.
-    pub fn simplify_rdp(&mut self, epsilon: f64) {
+    /// Simplify this path in place.
+    pub fn simplify(&mut self, geometry_epsilon: f64, pressure_epsilon: f64) {
         let elements = self.as_elements();
-        let simplified = ramer_douglas_peucker(&elements, epsilon);
+
+        if elements.len() < 3 {
+            return;
+        }
+
+        let keep_mask = ramer_douglas_peucker(&elements, geometry_epsilon, pressure_epsilon);
+        let simplified_elements = redistribute_pressure(&elements, &keep_mask);
 
         debug!(
             "simplified path from {} to {} elements",
             elements.len(),
-            simplified.len()
+            simplified_elements.len()
         );
 
-        if let Some(path) = Self::try_from_elements(simplified.into_iter()) {
+        if let Some(path) = Self::try_from_elements(simplified_elements.into_iter()) {
             *self = path;
         }
     }
@@ -301,68 +307,129 @@ pub(crate) fn no_subsegments_for_segment_len(len: f64) -> i32 {
     }
 }
 
-/// Squared distance from point p to the line segment ab.
-fn point_segment_distance_sq(p: na::Vector2<f64>, a: na::Vector2<f64>, b: na::Vector2<f64>) -> f64 {
+/// Projection parameter t of point `p` onto segment `a..b`.
+fn projection_t(p: na::Vector2<f64>, a: na::Vector2<f64>, b: na::Vector2<f64>) -> f64 {
     let ab = b - a;
     let ab_len_sq = ab.norm_squared();
 
     if ab_len_sq == 0.0 {
-        return (p - a).norm_squared();
+        return 0.5; // if a == b, use midpoint for pressure interpolation
     }
 
-    let t = ((p - a).dot(&ab) / ab_len_sq).clamp(0.0, 1.0);
-    (p - (a + ab * t)).norm_squared()
+    ((p - a).dot(&ab) / ab_len_sq).clamp(0.0, 1.0)
 }
 
-/// Ramer-Douglas-Peucker simplification for a slice of `Element`.
+/// Squared distance from point `p` to the segment `a..b`.
+fn point_segment_distance_sq(p: na::Vector2<f64>, a: na::Vector2<f64>, b: na::Vector2<f64>) -> f64 {
+    let t = projection_t(p, a, b);
+    let projection = a + (b - a) * t;
+    (p - projection).norm_squared()
+}
+
+/// Absolute deviation of point `p`'s pressure from linear interpolation between the pressures of points `a` and `b` at the projection of `p` onto the segment `a..b`.
+fn pressure_deviation_on_segment(p: &Element, a: &Element, b: &Element) -> f64 {
+    let t = projection_t(p.pos, a.pos, b.pos);
+    let interpolated_pressure = a.pressure + (b.pressure - a.pressure) * t;
+    (p.pressure - interpolated_pressure).abs()
+}
+
+/// Modified Ramer-Douglas-Peucker simplification that additionally considerspressure.
+/// Returns a mask for which points to keep.
 ///
 /// https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
-fn ramer_douglas_peucker(points: &[Element], epsilon: f64) -> Vec<Element> {
-    if points.len() < 3 {
-        return points.to_vec();
-    }
+fn ramer_douglas_peucker(points: &[Element], geometry_epsilon: f64, pressure_epsilon: f64) -> Vec<bool> {
+    let geometry_epsilon_sq = geometry_epsilon * geometry_epsilon;
 
-    let epsilon_sq = epsilon * epsilon;
+    let mut keep_mask = vec![false; points.len()];
+    keep_mask[0] = true;
+    keep_mask[points.len() - 1] = true;
 
-    // marks points that should be kept
-    let mut keep = vec![false; points.len()];
-    keep[0] = true;
-    keep[points.len() - 1] = true;
+    let mut ranges_stack = vec![(0, points.len() - 1)];
 
-    // stack of ranges [start, end]
-    let mut stack = vec![(0, points.len() - 1)];
-
-    while let Some((start_idx, end_idx)) = stack.pop() {
-        if end_idx <= start_idx + 1 {
+    while let Some((start_index, end_index)) = ranges_stack.pop() {
+        if end_index <= start_index + 1 {
             continue;
         }
 
-        let start = points[start_idx].pos;
-        let end = points[end_idx].pos;
+        let start_point = &points[start_index];
+        let end_point = &points[end_index];
 
-        let mut max_distance = 0.0;
-        let mut max_distance_index = 0;
+        let mut max_score = 0.0;
+        let mut max_score_index = start_index;
 
-        for i in (start_idx + 1)..end_idx {
-            let distance = point_segment_distance_sq(points[i].pos, start, end);
+        for point_index in (start_index + 1)..end_index {
+            let geometry_score =
+                point_segment_distance_sq(points[point_index].pos, start_point.pos, end_point.pos)
+                    / geometry_epsilon_sq;
 
-            if distance > max_distance {
-                max_distance = distance;
-                max_distance_index = i;
+            let pressure_score =
+                pressure_deviation_on_segment(&points[point_index], start_point, end_point)
+                    / pressure_epsilon;
+
+            let combined_score = geometry_score.max(pressure_score);
+
+            if combined_score > max_score {
+                max_score = combined_score;
+                max_score_index = point_index;
             }
         }
 
-        if max_distance > epsilon_sq {
-            keep[max_distance_index] = true;
-
-            stack.push((start_idx, max_distance_index));
-            stack.push((max_distance_index, end_idx));
+        if max_score > 1.0 {
+            keep_mask[max_score_index] = true;
+            ranges_stack.push((start_index, max_score_index));
+            ranges_stack.push((max_score_index, end_index));
         }
     }
 
-    points
+    keep_mask
+}
+
+/// Redistribute pressure from removed points to their neighboring kept points.
+fn redistribute_pressure(points: &[Element], keep_mask: &[bool]) -> Vec<Element> {
+    // build ordered kept indices
+    let kept_indices: Vec<usize> = keep_mask
         .iter()
-        .zip(keep)
-        .filter_map(|(point, keep)| keep.then_some(*point))
+        .enumerate()
+        .filter_map(|(idx, &keep)| keep.then_some(idx))
+        .collect();
+
+    let mut pressure_sums = vec![0.0; points.len()];
+    let mut pressure_weights = vec![0.0; points.len()];
+
+    let mut span_index = 0;
+    for point_index in 0..points.len() {
+        if keep_mask[point_index] {
+            continue;
+        }
+
+        while span_index + 1 < kept_indices.len() && point_index > kept_indices[span_index + 1] {
+            span_index += 1;
+        }
+
+        let left_index = kept_indices[span_index];
+        let right_index = kept_indices[span_index + 1];
+
+        let span_length = (right_index - left_index) as f64;
+        let t = (point_index - left_index) as f64 / span_length;
+        let left_weight = 1.0 - t;
+        let right_weight = t;
+
+        let pressure_value = points[point_index].pressure;
+        pressure_sums[left_index] += pressure_value * left_weight;
+        pressure_weights[left_index] += left_weight;
+        pressure_sums[right_index] += pressure_value * right_weight;
+        pressure_weights[right_index] += right_weight;
+    }
+
+    kept_indices
+        .into_iter()
+        .map(|index| {
+            let mut kept_point = points[index];
+            let weight = pressure_weights[index];
+            if weight > 0.0 {
+                kept_point.pressure = (pressure_sums[index] / weight).clamp(0.0, 1.0);
+            }
+            kept_point
+        })
         .collect()
 }

--- a/crates/rnote-compose/src/penpath/mod.rs
+++ b/crates/rnote-compose/src/penpath/mod.rs
@@ -145,8 +145,8 @@ impl PenPath {
         Some(Self { start, segments })
     }
 
-    /// Simplify this path in place.
-    pub fn simplify(&mut self, geometry_epsilon: f64, pressure_epsilon: f64) {
+    /// Simplify this path in place as a polyline that approximates the original path.
+    pub fn simplify_polyline(&mut self, geometry_epsilon: f64, pressure_epsilon: f64) {
         let elements = self.as_elements();
 
         if elements.len() < 3 {
@@ -157,7 +157,7 @@ impl PenPath {
         let simplified_elements = apply_mask_redistribute_pressure(&elements, &keep_mask);
 
         debug!(
-            "simplified path from {} to {} elements",
+            "simplified path from {} to {} elements (polyline)",
             elements.len(),
             simplified_elements.len()
         );

--- a/crates/rnote-compose/src/penpath/simplification.rs
+++ b/crates/rnote-compose/src/penpath/simplification.rs
@@ -1,0 +1,129 @@
+use crate::penpath::Element;
+
+/// Projection parameter of point `p` onto segment `a..b`.
+fn segment_projection(p: na::Vector2<f64>, a: na::Vector2<f64>, b: na::Vector2<f64>) -> f64 {
+    let ab = b - a;
+    let ab_len_sq = ab.norm_squared();
+
+    if ab_len_sq == 0.0 {
+        // if a == b, interpret as midpoint (for pressure interpolation)
+        return 0.5;
+    }
+
+    ((p - a).dot(&ab) / ab_len_sq).clamp(0.0, 1.0)
+}
+
+/// Modified Ramer-Douglas-Peucker simplification that additionally considers pressure.
+/// Returns a mask for which points to keep.
+///
+/// https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
+pub(crate) fn ramer_douglas_peucker(
+    points: &[Element],
+    geometry_epsilon: f64,
+    pressure_epsilon: f64,
+) -> Vec<bool> {
+    let geometry_epsilon_sq = geometry_epsilon * geometry_epsilon;
+
+    let mut keep_mask = vec![false; points.len()];
+    keep_mask[0] = true;
+    keep_mask[points.len() - 1] = true;
+
+    let mut ranges_stack = vec![(0, points.len() - 1)];
+
+    while let Some((start_index, end_index)) = ranges_stack.pop() {
+        if end_index <= start_index + 1 {
+            continue;
+        }
+
+        let start_point = &points[start_index];
+        let end_point = &points[end_index];
+
+        let mut max_score = 0.0;
+        let mut max_score_index = start_index;
+
+        for point_index in (start_index + 1)..end_index {
+            let current_point = &points[point_index];
+
+            let t = segment_projection(current_point.pos, start_point.pos, end_point.pos);
+            let projected_point = start_point.pos + t * (end_point.pos - start_point.pos);
+            let projected_point_pressure =
+                start_point.pressure + t * (end_point.pressure - start_point.pressure);
+
+            // squared distance to the closest point on the segment
+            let geometry_score =
+                (current_point.pos - projected_point).norm_squared() / geometry_epsilon_sq;
+
+            // pressure deviation from the interpolated pressure of the closest point on the segment
+            let pressure_score =
+                (current_point.pressure - projected_point_pressure).abs() / pressure_epsilon;
+
+            let combined_score = geometry_score.max(pressure_score);
+
+            if combined_score > max_score {
+                max_score = combined_score;
+                max_score_index = point_index;
+            }
+        }
+
+        if max_score > 1.0 {
+            keep_mask[max_score_index] = true;
+            ranges_stack.push((start_index, max_score_index));
+            ranges_stack.push((max_score_index, end_index));
+        }
+    }
+
+    keep_mask
+}
+
+/// Redistribute pressure from removed points to their neighboring kept points.
+pub(crate) fn apply_mask_redistribute_pressure(
+    points: &[Element],
+    keep_mask: &[bool],
+) -> Vec<Element> {
+    // build ordered kept indices
+    let kept_indices: Vec<usize> = keep_mask
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, &keep)| keep.then_some(idx))
+        .collect();
+
+    let mut pressure_sums = vec![0.0; points.len()];
+    let mut pressure_weights = vec![0.0; points.len()];
+
+    let mut span_index = 0;
+    for point_index in 0..points.len() {
+        if keep_mask[point_index] {
+            continue;
+        }
+
+        while span_index + 1 < kept_indices.len() && point_index > kept_indices[span_index + 1] {
+            span_index += 1;
+        }
+
+        let left_index = kept_indices[span_index];
+        let right_index = kept_indices[span_index + 1];
+
+        let span_length = (right_index - left_index) as f64;
+        let t = (point_index - left_index) as f64 / span_length;
+        let left_weight = 1.0 - t;
+        let right_weight = t;
+
+        let pressure_value = points[point_index].pressure;
+        pressure_sums[left_index] += pressure_value * left_weight;
+        pressure_weights[left_index] += left_weight;
+        pressure_sums[right_index] += pressure_value * right_weight;
+        pressure_weights[right_index] += right_weight;
+    }
+
+    kept_indices
+        .into_iter()
+        .map(|index| {
+            let mut kept_point = points[index];
+            let weight = pressure_weights[index];
+            if weight > 0.0 {
+                kept_point.pressure = (pressure_sums[index] / weight).clamp(0.0, 1.0);
+            }
+            kept_point
+        })
+        .collect()
+}

--- a/crates/rnote-compose/src/penpath/simplification.rs
+++ b/crates/rnote-compose/src/penpath/simplification.rs
@@ -14,14 +14,18 @@ fn segment_projection(p: na::Vector2<f64>, a: na::Vector2<f64>, b: na::Vector2<f
 }
 
 /// Modified Ramer-Douglas-Peucker simplification that additionally considers pressure.
-/// Returns a mask for which points to keep.
+/// Returns the optimized polyline elements that approximate the original path.
 ///
 /// https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
 pub(crate) fn ramer_douglas_peucker(
     points: &[Element],
     geometry_epsilon: f64,
     pressure_epsilon: f64,
-) -> Vec<bool> {
+) -> Vec<Element> {
+    if points.len() < 3 {
+        return points.to_vec();
+    }
+
     let geometry_epsilon_sq = geometry_epsilon * geometry_epsilon;
 
     let mut keep_mask = vec![false; points.len()];
@@ -73,57 +77,8 @@ pub(crate) fn ramer_douglas_peucker(
     }
 
     keep_mask
-}
-
-/// Redistribute pressure from removed points to their neighboring kept points.
-pub(crate) fn apply_mask_redistribute_pressure(
-    points: &[Element],
-    keep_mask: &[bool],
-) -> Vec<Element> {
-    // build ordered kept indices
-    let kept_indices: Vec<usize> = keep_mask
         .iter()
-        .enumerate()
-        .filter_map(|(idx, &keep)| keep.then_some(idx))
-        .collect();
-
-    let mut pressure_sums = vec![0.0; points.len()];
-    let mut pressure_weights = vec![0.0; points.len()];
-
-    let mut span_index = 0;
-    for point_index in 0..points.len() {
-        if keep_mask[point_index] {
-            continue;
-        }
-
-        while span_index + 1 < kept_indices.len() && point_index > kept_indices[span_index + 1] {
-            span_index += 1;
-        }
-
-        let left_index = kept_indices[span_index];
-        let right_index = kept_indices[span_index + 1];
-
-        let span_length = (right_index - left_index) as f64;
-        let t = (point_index - left_index) as f64 / span_length;
-        let left_weight = 1.0 - t;
-        let right_weight = t;
-
-        let pressure_value = points[point_index].pressure;
-        pressure_sums[left_index] += pressure_value * left_weight;
-        pressure_weights[left_index] += left_weight;
-        pressure_sums[right_index] += pressure_value * right_weight;
-        pressure_weights[right_index] += right_weight;
-    }
-
-    kept_indices
-        .into_iter()
-        .map(|index| {
-            let mut kept_point = points[index];
-            let weight = pressure_weights[index];
-            if weight > 0.0 {
-                kept_point.pressure = (pressure_sums[index] / weight).clamp(0.0, 1.0);
-            }
-            kept_point
-        })
+        .zip(points.iter())
+        .filter_map(|(&keep, point)| keep.then_some(*point))
         .collect()
 }

--- a/crates/rnote-engine/src/pens/brush.rs
+++ b/crates/rnote-engine/src/pens/brush.rs
@@ -261,6 +261,7 @@ impl PenBehaviour for Brush {
                         if let Some(Stroke::BrushStroke(brushstroke)) =
                             engine_view.store.get_stroke_mut(*current_stroke_key)
                         {
+                            brushstroke.path.simplify_rdp(0.1);
                             brushstroke.style = engine_view
                                 .config
                                 .pens_config

--- a/crates/rnote-engine/src/pens/brush.rs
+++ b/crates/rnote-engine/src/pens/brush.rs
@@ -261,7 +261,13 @@ impl PenBehaviour for Brush {
                         if let Some(Stroke::BrushStroke(brushstroke)) =
                             engine_view.store.get_stroke_mut(*current_stroke_key)
                         {
-                            brushstroke.path.simplify(0.1, 0.15);
+                            engine_view
+                                .config
+                                .pens_config
+                                .brush_config
+                                .simplification_options
+                                .simplify(&mut brushstroke.path);
+
                             brushstroke.style = engine_view
                                 .config
                                 .pens_config

--- a/crates/rnote-engine/src/pens/brush.rs
+++ b/crates/rnote-engine/src/pens/brush.rs
@@ -261,7 +261,7 @@ impl PenBehaviour for Brush {
                         if let Some(Stroke::BrushStroke(brushstroke)) =
                             engine_view.store.get_stroke_mut(*current_stroke_key)
                         {
-                            brushstroke.path.simplify_rdp(0.1);
+                            brushstroke.path.simplify(0.1, 0.15);
                             brushstroke.style = engine_view
                                 .config
                                 .pens_config

--- a/crates/rnote-engine/src/pens/pensconfig/brushconfig.rs
+++ b/crates/rnote-engine/src/pens/pensconfig/brushconfig.rs
@@ -1,6 +1,7 @@
 // Imports
 use crate::store::chrono_comp::StrokeLayer;
 use rand::{RngExt, SeedableRng};
+use rnote_compose::PenPath;
 use rnote_compose::Style;
 use rnote_compose::builders::PenPathBuilderType;
 use rnote_compose::style::PressureCurve;
@@ -97,6 +98,110 @@ impl std::ops::DerefMut for SolidOptions {
     }
 }
 
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    num_derive::FromPrimitive,
+    num_derive::ToPrimitive,
+)]
+#[serde(rename = "simplification_mode")]
+pub enum SimplificationMode {
+    #[serde(rename = "none")]
+    None = 0,
+    #[serde(rename = "polyline")]
+    Polyline,
+}
+
+impl Default for SimplificationMode {
+    fn default() -> Self {
+        Self::Polyline
+    }
+}
+
+impl TryFrom<u32> for SimplificationMode {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        num_traits::FromPrimitive::from_u32(value).ok_or_else(|| {
+            anyhow::anyhow!(
+                "SimplificationMode try_from::<u32>() for value {} failed",
+                value
+            )
+        })
+    }
+}
+
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    num_derive::FromPrimitive,
+    num_derive::ToPrimitive,
+)]
+#[serde(rename = "simplification_quality")]
+pub enum SimplificationQuality {
+    #[serde(rename = "low")]
+    Low = 0,
+    #[serde(rename = "medium")]
+    Medium,
+    #[serde(rename = "high")]
+    High,
+}
+
+impl Default for SimplificationQuality {
+    fn default() -> Self {
+        Self::Medium
+    }
+}
+
+impl TryFrom<u32> for SimplificationQuality {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        num_traits::FromPrimitive::from_u32(value).ok_or_else(|| {
+            anyhow::anyhow!(
+                "SimplificationQuality try_from::<u32>() for value {} failed",
+                value
+            )
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename = "simplification_options")]
+pub struct SimplificationOptions {
+    #[serde(rename = "mode")]
+    pub mode: SimplificationMode,
+    #[serde(rename = "quality")]
+    pub quality: SimplificationQuality,
+}
+
+impl SimplificationOptions {
+    pub(crate) fn simplify(&self, path: &mut PenPath) {
+        match self.mode {
+            SimplificationMode::None => {}
+            SimplificationMode::Polyline => {
+                let (geometry_epsilon, pressure_epsilon) = match self.quality {
+                    SimplificationQuality::Low => (0.175, 0.175 * 0.5),
+                    SimplificationQuality::Medium => (0.1, 0.1 * 0.5),
+                    SimplificationQuality::High => (0.025, 0.025 * 0.5),
+                };
+
+                path.simplify_polyline(geometry_epsilon, pressure_epsilon);
+            }
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(default, rename = "brush_config")]
 pub struct BrushConfig {
@@ -110,6 +215,8 @@ pub struct BrushConfig {
     pub solid_options: SolidOptions,
     #[serde(rename = "textured_options")]
     pub textured_options: TexturedOptions,
+    #[serde(rename = "simplification_options")]
+    pub simplification_options: SimplificationOptions,
 }
 
 impl BrushConfig {

--- a/crates/rnote-engine/src/store/render_comp.rs
+++ b/crates/rnote-engine/src/store/render_comp.rs
@@ -631,7 +631,7 @@ impl StrokeStore {
                 match stroke.as_ref() {
                     // Draw positions for brushstrokes
                     Stroke::BrushStroke(brushstroke) => {
-                        for element in brushstroke.path.clone().into_elements().iter() {
+                        for element in brushstroke.path.as_elements().iter() {
                             visual_debug::draw_pos_to_gtk_snapshot(
                                 snapshot,
                                 element.pos,

--- a/crates/rnote-engine/src/strokes/stroke.rs
+++ b/crates/rnote-engine/src/strokes/stroke.rs
@@ -473,7 +473,7 @@ impl Stroke {
                 };
 
                 let tool = xoppformat::XoppTool::Pen;
-                let elements_vec = brushstroke.path.into_elements();
+                let elements_vec = brushstroke.path.as_elements();
                 let stroke_style = &brushstroke.style;
                 let stroke_width =
                     utils::convert_value_dpi(stroke_width, current_dpi, xoppformat::XoppFile::DPI);

--- a/crates/rnote-ui/data/ui/penssidebar/brushpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/brushpage.ui
@@ -206,6 +206,41 @@ Results in the best looking handwriting.</property>
             </object>
           </child>
           <child>
+            <!-- Simplification options -->
+            <object class="AdwPreferencesGroup">
+              <property name="title" translatable="yes">Path Simplification</property>
+              <child>
+                <object class="AdwComboRow" id="simplification_mode_row">
+                  <property name="title" translatable="yes">Mode</property>
+                  <property name="subtitle" translatable="yes">Choose a simplification algorithm</property>
+                  <property name="model">
+                    <object class="GtkStringList">
+                      <items>
+                        <item translatable="yes">None</item>
+                        <item translatable="yes">Polyline</item>
+                      </items>
+                    </object>
+                  </property>
+                </object>
+              </child>
+              <child>
+                <object class="AdwComboRow" id="simplification_quality_row">
+                  <property name="title" translatable="yes">Quality</property>
+                  <property name="subtitle" translatable="yes">Choose a simplification quality</property>
+                  <property name="model">
+                    <object class="GtkStringList">
+                      <items>
+                        <item translatable="yes">Low</item>
+                        <item translatable="yes">Medium</item>
+                        <item translatable="yes">High</item>
+                      </items>
+                    </object>
+                  </property>
+                </object>
+              </child>
+            </object>
+          </child>
+          <child>
             <!-- Solid options -->
             <object class="AdwPreferencesGroup">
               <property name="title" translatable="yes">Solid Style</property>

--- a/crates/rnote-ui/src/penssidebar/brushpage.rs
+++ b/crates/rnote-ui/src/penssidebar/brushpage.rs
@@ -10,7 +10,9 @@ use rnote_compose::builders::PenPathBuilderType;
 use rnote_compose::style::PressureCurve;
 use rnote_compose::style::textured::{TexturedDotsDistribution, TexturedOptions};
 use rnote_engine::pens::pensconfig::BrushConfig;
-use rnote_engine::pens::pensconfig::brushconfig::{BrushStyle, SolidOptions};
+use rnote_engine::pens::pensconfig::brushconfig::{
+    BrushStyle, SimplificationMode, SimplificationQuality, SolidOptions,
+};
 
 mod imp {
     use super::*;
@@ -46,6 +48,10 @@ mod imp {
         pub(crate) brush_buildertype_curved: TemplateChild<adw::ActionRow>,
         #[template_child]
         pub(crate) brush_buildertype_modeled: TemplateChild<adw::ActionRow>,
+        #[template_child]
+        pub(crate) simplification_mode_row: TemplateChild<adw::ComboRow>,
+        #[template_child]
+        pub(crate) simplification_quality_row: TemplateChild<adw::ComboRow>,
         #[template_child]
         pub(crate) solidstyle_pressure_curves_row: TemplateChild<adw::ComboRow>,
         #[template_child]
@@ -155,6 +161,33 @@ impl RnBrushPage {
                 .brush_buildertype_listbox
                 .select_row(Some(&*self.imp().brush_buildertype_modeled)),
         }
+    }
+
+    pub(crate) fn simplification_mode(&self) -> SimplificationMode {
+        SimplificationMode::try_from(self.imp().simplification_mode_row.get().selected()).unwrap()
+    }
+
+    pub(crate) fn set_simplification_mode(&self, mode: SimplificationMode) {
+        let position = mode.to_u32().unwrap();
+
+        self.imp()
+            .simplification_mode_row
+            .get()
+            .set_selected(position);
+    }
+
+    pub(crate) fn simplification_quality(&self) -> SimplificationQuality {
+        SimplificationQuality::try_from(self.imp().simplification_quality_row.get().selected())
+            .unwrap()
+    }
+
+    pub(crate) fn set_simplification_quality(&self, quality: SimplificationQuality) {
+        let position = quality.to_u32().unwrap();
+
+        self.imp()
+            .simplification_quality_row
+            .get()
+            .set_selected(position);
     }
 
     pub(crate) fn solidstyle_pressure_curve(&self) -> PressureCurve {
@@ -363,6 +396,45 @@ impl RnBrushPage {
             }
         ));
 
+        // Simplification
+        // Mode
+        imp.simplification_mode_row
+            .get()
+            .connect_selected_notify(clone!(
+                #[weak(rename_to=brushpage)]
+                self,
+                #[weak]
+                appwindow,
+                move |_| {
+                    appwindow
+                        .engine_config()
+                        .write()
+                        .pens_config
+                        .brush_config
+                        .simplification_options
+                        .mode = brushpage.simplification_mode();
+                }
+            ));
+
+        // Quality
+        imp.simplification_quality_row
+            .get()
+            .connect_selected_notify(clone!(
+                #[weak(rename_to=brushpage)]
+                self,
+                #[weak]
+                appwindow,
+                move |_| {
+                    appwindow
+                        .engine_config()
+                        .write()
+                        .pens_config
+                        .brush_config
+                        .simplification_options
+                        .quality = brushpage.simplification_quality();
+                }
+            ));
+
         // Solid style
         // Pressure curve
         imp.solidstyle_pressure_curves_row
@@ -443,6 +515,8 @@ impl RnBrushPage {
 
         self.set_brush_style(brush_config.style);
         self.set_buildertype(brush_config.builder_type);
+        self.set_simplification_mode(brush_config.simplification_options.mode);
+        self.set_simplification_quality(brush_config.simplification_options.quality);
 
         match brush_config.style {
             BrushStyle::Marker => {


### PR DESCRIPTION
- Adds simplification to brush strokes, reducing file size and improving performance.
- Addresses #269 and #1217.
- Should be merged after #1775.

The simplification mode (none and this) and quality (low, medium, high) can be chosen in the brush configuration menu. They default to being enabled with medium quality. The quality levels were eyeballed with the following goals (subjective, feel free to test and propose changes):

- High - No visible changes.
- Medium - Very minor changes in very few (especially degenerate) cases if you zoom in.
- Low - Minor changes if you zoom in.

The file size savings naturally depend on the strokes, so they're difficult to quantify. Keeping that in mind, running this on handwritten lecture notes gave the following results:

|Quality|Path Elements|`.rnote`|`.pdf`|
|-|-|-|-|
|None|224177|1.984 MB|9.208 MB|
|High|98958 (44%)|1.011 MB (51%)|4.362 MB (47%)|
|Medium|49301 (22%)|0.535 MB (27%)|2.184 MB (24%)|
|Low|36489 (16%)|0.408 MB (21%)|1.601 MB (17%)|

### Implementation Details

- Simplification is based on the [Ramer–Douglas–Peucker algorithm](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm), but additionally considers pressure changes (so that e.g. straight line segments can be composed out of multiple points if pressure varies significantly).
- The amount of simplification is controlled through two constants, `geometry_epsilon` and `pressure_epsilon`. They specify how much the position and pressure are allowed to deviate from the original stroke.

### Discussion / TODO

- [ ] `geometry_epsilon` and `pressure_epsilon` are currently eyeballed magic numbers. Should the `geometry_epsilon` scale depending on the camera zoom? Should the `pressure_epsilon` scale depending on the stroke width?
- [ ] We could optimize existing files somehow by adding it as an action somewhere. (Where?)
- [ ] The appearance of textured strokes changes after finishing a stroke (because the simplification removes points). I'm not sure what to do about that.
- [ ] We could add an export option that allows for more lossy simplification.

### Demo (Constant Pressure)
[Bildschirmaufnahme_20260515_160451.webm](https://github.com/user-attachments/assets/9e28ada3-2f01-4f8f-b313-7a01936fc053)