### PR TITLE
fix(ui): use limit-events property for headerbar buttons

### DIFF
--- a/crates/rnote-ui/data/ui/dialogs/dialogs.ui
+++ b/crates/rnote-ui/data/ui/dialogs/dialogs.ui
@@ -71,11 +71,13 @@ Changes which are not saved will be permanently lost.</property>
             <property name="show-start-title-buttons">false</property>
             <child type="start">
               <object class="GtkButton" id="edit_selected_workspace_button_cancel">
+                <property name="limit-events">true</property>
                 <property name="label" translatable="yes">Cancel</property>
               </object>
             </child>
             <child type="end">
               <object class="GtkButton" id="edit_selected_workspace_button_apply">
+                <property name="limit-events">true</property>
                 <property name="label" translatable="yes">Apply</property>
                 <style>
                   <class name="suggested-action" />

--- a/crates/rnote-ui/data/ui/dialogs/export.ui
+++ b/crates/rnote-ui/data/ui/dialogs/export.ui
@@ -11,11 +11,13 @@
             <property name="show-start-title-buttons">false</property>
             <child type="start">
               <object class="GtkButton" id="export_doc_button_cancel">
+                <property name="limit-events">true</property>
                 <property name="label" translatable="yes">Cancel</property>
               </object>
             </child>
             <child type="end">
               <object class="GtkButton" id="export_doc_button_confirm">
+                <property name="limit-events">true</property>
                 <property name="label" translatable="yes">Export</property>
                 <property name="sensitive">false</property>
                 <style>
@@ -180,11 +182,13 @@ are cut into pages</property>
             <property name="show-start-title-buttons">false</property>
             <child type="start">
               <object class="GtkButton" id="export_doc_pages_button_cancel">
+                <property name="limit-events">true</property>
                 <property name="label" translatable="yes">Cancel</property>
               </object>
             </child>
             <child type="end">
               <object class="GtkButton" id="export_doc_pages_button_confirm">
+                <property name="limit-events">true</property>
                 <property name="label" translatable="yes">Export</property>
                 <property name="sensitive">false</property>
                 <style>
@@ -420,11 +424,13 @@ to the actual size on the document</property>
             <property name="show-start-title-buttons">false</property>
             <child type="start">
               <object class="GtkButton" id="export_selection_button_cancel">
+                <property name="limit-events">true</property>
                 <property name="label" translatable="yes">Cancel</property>
               </object>
             </child>
             <child type="end">
               <object class="GtkButton" id="export_selection_button_confirm">
+                <property name="limit-events">true</property>
                 <property name="label" translatable="yes">Export</property>
                 <property name="sensitive">false</property>
                 <style>

--- a/crates/rnote-ui/data/ui/dialogs/import.ui
+++ b/crates/rnote-ui/data/ui/dialogs/import.ui
@@ -11,11 +11,13 @@
             <property name="show-start-title-buttons">false</property>
             <child type="start">
               <object class="GtkButton" id="import_pdf_button_cancel">
+                <property name="limit-events">true</property>
                 <property name="label" translatable="yes">Cancel</property>
               </object>
             </child>
             <child type="end">
               <object class="GtkButton" id="import_pdf_button_confirm">
+                <property name="limit-events">true</property>
                 <property name="label" translatable="yes">Import</property>
                 <style>
                   <class name="suggested-action" />
@@ -204,11 +206,13 @@ to the actual size on the document</property>
             <property name="show-start-title-buttons">false</property>
             <child type="start">
               <object class="GtkButton" id="import_xopp_button_cancel">
+                <property name="limit-events">true</property>
                 <property name="label" translatable="yes">Cancel</property>
               </object>
             </child>
             <child type="end">
               <object class="GtkButton" id="import_xopp_button_confirm">
+                <property name="limit-events">true</property>
                 <property name="label" translatable="yes">Import</property>
                 <style>
                   <class name="suggested-action" />

--- a/crates/rnote-ui/data/ui/mainheader.ui
+++ b/crates/rnote-ui/data/ui/mainheader.ui
@@ -30,6 +30,7 @@
         </property>
         <child type="start">
           <object class="GtkBox" id="quickactions_box">
