### PR TITLE
wrap `shapeconfig_popover` in a scrolled window

### DIFF
--- a/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
@@ -65,223 +65,231 @@
     <!-- Shape config -->
     <object class="GtkPopover" id="shapeconfig_popover">
       <child>
-        <object class="GtkBox">
-          <property name="orientation">vertical</property>
-          <property name="margin-top">6</property>
-          <property name="margin-bottom">6</property>
-          <property name="margin-start">6</property>
-          <property name="margin-end">6</property>
-          <property name="spacing">12</property>
-          <property name="width-request">330</property>
-          <child>
-            <object class="GtkBox">
-              <child>
-                <object class="GtkLabel">
-                  <property name="label" translatable="yes">Shape Configuration</property>
-                  <property name="hexpand">true</property>
-                  <property name="halign">center</property>
-                  <style>
-                    <class name="title-3" />
-                  </style>
-                </object>
-              </child>
-              <child>
-                <object class="GtkButton" id="shapeconfig_popover_close_button">
-                  <property name="icon-name">window-close-symbolic</property>
-                  <style>
-                    <class name="flat" />
-                    <class name="circular" />
-                  </style>
-                </object>
-              </child>
-            </object>
-          </child>
-
-          <!-- Shaper Style -->
-          <child>
-            <object class="AdwPreferencesGroup">
-              <property name="title" translatable="yes">Shaper Style</property>
-              <child>
-                <object class="GtkListBox" id="shaperstyle_listbox">
-                  <property name="selection-mode">browse</property>
-                  <style>
-                    <class name="content" />
-                    <class name="large" />
-                  </style>
-                  <child>
-                    <object class="AdwActionRow" id="shaperstyle_smooth_row">
-                      <property name="title" translatable="yes">Smooth</property>
-                      <child type="prefix">
-                        <object class="GtkImage">
-                          <property name="icon-name">pen-shaper-style-smooth-symbolic</property>
-                          <property name="icon-size">large</property>
+        <object class="GtkScrolledWindow">
+            <property name="hscrollbar-policy">never</property>
+            <property name="vscrollbar-policy">automatic</property>
+            <property name="propagate-natural-height">true</property>
+            <property name="propagate-natural-width">true</property>
+            <child>
+                <object class="GtkBox">
+                <property name="orientation">vertical</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
+                <property name="spacing">12</property>
+                <property name="width-request">330</property>
+                <child>
+                    <object class="GtkBox">
+                    <child>
+                        <object class="GtkLabel">
+                        <property name="label" translatable="yes">Shape Configuration</property>
+                        <property name="hexpand">true</property>
+                        <property name="halign">center</property>
+                        <style>
+                            <class name="title-3" />
+                        </style>
                         </object>
-                      </child>
-                    </object>
-                  </child>
-                  <child>
-                    <object class="AdwActionRow" id="shaperstyle_rough_row">
-                      <property name="title" translatable="yes">Rough</property>
-                      <child type="prefix">
-                        <object class="GtkImage">
-                          <property name="icon-name">pen-shaper-style-rough-symbolic</property>
-                          <property name="icon-size">large</property>
+                    </child>
+                    <child>
+                        <object class="GtkButton" id="shapeconfig_popover_close_button">
+                        <property name="icon-name">window-close-symbolic</property>
+                        <style>
+                            <class name="flat" />
+                            <class name="circular" />
+                        </style>
                         </object>
-                      </child>
+                    </child>
                     </object>
-                  </child>
-                </object>
-              </child>
-            </object>
-          </child>
+                </child>
 
