### PR TITLE
fixup: fix setters for doc_background_pattern_width/height_unitentry …

### DIFF
--- a/crates/rnote-ui/src/settingspanel/mod.rs
+++ b/crates/rnote-ui/src/settingspanel/mod.rs
@@ -441,10 +441,10 @@ impl RnSettingsPanel {
             self.set_format_predefined_format_variant(format::PredefinedFormat::Custom);
             self.set_format_orientation(format.orientation());
             imp.format_dpi_adj.set_value(format.dpi());
-            imp.format_width_unitentry.set_dpi(format.dpi());
-            imp.format_width_unitentry.set_value_in_px(format.width());
-            imp.format_height_unitentry.set_dpi(format.dpi());
-            imp.format_height_unitentry.set_value_in_px(format.height());
+            imp.format_width_unitentry
+                .set_dpi_and_value_px(format.dpi(), format.width());
+            imp.format_height_unitentry
+                .set_dpi_and_value_px(format.dpi(), format.height());
         }
         // TODO: else insensitive  options
     }
@@ -474,13 +474,9 @@ impl RnSettingsPanel {
                 .set_rgba(&gdk::RGBA::from_compose_color(background.color));
             self.set_background_pattern(background.pattern);
             imp.doc_background_pattern_width_unitentry
-                .set_dpi(format.dpi());
-            imp.doc_background_pattern_width_unitentry
-                .set_value_in_px(background.pattern_size[0]);
+                .set_dpi_and_value_px(format.dpi(), background.pattern_size[0]);
             imp.doc_background_pattern_height_unitentry
-                .set_dpi(format.dpi());
-            imp.doc_background_pattern_height_unitentry
-                .set_value_in_px(background.pattern_size[1]);
+                .set_dpi_and_value_px(format.dpi(), background.pattern_size[1]);
             self.set_document_layout(&document_layout);
             imp.doc_show_origin_indicator_row
                 .set_active(show_origin_indicator);

--- a/crates/rnote-ui/src/settingspanel/mod.rs
+++ b/crates/rnote-ui/src/settingspanel/mod.rs
@@ -1403,12 +1403,8 @@ impl RnSettingsPanel {
 
         self.set_format_predefined_format_variant(format::PredefinedFormat::Custom);
         imp.format_dpi_adj.set_value(revert_format.dpi());
-        imp.format_width_unitentry.set_dpi(revert_format.dpi());
-        imp.format_width_unitentry
-            .set_value_in_px(revert_format.width());
-        imp.format_height_unitentry.set_dpi(revert_format.dpi());
-        imp.format_height_unitentry
-            .set_value_in_px(revert_format.height());
+        imp.format_width_unitentry.set_dpi_and_value_px(revert_format.dpi(), revert_format.width());
+        imp.format_height_unitentry.set_dpi_and_value_px(revert_format.dpi(), revert_format.height());
     }
 
     fn apply_format(&self, appwindow: &RnAppWindow) {

--- a/crates/rnote-ui/src/settingspanel/mod.rs
+++ b/crates/rnote-ui/src/settingspanel/mod.rs
@@ -1403,8 +1403,10 @@ impl RnSettingsPanel {
 
         self.set_format_predefined_format_variant(format::PredefinedFormat::Custom);
         imp.format_dpi_adj.set_value(revert_format.dpi());
-        imp.format_width_unitentry.set_dpi_and_value_px(revert_format.dpi(), revert_format.width());
-        imp.format_height_unitentry.set_dpi_and_value_px(revert_format.dpi(), revert_format.height());
+        imp.format_width_unitentry
+            .set_dpi_and_value_px(revert_format.dpi(), revert_format.width());
+        imp.format_height_unitentry
+            .set_dpi_and_value_px(revert_format.dpi(), revert_format.height());
     }
 
     fn apply_format(&self, appwindow: &RnAppWindow) {

--- a/crates/rnote-ui/src/unitentry.rs
+++ b/crates/rnote-ui/src/unitentry.rs
@@ -317,4 +317,36 @@ impl RnUnitEntry {
         self.set_dpi(dpi);
         self.set_value(value);
     }
+
+    /// sets both dpi and value such that the value property is
+    /// only changed once with the correct self.value_in_px() callback
+    pub(crate) fn set_dpi_and_value_px(&self, dpi: f64, val_px: f64) {
+        if self.unit() == MeasureUnit::Px {
+            // Note : setting value then dpi will work if and only if the unit is is px
+            // Then value_in_px returns self.value() directly
+            // because dpi is not a variable in the convert_measurement call
+
+            self.set_value_in_px(val_px);
+            self.set_dpi(dpi);
+        } else {
+            // NOTE : this is mostly for security
+            // as we default to px for now on startup for the unit
+            // this shouldn't matter too much (at most this will limit duplicated
+            // calls to the engine with erroneous value_px on the first call)
+
+            // silent set on the dpi (because the new dpi value == to the cell one,
+            // does not trigger a calculation on value again)
+            // hence both the property and the cell have the new value
+            self.imp().dpi.replace(dpi);
+            self.set_dpi(dpi);
+
+            self.set_value(MeasureUnit::convert_measurement(
+                val_px,
+                MeasureUnit::Px,
+                dpi,
+                self.unit(),
+                dpi,
+            ));
+        }
+    }
 }

--- a/crates/rnote-ui/src/unitentry.rs
+++ b/crates/rnote-ui/src/unitentry.rs
@@ -322,7 +322,7 @@ impl RnUnitEntry {
         self.set_value(value);
     }
 
-    /// Sets both dpi and value such that no intermittent wrong "value" 
+    /// Sets both dpi and value such that no intermittent wrong "value"
     /// change signals are emitted by the Widget.
     pub(crate) fn set_dpi_and_value_px(&self, dpi: f64, val_px: f64) {
         if self.unit() == MeasureUnit::Px {

--- a/crates/rnote-ui/src/unitentry.rs
+++ b/crates/rnote-ui/src/unitentry.rs
@@ -288,6 +288,8 @@ impl RnUnitEntry {
     }
 
     #[allow(unused)]
+    /// **Note**: if both "value" and "dpi" should be changed at the same time, use [Self::set_dpi_and_value_px()] instead.
+    /// It ensures that no intermittent wrong "value" change signals are emitted by the Widget.
     pub(crate) fn set_dpi(&self, dpi: f64) {
         self.set_property("dpi", dpi.to_value());
     }
@@ -302,6 +304,8 @@ impl RnUnitEntry {
         )
     }
 
+    /// **Note**: if both "value" and "dpi" should be changed at the same time, use [Self::set_dpi_and_value_px()] instead.
+    /// It ensures that no intermittent wrong "value" change signals are emitted by the Widget.
     pub(crate) fn set_value_in_px(&self, val_px: f64) {
         self.set_value(MeasureUnit::convert_measurement(
             val_px,
@@ -318,8 +322,8 @@ impl RnUnitEntry {
         self.set_value(value);
     }
 
-    /// sets both dpi and value such that the value property is
-    /// only changed once with the correct self.value_in_px() callback
+    /// Sets both dpi and value such that no intermittent wrong "value" 
+    /// change signals are emitted by the Widget.
     pub(crate) fn set_dpi_and_value_px(&self, dpi: f64, val_px: f64) {
         if self.unit() == MeasureUnit::Px {
             // Note : setting value then dpi will work if and only if the unit is is px


### PR DESCRIPTION
…on setup

Otherwise the following occurs :
- the unitentry starts with default dpi and value whereas the engine has the correct value
- setting the dpi first makes the unitentry recalculate with the new dpi but default value so a new value in px is applied to the engine through the connect_notify on "value"
- setting the value in px afterwards will recalculate the value (this time with the correct dpi/value/unit combo) so the value in px is correct but this triggers again a modification on the engine because we changed this value just before.

This thus triggers 2*2 updates of the engine upon startup. But changing the order isn't enough (as in that case the first change of the value will return the expected value in px but not the second one if the unit is not px (because of the dpi scaling changing when setting the dpi with a unit != from px.).

To fix this, create a setter that changes both dpi and value in a way where the value property is only set once with the correct value_in_px callback

Fixes #1258. Replaces #1453  

NOTE : the `else` part in `set_dpi_and_value_px` is not technically needed for the fix (I kinda figured it'd be better to have an helper function with all cases covered anyway, and that it's a little clearer this way)