### PR TITLE
feat: add document layers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4231,6 +4231,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slotmap",
+ "smol",
  "svg",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/rnote-engine/Cargo.toml
+++ b/crates/rnote-engine/Cargo.toml
@@ -62,6 +62,7 @@ gtk4 = { workspace = true, optional = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+smol = { workspace = true }
 
 [features]
 cli = ["dep:clap"]

--- a/crates/rnote-engine/src/engine/export.rs
+++ b/crates/rnote-engine/src/engine/export.rs
@@ -2,12 +2,14 @@
 use super::{Engine, StrokeContent};
 use crate::fileformats::rnoteformat::RnoteFile;
 use crate::fileformats::{FileFormatSaver, xoppformat};
+use crate::store::DocumentLayerId;
 use anyhow::Context;
 use futures::channel::oneshot;
 use rayon::prelude::*;
 use rnote_compose::SplitOrder;
 use rnote_compose::transform::Transformable;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::io::Cursor;
 use std::sync::Arc;
 use tracing::error;
@@ -540,7 +542,7 @@ impl Engine {
     }
 
     /// Export the document as a Xournal++ .xopp file.
-    fn export_doc_as_xopp_bytes(
+    pub(crate) fn export_doc_as_xopp_bytes(
         &self,
         title: String,
         doc_export_prefs_override: Option<DocExportPrefs>,
@@ -548,8 +550,60 @@ impl Engine {
         let (oneshot_sender, oneshot_receiver) = oneshot::channel::<anyhow::Result<Vec<u8>>>();
         let doc_export_prefs =
             doc_export_prefs_override.unwrap_or(self.config.read().export_prefs.doc_export_prefs);
-        let pages_content = self.extract_pages_content(doc_export_prefs.page_order);
+        let dpi = self.document.config.format.dpi();
         let document = self.document.clone();
+
+        // Pre-compute page content grouped by DocumentLayer.
+        // We must do this before rayon::spawn because StrokeStore is not Clone/Send.
+        let pages_bounds = self.pages_bounds_w_content(doc_export_prefs.page_order);
+        let layers_arc = self.store.layers().to_vec();
+        let mut pages_layer_data: Vec<(
+            p2d::bounding_volume::Aabb,
+            Vec<(DocumentLayerId, String, Vec<Arc<crate::strokes::Stroke>>)>,
+        )> = vec![];
+
+        for &page_bounds in &pages_bounds {
+            let keys = self
+                .store
+                .stroke_keys_as_rendered_intersecting_bounds(page_bounds);
+            let mut layer_strokes: HashMap<
+                DocumentLayerId,
+                (String, Vec<Arc<crate::strokes::Stroke>>),
+            > = HashMap::new();
+
+            for &key in &keys {
+                if let Some(stroke) = self.store.get_stroke_arc(key) {
+                    let layer_id = self.store.stroke_document_layer_id(key).unwrap_or(0);
+                    let entry = layer_strokes.entry(layer_id).or_insert_with(|| {
+                        let name = layers_arc
+                            .iter()
+                            .find(|l| l.id == layer_id)
+                            .map(|l| l.name.clone())
+                            .unwrap_or_else(|| format!("Layer {}", layer_id));
+                        (name, vec![])
+                    });
+                    entry.1.push(stroke);
+                }
+            }
+
+            // Preserve DocumentLayer order from rnote
+            let mut ordered = vec![];
+            for layer in layers_arc.iter() {
+                match layer_strokes.remove(&layer.id) {
+                    Some((name, strokes)) => ordered.push((layer.id, name, strokes)),
+                    None if !layer.name.is_empty() && layer.visible => {
+                        ordered.push((layer.id, layer.name.clone(), vec![]));
+                    }
+                    None => {}
+                }
+            }
+            // Any leftover layers (should be unreachable if all layers are in layers_arc)
+            for (id, (name, strokes)) in layer_strokes {
+                ordered.push((id, name, strokes));
+            }
+
+            pages_layer_data.push((page_bounds, ordered));
+        }
 
         rayon::spawn(move || {
             let result = || -> anyhow::Result<Vec<u8>> {
@@ -557,91 +611,67 @@ impl Engine {
                 let xopp_background = xoppformat::XoppBackground {
                     name: None,
                     bg_type: xoppformat::XoppBackgroundType::Solid {
-                        color: crate::utils::xoppcolor_from_color(document.config.background.color),
+                        color: crate::utils::xoppcolor_from_color(
+                            document.config.background.color,
+                        ),
                         style: xoppformat::XoppBackgroundSolidStyle::Plain,
                     },
                 };
 
-                // xopp spec needs at least one page in vec,
-                // but it is fine because pages_bounds_w_content() always produces at least one.
-                let pages = pages_content
+                let pages = pages_layer_data
                     .into_iter()
-                    .filter_map(|page_content| {
-                        let page_bounds = page_content.bounds()?;
-                        // Translate strokes to to page mins and convert to XoppStrokStyle
-                        let xopp_strokestyles = page_content
-                            .strokes
-                            .into_iter()
-                            .filter_map(|mut stroke| {
-                                let mut stroke = Arc::make_mut(&mut stroke).clone();
-                                stroke.translate(-page_bounds.mins.coords);
-                                stroke.into_xopp(document.config.format.dpi())
-                            })
-                            .collect::<Vec<xoppformat::XoppStrokeType>>();
-
-                        // Extract the strokes
-                        let xopp_strokes = xopp_strokestyles
-                            .iter()
-                            .filter_map(|stroke| {
-                                if let xoppformat::XoppStrokeType::XoppStroke(xoppstroke) = stroke {
-                                    Some(xoppstroke.clone())
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect::<Vec<xoppformat::XoppStroke>>();
-
-                        // Extract the texts
-                        let xopp_texts = xopp_strokestyles
-                            .iter()
-                            .filter_map(|stroke| {
-                                if let xoppformat::XoppStrokeType::XoppText(xopptext) = stroke {
-                                    Some(xopptext.clone())
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect::<Vec<xoppformat::XoppText>>();
-
-                        // Extract the images
-                        let xopp_images = xopp_strokestyles
-                            .iter()
-                            .filter_map(|stroke| {
-                                if let xoppformat::XoppStrokeType::XoppImage(xoppstroke) = stroke {
-                                    Some(xoppstroke.clone())
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect::<Vec<xoppformat::XoppImage>>();
-
-                        // In Rnote images are always rendered below strokes and text.
-                        // To match this behaviour accurately, images are separated into another layer.
-                        let image_layer = xoppformat::XoppLayer {
-                            name: None,
-                            strokes: vec![],
-                            texts: vec![],
-                            images: xopp_images,
-                        };
-
-                        let strokes_layer = xoppformat::XoppLayer {
-                            name: None,
-                            strokes: xopp_strokes,
-                            texts: xopp_texts,
-                            images: vec![],
-                        };
+                    .filter_map(|(page_bounds, layer_strokes)| {
+                        if page_bounds.extents()[0] <= f64::EPSILON
+                            || page_bounds.extents()[1] <= f64::EPSILON
+                        {
+                            return None;
+                        }
 
                         let page_dimensions = crate::utils::convert_coord_dpi(
                             page_bounds.extents(),
-                            document.config.format.dpi(),
+                            dpi,
                             xoppformat::XoppFile::DPI,
                         );
+
+                        let xopp_layers: Vec<xoppformat::XoppLayer> = layer_strokes
+                            .into_iter()
+                            .filter_map(|(_layer_id, layer_name, strokes)| {
+                                let elements: Vec<xoppformat::XoppStrokeType> = strokes
+                                    .into_iter()
+                                    .filter_map(|stroke| {
+                                        let mut s = (*stroke).clone();
+                                        s.translate(-page_bounds.mins.coords);
+                                        s.into_xopp(dpi)
+                                    })
+                                    .collect();
+
+                                if elements.is_empty() && layer_name.is_empty() {
+                                    None
+                                } else {
+                                    Some(xoppformat::XoppLayer {
+                                        name: if layer_name.is_empty() {
+                                            None
+                                        } else {
+                                            Some(layer_name)
+                                        },
+                                        strokes: vec![],
+                                        texts: vec![],
+                                        images: vec![],
+                                        elements,
+                                    })
+                                }
+                            })
+                            .collect();
+
+                        if xopp_layers.is_empty() {
+                            return None;
+                        }
 
                         Some(xoppformat::XoppPage {
                             width: page_dimensions[0],
                             height: page_dimensions[1],
                             background: xopp_background.clone(),
-                            layers: vec![image_layer, strokes_layer],
+                            layers: xopp_layers,
                         })
                     })
                     .collect::<Vec<xoppformat::XoppPage>>();

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -1027,6 +1027,12 @@ mod tests {
     use crate::fileformats::FileFormatLoader;
     use crate::fileformats::FileFormatSaver;
     use crate::fileformats::rnoteformat::RnoteFile;
+    use crate::fileformats::xoppformat;
+    use crate::engine::import::XoppImportPrefs;
+    use crate::strokes::BrushStroke;
+    use crate::strokes::Stroke;
+    use rnote_compose::Style;
+    use rnote_compose::penpath::Element;
 
     #[test]
     fn rnote_snapshot_roundtrip_preserves_layer_metadata() {
@@ -1092,4 +1098,238 @@ mod tests {
         engine.redo(Instant::now());
         assert!(engine.layers()[1].locked);
     }
+
+    fn build_minimal_xopp_bytes(
+        pages: Vec<Vec<(Option<&str>, Vec<&str>)>>,
+    ) -> Vec<u8> {
+        let mut xml = String::new();
+        xml.push_str(
+            r#"<?xml version="1.0" encoding="UTF-8"?><xournal creator="rnote test" fileversion="4"><title>Test</title>"#,
+        );
+
+        for page_layers in &pages {
+            let width = 800.0;
+            let height = 600.0;
+            xml.push_str(&format!(
+                "<page width=\"{}\" height=\"{}\"><background type=\"solid\" color=\"#ffffffff\" style=\"plain\"/>",
+                width, height
+            ));
+            for (name_opt, coords_list) in page_layers {
+                xml.push_str("<layer");
+                if let Some(name) = name_opt {
+                    xml.push_str(&format!(" name=\"{}\"", xml_escape(name)));
+                }
+                xml.push('>');
+                for coords in coords_list {
+                    xml.push_str(&format!(
+                        r##"<stroke tool="pen" color="#000000ff" width="2.0 2.0 2.0 2.0">{}</stroke>"##,
+                        xml_escape(coords)
+                    ));
+                }
+                xml.push_str("</layer>");
+            }
+            xml.push_str("</page>");
+        }
+
+        xml.push_str("</xournal>");
+        xoppformat::compress_to_gzip(xml.as_bytes()).unwrap()
+    }
+
+    fn xml_escape(s: &str) -> String {
+        s.replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+            .replace('"', "&quot;")
+            .replace('\'', "&apos;")
+    }
+
+    #[test]
+    fn xopp_xml_layer_elements_roundtrip() {
+        // Test that elements field is populated during parse and used during write
+        let xopp_bytes = build_minimal_xopp_bytes(vec![vec![
+            (Some("Layer A"), vec!["10.0 20.0 30.0 40.0"]),
+            (Some("Layer B"), vec!["50.0 60.0 70.0 80.0"]),
+        ]]);
+
+        let xopp_file = xoppformat::XoppFile::load_from_bytes(&xopp_bytes).unwrap();
+        let pages = &xopp_file.xopp_root.pages;
+
+        // Verify elements are populated
+        assert_eq!(pages.len(), 1);
+        assert_eq!(pages[0].layers.len(), 2);
+        assert_eq!(pages[0].layers[0].name, Some("Layer A".into()));
+        assert_eq!(pages[0].layers[1].name, Some("Layer B".into()));
+        assert!(!pages[0].layers[0].elements.is_empty());
+        assert!(!pages[0].layers[1].elements.is_empty());
+
+        // Roundtrip through XML write and verify names preserved
+        let roundtrip_bytes = xopp_file.save_as_bytes("test.xopp").unwrap();
+        let roundtrip_file = xoppformat::XoppFile::load_from_bytes(&roundtrip_bytes).unwrap();
+        assert_eq!(roundtrip_file.xopp_root.pages[0].layers.len(), 2);
+        assert_eq!(
+            roundtrip_file.xopp_root.pages[0].layers[0].name,
+            Some("Layer A".into())
+        );
+        assert_eq!(
+            roundtrip_file.xopp_root.pages[0].layers[1].name,
+            Some("Layer B".into())
+        );
+    }
+
+    #[test]
+    fn xopp_import_preserves_named_layers() {
+        let xopp_bytes = build_minimal_xopp_bytes(vec![vec![
+            (Some("Notes"), vec!["10.0 20.0 30.0 40.0"]),
+            (Some("Sketches"), vec!["50.0 60.0 70.0 80.0"]),
+        ]]);
+
+        let snapshot = smol::block_on(EngineSnapshot::load_from_xopp_bytes(
+            xopp_bytes,
+            XoppImportPrefs::default(),
+        ))
+        .unwrap();
+
+        let layers: Vec<&DocumentLayer> = snapshot.layers.iter().collect();
+        assert_eq!(layers.len(), 2);
+        assert_eq!(layers[0].name, "Notes");
+        assert_eq!(layers[1].name, "Sketches");
+    }
+
+    #[test]
+    fn xopp_import_merges_layers_by_name_across_pages() {
+        // Two pages, each with "Notes" and "Sketches" layers
+        let xopp_bytes = build_minimal_xopp_bytes(vec![
+            vec![
+                (Some("Notes"), vec!["10.0 20.0 30.0 40.0"]),
+                (Some("Sketches"), vec!["50.0 60.0 70.0 80.0"]),
+            ],
+            vec![
+                (Some("Notes"), vec!["90.0 100.0 110.0 120.0"]),
+                (Some("Sketches"), vec!["130.0 140.0 150.0 160.0"]),
+            ],
+        ]);
+
+        let snapshot = smol::block_on(EngineSnapshot::load_from_xopp_bytes(
+            xopp_bytes,
+            XoppImportPrefs::default(),
+        ))
+        .unwrap();
+
+        // Should be merged to 2 layers, not 4
+        let layers: Vec<&DocumentLayer> = snapshot.layers.iter().collect();
+        assert_eq!(layers.len(), 2);
+        assert_eq!(layers[0].name, "Notes");
+        assert_eq!(layers[1].name, "Sketches");
+
+        // All 4 strokes should be imported
+        assert_eq!(snapshot.stroke_components.len(), 4);
+    }
+
+    #[test]
+    fn xopp_import_handles_unnamed_layers() {
+        // Two pages with unnamed layers at the same position
+        let xopp_bytes = build_minimal_xopp_bytes(vec![
+            vec![(None, vec!["10.0 20.0 30.0 40.0"])],
+            vec![(None, vec!["50.0 60.0 70.0 80.0"])],
+        ]);
+
+        let snapshot = smol::block_on(EngineSnapshot::load_from_xopp_bytes(
+            xopp_bytes,
+            XoppImportPrefs::default(),
+        ))
+        .unwrap();
+
+        // Unnamed layers at same position should merge into Layer 1
+        let layers: Vec<&DocumentLayer> = snapshot.layers.iter().collect();
+        assert_eq!(layers.len(), 1);
+        assert!(layers[0].name.starts_with("Layer"));
+    }
+
+    fn make_test_stroke(x: f64) -> Stroke {
+        Stroke::BrushStroke(BrushStroke::new(
+            Element::new(na::vector![x, 0.0], Element::PRESSURE_DEFAULT),
+            Style::default(),
+        ))
+    }
+
+    #[test]
+    fn xopp_export_preserves_layer_names() {
+        let mut engine = Engine::default();
+
+        // Layer 1 (default) with a stroke
+        engine.store.insert_stroke(make_test_stroke(10.0), None);
+
+        // Add a second named layer with a stroke
+        let layer2_id = engine.store.add_layer(Some("Sketches".into()));
+        engine.store.set_active_layer(layer2_id);
+        engine.store.insert_stroke(make_test_stroke(50.0), None);
+
+        // Add a third named layer with a stroke
+        let layer3_id = engine.store.add_layer(Some("Annotations".into()));
+        engine.store.set_active_layer(layer3_id);
+        engine.store.insert_stroke(make_test_stroke(100.0), None);
+
+        // Export to xopp
+        let xopp_bytes: Vec<u8> = smol::block_on(
+            engine.export_doc_as_xopp_bytes("test".into(), None),
+        )
+        .unwrap()
+        .unwrap();
+
+        // Re-import to verify layer structure
+        let snapshot = smol::block_on(EngineSnapshot::load_from_xopp_bytes(
+            xopp_bytes,
+            XoppImportPrefs::default(),
+        ))
+        .unwrap();
+
+        let layers: Vec<&DocumentLayer> = snapshot.layers.iter().collect();
+        assert_eq!(layers.len(), 3);
+        assert!(layers.iter().any(|l| l.name == "Sketches"));
+        assert!(layers.iter().any(|l| l.name == "Annotations"));
+    }
+
+    #[test]
+    fn xopp_export_excludes_hidden_layers() {
+        let mut engine = Engine::default();
+
+        engine.store.insert_stroke(make_test_stroke(10.0), None);
+        let hidden_layer_id = engine.store.add_layer(Some("Hidden".into()));
+        engine.store.insert_stroke(make_test_stroke(50.0), None);
+        engine.store.set_layer_visible(hidden_layer_id, false);
+
+        let xopp_bytes: Vec<u8> = smol::block_on(
+            engine.export_doc_as_xopp_bytes("test".into(), None),
+        )
+        .unwrap()
+        .unwrap();
+
+        // Parse the xopp XML to check it doesn't contain "Hidden" layer
+        let xopp_xml = xoppformat::decompress_from_gzip(&xopp_bytes).unwrap();
+        let xopp_str = String::from_utf8(xopp_xml).unwrap();
+        assert!(!xopp_str.contains("Hidden"));
+    }
+
+    #[test]
+    fn xopp_empty_named_layer_writes_self_closing_tag() {
+        // An rnote document with an empty named layer should still write it to xopp
+        let mut engine = Engine::default();
+
+        engine.store.insert_stroke(make_test_stroke(10.0), None);
+        let _empty_layer_id = engine.store.add_layer(Some("Empty".into()));
+        // Don't insert any strokes in this layer
+
+        let xopp_bytes: Vec<u8> = smol::block_on(
+            engine.export_doc_as_xopp_bytes("test".into(), None),
+        )
+        .unwrap()
+        .unwrap();
+
+        // Parse the xopp XML to verify the empty named layer tag exists
+        let xopp_xml = xoppformat::decompress_from_gzip(&xopp_bytes).unwrap();
+        let xopp_str = String::from_utf8(xopp_xml).unwrap();
+        // The layer "Empty" should appear in the output even if it's empty
+        assert!(xopp_str.contains("Empty"));
+    }
 }
+

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -22,8 +22,8 @@ use crate::Image;
 use crate::document::Layout;
 use crate::pens::PenMode;
 use crate::pens::{Pen, PenStyle};
-use crate::store::StrokeKey;
 use crate::store::render_comp::{self, RenderCompState};
+use crate::store::{DocumentLayer, DocumentLayerId, StrokeKey};
 use crate::strokes::content::GeneratedContentImages;
 use crate::strokes::textstroke::{TextAttribute, TextStyle};
 use crate::{Camera, Document, PenHolder, StrokeStore};
@@ -328,6 +328,8 @@ impl Engine {
 
         for key in trashed_keys {
             Arc::make_mut(&mut store_history_entry.stroke_components).remove(key);
+            Arc::make_mut(&mut store_history_entry.layer_components).remove(key);
+            Arc::make_mut(&mut store_history_entry.chrono_components).remove(key);
         }
 
         EngineSnapshot {
@@ -335,6 +337,10 @@ impl Engine {
             camera: self.camera.extract_snapshot_data(),
             stroke_components: Arc::clone(&store_history_entry.stroke_components),
             chrono_components: Arc::clone(&store_history_entry.chrono_components),
+            layer_components: Arc::clone(&store_history_entry.layer_components),
+            layers: Arc::clone(&store_history_entry.layers),
+            active_layer_id: store_history_entry.active_layer_id,
+            layer_counter: store_history_entry.layer_counter,
             chrono_counter: store_history_entry.chrono_counter,
         }
     }
@@ -365,18 +371,22 @@ impl Engine {
 
     /// Undo the latest changes.
     pub fn undo(&mut self, now: Instant) -> WidgetFlags {
-        self.store.undo(now)
+        let mut widget_flags = self.store.undo(now)
             | self.doc_resize_autoexpand()
             | self.current_pen_update_state()
-            | self.update_rendering_current_viewport()
+            | self.update_rendering_current_viewport();
+        widget_flags.refresh_ui = true;
+        widget_flags
     }
 
     /// Redo the latest changes.
     pub fn redo(&mut self, now: Instant) -> WidgetFlags {
-        self.store.redo(now)
+        let mut widget_flags = self.store.redo(now)
             | self.doc_resize_autoexpand()
             | self.current_pen_update_state()
-            | self.update_rendering_current_viewport()
+            | self.update_rendering_current_viewport();
+        widget_flags.refresh_ui = true;
+        widget_flags
     }
 
     pub fn can_undo(&self) -> bool {
@@ -747,7 +757,7 @@ impl Engine {
     pub fn select_all_strokes(&mut self) -> WidgetFlags {
         let widget_flags = self.change_pen_style(PenStyle::Selector);
         self.store
-            .set_selected_keys(&self.store.stroke_keys_as_rendered(), true);
+            .set_selected_keys(&self.store.stroke_keys_as_rendered_editable_active(), true);
         widget_flags
             | self.current_pen_update_state()
             | self.doc_resize_autoexpand()
@@ -776,11 +786,108 @@ impl Engine {
             SelectionCollision::Intersects => self
                 .store
                 .stroke_keys_as_rendered_intersecting_bounds(bounds),
-        };
+        }
+        .into_iter()
+        .filter(|&key| self.store.stroke_editable_in_active_layer(key))
+        .collect::<Vec<StrokeKey>>();
         self.store.set_selected_keys(&select, true);
         self.doc_resize_autoexpand()
             | self.record(Instant::now())
             | self.update_rendering_current_viewport()
+    }
+
+    pub fn layers(&self) -> &[DocumentLayer] {
+        self.store.layers()
+    }
+
+    pub fn active_layer_id(&self) -> DocumentLayerId {
+        self.store.active_layer_id()
+    }
+
+    pub fn set_active_layer(&mut self, layer_id: DocumentLayerId) -> WidgetFlags {
+        let mut widget_flags = WidgetFlags::default();
+        if self.store.set_active_layer(layer_id) {
+            widget_flags |= self.current_pen_update_state() | self.record(Instant::now());
+            widget_flags.store_modified = true;
+            widget_flags.refresh_ui = true;
+        }
+        widget_flags
+    }
+
+    pub fn add_layer(&mut self, name: Option<String>) -> WidgetFlags {
+        self.store.add_layer(name);
+        let mut widget_flags = self.current_pen_update_state() | self.record(Instant::now());
+        widget_flags.store_modified = true;
+        widget_flags.refresh_ui = true;
+        widget_flags
+    }
+
+    pub fn delete_layer(&mut self, layer_id: DocumentLayerId) -> WidgetFlags {
+        let mut widget_flags = WidgetFlags::default();
+        if self.store.delete_layer(layer_id) {
+            widget_flags |= self.current_pen_update_state()
+                | self.doc_resize_autoexpand()
+                | self.record(Instant::now())
+                | self.update_rendering_current_viewport();
+            widget_flags.store_modified = true;
+            widget_flags.refresh_ui = true;
+        }
+        widget_flags
+    }
+
+    pub fn rename_layer(&mut self, layer_id: DocumentLayerId, name: String) -> WidgetFlags {
+        let mut widget_flags = WidgetFlags::default();
+        if self.store.rename_layer(layer_id, name) {
+            widget_flags |= self.record(Instant::now());
+            widget_flags.store_modified = true;
+            widget_flags.refresh_ui = true;
+        }
+        widget_flags
+    }
+
+    pub fn set_layer_visible(&mut self, layer_id: DocumentLayerId, visible: bool) -> WidgetFlags {
+        let mut widget_flags = WidgetFlags::default();
+        if self.store.set_layer_visible(layer_id, visible) {
+            widget_flags |= self.current_pen_update_state()
+                | self.record(Instant::now())
+                | self.update_rendering_current_viewport();
+            widget_flags.store_modified = true;
+            widget_flags.refresh_ui = true;
+        }
+        widget_flags
+    }
+
+    pub fn set_layer_locked(&mut self, layer_id: DocumentLayerId, locked: bool) -> WidgetFlags {
+        let mut widget_flags = WidgetFlags::default();
+        if self.store.set_layer_locked(layer_id, locked) {
+            widget_flags |= self.current_pen_update_state() | self.record(Instant::now());
+            widget_flags.store_modified = true;
+            widget_flags.refresh_ui = true;
+        }
+        widget_flags
+    }
+
+    pub fn move_layer_up(&mut self, layer_id: DocumentLayerId) -> WidgetFlags {
+        self.move_layer(layer_id, true)
+    }
+
+    pub fn move_layer_down(&mut self, layer_id: DocumentLayerId) -> WidgetFlags {
+        self.move_layer(layer_id, false)
+    }
+
+    fn move_layer(&mut self, layer_id: DocumentLayerId, up: bool) -> WidgetFlags {
+        let mut widget_flags = WidgetFlags::default();
+        let moved = if up {
+            self.store.move_layer_up(layer_id)
+        } else {
+            self.store.move_layer_down(layer_id)
+        };
+        if moved {
+            widget_flags |= self.record(Instant::now()) | self.update_rendering_current_viewport();
+            widget_flags.store_modified = true;
+            widget_flags.refresh_ui = true;
+        }
+        widget_flags
     }
 
     pub fn duplicate_selection(&mut self) -> WidgetFlags {
@@ -911,5 +1018,78 @@ impl Engine {
     pub fn current_pen_style_w_override(&self) -> PenStyle {
         self.penholder
             .current_pen_style_w_override(&engine_view!(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fileformats::FileFormatLoader;
+    use crate::fileformats::FileFormatSaver;
+    use crate::fileformats::rnoteformat::RnoteFile;
+
+    #[test]
+    fn rnote_snapshot_roundtrip_preserves_layer_metadata() {
+        let mut engine = Engine::default();
+
+        engine.add_layer(Some(String::from("Annotations")));
+        let layer_id = engine.active_layer_id();
+        engine.rename_layer(layer_id, String::from("Renamed"));
+        engine.set_layer_locked(layer_id, true);
+        engine.set_layer_visible(layer_id, false);
+        engine.move_layer_down(layer_id);
+
+        let snapshot = engine.take_snapshot();
+        let bytes = RnoteFile {
+            engine_snapshot: ijson::to_value(&snapshot).unwrap(),
+        }
+        .save_as_bytes("test.rnote")
+        .unwrap();
+        let loaded_file = RnoteFile::load_from_bytes(&bytes).unwrap();
+        let loaded_snapshot: EngineSnapshot =
+            ijson::from_value(&loaded_file.engine_snapshot).unwrap();
+
+        assert_eq!(loaded_snapshot.layers.len(), 2);
+        assert_eq!(loaded_snapshot.layers[0].id, layer_id);
+        assert_eq!(loaded_snapshot.layers[0].name, "Renamed");
+        assert!(!loaded_snapshot.layers[0].visible);
+        assert!(loaded_snapshot.layers[0].locked);
+        assert_eq!(loaded_snapshot.layers[1].id, 0);
+        assert!(loaded_snapshot.layers[1].visible);
+        assert!(!loaded_snapshot.layers[1].locked);
+    }
+
+    #[test]
+    fn engine_layer_operations_are_undoable_and_redoable() {
+        let mut engine = Engine::default();
+
+        engine.add_layer(Some(String::from("Layer 2")));
+        let layer_id = engine.active_layer_id();
+        assert_eq!(engine.layers().len(), 2);
+
+        engine.undo(Instant::now());
+        assert_eq!(engine.layers().len(), 1);
+
+        engine.redo(Instant::now());
+        assert_eq!(engine.layers().len(), 2);
+        assert_eq!(engine.active_layer_id(), layer_id);
+
+        engine.rename_layer(layer_id, String::from("Renamed"));
+        assert_eq!(engine.layers()[1].name, "Renamed");
+
+        engine.undo(Instant::now());
+        assert_eq!(engine.layers()[1].name, "Layer 2");
+
+        engine.redo(Instant::now());
+        assert_eq!(engine.layers()[1].name, "Renamed");
+
+        engine.set_layer_locked(layer_id, true);
+        assert!(engine.layers()[1].locked);
+
+        engine.undo(Instant::now());
+        assert!(!engine.layers()[1].locked);
+
+        engine.redo(Instant::now());
+        assert!(engine.layers()[1].locked);
     }
 }

--- a/crates/rnote-engine/src/engine/mod.rs
+++ b/crates/rnote-engine/src/engine/mod.rs
@@ -852,8 +852,8 @@ impl Engine {
                 | self.record(Instant::now())
                 | self.update_rendering_current_viewport();
             widget_flags.store_modified = true;
-            widget_flags.refresh_ui = true;
         }
+        widget_flags.refresh_ui = true;
         widget_flags
     }
 
@@ -862,8 +862,8 @@ impl Engine {
         if self.store.set_layer_locked(layer_id, locked) {
             widget_flags |= self.current_pen_update_state() | self.record(Instant::now());
             widget_flags.store_modified = true;
-            widget_flags.refresh_ui = true;
         }
+        widget_flags.refresh_ui = true;
         widget_flags
     }
 

--- a/crates/rnote-engine/src/engine/snapshot.rs
+++ b/crates/rnote-engine/src/engine/snapshot.rs
@@ -157,10 +157,58 @@ impl EngineSnapshot {
                 // Offsetting as rnote has one global coordinate space
                 let mut offset = na::Vector2::<f64>::zeros();
 
+                // Map from layer key to rnote DocumentLayerId for merging layers across pages.
+                // Named layers use their name as key; unnamed layers use page-level index.
+                let mut layer_id_map: std::collections::HashMap<String, DocumentLayerId> =
+                    std::collections::HashMap::new();
+                let mut is_first_layer = true;
+
                 for page in xopp_file.xopp_root.pages.into_iter() {
-                    for layers in page.layers.into_iter() {
-                        // import strokes
-                        for new_xoppstroke in layers.strokes.into_iter() {
+                    let mut page_unnamed_index: usize = 0;
+
+                    for xopp_layer in page.layers.into_iter() {
+                        let layer_key = xopp_layer
+                            .name
+                            .as_ref()
+                            .filter(|n| !n.is_empty())
+                            .cloned()
+                            .unwrap_or_else(|| {
+                                let index = page_unnamed_index;
+                                page_unnamed_index += 1;
+                                format!("__unnamed_{}", index)
+                            });
+
+                        let layer_id = if is_first_layer {
+                            is_first_layer = false;
+                            if let Some(ref name) = xopp_layer.name {
+                                if !name.is_empty() {
+                                    engine.store.rename_layer(0, name.clone());
+                                }
+                            }
+                            layer_id_map.insert(layer_key, 0);
+                            0
+                        } else if let Some(&existing_id) = layer_id_map.get(&layer_key) {
+                            existing_id
+                        } else {
+                            let display_name = if layer_key.starts_with("__unnamed_") {
+                                None
+                            } else {
+                                Some(layer_key.clone())
+                            };
+                            let new_id = engine.store.add_layer(display_name);
+                            layer_id_map.insert(layer_key, new_id);
+                            new_id
+                        };
+
+                        if !engine.store.set_active_layer(layer_id) {
+                            error!(
+                                "failed to set active layer to {} while importing xopp, skipping layer content",
+                                layer_id
+                            );
+                            continue;
+                        }
+
+                        for new_xoppstroke in xopp_layer.strokes.into_iter() {
                             match Stroke::from_xoppstroke(
                                 new_xoppstroke,
                                 offset,
@@ -171,14 +219,13 @@ impl EngineSnapshot {
                                 }
                                 Err(e) => {
                                     error!(
-                                        "Creating Stroke from XoppStroke failed while loading Xopp bytess, Err: {e:?}",
+                                        "Creating Stroke from XoppStroke failed while loading Xopp bytes, Err: {e:?}",
                                     );
                                 }
                             }
                         }
 
-                        // import images
-                        for new_xoppimage in layers.images.into_iter() {
+                        for new_xoppimage in xopp_layer.images.into_iter() {
                             match Stroke::from_xoppimage(
                                 new_xoppimage,
                                 offset,
@@ -195,9 +242,12 @@ impl EngineSnapshot {
                             }
                         }
 
-                        for new_xopptext in layers.texts.into_iter() {
-                            match Stroke::from_xopptext(new_xopptext, offset, xopp_import_prefs.dpi)
-                            {
+                        for new_xopptext in xopp_layer.texts.into_iter() {
+                            match Stroke::from_xopptext(
+                                new_xopptext,
+                                offset,
+                                xopp_import_prefs.dpi,
+                            ) {
                                 Ok(new_text) => {
                                     engine.store.insert_stroke(new_text, None);
                                 }

--- a/crates/rnote-engine/src/engine/snapshot.rs
+++ b/crates/rnote-engine/src/engine/snapshot.rs
@@ -2,7 +2,7 @@
 use crate::document::background;
 use crate::engine::import::XoppImportPrefs;
 use crate::fileformats::{FileFormatLoader, rnoteformat, xoppformat};
-use crate::store::{ChronoComponent, StrokeKey};
+use crate::store::{ChronoComponent, DocumentLayer, DocumentLayerId, LayerComponent, StrokeKey};
 use crate::strokes::Stroke;
 use crate::{Camera, Document, Engine};
 use anyhow::Context;
@@ -29,6 +29,14 @@ pub struct EngineSnapshot {
     pub stroke_components: Arc<SlotMap<StrokeKey, Arc<Stroke>>>,
     #[serde(rename = "chrono_components")]
     pub chrono_components: Arc<SecondaryMap<StrokeKey, Arc<ChronoComponent>>>,
+    #[serde(rename = "layer_components")]
+    pub layer_components: Arc<SecondaryMap<StrokeKey, Arc<LayerComponent>>>,
+    #[serde(rename = "layers")]
+    pub layers: Arc<Vec<DocumentLayer>>,
+    #[serde(rename = "active_layer_id")]
+    pub active_layer_id: DocumentLayerId,
+    #[serde(rename = "layer_counter")]
+    pub layer_counter: u32,
     #[serde(rename = "chrono_counter")]
     pub chrono_counter: u32,
 }
@@ -40,6 +48,10 @@ impl Default for EngineSnapshot {
             camera: Camera::default(),
             stroke_components: Arc::new(SlotMap::with_key()),
             chrono_components: Arc::new(SecondaryMap::new()),
+            layer_components: Arc::new(SecondaryMap::new()),
+            layers: Arc::new(vec![DocumentLayer::default()]),
+            active_layer_id: DocumentLayer::default().id,
+            layer_counter: DocumentLayer::default().id,
             chrono_counter: 0,
         }
     }

--- a/crates/rnote-engine/src/fileformats/xoppformat.rs
+++ b/crates/rnote-engine/src/fileformats/xoppformat.rs
@@ -10,7 +10,7 @@ use tracing::{error, trace};
 pub const VALS_DEC_PLACES: usize = 3;
 
 /// Compress bytes with gzip.
-fn compress_to_gzip(to_compress: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
+pub(crate) fn compress_to_gzip(to_compress: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
     let mut encoder =
         flate2::write::GzEncoder::new(Vec::<u8>::new(), flate2::Compression::default());
     encoder.write_all(to_compress)?;
@@ -18,7 +18,7 @@ fn compress_to_gzip(to_compress: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
 }
 
 /// Decompress from gzip.
-fn decompress_from_gzip(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
+pub(crate) fn decompress_from_gzip(compressed: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
     let mut decoder = flate2::read::MultiGzDecoder::new(compressed);
     let mut bytes: Vec<u8> = Vec::new();
     decoder.read_to_end(&mut bytes)?;
@@ -429,16 +429,35 @@ impl XmlWritable for XoppBackground {
 }
 
 /// A Xopp Layer.
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct XoppLayer {
     /// Optional layer name.
     pub name: Option<String>,
     /// Strokes on this layer.
+    #[serde(default)]
     pub strokes: Vec<XoppStroke>,
     /// Texts on this layer.
+    #[serde(default)]
     pub texts: Vec<XoppText>,
     /// Images on this layer.
+    #[serde(default)]
     pub images: Vec<XoppImage>,
+    /// All elements in the layer, preserving XML order.
+    /// When set, `write_to_xml` writes from this instead of the separate Vec fields.
+    #[serde(default)]
+    pub elements: Vec<XoppStrokeType>,
+}
+
+impl Default for XoppLayer {
+    fn default() -> Self {
+        Self {
+            name: None,
+            strokes: vec![],
+            texts: vec![],
+            images: vec![],
+            elements: vec![],
+        }
+    }
 }
 
 impl XmlLoadable for XoppLayer {
@@ -451,17 +470,23 @@ impl XmlLoadable for XoppLayer {
                     "stroke" => {
                         let mut new_stroke = XoppStroke::default();
                         new_stroke.load_from_xml(child)?;
-                        self.strokes.push(new_stroke);
+                        self.strokes.push(new_stroke.clone());
+                        self.elements
+                            .push(XoppStrokeType::XoppStroke(new_stroke));
                     }
                     "text" => {
                         let mut new_text = XoppText::default();
                         new_text.load_from_xml(child)?;
-                        self.texts.push(new_text);
+                        self.texts.push(new_text.clone());
+                        self.elements
+                            .push(XoppStrokeType::XoppText(new_text));
                     }
                     "image" => {
                         let mut new_image = XoppImage::default();
                         new_image.load_from_xml(child)?;
-                        self.images.push(new_image);
+                        self.images.push(new_image.clone());
+                        self.elements
+                            .push(XoppStrokeType::XoppImage(new_image));
                     }
                     _ => {}
                 },
@@ -474,11 +499,20 @@ impl XmlLoadable for XoppLayer {
 
 impl XmlWritable for XoppLayer {
     fn write_to_xml(&self, w: &mut xmlwriter::XmlWriter) {
-        // only do something if we are sure the layer is not empty
-        // Fix for #985
-        let is_empty = self.strokes.is_empty() && self.texts.is_empty() && self.images.is_empty();
+        let has_elements = !self.elements.is_empty();
+        let is_empty = self.strokes.is_empty()
+            && self.texts.is_empty()
+            && self.images.is_empty()
+            && !has_elements;
+
         if is_empty {
-            trace!("empty layer, skipped")
+            if self.name.is_some() {
+                w.start_element("layer");
+                w.write_attribute("name", self.name.as_ref().unwrap().as_str());
+                w.end_element();
+            } else {
+                trace!("empty layer, skipped")
+            }
         } else {
             w.start_element("layer");
             trace!("layer element opened");
@@ -487,14 +521,24 @@ impl XmlWritable for XoppLayer {
                 w.write_attribute("name", name.as_str());
             }
 
-            for stroke in self.strokes.iter() {
-                stroke.write_to_xml(w);
-            }
-            for text in self.texts.iter() {
-                text.write_to_xml(w);
-            }
-            for image in self.images.iter() {
-                image.write_to_xml(w);
+            if has_elements {
+                for element in self.elements.iter() {
+                    match element {
+                        XoppStrokeType::XoppStroke(stroke) => stroke.write_to_xml(w),
+                        XoppStrokeType::XoppText(text) => text.write_to_xml(w),
+                        XoppStrokeType::XoppImage(image) => image.write_to_xml(w),
+                    }
+                }
+            } else {
+                for stroke in self.strokes.iter() {
+                    stroke.write_to_xml(w);
+                }
+                for text in self.texts.iter() {
+                    text.write_to_xml(w);
+                }
+                for image in self.images.iter() {
+                    image.write_to_xml(w);
+                }
             }
             w.end_element();
         }

--- a/crates/rnote-engine/src/store/chrono_comp.rs
+++ b/crates/rnote-engine/src/store/chrono_comp.rs
@@ -4,6 +4,7 @@ use p2d::bounding_volume::Aabb;
 use rayon::slice::ParallelSliceMut;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq)]
@@ -115,10 +116,33 @@ impl StrokeStore {
 
     pub(super) fn sort_keys_chrono(&self, keys: &mut [StrokeKey]) {
         let chrono_components = &self.chrono_components;
+        let layer_components = &self.layer_components;
+        let layer_order = self
+            .layers
+            .iter()
+            .enumerate()
+            .map(|(index, layer)| (layer.id, index))
+            .collect::<HashMap<_, _>>();
         keys.par_sort_unstable_by(|&first, &second| {
             if let Some(first_chrono) = chrono_components.get(first)
                 && let Some(second_chrono) = chrono_components.get(second)
             {
+                let first_layer_order = layer_components
+                    .get(first)
+                    .and_then(|layer_comp| layer_order.get(&layer_comp.layer_id))
+                    .copied()
+                    .unwrap_or_default();
+                let second_layer_order = layer_components
+                    .get(second)
+                    .and_then(|layer_comp| layer_order.get(&layer_comp.layer_id))
+                    .copied()
+                    .unwrap_or_default();
+                let document_layer_order = first_layer_order.cmp(&second_layer_order);
+
+                if document_layer_order != std::cmp::Ordering::Equal {
+                    return document_layer_order;
+                }
+
                 let layer_order = first_chrono.layer.cmp(&second_chrono.layer);
 
                 if layer_order != std::cmp::Ordering::Equal {

--- a/crates/rnote-engine/src/store/layer_comp.rs
+++ b/crates/rnote-engine/src/store/layer_comp.rs
@@ -1,0 +1,335 @@
+// Imports
+use super::{StrokeKey, StrokeStore};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+pub type DocumentLayerId = u32;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename = "document_layer")]
+pub struct DocumentLayer {
+    #[serde(rename = "id")]
+    pub id: DocumentLayerId,
+    #[serde(rename = "name")]
+    pub name: String,
+    #[serde(rename = "visible")]
+    pub visible: bool,
+    #[serde(rename = "locked")]
+    pub locked: bool,
+}
+
+impl Default for DocumentLayer {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            name: String::from("Layer 1"),
+            visible: true,
+            locked: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(default, rename = "layer_component")]
+pub struct LayerComponent {
+    #[serde(rename = "layer_id")]
+    pub layer_id: DocumentLayerId,
+}
+
+impl Default for LayerComponent {
+    fn default() -> Self {
+        Self { layer_id: 0 }
+    }
+}
+
+impl StrokeStore {
+    pub(crate) fn layers(&self) -> &[DocumentLayer] {
+        self.layers.as_slice()
+    }
+
+    pub(crate) fn active_layer_id(&self) -> DocumentLayerId {
+        self.active_layer_id
+    }
+
+    pub(crate) fn set_active_layer(&mut self, layer_id: DocumentLayerId) -> bool {
+        if self
+            .layers
+            .iter()
+            .any(|layer| layer.id == layer_id && layer.visible && !layer.locked)
+        {
+            self.active_layer_id = layer_id;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn add_layer(&mut self, name: Option<String>) -> DocumentLayerId {
+        self.layer_counter += 1;
+        let id = self.layer_counter;
+        let layer = DocumentLayer {
+            id,
+            name: name.unwrap_or_else(|| format!("Layer {}", self.layers.len() + 1)),
+            visible: true,
+            locked: false,
+        };
+        Arc::make_mut(&mut self.layers).push(layer);
+        self.active_layer_id = id;
+        id
+    }
+
+    pub(crate) fn delete_layer(&mut self, layer_id: DocumentLayerId) -> bool {
+        if self.layers.len() <= 1 || !self.layers.iter().any(|layer| layer.id == layer_id) {
+            return false;
+        }
+
+        let keys_to_remove = self
+            .layer_components
+            .iter()
+            .filter_map(|(key, layer_comp)| {
+                if layer_comp.layer_id == layer_id {
+                    Some(key)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<StrokeKey>>();
+
+        for key in keys_to_remove {
+            self.remove_stroke(key);
+        }
+
+        Arc::make_mut(&mut self.layers).retain(|layer| layer.id != layer_id);
+        self.ensure_active_layer_editable();
+
+        true
+    }
+
+    pub(crate) fn rename_layer(&mut self, layer_id: DocumentLayerId, name: String) -> bool {
+        if let Some(layer) = Arc::make_mut(&mut self.layers)
+            .iter_mut()
+            .find(|layer| layer.id == layer_id)
+        {
+            layer.name = name;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn set_layer_visible(&mut self, layer_id: DocumentLayerId, visible: bool) -> bool {
+        if !visible && !self.has_editable_layer_after(layer_id, Some(visible), None) {
+            return false;
+        }
+
+        if let Some(layer) = Arc::make_mut(&mut self.layers)
+            .iter_mut()
+            .find(|layer| layer.id == layer_id)
+        {
+            layer.visible = visible;
+            self.ensure_active_layer_editable();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn set_layer_locked(&mut self, layer_id: DocumentLayerId, locked: bool) -> bool {
+        if locked && !self.has_editable_layer_after(layer_id, None, Some(locked)) {
+            return false;
+        }
+
+        if let Some(layer) = Arc::make_mut(&mut self.layers)
+            .iter_mut()
+            .find(|layer| layer.id == layer_id)
+        {
+            layer.locked = locked;
+            self.ensure_active_layer_editable();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn has_editable_layer_after(
+        &self,
+        layer_id: DocumentLayerId,
+        visible_override: Option<bool>,
+        locked_override: Option<bool>,
+    ) -> bool {
+        self.layers.iter().any(|layer| {
+            let visible = if layer.id == layer_id {
+                visible_override.unwrap_or(layer.visible)
+            } else {
+                layer.visible
+            };
+            let locked = if layer.id == layer_id {
+                locked_override.unwrap_or(layer.locked)
+            } else {
+                layer.locked
+            };
+            visible && !locked
+        })
+    }
+
+    fn ensure_active_layer_editable(&mut self) {
+        if self
+            .layers
+            .iter()
+            .any(|layer| layer.id == self.active_layer_id && layer.visible && !layer.locked)
+        {
+            return;
+        }
+
+        if let Some(layer) = self
+            .layers
+            .iter()
+            .find(|layer| layer.visible && !layer.locked)
+        {
+            self.active_layer_id = layer.id;
+        }
+    }
+
+    pub(crate) fn move_layer_up(&mut self, layer_id: DocumentLayerId) -> bool {
+        self.move_layer(layer_id, true)
+    }
+
+    pub(crate) fn move_layer_down(&mut self, layer_id: DocumentLayerId) -> bool {
+        self.move_layer(layer_id, false)
+    }
+
+    fn move_layer(&mut self, layer_id: DocumentLayerId, up: bool) -> bool {
+        let Some(index) = self.layers.iter().position(|layer| layer.id == layer_id) else {
+            return false;
+        };
+        let swap_index = if up {
+            index.checked_add(1).filter(|&i| i < self.layers.len())
+        } else {
+            index.checked_sub(1)
+        };
+
+        if let Some(swap_index) = swap_index {
+            Arc::make_mut(&mut self.layers).swap(index, swap_index);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn stroke_document_layer_id(&self, key: StrokeKey) -> Option<DocumentLayerId> {
+        self.layer_components.get(key).map(|comp| comp.layer_id)
+    }
+
+    #[allow(unused)]
+    pub(crate) fn set_stroke_document_layer(
+        &mut self,
+        key: StrokeKey,
+        layer_id: DocumentLayerId,
+    ) -> bool {
+        if !self.layers.iter().any(|layer| layer.id == layer_id) {
+            return false;
+        }
+        if let Some(layer_comp) = Arc::make_mut(&mut self.layer_components)
+            .get_mut(key)
+            .map(Arc::make_mut)
+        {
+            layer_comp.layer_id = layer_id;
+            true
+        } else {
+            false
+        }
+    }
+
+    #[allow(unused)]
+    pub(crate) fn stroke_layer_order(&self, key: StrokeKey) -> usize {
+        self.stroke_document_layer_id(key)
+            .and_then(|layer_id| self.layers.iter().position(|layer| layer.id == layer_id))
+            .unwrap_or(0)
+    }
+
+    pub(crate) fn stroke_layer_visible(&self, key: StrokeKey) -> bool {
+        self.stroke_document_layer_id(key)
+            .and_then(|layer_id| self.layers.iter().find(|layer| layer.id == layer_id))
+            .map(|layer| layer.visible)
+            .unwrap_or(true)
+    }
+
+    pub(crate) fn stroke_layer_editable(&self, key: StrokeKey) -> bool {
+        self.stroke_document_layer_id(key)
+            .and_then(|layer_id| self.layers.iter().find(|layer| layer.id == layer_id))
+            .map(|layer| layer.visible && !layer.locked)
+            .unwrap_or(true)
+    }
+
+    pub(crate) fn stroke_in_active_layer(&self, key: StrokeKey) -> bool {
+        self.stroke_document_layer_id(key)
+            .map(|layer_id| layer_id == self.active_layer_id)
+            .unwrap_or(true)
+    }
+
+    pub(crate) fn stroke_editable_in_active_layer(&self, key: StrokeKey) -> bool {
+        self.stroke_in_active_layer(key) && self.stroke_layer_editable(key)
+    }
+
+    #[allow(unused)]
+    pub(super) fn rebuild_layer_components_slotmap(&mut self) {
+        self.layer_components = Arc::new(slotmap::SecondaryMap::new());
+        self.stroke_components.keys().for_each(|key| {
+            Arc::make_mut(&mut self.layer_components)
+                .insert(key, Arc::new(LayerComponent::default()));
+        });
+    }
+
+    pub(super) fn normalize_layers(&mut self) {
+        if self.layers.is_empty() {
+            self.layers = Arc::new(vec![DocumentLayer::default()]);
+        }
+
+        if !self
+            .layers
+            .iter()
+            .any(|layer| layer.id == self.active_layer_id)
+        {
+            self.active_layer_id = self
+                .layers
+                .first()
+                .map(|layer| layer.id)
+                .unwrap_or_default();
+        }
+
+        self.layer_counter = self.layer_counter.max(
+            self.layers
+                .iter()
+                .map(|layer| layer.id)
+                .max()
+                .unwrap_or_default(),
+        );
+
+        let default_layer_id = self
+            .layers
+            .first()
+            .map(|layer| layer.id)
+            .unwrap_or_default();
+        for key in self.stroke_components.keys() {
+            if !self.layer_components.contains_key(key) {
+                Arc::make_mut(&mut self.layer_components).insert(
+                    key,
+                    Arc::new(LayerComponent {
+                        layer_id: default_layer_id,
+                    }),
+                );
+            }
+        }
+
+        let valid_layer_ids = self
+            .layers
+            .iter()
+            .map(|layer| layer.id)
+            .collect::<std::collections::HashSet<_>>();
+        for (_, layer_comp) in Arc::make_mut(&mut self.layer_components).iter_mut() {
+            if !valid_layer_ids.contains(&layer_comp.layer_id) {
+                Arc::make_mut(layer_comp).layer_id = default_layer_id;
+            }
+        }
+    }
+}

--- a/crates/rnote-engine/src/store/layer_comp.rs
+++ b/crates/rnote-engine/src/store/layer_comp.rs
@@ -106,14 +106,15 @@ impl StrokeStore {
     }
 
     pub(crate) fn rename_layer(&mut self, layer_id: DocumentLayerId, name: String) -> bool {
-        if let Some(layer) = Arc::make_mut(&mut self.layers)
-            .iter_mut()
-            .find(|layer| layer.id == layer_id)
-        {
-            layer.name = name;
-            true
-        } else {
+        let Some(layer_index) = self.layers.iter().position(|layer| layer.id == layer_id) else {
+            return false;
+        };
+
+        if self.layers[layer_index].name == name {
             false
+        } else {
+            Arc::make_mut(&mut self.layers)[layer_index].name = name;
+            true
         }
     }
 
@@ -122,15 +123,16 @@ impl StrokeStore {
             return false;
         }
 
-        if let Some(layer) = Arc::make_mut(&mut self.layers)
-            .iter_mut()
-            .find(|layer| layer.id == layer_id)
-        {
-            layer.visible = visible;
+        let Some(layer_index) = self.layers.iter().position(|layer| layer.id == layer_id) else {
+            return false;
+        };
+
+        if self.layers[layer_index].visible == visible {
+            false
+        } else {
+            Arc::make_mut(&mut self.layers)[layer_index].visible = visible;
             self.ensure_active_layer_editable();
             true
-        } else {
-            false
         }
     }
 
@@ -139,15 +141,16 @@ impl StrokeStore {
             return false;
         }
 
-        if let Some(layer) = Arc::make_mut(&mut self.layers)
-            .iter_mut()
-            .find(|layer| layer.id == layer_id)
-        {
-            layer.locked = locked;
+        let Some(layer_index) = self.layers.iter().position(|layer| layer.id == layer_id) else {
+            return false;
+        };
+
+        if self.layers[layer_index].locked == locked {
+            false
+        } else {
+            Arc::make_mut(&mut self.layers)[layer_index].locked = locked;
             self.ensure_active_layer_editable();
             true
-        } else {
-            false
         }
     }
 

--- a/crates/rnote-engine/src/store/mod.rs
+++ b/crates/rnote-engine/src/store/mod.rs
@@ -1,6 +1,7 @@
 // Modules
 pub mod chrono_comp;
 pub mod keytree;
+pub mod layer_comp;
 pub mod render_comp;
 pub mod selection_comp;
 pub mod stroke_comp;
@@ -9,6 +10,7 @@ pub mod trash_comp;
 // Re-exports
 pub use chrono_comp::ChronoComponent;
 use keytree::KeyTree;
+pub use layer_comp::{DocumentLayer, DocumentLayerId, LayerComponent};
 pub use render_comp::RenderComponent;
 pub use selection_comp::SelectionComponent;
 pub use trash_comp::TrashComponent;
@@ -30,6 +32,129 @@ slotmap::new_key_type! {
     pub struct StrokeKey;
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::strokes::BrushStroke;
+    use rnote_compose::Style;
+    use rnote_compose::penpath::Element;
+    use std::time::Instant;
+
+    fn test_stroke(x: f64) -> Stroke {
+        Stroke::BrushStroke(BrushStroke::new(
+            Element::new(na::vector![x, 0.0], Element::PRESSURE_DEFAULT),
+            Style::default(),
+        ))
+    }
+
+    #[test]
+    fn inserted_strokes_use_active_layer() {
+        let mut store = StrokeStore::default();
+
+        let first = store.insert_stroke(test_stroke(0.0), None);
+        let new_layer = store.add_layer(Some(String::from("Layer 2")));
+        let second = store.insert_stroke(test_stroke(10.0), None);
+
+        assert_eq!(store.stroke_document_layer_id(first), Some(0));
+        assert_eq!(store.stroke_document_layer_id(second), Some(new_layer));
+        assert_eq!(store.active_layer_id(), new_layer);
+    }
+
+    #[test]
+    fn hidden_layers_are_not_rendered() {
+        let mut store = StrokeStore::default();
+
+        let first = store.insert_stroke(test_stroke(0.0), None);
+        let new_layer = store.add_layer(Some(String::from("Layer 2")));
+        let second = store.insert_stroke(test_stroke(10.0), None);
+
+        assert_eq!(store.stroke_keys_as_rendered(), vec![first, second]);
+
+        assert!(store.set_layer_visible(new_layer, false));
+
+        assert_eq!(store.stroke_keys_as_rendered(), vec![first]);
+    }
+
+    #[test]
+    fn locked_and_hidden_active_layer_strokes_cannot_be_selected() {
+        let mut store = StrokeStore::default();
+
+        let layer = store.add_layer(Some(String::from("Layer 2")));
+        let key = store.insert_stroke(test_stroke(0.0), None);
+
+        assert!(store.set_layer_locked(layer, true));
+        store.set_selected(key, true);
+        assert!(!store.selected(key).unwrap());
+
+        assert!(store.set_layer_locked(layer, false));
+        assert!(store.set_layer_visible(layer, false));
+        store.set_selected(key, true);
+        assert!(!store.selected(key).unwrap());
+    }
+
+    #[test]
+    fn document_layer_order_controls_render_order() {
+        let mut store = StrokeStore::default();
+
+        let first = store.insert_stroke(test_stroke(0.0), None);
+        let layer = store.add_layer(Some(String::from("Layer 2")));
+        let second = store.insert_stroke(test_stroke(10.0), None);
+
+        assert_eq!(store.stroke_keys_as_rendered(), vec![first, second]);
+
+        assert!(store.move_layer_up(0));
+
+        assert_eq!(
+            store
+                .layers()
+                .iter()
+                .map(|layer| layer.id)
+                .collect::<Vec<_>>(),
+            vec![layer, 0]
+        );
+        assert_eq!(store.stroke_keys_as_rendered(), vec![second, first]);
+    }
+
+    #[test]
+    fn layer_changes_are_undoable() {
+        let mut store = StrokeStore::default();
+
+        let layer = store.add_layer(Some(String::from("Layer 2")));
+        store.record(Instant::now());
+
+        assert_eq!(store.layers().len(), 2);
+        assert_eq!(store.active_layer_id(), layer);
+
+        store.undo(Instant::now());
+
+        assert_eq!(store.layers().len(), 1);
+        assert_eq!(store.active_layer_id(), 0);
+    }
+
+    #[test]
+    fn importing_snapshot_without_layers_assigns_default_layer() {
+        let mut stroke_components = SlotMap::with_key();
+        let key = stroke_components.insert(Arc::new(test_stroke(0.0)));
+        let mut chrono_components = SecondaryMap::new();
+        chrono_components.insert(
+            key,
+            Arc::new(ChronoComponent::new(1, StrokeLayer::UserLayer(0))),
+        );
+        let snapshot = EngineSnapshot {
+            stroke_components: Arc::new(stroke_components),
+            chrono_components: Arc::new(chrono_components),
+            chrono_counter: 1,
+            ..EngineSnapshot::default()
+        };
+        let mut store = StrokeStore::default();
+
+        store.import_from_snapshot(&snapshot);
+
+        assert_eq!(store.layers(), &[DocumentLayer::default()]);
+        assert_eq!(store.stroke_document_layer_id(key), Some(0));
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename = "history_entry")]
 pub struct HistoryEntry {
@@ -39,6 +164,14 @@ pub struct HistoryEntry {
     pub trash_components: Arc<SecondaryMap<StrokeKey, Arc<TrashComponent>>>,
     #[serde(rename = "chrono_components")]
     pub chrono_components: Arc<SecondaryMap<StrokeKey, Arc<ChronoComponent>>>,
+    #[serde(rename = "layer_components")]
+    pub layer_components: Arc<SecondaryMap<StrokeKey, Arc<LayerComponent>>>,
+    #[serde(rename = "layers")]
+    pub layers: Arc<Vec<DocumentLayer>>,
+    #[serde(rename = "active_layer_id")]
+    pub active_layer_id: DocumentLayerId,
+    #[serde(rename = "layer_counter")]
+    pub layer_counter: u32,
     #[serde(rename = "chrono_counter")]
     pub chrono_counter: u32,
 }
@@ -49,6 +182,10 @@ impl Default for HistoryEntry {
             stroke_components: Arc::new(SlotMap::with_key()),
             trash_components: Arc::new(SecondaryMap::new()),
             chrono_components: Arc::new(SecondaryMap::new()),
+            layer_components: Arc::new(SecondaryMap::new()),
+            layers: Arc::new(vec![DocumentLayer::default()]),
+            active_layer_id: DocumentLayer::default().id,
+            layer_counter: DocumentLayer::default().id,
 
             chrono_counter: 0,
         }
@@ -79,6 +216,14 @@ pub struct StrokeStore {
     selection_components: Arc<SecondaryMap<StrokeKey, Arc<SelectionComponent>>>,
     #[serde(rename = "chrono_components")]
     chrono_components: Arc<SecondaryMap<StrokeKey, Arc<ChronoComponent>>>,
+    #[serde(rename = "layer_components")]
+    layer_components: Arc<SecondaryMap<StrokeKey, Arc<LayerComponent>>>,
+    #[serde(rename = "layers")]
+    layers: Arc<Vec<DocumentLayer>>,
+    #[serde(rename = "active_layer_id")]
+    active_layer_id: DocumentLayerId,
+    #[serde(rename = "layer_counter")]
+    layer_counter: u32,
     /// Incrementing counter for chrono_components.
     ///
     /// Value must be kept equal to the [ChronoComponent] of the newest inserted or modified stroke.
@@ -105,6 +250,10 @@ impl Default for StrokeStore {
             trash_components: Arc::new(SecondaryMap::new()),
             selection_components: Arc::new(SecondaryMap::new()),
             chrono_components: Arc::new(SecondaryMap::new()),
+            layer_components: Arc::new(SecondaryMap::new()),
+            layers: Arc::new(vec![DocumentLayer::default()]),
+            active_layer_id: DocumentLayer::default().id,
+            layer_counter: DocumentLayer::default().id,
             render_components: SecondaryMap::new(),
 
             // Start off with state in the history
@@ -131,7 +280,12 @@ impl StrokeStore {
         widget_flags |= self.clear();
         self.stroke_components = Arc::clone(&snapshot.stroke_components);
         self.chrono_components = Arc::clone(&snapshot.chrono_components);
+        self.layer_components = Arc::clone(&snapshot.layer_components);
+        self.layers = Arc::clone(&snapshot.layers);
+        self.active_layer_id = snapshot.active_layer_id;
+        self.layer_counter = snapshot.layer_counter;
         self.chrono_counter = snapshot.chrono_counter;
+        self.normalize_layers();
 
         self.update_geometry_for_strokes(&self.keys_unordered());
         self.rebuild_selection_components_slotmap();
@@ -158,6 +312,10 @@ impl StrokeStore {
         Arc::ptr_eq(&self.stroke_components, &history_entry.stroke_components)
             && Arc::ptr_eq(&self.trash_components, &history_entry.trash_components)
             && Arc::ptr_eq(&self.chrono_components, &history_entry.chrono_components)
+            && Arc::ptr_eq(&self.layer_components, &history_entry.layer_components)
+            && Arc::ptr_eq(&self.layers, &history_entry.layers)
+            && self.active_layer_id == history_entry.active_layer_id
+            && self.layer_counter == history_entry.layer_counter
             && self.chrono_counter == history_entry.chrono_counter
     }
 
@@ -167,6 +325,10 @@ impl StrokeStore {
             stroke_components: Arc::clone(&self.stroke_components),
             trash_components: Arc::clone(&self.trash_components),
             chrono_components: Arc::clone(&self.chrono_components),
+            layer_components: Arc::clone(&self.layer_components),
+            layers: Arc::clone(&self.layers),
+            active_layer_id: self.active_layer_id,
+            layer_counter: self.layer_counter,
             chrono_counter: self.chrono_counter,
         }
     }
@@ -176,7 +338,12 @@ impl StrokeStore {
         self.stroke_components = Arc::clone(&history_entry.stroke_components);
         self.trash_components = Arc::clone(&history_entry.trash_components);
         self.chrono_components = Arc::clone(&history_entry.chrono_components);
+        self.layer_components = Arc::clone(&history_entry.layer_components);
+        self.layers = Arc::clone(&history_entry.layers);
+        self.active_layer_id = history_entry.active_layer_id;
+        self.layer_counter = history_entry.layer_counter;
         self.chrono_counter = history_entry.chrono_counter;
+        self.normalize_layers();
 
         // Since we don't store the rtree in the history, we need to rebuild it.
         self.rebuild_rtree();
@@ -321,6 +488,7 @@ impl StrokeStore {
     ) -> StrokeKey {
         let bounds = stroke.bounds();
         let layer = layer.unwrap_or_else(|| stroke.extract_default_layer());
+        let document_layer_id = self.active_layer_id;
 
         let key = Arc::make_mut(&mut self.stroke_components).insert(Arc::new(stroke));
         self.key_tree.insert_with_key(key, bounds);
@@ -332,6 +500,12 @@ impl StrokeStore {
         Arc::make_mut(&mut self.chrono_components).insert(
             key,
             Arc::new(ChronoComponent::new(self.chrono_counter, layer)),
+        );
+        Arc::make_mut(&mut self.layer_components).insert(
+            key,
+            Arc::new(LayerComponent {
+                layer_id: document_layer_id,
+            }),
         );
         self.render_components
             .insert(key, RenderComponent::default());
@@ -345,6 +519,7 @@ impl StrokeStore {
         Arc::make_mut(&mut self.trash_components).remove(key);
         Arc::make_mut(&mut self.selection_components).remove(key);
         Arc::make_mut(&mut self.chrono_components).remove(key);
+        Arc::make_mut(&mut self.layer_components).remove(key);
         self.render_components.remove(key);
 
         self.key_tree.remove_with_key(key);
@@ -359,6 +534,10 @@ impl StrokeStore {
         Arc::make_mut(&mut self.trash_components).clear();
         Arc::make_mut(&mut self.selection_components).clear();
         Arc::make_mut(&mut self.chrono_components).clear();
+        Arc::make_mut(&mut self.layer_components).clear();
+        self.layers = Arc::new(vec![DocumentLayer::default()]);
+        self.active_layer_id = DocumentLayer::default().id;
+        self.layer_counter = DocumentLayer::default().id;
 
         self.chrono_counter = 0;
         let widget_flags = self.clear_history(HistoryEntry::default());

--- a/crates/rnote-engine/src/store/mod.rs
+++ b/crates/rnote-engine/src/store/mod.rs
@@ -73,6 +73,9 @@ mod tests {
         assert!(store.set_layer_visible(new_layer, false));
 
         assert_eq!(store.stroke_keys_as_rendered(), vec![first]);
+        let (thumbnail_keys, _) = store.thumbnail_keys_as_rendered(na::vector![1000.0, 1000.0]);
+        assert!(thumbnail_keys.contains(&first));
+        assert!(!thumbnail_keys.contains(&second));
     }
 
     #[test]
@@ -129,6 +132,20 @@ mod tests {
 
         assert_eq!(store.layers().len(), 1);
         assert_eq!(store.active_layer_id(), 0);
+    }
+
+    #[test]
+    fn renaming_layer_to_same_name_is_noop() {
+        let mut store = StrokeStore::default();
+
+        let layer = store.add_layer(Some(String::from("Layer 2")));
+        store.record(Instant::now());
+        assert!(!store.rename_layer(layer, String::from("Layer 2")));
+        store.record(Instant::now());
+
+        store.undo(Instant::now());
+
+        assert_eq!(store.layers().len(), 1);
     }
 
     #[test]

--- a/crates/rnote-engine/src/store/render_comp.rs
+++ b/crates/rnote-engine/src/store/render_comp.rs
@@ -244,9 +244,20 @@ impl StrokeStore {
         let keys = self.render_components.keys().collect::<Vec<StrokeKey>>();
 
         for key in keys {
+            let stroke_layer_visible = self.stroke_layer_visible(key);
             if let Some(stroke) = self.stroke_components.get(key)
                 && let Some(render_comp) = self.render_components.get_mut(key)
             {
+                if !stroke_layer_visible {
+                    #[cfg(feature = "ui")]
+                    {
+                        render_comp.rendernodes = vec![];
+                    }
+                    render_comp.images = vec![];
+                    render_comp.state = RenderCompState::Dirty;
+                    continue;
+                }
+
                 let tasks_tx = tasks_tx.clone();
                 let stroke_bounds = stroke.bounds();
                 let viewport_extended =

--- a/crates/rnote-engine/src/store/selection_comp.rs
+++ b/crates/rnote-engine/src/store/selection_comp.rs
@@ -46,6 +46,10 @@ impl StrokeStore {
 
     /// Set if the stroke is currently selected.
     pub(crate) fn set_selected(&mut self, key: StrokeKey, selected: bool) {
+        if selected && !self.stroke_editable_in_active_layer(key) {
+            return;
+        }
+
         if let Some(selection_comp) = Arc::make_mut(&mut self.selection_components)
             .get_mut(key)
             .map(Arc::make_mut)
@@ -66,7 +70,9 @@ impl StrokeStore {
         self.stroke_components
             .keys()
             .filter(|&key| {
-                !(self.trashed(key).unwrap_or(false)) && (self.selected(key).unwrap_or(false))
+                !(self.trashed(key).unwrap_or(false))
+                    && self.stroke_editable_in_active_layer(key)
+                    && (self.selected(key).unwrap_or(false))
             })
             .collect()
     }
@@ -80,7 +86,9 @@ impl StrokeStore {
         keys_sorted_chrono
             .into_iter()
             .filter(|&key| {
-                !(self.trashed(key).unwrap_or(false)) && (self.selected(key).unwrap_or(false))
+                !(self.trashed(key).unwrap_or(false))
+                    && self.stroke_editable_in_active_layer(key)
+                    && (self.selected(key).unwrap_or(false))
             })
             .collect::<Vec<StrokeKey>>()
     }

--- a/crates/rnote-engine/src/store/selection_comp.rs
+++ b/crates/rnote-engine/src/store/selection_comp.rs
@@ -152,7 +152,9 @@ impl StrokeStore {
         let keys: Vec<(StrokeKey, Aabb)> = self
             .key_tree
             .iter()
-            .filter(|(key, _)| !(self.trashed(*key).unwrap_or(false)))
+            .filter(|(key, _)| {
+                !(self.trashed(*key).unwrap_or(false)) && self.stroke_layer_visible(*key)
+            })
             .collect();
         if keys.is_empty() {
             return (Vec::new(), None);

--- a/crates/rnote-engine/src/store/stroke_comp.rs
+++ b/crates/rnote-engine/src/store/stroke_comp.rs
@@ -71,7 +71,17 @@ impl StrokeStore {
     pub(crate) fn stroke_keys_as_rendered(&self) -> Vec<StrokeKey> {
         self.keys_sorted_chrono()
             .into_iter()
-            .filter(|&key| !(self.trashed(key).unwrap_or(false)))
+            .filter(|&key| !(self.trashed(key).unwrap_or(false)) && self.stroke_layer_visible(key))
+            .collect::<Vec<StrokeKey>>()
+    }
+
+    /// Stroke keys in rendering order that can be edited on the active layer.
+    pub(crate) fn stroke_keys_as_rendered_editable_active(&self) -> Vec<StrokeKey> {
+        self.keys_sorted_chrono()
+            .into_iter()
+            .filter(|&key| {
+                !(self.trashed(key).unwrap_or(false)) && self.stroke_editable_in_active_layer(key)
+            })
             .collect::<Vec<StrokeKey>>()
     }
 
@@ -82,7 +92,19 @@ impl StrokeStore {
     ) -> Vec<StrokeKey> {
         self.keys_sorted_chrono_intersecting_bounds(bounds)
             .into_iter()
-            .filter(|&key| !(self.trashed(key).unwrap_or(false)))
+            .filter(|&key| !(self.trashed(key).unwrap_or(false)) && self.stroke_layer_visible(key))
+            .collect::<Vec<StrokeKey>>()
+    }
+
+    pub(crate) fn stroke_keys_as_rendered_intersecting_bounds_editable_active(
+        &self,
+        bounds: Aabb,
+    ) -> Vec<StrokeKey> {
+        self.keys_sorted_chrono_intersecting_bounds(bounds)
+            .into_iter()
+            .filter(|&key| {
+                !(self.trashed(key).unwrap_or(false)) && self.stroke_editable_in_active_layer(key)
+            })
             .collect::<Vec<StrokeKey>>()
     }
 
@@ -90,7 +112,7 @@ impl StrokeStore {
     pub(crate) fn stroke_keys_as_rendered_in_bounds(&self, bounds: Aabb) -> Vec<StrokeKey> {
         self.keys_sorted_chrono_in_bounds(bounds)
             .into_iter()
-            .filter(|&key| !(self.trashed(key).unwrap_or(false)))
+            .filter(|&key| !(self.trashed(key).unwrap_or(false)) && self.stroke_layer_visible(key))
             .collect::<Vec<StrokeKey>>()
     }
 
@@ -492,7 +514,7 @@ impl StrokeStore {
             .into_iter()
             .filter_map(|key| {
                 // skip if stroke is trashed
-                if self.trashed(key)? {
+                if self.trashed(key)? || !self.stroke_editable_in_active_layer(key) {
                     return None;
                 }
 
@@ -547,7 +569,7 @@ impl StrokeStore {
             .into_iter()
             .filter_map(|key| {
                 // skip if stroke is trashed
-                if self.trashed(key)? {
+                if self.trashed(key)? || !self.stroke_editable_in_active_layer(key) {
                     return None;
                 }
 
@@ -580,7 +602,7 @@ impl StrokeStore {
             .into_iter()
             .filter_map(|key| {
                 // skip if stroke is trashed
-                if self.trashed(key)? {
+                if self.trashed(key)? || !self.stroke_editable_in_active_layer(key) {
                     return None;
                 }
 
@@ -613,7 +635,7 @@ impl StrokeStore {
         let mut bounds = viewport;
         bounds.take_point(coord.into());
 
-        self.stroke_keys_as_rendered_intersecting_bounds(bounds)
+        self.stroke_keys_as_rendered_intersecting_bounds_editable_active(bounds)
             .into_iter()
             .filter(|&key| {
                 if let Some(stroke) = self.stroke_components.get(key) {

--- a/crates/rnote-engine/src/store/trash_comp.rs
+++ b/crates/rnote-engine/src/store/trash_comp.rs
@@ -85,7 +85,7 @@ impl StrokeStore {
     ) -> WidgetFlags {
         let mut widget_flags = WidgetFlags::default();
 
-        self.stroke_keys_as_rendered_intersecting_bounds(viewport)
+        self.stroke_keys_as_rendered_intersecting_bounds_editable_active(viewport)
             .into_iter()
             .for_each(|key| {
                 let mut trash_current_stroke = false;
@@ -135,7 +135,7 @@ impl StrokeStore {
         let mut modified_keys = vec![];
 
         let new_strokes = self
-            .stroke_keys_as_rendered_intersecting_bounds(viewport)
+            .stroke_keys_as_rendered_intersecting_bounds_editable_active(viewport)
             .into_iter()
             .flat_map(|key| {
                 let Some(stroke) = Arc::make_mut(&mut self.stroke_components)

--- a/crates/rnote-ui/data/ui/sidebar.ui
+++ b/crates/rnote-ui/data/ui/sidebar.ui
@@ -57,6 +57,41 @@
             <!-- settings page -->
             <child>
               <object class="AdwViewStackPage">
+                <property name="name">layers_page</property>
+                <property name="title" translatable="yes">Layers</property>
+                <property name="icon-name">view-list-symbolic</property>
+                <property name="child">
+                  <object class="GtkBox">
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">12</property>
+                    <property name="margin-top">12</property>
+                    <property name="margin-bottom">12</property>
+                    <property name="margin-start">12</property>
+                    <property name="margin-end">12</property>
+                    <child>
+                      <object class="GtkButton" id="new_layer_button">
+                        <property name="label" translatable="yes">Add Layer</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkScrolledWindow">
+                        <property name="vexpand">true</property>
+                        <property name="child">
+                          <object class="GtkListBox" id="layers_list">
+                            <style>
+                              <class name="boxed-list" />
+                            </style>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <!-- settings page -->
+            <child>
+              <object class="AdwViewStackPage">
                 <property name="name">settings_page</property>
                 <property name="title" translatable="yes">Settings</property>
                 <property name="icon-name">settings-symbolic</property>

--- a/crates/rnote-ui/po/POTFILES
+++ b/crates/rnote-ui/po/POTFILES
@@ -47,6 +47,7 @@ crates/rnote-ui/src/dialogs/mod.rs
 crates/rnote-ui/src/penssidebar/shaperpage.rs
 crates/rnote-ui/src/settingspanel/mod.rs
 crates/rnote-ui/src/settingspanel/penshortcutmodels.rs
+crates/rnote-ui/src/sidebar.rs
 crates/rnote-ui/src/workspacebrowser/filerow/actions/duplicate.rs
 crates/rnote-ui/src/workspacebrowser/filerow/actions/open_in_default_app.rs
 crates/rnote-ui/src/workspacebrowser/filerow/actions/open.rs

--- a/crates/rnote-ui/po/enm.po
+++ b/crates/rnote-ui/po/enm.po
@@ -2616,3 +2616,35 @@ msgstr ""
 msgctxt "part of string representation of a color"
 msgid "white"
 msgstr ""
+
+#: crates/rnote-ui/data/ui/sidebar.ui:61
+msgid "Layers"
+msgstr ""
+
+#: crates/rnote-ui/data/ui/sidebar.ui:73
+msgid "Add Layer"
+msgstr ""
+
+#: crates/rnote-ui/src/sidebar.rs:178
+msgid "Set as active layer"
+msgstr ""
+
+#: crates/rnote-ui/src/sidebar.rs:246
+msgid "Layer visible"
+msgstr ""
+
+#: crates/rnote-ui/src/sidebar.rs:271
+msgid "Layer locked"
+msgstr ""
+
+#: crates/rnote-ui/src/sidebar.rs:292
+msgid "Move layer down"
+msgstr ""
+
+#: crates/rnote-ui/src/sidebar.rs:312
+msgid "Move layer up"
+msgstr ""
+
+#: crates/rnote-ui/src/sidebar.rs:333
+msgid "Delete layer"
+msgstr ""

--- a/crates/rnote-ui/po/rnote.pot
+++ b/crates/rnote-ui/po/rnote.pot
@@ -2617,3 +2617,35 @@ msgstr ""
 msgctxt "part of string representation of a color"
 msgid "white"
 msgstr ""
+
+#: crates/rnote-ui/data/ui/sidebar.ui:61
+msgid "Layers"
+msgstr ""
+
+#: crates/rnote-ui/data/ui/sidebar.ui:73
+msgid "Add Layer"
+msgstr ""
+
+#: crates/rnote-ui/src/sidebar.rs:178
+msgid "Set as active layer"
+msgstr ""
+
+#: crates/rnote-ui/src/sidebar.rs:246
+msgid "Layer visible"
+msgstr ""
+
+#: crates/rnote-ui/src/sidebar.rs:271
+msgid "Layer locked"
+msgstr ""
+
+#: crates/rnote-ui/src/sidebar.rs:292
+msgid "Move layer down"
+msgstr ""
+
+#: crates/rnote-ui/src/sidebar.rs:312
+msgid "Move layer up"
+msgstr ""
+
+#: crates/rnote-ui/src/sidebar.rs:333
+msgid "Delete layer"
+msgstr ""

--- a/crates/rnote-ui/po/zh_Hans.po
+++ b/crates/rnote-ui/po/zh_Hans.po
@@ -2673,6 +2673,38 @@ msgctxt "part of string representation of a color"
 msgid "white"
 msgstr "白色"
 
+#: crates/rnote-ui/data/ui/sidebar.ui:61
+msgid "Layers"
+msgstr "图层"
+
+#: crates/rnote-ui/data/ui/sidebar.ui:73
+msgid "Add Layer"
+msgstr "添加图层"
+
+#: crates/rnote-ui/src/sidebar.rs:178
+msgid "Set as active layer"
+msgstr "设为活动图层"
+
+#: crates/rnote-ui/src/sidebar.rs:246
+msgid "Layer visible"
+msgstr "图层可见"
+
+#: crates/rnote-ui/src/sidebar.rs:271
+msgid "Layer locked"
+msgstr "图层锁定"
+
+#: crates/rnote-ui/src/sidebar.rs:292
+msgid "Move layer down"
+msgstr "下移图层"
+
+#: crates/rnote-ui/src/sidebar.rs:312
+msgid "Move layer up"
+msgstr "上移图层"
+
+#: crates/rnote-ui/src/sidebar.rs:333
+msgid "Delete layer"
+msgstr "删除图层"
+
 #~ msgid "Page Borders"
 #~ msgstr "页面边框"
 

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -708,6 +708,7 @@ impl RnAppWindow {
             .refresh_ui(self);
         self.overlays().penssidebar().tools_page().refresh_ui(self);
         self.sidebar().settings_panel().refresh_ui(self);
+        self.sidebar().refresh_layers_panel(self);
 
         if let Some(canvas) = canvas {
             self.refresh_titles(&canvas);

--- a/crates/rnote-ui/src/sidebar.rs
+++ b/crates/rnote-ui/src/sidebar.rs
@@ -1,7 +1,9 @@
 // Imports
 use crate::{RnAppMenu, RnAppWindow, RnSettingsPanel, RnWorkspaceBrowser};
+use gettextrs::gettext;
 use gtk4::{
-    Button, CompositeTemplate, Widget, glib, glib::clone, prelude::*, subclass::prelude::*,
+    Align, Button, CompositeTemplate, Orientation, Widget, glib, glib::clone, prelude::*,
+    subclass::prelude::*,
 };
 
 mod imp {
@@ -22,6 +24,10 @@ mod imp {
         pub(crate) sidebar_stack: TemplateChild<adw::ViewStack>,
         #[template_child]
         pub(crate) workspacebrowser: TemplateChild<RnWorkspaceBrowser>,
+        #[template_child]
+        pub(crate) new_layer_button: TemplateChild<Button>,
+        #[template_child]
+        pub(crate) layers_list: TemplateChild<gtk4::ListBox>,
         #[template_child]
         pub(crate) settings_panel: TemplateChild<RnSettingsPanel>,
     }
@@ -109,6 +115,17 @@ impl RnSidebar {
         imp.workspacebrowser.get().init(appwindow);
         imp.settings_panel.get().init(appwindow);
 
+        imp.new_layer_button.connect_clicked(clone!(
+            #[weak]
+            appwindow,
+            move |_| {
+                if let Some(canvas) = appwindow.active_tab_canvas() {
+                    let widget_flags = canvas.engine_mut().add_layer(None);
+                    appwindow.handle_widget_flags(widget_flags, &canvas);
+                }
+            }
+        ));
+
         imp.left_close_button.connect_clicked(clone!(
             #[weak]
             appwindow,
@@ -123,5 +140,189 @@ impl RnSidebar {
                 appwindow.split_view().set_show_sidebar(false);
             }
         ));
+
+        self.refresh_layers_panel(appwindow);
+    }
+
+    pub(crate) fn refresh_layers_panel(&self, appwindow: &RnAppWindow) {
+        let list = self.imp().layers_list.get();
+        while let Some(child) = list.first_child() {
+            list.remove(&child);
+        }
+
+        let Some(canvas) = appwindow.active_tab_canvas() else {
+            return;
+        };
+
+        let (layers, active_layer_id) = {
+            let engine = canvas.engine_ref();
+            (engine.layers().to_vec(), engine.active_layer_id())
+        };
+        let can_delete = layers.len() > 1;
+
+        for layer in layers.iter().rev().cloned() {
+            let row = gtk4::ListBoxRow::new();
+            let row_box = gtk4::Box::new(Orientation::Horizontal, 6);
+            row_box.set_margin_top(6);
+            row_box.set_margin_bottom(6);
+            row_box.set_margin_start(6);
+            row_box.set_margin_end(6);
+
+            let active_button = Button::with_label(if layer.id == active_layer_id {
+                "*"
+            } else {
+                " "
+            });
+            active_button.set_tooltip_text(Some(&gettext("Set as active layer")));
+            active_button.set_valign(Align::Center);
+            active_button.connect_clicked(clone!(
+                #[weak]
+                appwindow,
+                #[strong]
+                layer,
+                move |_| {
+                    if let Some(canvas) = appwindow.active_tab_canvas() {
+                        let widget_flags = canvas.engine_mut().set_active_layer(layer.id);
+                        appwindow.handle_widget_flags(widget_flags, &canvas);
+                    }
+                }
+            ));
+            row_box.append(&active_button);
+
+            let name_entry = gtk4::Entry::new();
+            name_entry.set_hexpand(true);
+            name_entry.set_text(&layer.name);
+            name_entry.set_valign(Align::Center);
+            name_entry.connect_activate(clone!(
+                #[weak]
+                appwindow,
+                #[strong]
+                layer,
+                move |entry| {
+                    if let Some(canvas) = appwindow.active_tab_canvas() {
+                        let widget_flags = canvas
+                            .engine_mut()
+                            .rename_layer(layer.id, entry.text().to_string());
+                        appwindow.handle_widget_flags(widget_flags, &canvas);
+                    }
+                }
+            ));
+            name_entry.connect_has_focus_notify(clone!(
+                #[weak]
+                appwindow,
+                #[strong]
+                layer,
+                move |entry| {
+                    if entry.has_focus() || entry.text() == layer.name {
+                        return;
+                    }
+
+                    if let Some(canvas) = appwindow.active_tab_canvas() {
+                        let widget_flags = canvas
+                            .engine_mut()
+                            .rename_layer(layer.id, entry.text().to_string());
+                        appwindow.handle_widget_flags(widget_flags, &canvas);
+                    }
+                }
+            ));
+            row_box.append(&name_entry);
+
+            let visible_switch = gtk4::Switch::builder()
+                .active(layer.visible)
+                .valign(Align::Center)
+                .build();
+            visible_switch.set_tooltip_text(Some(&gettext("Layer visible")));
+            visible_switch.connect_active_notify(clone!(
+                #[weak]
+                appwindow,
+                #[strong]
+                layer,
+                move |switch| {
+                    if let Some(canvas) = appwindow.active_tab_canvas() {
+                        let widget_flags = canvas
+                            .engine_mut()
+                            .set_layer_visible(layer.id, switch.is_active());
+                        appwindow.handle_widget_flags(widget_flags, &canvas);
+                    }
+                }
+            ));
+            row_box.append(&visible_switch);
+
+            let lock_switch = gtk4::Switch::builder()
+                .active(layer.locked)
+                .valign(Align::Center)
+                .build();
+            lock_switch.set_tooltip_text(Some(&gettext("Layer locked")));
+            lock_switch.connect_active_notify(clone!(
+                #[weak]
+                appwindow,
+                #[strong]
+                layer,
+                move |switch| {
+                    if let Some(canvas) = appwindow.active_tab_canvas() {
+                        let widget_flags = canvas
+                            .engine_mut()
+                            .set_layer_locked(layer.id, switch.is_active());
+                        appwindow.handle_widget_flags(widget_flags, &canvas);
+                    }
+                }
+            ));
+            row_box.append(&lock_switch);
+
+            let down_button = Button::with_label("v");
+            down_button.set_tooltip_text(Some(&gettext("Move layer down")));
+            down_button.set_valign(Align::Center);
+            down_button.connect_clicked(clone!(
+                #[weak]
+                appwindow,
+                #[strong]
+                layer,
+                move |_| {
+                    if let Some(canvas) = appwindow.active_tab_canvas() {
+                        let widget_flags = canvas.engine_mut().move_layer_down(layer.id);
+                        appwindow.handle_widget_flags(widget_flags, &canvas);
+                    }
+                }
+            ));
+            row_box.append(&down_button);
+
+            let up_button = Button::with_label("^");
+            up_button.set_tooltip_text(Some(&gettext("Move layer up")));
+            up_button.set_valign(Align::Center);
+            up_button.connect_clicked(clone!(
+                #[weak]
+                appwindow,
+                #[strong]
+                layer,
+                move |_| {
+                    if let Some(canvas) = appwindow.active_tab_canvas() {
+                        let widget_flags = canvas.engine_mut().move_layer_up(layer.id);
+                        appwindow.handle_widget_flags(widget_flags, &canvas);
+                    }
+                }
+            ));
+            row_box.append(&up_button);
+
+            let delete_button = Button::with_label("-");
+            delete_button.set_sensitive(can_delete);
+            delete_button.set_tooltip_text(Some(&gettext("Delete layer")));
+            delete_button.set_valign(Align::Center);
+            delete_button.connect_clicked(clone!(
+                #[weak]
+                appwindow,
+                #[strong]
+                layer,
+                move |_| {
+                    if let Some(canvas) = appwindow.active_tab_canvas() {
+                        let widget_flags = canvas.engine_mut().delete_layer(layer.id);
+                        appwindow.handle_widget_flags(widget_flags, &canvas);
+                    }
+                }
+            ));
+            row_box.append(&delete_button);
+
+            row.set_child(Some(&row_box));
+            list.append(&row);
+        }
     }
 }

--- a/crates/rnote-ui/src/sidebar.rs
+++ b/crates/rnote-ui/src/sidebar.rs
@@ -2,8 +2,8 @@
 use crate::{RnAppMenu, RnAppWindow, RnSettingsPanel, RnWorkspaceBrowser};
 use gettextrs::gettext;
 use gtk4::{
-    Align, Button, CompositeTemplate, Orientation, Widget, glib, glib::clone, prelude::*,
-    subclass::prelude::*,
+    Align, Button, CheckButton, CompositeTemplate, Orientation, SelectionMode, ToggleButton,
+    Widget, glib, glib::clone, prelude::*, subclass::prelude::*,
 };
 
 mod imp {
@@ -146,6 +146,7 @@ impl RnSidebar {
 
     pub(crate) fn refresh_layers_panel(&self, appwindow: &RnAppWindow) {
         let list = self.imp().layers_list.get();
+        list.set_selection_mode(SelectionMode::None);
         while let Some(child) = list.first_child() {
             list.remove(&child);
         }
@@ -160,6 +161,8 @@ impl RnSidebar {
         };
         let can_delete = layers.len() > 1;
 
+        let mut first_radio: Option<CheckButton> = None;
+
         for layer in layers.iter().rev().cloned() {
             let row = gtk4::ListBoxRow::new();
             let row_box = gtk4::Box::new(Orientation::Horizontal, 6);
@@ -168,26 +171,33 @@ impl RnSidebar {
             row_box.set_margin_start(6);
             row_box.set_margin_end(6);
 
-            let active_button = Button::with_label(if layer.id == active_layer_id {
-                "*"
+            let active_radio = CheckButton::builder()
+                .active(layer.id == active_layer_id)
+                .valign(Align::Center)
+                .build();
+            active_radio.set_tooltip_text(Some(&gettext("Set as active layer")));
+            active_radio.set_can_focus(false);
+            active_radio.set_focus_on_click(false);
+            if let Some(ref group) = first_radio {
+                active_radio.set_group(Some(group));
             } else {
-                " "
-            });
-            active_button.set_tooltip_text(Some(&gettext("Set as active layer")));
-            active_button.set_valign(Align::Center);
-            active_button.connect_clicked(clone!(
+                first_radio = Some(active_radio.clone());
+            }
+            active_radio.connect_toggled(clone!(
                 #[weak]
                 appwindow,
                 #[strong]
                 layer,
-                move |_| {
-                    if let Some(canvas) = appwindow.active_tab_canvas() {
-                        let widget_flags = canvas.engine_mut().set_active_layer(layer.id);
-                        appwindow.handle_widget_flags(widget_flags, &canvas);
+                move |radio| {
+                    if radio.is_active() {
+                        if let Some(canvas) = appwindow.active_tab_canvas() {
+                            let widget_flags = canvas.engine_mut().set_active_layer(layer.id);
+                            appwindow.handle_widget_flags(widget_flags, &canvas);
+                        }
                     }
                 }
             ));
-            row_box.append(&active_button);
+            row_box.append(&active_radio);
 
             let name_entry = gtk4::Entry::new();
             name_entry.set_hexpand(true);
@@ -227,51 +237,62 @@ impl RnSidebar {
             ));
             row_box.append(&name_entry);
 
-            let visible_switch = gtk4::Switch::builder()
+            let visible_button = ToggleButton::builder()
+                .icon_name("view-reveal-symbolic")
                 .active(layer.visible)
                 .valign(Align::Center)
                 .build();
-            visible_switch.set_tooltip_text(Some(&gettext("Layer visible")));
-            visible_switch.connect_active_notify(clone!(
+            visible_button.add_css_class("flat");
+            visible_button.set_tooltip_text(Some(&gettext("Layer visible")));
+            visible_button.set_can_focus(false);
+            visible_button.set_focus_on_click(false);
+            visible_button.connect_toggled(clone!(
                 #[weak]
                 appwindow,
                 #[strong]
                 layer,
-                move |switch| {
+                move |button| {
                     if let Some(canvas) = appwindow.active_tab_canvas() {
                         let widget_flags = canvas
                             .engine_mut()
-                            .set_layer_visible(layer.id, switch.is_active());
+                            .set_layer_visible(layer.id, button.is_active());
                         appwindow.handle_widget_flags(widget_flags, &canvas);
                     }
                 }
             ));
-            row_box.append(&visible_switch);
+            row_box.append(&visible_button);
 
-            let lock_switch = gtk4::Switch::builder()
+            let lock_button = ToggleButton::builder()
+                .icon_name("changes-prevent-symbolic")
                 .active(layer.locked)
                 .valign(Align::Center)
                 .build();
-            lock_switch.set_tooltip_text(Some(&gettext("Layer locked")));
-            lock_switch.connect_active_notify(clone!(
+            lock_button.add_css_class("flat");
+            lock_button.set_tooltip_text(Some(&gettext("Layer locked")));
+            lock_button.set_can_focus(false);
+            lock_button.set_focus_on_click(false);
+            lock_button.connect_toggled(clone!(
                 #[weak]
                 appwindow,
                 #[strong]
                 layer,
-                move |switch| {
+                move |button| {
                     if let Some(canvas) = appwindow.active_tab_canvas() {
                         let widget_flags = canvas
                             .engine_mut()
-                            .set_layer_locked(layer.id, switch.is_active());
+                            .set_layer_locked(layer.id, button.is_active());
                         appwindow.handle_widget_flags(widget_flags, &canvas);
                     }
                 }
             ));
-            row_box.append(&lock_switch);
+            row_box.append(&lock_button);
 
-            let down_button = Button::with_label("v");
-            down_button.set_tooltip_text(Some(&gettext("Move layer down")));
-            down_button.set_valign(Align::Center);
+            let down_button = Button::builder()
+                .icon_name("dir-down-symbolic")
+                .tooltip_text(gettext("Move layer down"))
+                .valign(Align::Center)
+                .build();
+            down_button.add_css_class("flat");
             down_button.connect_clicked(clone!(
                 #[weak]
                 appwindow,
@@ -286,9 +307,12 @@ impl RnSidebar {
             ));
             row_box.append(&down_button);
 
-            let up_button = Button::with_label("^");
-            up_button.set_tooltip_text(Some(&gettext("Move layer up")));
-            up_button.set_valign(Align::Center);
+            let up_button = Button::builder()
+                .icon_name("dir-up-symbolic")
+                .tooltip_text(gettext("Move layer up"))
+                .valign(Align::Center)
+                .build();
+            up_button.add_css_class("flat");
             up_button.connect_clicked(clone!(
                 #[weak]
                 appwindow,
@@ -303,10 +327,13 @@ impl RnSidebar {
             ));
             row_box.append(&up_button);
 
-            let delete_button = Button::with_label("-");
-            delete_button.set_sensitive(can_delete);
-            delete_button.set_tooltip_text(Some(&gettext("Delete layer")));
-            delete_button.set_valign(Align::Center);
+            let delete_button = Button::builder()
+                .icon_name("selection-trash-symbolic")
+                .sensitive(can_delete)
+                .tooltip_text(gettext("Delete layer"))
+                .valign(Align::Center)
+                .build();
+            delete_button.add_css_class("flat");
             delete_button.connect_clicked(clone!(
                 #[weak]
                 appwindow,
@@ -324,5 +351,30 @@ impl RnSidebar {
             row.set_child(Some(&row_box));
             list.append(&row);
         }
+
+        list.set_activate_on_single_click(true);
+        list.connect_row_activated(clone!(
+            #[weak]
+            appwindow,
+            move |_list, row| {
+                let Some(canvas) = appwindow.active_tab_canvas() else {
+                    return;
+                };
+                let layers = {
+                    let engine = canvas.engine_ref();
+                    engine.layers().to_vec()
+                };
+                let row_idx = row.index() as usize;
+                if row_idx < layers.len() {
+                    #[allow(clippy::borrow_deref_ref)]
+                    let layer_id = layers[layers.len() - 1 - row_idx].id;
+                    let active_id = canvas.engine_ref().active_layer_id();
+                    if layer_id != active_id {
+                        let widget_flags = canvas.engine_mut().set_active_layer(layer_id);
+                        appwindow.handle_widget_flags(widget_flags, &canvas);
+                    }
+                }
+            }
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Add document layers (similar to image editors like Photoshop/GIMP) to Rnote. Closes #1253.

Each document now has a list of layers with **name**, **visible**, **locked** states. Strokes belong to a layer; only the active layer is drawn/edited on by default.

## Changes

### Data model (crates/rnote-engine/src/store/layer_comp.rs)

- New types: `DocumentLayer`, `DocumentLayerId`, `LayerComponent`.
- `StrokeStore` gains `layers`, `layer_components`, `active_layer_id`, `layer_counter`.
- Old `.rnote` files without layer data are backward-compatible — all strokes default to `Layer 1`.

### Rendering order

Sorting in `chrono_comp.rs` now respects **document layer order** → **existing StrokeLayer** → **chrono timestamp**.

### Per-layer filtering

- **Render**: only visible layers are rendered (`stroke_keys_as_rendered`, `regenerate_rendering_in_viewport_threaded`).
- **Selection**: only active, editable (visible & unlocked) layer strokes are selectable.
- **Eraser**: only editable active layer strokes are erased/split.
- **Thumbnails**: hidden layers are excluded.
- **Export**: uses the render path, so hidden layers are excluded.

### Engine API

Public methods added on `Engine`:
- `layers()`, `active_layer_id()`
- `set_active_layer()`, `add_layer()`, `delete_layer()`, `rename_layer()`
- `set_layer_visible()`, `set_layer_locked()`
- `move_layer_up()`, `move_layer_down()`

All layer mutations enter undo/redo history.

### Xournal++ (.xopp) import/export preservation

.xopp files now preserve document layer structure on import and export:

- **Import**: xopp layers are mapped to rnote `DocumentLayer`s by name (merge across pages), preserving layer names and stroke-to-layer assignment.
- **Export**: each rnote `DocumentLayer` produces a named `<layer>` in the xopp output, with elements ordered to match rnote z-order (images below strokes). Empty named layers are written as placeholders; hidden layers are excluded.

### UI (crates/rnote-ui)

A new "Layers" page in the sidebar with controls to:
- Add/delete layers
- Rename (inline entry)
- Toggle visibility and lock
- Move up/down
- Set as active layer

Layer buttons use symbolic SVG icons instead of text. Sidebar has i18n support for all layer-related labels.

## Tests

Engine unit tests cover:
- Stroke insertion respects active layer
- Hidden layers are excluded from rendering/thumbnails
- Locked/hidden layers cannot be selected
- Layer order controls render order
- Layer mutations are undoable/redoable
- `.rnote` snapshot preserves layer metadata (name, order, visible, locked)
- Old snapshots without layer data assign default layer
- Renaming to same name is a no-op
- Xopp XML layer elements roundtrip with `elements` field
- Xopp import preserves named layers, merges across pages by name
- Xopp import handles unnamed layers correctly (index-based merge)
- Xopp export preserves layer names and excludes hidden/empty layers

## Build verification

All targets pass:
- `meson compile ui-cargo-check`
- `meson compile cli-cargo-check`
- `meson test` (validation tests: 3/3 OK)
- `cargo test --workspace` (18 passed, 1 ignored)
- `meson compile cargo-fmt-check` (pass)