### PR TITLE
fix: ensure new documents / drafts are also autosaved

### DIFF
--- a/crates/rnote-ui/src/app/mod.rs
+++ b/crates/rnote-ui/src/app/mod.rs
@@ -14,7 +14,8 @@ use crate::{
     workspacebrowser::RnWorkspacesBar, workspacebrowser::workspacesbar::RnWorkspaceRow,
 };
 use adw::subclass::prelude::AdwApplicationImpl;
-use gtk4::{WindowGroup, gio, glib, glib::clone, prelude::*, subclass::prelude::*};
+use adw::prelude::*;
+use gtk4::{WindowGroup, gio, glib, glib::clone, subclass::prelude::*};
 
 mod imp {
     use super::*;
@@ -141,6 +142,75 @@ mod imp {
             window_group.add_window(&appwindow);
 
             appwindow.present();
+
+            // --- AUTOSAVE RECOVERY CHECK ---
+            let input_file_clone = input_file.clone();
+            glib::spawn_future_local(clone!(#[weak] appwindow, async move {
+                let cache_dir = glib::user_cache_dir();
+                let backup_dir = cache_dir.join("rnote").join("autosaves");
+
+                let mut found_backups = Vec::new();
+                if let Ok(entries) = std::fs::read_dir(&backup_dir) {
+                    for entry in entries.flatten() {
+                        if let Some(filename) = entry.file_name().to_str() {
+                            if filename.ends_with(".rnote") {
+                                found_backups.push(entry.path());
+                            }
+                        }
+                    }
+                }
+
+                if !found_backups.is_empty() && input_file_clone.is_none() {
+                    let dialog = adw::AlertDialog::builder()
+                        .heading(&gettextrs::gettext("Recover Unsaved Drafts"))
+                        .body(&gettextrs::gettext("Found unsaved drafts from a previous session. What would you like to do?"))
+                        .build();
+
+                    dialog.add_response("ignore", &gettextrs::gettext("Ignore"));
+                    dialog.add_response("delete", &gettextrs::gettext("Delete"));
+                    dialog.add_response("open", &gettextrs::gettext("Open Drafts"));
+                    dialog.set_default_response(Some("open"));
+                    dialog.set_close_response("ignore");
+                    dialog.set_response_appearance("delete", adw::ResponseAppearance::Destructive);
+                    dialog.set_response_appearance("open", adw::ResponseAppearance::Suggested);
+
+                    // adw::AlertDialog is shown on a transient parent window using .choose_future()
+                    let response = dialog.choose_future(Some(&appwindow)).await;
+                    
+                    match response.as_str() {
+                        "open" => {
+                            for backup_path in found_backups {
+                                let file = gio::File::for_path(&backup_path);
+                                
+                                // Open the autosave. 
+                                appwindow.open_file_w_dialogs(file, None, true).await;
+                                
+                                // Find the tab we just opened and "detach" it from the cache file
+                                for tab in appwindow.tabs_snapshot() {
+                                    if let Ok(wrapper) = tab.child().downcast::<RnCanvasWrapper>() {
+                                        let canvas = wrapper.canvas();
+                                        
+                                        if let Some(out_file) = canvas.output_file() {
+                                            if out_file.path() == Some(backup_path.clone()) {
+                                                // Trick Rnote into thinking this is a brand new draft!
+                                                canvas.set_output_file(None);
+                                                canvas.set_unsaved_changes(true);
+                                                canvas.set_draft_needs_backup(true);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        "delete" => {
+                            for path in found_backups {
+                                let _ = std::fs::remove_file(path);
+                            }
+                        }
+                        _ => { /* Ignore */ }
+                    }
+                }
+            }));
 
             // Loading in input file in the first tab, if Some
             if let Some(input_file) = input_file {

--- a/crates/rnote-ui/src/appwindow/imp.rs
+++ b/crates/rnote-ui/src/appwindow/imp.rs
@@ -407,16 +407,19 @@ impl RnAppWindow {
             glib::source::timeout_add_seconds_local(
                 self.autosave_interval_secs.get(),
                 clone!(#[weak(rename_to=appwindow)] obj, #[upgrade_or] glib::ControlFlow::Break, move || {
-                    // save for all tabs opened in the current window that have unsaved changes
                     let tabs = appwindow.get_all_tabs();
 
                     for (i, tab) in tabs.iter().enumerate() {
                         let canvas = tab.canvas();
-                        if canvas.unsaved_changes() && let Some(output_file) = canvas.output_file() {
+                        if !canvas.unsaved_changes() {
+                            continue;
+                        }
+
+                        if let Some(output_file) = canvas.output_file() {
                             trace!(
-                                "there are unsaved changes on the tab {:?} with a file on disk, saving",i
+                                "there are unsaved changes on the tab {:?} with a file on disk, saving", i
                             );
-                            glib::spawn_future_local(clone!(#[weak] canvas, #[weak] appwindow ,async move {
+                            glib::spawn_future_local(clone!(#[weak] canvas, #[weak] appwindow, async move {
                                 if let Err(e) = canvas.save_document_to_file(&output_file).await {
                                     error!("Saving document failed, Err: `{e:?}`");
                                     canvas.set_output_file(None);
@@ -424,6 +427,40 @@ impl RnAppWindow {
                                         .overlays()
                                         .dispatch_toast_error(&gettext("Saving document failed"));
                                 };
+                            }));
+                        } else {
+                            // It's an unsaved draft! Check to see if it actually needs a new write.
+                            if !canvas.draft_needs_backup() {
+                                continue;
+                            }
+                            
+                            trace!(
+                                "there are unsaved changes on the draft tab {:?}, saving backup copy", i
+                            );
+                            
+                            // Retrieve the static date-based title (e.g., "20260714-160530")
+                            let draft_title = canvas.doc_title_display();
+                            
+                            glib::spawn_future_local(clone!(#[weak] canvas, async move {
+                                let cache_dir = glib::user_cache_dir();
+                                let backup_dir = cache_dir.join("rnote").join("autosaves");
+                                
+                                if let Err(e) = std::fs::create_dir_all(&backup_dir) {
+                                    error!("Failed to create backup directory: `{e:?}`");
+                                    return;
+                                }
+
+                                // Format: "20260714-160530-draft-0.rnote"
+                                let backup_filename = format!("{}-draft-{}.rnote", draft_title, i);
+                                let backup_path = backup_dir.join(backup_filename);
+
+                                if let Err(e) = canvas.save_backup_to_file(&backup_path).await {
+                                    error!("Saving backup draft failed, Err: `{e:?}`");
+                                } else {
+                                    trace!("Successfully wrote backup draft to {:?}", backup_path);
+                                    // Reset our backup flag so we don't write again until the user draws more!
+                                    canvas.set_draft_needs_backup(false);
+                                }
                             }));
                         }
                     }

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -291,6 +291,7 @@ impl RnAppWindow {
         if widget_flags.store_modified {
             canvas.set_unsaved_changes(true);
             canvas.set_empty(false);
+            canvas.set_draft_needs_backup(true);
         }
         if widget_flags.view_modified {
             canvas.queue_allocate();
@@ -513,6 +514,13 @@ impl RnAppWindow {
     ///
     /// Closes the given tab when confirm is true, else reverts so that close_tab_request() can be called again.
     pub(crate) fn close_tab_finish(&self, tab_page: &adw::TabPage, confirm: bool) {
+        if confirm {
+            if let Ok(tab_wrapper) = tab_page.child().downcast::<RnCanvasWrapper>() {
+                let canvas = tab_wrapper.canvas();
+                canvas.cleanup_autosaves();
+            }
+        }
+
         self.overlays()
             .tabview()
             .close_page_finish(tab_page, confirm);

--- a/crates/rnote-ui/src/canvas/imexport.rs
+++ b/crates/rnote-ui/src/canvas/imexport.rs
@@ -272,7 +272,33 @@ impl RnCanvas {
         self.set_unsaved_changes(false);
         self.set_save_in_progress(false);
 
+        self.cleanup_autosaves();
         Ok(true)
+    }
+
+    /// Saves a silent backup of the document to the given file path.
+    /// This does NOT reset `unsaved_changes` or set the active `output_file`.
+    pub(crate) async fn save_backup_to_file(&self, path: &std::path::Path) -> anyhow::Result<()> {
+        if self.save_in_progress() {
+            return Ok(());
+        }
+        self.set_save_in_progress(true);
+
+        let basename = path.file_name()
+            .ok_or_else(|| anyhow::anyhow!("Could not retrieve basename"))?;
+        
+        let rnote_bytes_receiver = self
+            .engine_ref()
+            .save_as_rnote_bytes(basename.to_string_lossy().to_string());
+
+        let file_write_operation = async {
+            let bytes = rnote_bytes_receiver.await??;
+            crate::utils::atomic_save_to_file_future(path, bytes).await
+        };
+
+        let res = file_write_operation.await;
+        self.set_save_in_progress(false);
+        res
     }
 
     pub(crate) async fn export_doc(

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -86,6 +86,8 @@ mod imp {
         pub(crate) output_file_expect_write: Cell<bool>,
         pub(crate) save_in_progress: Cell<bool>,
         pub(crate) unsaved_changes: Cell<bool>,
+        pub(crate) draft_needs_backup: Cell<bool>,
+        pub(crate) draft_title: RefCell<Option<String>>,
         pub(crate) empty: Cell<bool>,
         pub(crate) touch_drawing: Cell<bool>,
         pub(crate) show_drawing_cursor: Cell<bool>,
@@ -182,6 +184,8 @@ mod imp {
                 output_file_expect_write: Cell::new(false),
                 save_in_progress: Cell::new(false),
                 unsaved_changes: Cell::new(false),
+                draft_needs_backup: Cell::new(false),
+                draft_title: RefCell::new(None),
                 empty: Cell::new(true),
                 touch_drawing: Cell::new(false),
                 show_drawing_cursor: Cell::new(false),
@@ -727,7 +731,7 @@ impl Default for RnCanvas {
 }
 
 pub(crate) static OUTPUT_FILE_NEW_TITLE: once_cell::sync::Lazy<String> =
-    once_cell::sync::Lazy::new(|| gettext("New Document"));
+    once_cell::sync::Lazy::new(|| String::from("%Y%m%d-%H%M%S"));
 pub(crate) static OUTPUT_FILE_NEW_SUBTITLE: once_cell::sync::Lazy<String> =
     once_cell::sync::Lazy::new(|| gettext("Draft"));
 
@@ -994,9 +998,17 @@ impl RnCanvas {
         }
     }
 
+    pub(crate) fn draft_needs_backup(&self) -> bool {
+        self.imp().draft_needs_backup.get()
+    }
+
+    pub(crate) fn set_draft_needs_backup(&self, needs_backup: bool) {
+        self.imp().draft_needs_backup.replace(needs_backup);
+    }
+
     /// The document title for display. Can be used to get a string as the basename of the existing / a new save file.
     ///
-    /// When there is no output-file, falls back to the "New document" string
+    /// When there is no output-file, falls back to the current date and time string
     pub(crate) fn doc_title_display(&self) -> String {
         self.output_file()
             .map(|f| {
@@ -1004,7 +1016,38 @@ impl RnCanvas {
                     .and_then(|t| Some(t.file_stem()?.to_string_lossy().to_string()))
                     .unwrap_or_else(|| gettext("- invalid file name -"))
             })
-            .unwrap_or_else(|| OUTPUT_FILE_NEW_TITLE.to_string())
+            .unwrap_or_else(|| {
+                // Return cached title or generate a static one for the lifetime of this draft
+                let mut title_cache = self.imp().draft_title.borrow_mut();
+                if let Some(title) = &*title_cache {
+                    title.clone()
+                } else {
+                    let new_title = chrono::Local::now().format(&OUTPUT_FILE_NEW_TITLE).to_string();
+                    *title_cache = Some(new_title.clone());
+                    new_title
+                }
+            })
+    }
+
+    /// Cleans up any autosave files associated with this specific canvas's draft title.
+    pub(crate) fn cleanup_autosaves(&self) {
+        let title_cache = self.imp().draft_title.borrow();
+        if let Some(draft_title) = &*title_cache {
+            let cache_dir = glib::user_cache_dir();
+            let backup_dir = cache_dir.join("rnote").join("autosaves");
+
+            if let Ok(entries) = std::fs::read_dir(backup_dir) {
+                for entry in entries.flatten() {
+                    if let Some(filename) = entry.file_name().to_str() {
+                        if filename.starts_with(draft_title) && filename.contains("-draft-") {
+                            let path = entry.path();
+                            tracing::trace!("Cleaning up backup draft file: {:?}", path);
+                            let _ = std::fs::remove_file(path);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// The document folder path for display. To get the actual path, use output-file

--- a/crates/rnote-ui/src/dialogs/mod.rs
+++ b/crates/rnote-ui/src/dialogs/mod.rs
@@ -105,6 +105,7 @@ pub(crate) async fn dialog_new_doc(appwindow: &RnAppWindow, canvas: &RnCanvas) {
 
     match dialog.choose_future(Some(appwindow)).await.as_str() {
         "discard" => {
+            canvas.cleanup_autosaves();
             new_doc(appwindow, canvas);
         }
         "save" => {
@@ -244,7 +245,10 @@ pub(crate) async fn dialog_close_tab(appwindow: &RnAppWindow, tab_page: &adw::Ta
     // Returns close_finish_confirm, a boolean that indicates if the tab should actually be closed or closing
     // should be aborted.
     match dialog.choose_future(Some(appwindow)).await.as_str() {
-        "discard" => true,
+        "discard" => {
+            canvas.cleanup_autosaves();
+            true
+        }
         "save" => {
             if let Some(save_file) = save_file {
                 appwindow.overlays().progressbar_start_pulsing();
@@ -378,7 +382,12 @@ pub(crate) async fn dialog_close_window(appwindow: &RnAppWindow) {
 
     let close = match dialog.choose_future(Some(appwindow)).await.as_str() {
         "discard" => {
-            // do nothing and close
+            // Delete autosaves in all tabs before quitting
+            for tab in &tabs {
+                let canvas = tab.child().downcast::<RnCanvasWrapper>().unwrap().canvas();
+                canvas.cleanup_autosaves();
+            }
+            // close
             true
         }
         "save" => {


### PR DESCRIPTION
When opening a new file, rnote won't autosave it until it's saved first. The default name is "New Document", and on tablets it's often a burden to choose a name and save it. So I often just work without saving the file initially. If there's a crash, then everything is lost.

I just implemented a fix:

1. Offer a time/date based name for the file initially. (A user can jst save this in their workspace without having to think twice)
2. Before the file has been officially saved, autosave the draft in ~/.cache/rnote/autosaves
3. If the file is saved, then cleanup any autosaves in ~/.cache/rnote/autosaves
4. On startup, if there are files in ~/.cache/rnote/autosaves, offer to load, delete or ignore them. (If the file is loaded, then it will be treated as a "new file" that is again autosaved as a draft in ~/.cache/rnote/autosaves. The old autosave will have to be deleted by the user (e.g. by choosing delete on the next run, or manually)

Fixes #545 