-          <!-- Highlighting -->
-          <child>
-            <object class="AdwPreferencesGroup">
-              <property name="title" translatable="yes">Highlighting</property>
-              <child>
-                <object class="AdwSwitchRow" id="highlight_mode_row">
-                  <property name="title" translatable="yes">Highlight-Mode</property>
-                  <property name="subtitle" translatable="yes">Fade active color</property>
-                </object>
-              </child>
-              <child>
-                <object class="AdwSpinRow" id="highlight_opacity_row">
-                  <property name="title" translatable="yes">Highlight-Opacity</property>
-                  <property name="subtitle" translatable="yes">Modify the highlight opacity (%)</property>
-                  <property name="adjustment">
-                    <object class="GtkAdjustment">
-                      <property name="lower">0</property>
-                      <property name="upper">100</property>
-                      <property name="value">50</property>
-                      <property name="step-increment">1</property>
+                <!-- Shaper Style -->
+                <child>
+                    <object class="AdwPreferencesGroup">
+                    <property name="title" translatable="yes">Shaper Style</property>
+                    <child>
+                        <object class="GtkListBox" id="shaperstyle_listbox">
+                        <property name="selection-mode">browse</property>
+                        <style>
+                            <class name="content" />
+                            <class name="large" />
+                        </style>
+                        <child>
+                            <object class="AdwActionRow" id="shaperstyle_smooth_row">
+                            <property name="title" translatable="yes">Smooth</property>
+                            <child type="prefix">
+                                <object class="GtkImage">
+                                <property name="icon-name">pen-shaper-style-smooth-symbolic</property>
+                                <property name="icon-size">large</property>
+                                </object>
+                            </child>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="AdwActionRow" id="shaperstyle_rough_row">
+                            <property name="title" translatable="yes">Rough</property>
+                            <child type="prefix">
+                                <object class="GtkImage">
+                                <property name="icon-name">pen-shaper-style-rough-symbolic</property>
+                                <property name="icon-size">large</property>
+                                </object>
+                            </child>
+                            </object>
+                        </child>
+                        </object>
+                    </child>
                     </object>
-                  </property>
-                  <property name="numeric">true</property>
-                  <property name="digits">0</property>
-                </object>
-              </child>
-            </object>
-          </child>
+                </child>
 
-          <!-- Smooth options -->
-          <child>
-            <object class="AdwPreferencesGroup" id="smoothstyle_group">
-              <property name="title" translatable="yes">Smooth Style</property>
-              <child>
-                <object class="AdwComboRow" id="smoothstyle_line_cap_row">
-                  <property name="title" translatable="yes">Line Cap</property>
-                  <property name="subtitle" translatable="yes">Choose a line cap</property>
-                  <property name="model">
-                    <object class="GtkStringList">
-                      <items>
-                        <item translatable="yes">Straight</item>
-                        <item translatable="yes">Round</item>
-                      </items>
+                <!-- Highlighting -->
+                <child>
+                    <object class="AdwPreferencesGroup">
+                    <property name="title" translatable="yes">Highlighting</property>
+                    <child>
+                        <object class="AdwSwitchRow" id="highlight_mode_row">
+                        <property name="title" translatable="yes">Highlight-Mode</property>
+                        <property name="subtitle" translatable="yes">Fade active color</property>
+                        </object>
+                    </child>
+                    <child>
+                        <object class="AdwSpinRow" id="highlight_opacity_row">
+                        <property name="title" translatable="yes">Highlight-Opacity</property>
+                        <property name="subtitle" translatable="yes">Modify the highlight opacity (%)</property>
+                        <property name="adjustment">
+                            <object class="GtkAdjustment">
+                            <property name="lower">0</property>
+                            <property name="upper">100</property>
+                            <property name="value">50</property>
+                            <property name="step-increment">1</property>
+                            </object>
+                        </property>
+                        <property name="numeric">true</property>
+                        <property name="digits">0</property>
+                        </object>
+                    </child>
                     </object>
-                  </property>
-                </object>
-              </child>
-              <child>
-                <object class="AdwComboRow" id="smoothstyle_line_style_row">
-                  <property name="title" translatable="yes">Line Style</property>
-                  <property name="subtitle" translatable="yes">Choose a line style</property>
-                  <property name="model">
-                    <object class="GtkStringList">
-                      <items>
-                        <item translatable="yes">Solid</item>
-                        <item translatable="yes">Dotted</item>
-                        <item translatable="yes">Dashed (narrow)</item>
-                        <item translatable="yes">Dashed (equidistant)</item>
-                        <item translatable="yes">Dashed (wide)</item>
-                      </items>
-                    </object>
-                  </property>
-                </object>
-              </child>
-            </object>
-          </child>
+                </child>
 