+            <property name="limit-events">true</property>
             <property name="spacing">3</property>
             <child>
               <object class="GtkBox">
@@ -67,6 +68,7 @@
         </child>
         <child type="end">
           <object class="GtkBox">
+            <property name="limit-events">true</property>
             <property name="spacing">3</property>
             <child>
               <object class="GtkButton">

--- a/crates/rnote-ui/data/ui/mainheader.ui
+++ b/crates/rnote-ui/data/ui/mainheader.ui
@@ -66,7 +66,7 @@
           </object>
         </child>
         <child type="end">
-          <object class="GtkBox" id="right_buttons_box">
+          <object class="GtkBox">
             <property name="spacing">3</property>
             <child>
               <object class="GtkButton">

--- a/crates/rnote-ui/data/ui/sidebar.ui
+++ b/crates/rnote-ui/data/ui/sidebar.ui
@@ -16,6 +16,7 @@
             </property>
             <child type="start">
               <object class="GtkBox">
+                <property name="limit-events">true</property>
                 <child>
                   <object class="GtkButton" id="left_close_button">
                     <property name="icon-name">dir-right-symbolic</property>
@@ -25,6 +26,7 @@
             </child>
             <child type="end">
               <object class="GtkBox">
+                <property name="limit-events">true</property>
                 <child>
                   <object class="RnAppMenu" id="appmenu">
                   </object>

--- a/crates/rnote-ui/src/mainheader.rs
+++ b/crates/rnote-ui/src/mainheader.rs
@@ -1,8 +1,7 @@
 // Imports
 use crate::{appmenu::RnAppMenu, appwindow::RnAppWindow, canvasmenu::RnCanvasMenu};
 use gtk4::{
-    Box, CompositeTemplate, EventControllerLegacy, Label, ToggleButton, Widget, glib, prelude::*,
-    subclass::prelude::*,
+    CompositeTemplate, Label, ToggleButton, Widget, glib, prelude::*, subclass::prelude::*,
 };
 
 mod imp {
@@ -25,10 +24,6 @@ mod imp {
         pub(crate) canvasmenu: TemplateChild<RnCanvasMenu>,
         #[template_child]
         pub(crate) appmenu: TemplateChild<RnAppMenu>,
-        #[template_child]
-        pub(crate) quickactions_box: TemplateChild<Box>,
-        #[template_child]
-        pub(crate) right_buttons_box: TemplateChild<Box>,
     }
 
     #[glib::object_subclass]
@@ -111,23 +106,5 @@ impl RnMainHeader {
 
         imp.canvasmenu.get().init(appwindow);
         imp.appmenu.get().init(appwindow);
-
-        // add controllers to elements to prevent accidental resizes: left buttons
-        let capture_left = EventControllerLegacy::builder()
-            .name("capture_event_left")
-            .propagation_phase(gtk4::PropagationPhase::Bubble)
-            .build();
-
-        capture_left.connect_event(|_, _| glib::Propagation::Stop);
-        imp.quickactions_box.add_controller(capture_left);
-
-        // add controllers to elements to prevent accidental resizes: right buttons
-        let capture_right = EventControllerLegacy::builder()
-            .name("capture_event_right")
-            .propagation_phase(gtk4::PropagationPhase::Bubble)
-            .build();
-
-        capture_right.connect_event(|_, _| glib::Propagation::Stop);
-        imp.right_buttons_box.add_controller(capture_right);
     }
 }


### PR DESCRIPTION
Fixes #1770 (Previous #1142).

**Description**
This PR reverts the `EventControllerLegacy` workaround introduced in #1143 and replaces it with the native GTK 4.18+ `limit-events` property. This provides a cleaner, long-term solution to prevent accidental window behaviour (moving, resizing) when interacting with buttons in the headerbar.

**Testing performed**
- Reverted the previous PR and reproduced the event leaking.
- Applied `<property name="limit-events">true</property>`.
- Verified that clicking, double-clicking, and dragging on the headerbar buttons no longer propagates to the window.


https://github.com/user-attachments/assets/b09af605-c851-4db9-b489-45f22d4f6954

