### PR TITLE
fix: cargo build script issues

### DIFF
--- a/build-aux/cargo_build.py
+++ b/build-aux/cargo_build.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
+import subprocess
+from subprocess import CalledProcessError
 import sys
-import os
 
 project_build_root = sys.argv[1]
 project_src_root = sys.argv[2]
@@ -11,7 +12,8 @@ cargo_options = sys.argv[5]
 bin_output = sys.argv[6]
 output_file = sys.argv[7]
 
-print(f"""
+print(
+    f"""
 ### executing cargo build script with arguments: ###
     project_build_root: {project_build_root}
     project_src_root: {project_src_root}
@@ -20,21 +22,23 @@ print(f"""
     cargo_options: {cargo_options}
     bin_output: {bin_output}
     output_file: {output_file}
-""", file=sys.stderr)
+""",
+    file=sys.stderr,
+)
 
 cargo_call = f"env {cargo_env} {cargo_cmd} build {cargo_options}"
 cp_call = f"cp {bin_output} {output_file}"
 
 print(cargo_call, file=sys.stderr)
-res = os.system(cargo_call)
-if res != 0:
-    print(f"cargo call failed, code {res}", file=sys.stderr)
-    sys.exit(1)
+try:
+    subprocess.run(cargo_call, shell=True, check=True)
+except CalledProcessError as e:
+    print(f"cargo call failed: {e}", file=sys.stderr)
 
 print(cp_call, file=sys.stderr)
-res = os.system(cp_call)
-if res != 0:
-    print(f"cp call failed, code {res}", file=sys.stderr)
-    sys.exit(1)
+try:
+    subprocess.run(cp_call, shell=True, check=True)
+except CalledProcessError as e:
+    print(f"cp call failed: {e}", file=sys.stderr)
 
 print("### cargo build script finished ###", file=sys.stderr)

--- a/meson.build
+++ b/meson.build
@@ -206,7 +206,7 @@ if build_ui == true
             cargo_build_script,
             meson.project_build_root(),
             meson.project_source_root(),
-            cargo_env,
+            ' '.join(cargo_env),
             cargo,
             ' '.join(ui_cargo_options),
             cargo_target_dir / rust_target_folder / app_name,


### PR DESCRIPTION
Fixes two issues related to the cargo build script:
- `cargo_env` was not passed correctly to it
- replace deprecated calls to `os.system()` with `subprocess.run()`