-          <!-- Rough options -->
-          <child>
-            <object class="AdwPreferencesGroup" id="roughstyle_group">
-              <property name="title" translatable="yes">Rough Style</property>
-              <child>
-                <object class="AdwComboRow" id="roughstyle_fillstyle_row">
-                  <property name="title" translatable="yes">Fill Style</property>
-                  <property name="subtitle" translatable="yes">Choose a fill style</property>
-                  <property name="model">
-                    <object class="GtkStringList">
-                      <items>
-                        <item translatable="yes">Solid</item>
-                        <item translatable="yes">Hachure</item>
-                        <item translatable="yes">Zig-Zag</item>
-                        <item translatable="yes">Zig-Zag Line</item>
-                        <item translatable="yes">Crosshatch</item>
-                        <item translatable="yes">Dots</item>
-                        <item translatable="yes">Dashed</item>
-                      </items>
+                <!-- Smooth options -->
+                <child>
+                    <object class="AdwPreferencesGroup" id="smoothstyle_group">
+                    <property name="title" translatable="yes">Smooth Style</property>
+                    <child>
+                        <object class="AdwComboRow" id="smoothstyle_line_cap_row">
+                        <property name="title" translatable="yes">Line Cap</property>
+                        <property name="subtitle" translatable="yes">Choose a line cap</property>
+                        <property name="model">
+                            <object class="GtkStringList">
+                            <items>
+                                <item translatable="yes">Straight</item>
+                                <item translatable="yes">Round</item>
+                            </items>
+                            </object>
+                        </property>
+                        </object>
+                    </child>
+                    <child>
+                        <object class="AdwComboRow" id="smoothstyle_line_style_row">
+                        <property name="title" translatable="yes">Line Style</property>
+                        <property name="subtitle" translatable="yes">Choose a line style</property>
+                        <property name="model">
+                            <object class="GtkStringList">
+                            <items>
+                                <item translatable="yes">Solid</item>
+                                <item translatable="yes">Dotted</item>
+                                <item translatable="yes">Dashed (narrow)</item>
+                                <item translatable="yes">Dashed (equidistant)</item>
+                                <item translatable="yes">Dashed (wide)</item>
+                            </items>
+                            </object>
+                        </property>
+                        </object>
+                    </child>
                     </object>
-                  </property>
-                </object>
-              </child>
-              <child>
-                <object class="AdwSpinRow" id="roughstyle_hachure_angle_row">
-                  <property name="title" translatable="yes">Hachure Angle</property>
-                  <property name="subtitle" translatable="yes">Set the angle of hachure fills</property>
-                  <property name="adjustment">
-                    <object class="GtkAdjustment">
-                      <property name="step-increment">2</property>
-                      <property name="upper">180.0</property>
-                      <property name="lower">-180.0</property>
-                      <property name="value">90.0</property>
-                    </object>
-                  </property>
-                  <property name="numeric">true</property>
-                  <property name="digits">0</property>
-                </object>
-              </child>
-            </object>
-          </child>
+                </child>
 
-          <!-- Constraints -->
-          <child>
-            <object class="AdwPreferencesGroup">
-              <property name="title" translatable="yes">Constraints</property>
-              <child>
-                <object class="GtkListBox">
-                  <property name="width-request">300</property>
-                  <property name="selection-mode">none</property>
-                  <style>
-                    <class name="content" />
-                    <class name="medium" />
-                  </style>
-                  <child>
-                    <object class="AdwSwitchRow" id="constraint_enabled_row">
-                      <property name="title" translatable="yes">Enabled</property>
-                      <property name="subtitle" translatable="yes">Hold Ctrl to temporarily enable/disable
-constraints when this switch is off/on</property>
+                <!-- Rough options -->
+                <child>
+                    <object class="AdwPreferencesGroup" id="roughstyle_group">
+                    <property name="title" translatable="yes">Rough Style</property>
+                    <child>
+                        <object class="AdwComboRow" id="roughstyle_fillstyle_row">
+                        <property name="title" translatable="yes">Fill Style</property>
+                        <property name="subtitle" translatable="yes">Choose a fill style</property>
+                        <property name="model">
+                            <object class="GtkStringList">
+                            <items>
+                                <item translatable="yes">Solid</item>
+                                <item translatable="yes">Hachure</item>
+                                <item translatable="yes">Zig-Zag</item>
+                                <item translatable="yes">Zig-Zag Line</item>
+                                <item translatable="yes">Crosshatch</item>
+                                <item translatable="yes">Dots</item>
+                                <item translatable="yes">Dashed</item>
+                            </items>
+                            </object>
+                        </property>
+                        </object>
+                    </child>
+                    <child>
+                        <object class="AdwSpinRow" id="roughstyle_hachure_angle_row">
+                        <property name="title" translatable="yes">Hachure Angle</property>
+                        <property name="subtitle" translatable="yes">Set the angle of hachure fills</property>
+                        <property name="adjustment">
+                            <object class="GtkAdjustment">
+                            <property name="step-increment">2</property>
+                            <property name="upper">180.0</property>
+                            <property name="lower">-180.0</property>
+                            <property name="value">90.0</property>
+                            </object>
+                        </property>
+                        <property name="numeric">true</property>
+                        <property name="digits">0</property>
+                        </object>
+                    </child>
                     </object>
-                  </child>
-                  <child>
-                    <object class="AdwSwitchRow" id="constraint_one_to_one_row">
-                      <property name="title" translatable="yes">1:1</property>
+                </child>
+
+                <!-- Constraints -->
+                <child>
+                    <object class="AdwPreferencesGroup">
+                    <property name="title" translatable="yes">Constraints</property>
+                    <child>
+                        <object class="GtkListBox">
+                        <property name="width-request">300</property>
+                        <property name="selection-mode">none</property>
+                        <style>
+                            <class name="content" />
+                            <class name="medium" />
+                        </style>
+                        <child>
+                            <object class="AdwSwitchRow" id="constraint_enabled_row">
+                            <property name="title" translatable="yes">Enabled</property>
+                            <property name="subtitle" translatable="yes">Hold Ctrl to temporarily enable/disable
+        constraints when this switch is off/on</property>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="AdwSwitchRow" id="constraint_one_to_one_row">
+                            <property name="title" translatable="yes">1:1</property>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="AdwSwitchRow" id="constraint_three_to_two_row">
+                            <property name="title" translatable="yes">3:2</property>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="AdwSwitchRow" id="constraint_golden_row">
+                            <property name="title" translatable="yes">Golden Ratio (1:1.618)</property>
+                            </object>
+                        </child>
+                        </object>
+                    </child>
                     </object>
-                  </child>
-                  <child>
-                    <object class="AdwSwitchRow" id="constraint_three_to_two_row">
-                      <property name="title" translatable="yes">3:2</property>
-                    </object>
-                  </child>
-                  <child>
-                    <object class="AdwSwitchRow" id="constraint_golden_row">
-                      <property name="title" translatable="yes">Golden Ratio (1:1.618)</property>
-                    </object>
-                  </child>
+                </child>
                 </object>
-              </child>
-            </object>
-          </child>
+            </child>
         </object>
       </child>
     </object>


### PR DESCRIPTION
To prevent the popover from failing to open up if the screen is too narrow to display everything

Follow up on #1524 with option 1 : wrap the (now pretty tall) popover in a scrolled window. I've done this using the xml directly.

<img width="979" height="1348" alt="image" src="https://github.com/user-attachments/assets/ce37d3ff-0918-447b-a9fb-f2c9abb6e1a9" />


Fixes #1504 