### PR TITLE
wrap `shapeconfig_popover` in a paged popover

### DIFF
--- a/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <interface>
   <template class="RnShaperPage" parent="GtkWidget">
     <property name="layout-manager">
@@ -35,22 +35,23 @@
           </object>
         </child>
         <child>
-          <object class="GtkMenuButton" id="shapeconfig_menubutton">
-            <property name="icon-name">settings-symbolic</property>
+          <object class="GtkMenuButton" id="shapestyling_menubutton">
+            <property name="icon-name">pen-shaper-style-smooth-symbolic</property>
             <property name="direction">left</property>
-            <property name="tooltip_text" translatable="yes">Shape Configuration</property>
-            <property name="popover">shapeconfig_popover</property>
+            <property name="tooltip_text" translatable="yes">Shape Styling</property>
+            <property name="popover">shapestyling_popover</property>
             <style>
               <class name="flat" />
-            </style>
+              <class name="sidebar_action_button" />
+            </style>s
           </object>
         </child>
         <child>
-          <object class="GtkMenuButton" id="shaperextra_menubutton">
-            <property name="icon-name">misc-menu-symbolic</property>
+          <object class="GtkMenuButton" id="shaperconfig_menubutton">
+            <property name="icon-name">settings-symbolic</property>
             <property name="direction">left</property>
-            <property name="tooltip_text" translatable="yes">Shaper Extra</property>
-            <property name="popover">shaperextra_popover</property>
+            <property name="tooltip_text" translatable="yes">Shaper Configuration</property>
+            <property name="popover">shaperconfig_popover</property>
             <style>
               <class name="flat" />
             </style>
@@ -73,8 +74,8 @@
       </object>
     </child>
 
-    <!-- Shape config -->
-    <object class="GtkPopover" id="shapeconfig_popover">
+    <!-- Shape styling -->
+    <object class="GtkPopover" id="shapestyling_popover">
       <child>
         <object class="GtkBox">
           <property name="orientation">vertical</property>
@@ -88,7 +89,7 @@
             <object class="GtkBox">
               <child>
                 <object class="GtkLabel">
-                  <property name="label" translatable="yes">Shape Configuration</property>
+                  <property name="label" translatable="yes">Shape Styling</property>
                   <property name="hexpand">true</property>
                   <property name="halign">center</property>
                   <style>
@@ -97,7 +98,7 @@
                 </object>
               </child>
               <child>
-                <object class="GtkButton" id="shapeconfig_popover_close_button">
+                <object class="GtkButton" id="shapestyling_popover_close_button">
                   <property name="icon-name">window-close-symbolic</property>
                   <style>
                     <class name="flat" />
@@ -148,10 +149,10 @@
 
           <!-- Smooth options -->
           <child>
-            <object class="AdwPreferencesGroup" id="smoothstyle_group">
-              <property name="title" translatable="yes">Smooth Style</property>
+            <object class="AdwPreferencesGroup" id="smoothoptions_group">
+              <property name="title" translatable="yes">Smooth Options</property>
               <child>
-                <object class="AdwComboRow" id="smoothstyle_line_cap_row">
+                <object class="AdwComboRow" id="smoothoptions_line_cap_row">
                   <property name="title" translatable="yes">Line Cap</property>
                   <property name="subtitle" translatable="yes">Choose a line cap</property>
                   <property name="model">
@@ -165,7 +166,7 @@
                 </object>
               </child>
               <child>
-                <object class="AdwComboRow" id="smoothstyle_line_style_row">
+                <object class="AdwComboRow" id="smoothoptions_line_style_row">
                   <property name="title" translatable="yes">Line Style</property>
                   <property name="subtitle" translatable="yes">Choose a line style</property>
                   <property name="model">
@@ -186,10 +187,10 @@
 
           <!-- Rough options -->
           <child>
-            <object class="AdwPreferencesGroup" id="roughstyle_group">
-              <property name="title" translatable="yes">Rough Style</property>
+            <object class="AdwPreferencesGroup" id="roughoptions_group">
+              <property name="title" translatable="yes">Rough Options</property>
               <child>
-                <object class="AdwComboRow" id="roughstyle_fillstyle_row">
+                <object class="AdwComboRow" id="roughoptions_fillstyle_row">
                   <property name="title" translatable="yes">Fill Style</property>
                   <property name="subtitle" translatable="yes">Choose a fill style</property>
                   <property name="model">
@@ -208,7 +209,7 @@
                 </object>
               </child>
               <child>
-                <object class="AdwSpinRow" id="roughstyle_hachure_angle_row">
+                <object class="AdwSpinRow" id="roughoptions_hachure_angle_row">
                   <property name="title" translatable="yes">Hachure Angle</property>
                   <property name="subtitle" translatable="yes">Set the angle of hachure fills</property>
                   <property name="adjustment">
@@ -229,8 +230,8 @@
       </child>
     </object>
 
-    <!-- Shaper Extra -->
-    <object class="GtkPopover" id="shaperextra_popover">
+    <!-- Shaper Config -->
+    <object class="GtkPopover" id="shaperconfig_popover">
       <child>
         <object class="GtkBox">
           <property name="orientation">vertical</property>
@@ -244,7 +245,7 @@
             <object class="GtkBox">
               <child>
                 <object class="GtkLabel">
-                  <property name="label" translatable="yes">Shaper Extra</property>
+                  <property name="label" translatable="yes">Shaper Configuration</property>
                   <property name="hexpand">true</property>
                   <property name="halign">center</property>
                   <style>
@@ -253,7 +254,7 @@
                 </object>
               </child>
               <child>
-                <object class="GtkButton" id="shaperextra_popover_close_button">
+                <object class="GtkButton" id="shaperconfig_popover_close_button">
                   <property name="icon-name">window-close-symbolic</property>
                   <style>
                     <class name="flat" />

--- a/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <interface>
   <template class="RnShaperPage" parent="GtkWidget">
     <property name="layout-manager">
@@ -40,6 +40,17 @@
             <property name="direction">left</property>
             <property name="tooltip_text" translatable="yes">Shape Configuration</property>
             <property name="popover">shapeconfig_popover</property>
+            <style>
+              <class name="flat" />
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkMenuButton" id="shaperextra_menubutton">
+            <property name="icon-name">misc-menu-symbolic</property>
+            <property name="direction">left</property>
+            <property name="tooltip_text" translatable="yes">Shaper Extra</property>
+            <property name="popover">shaperextra_popover</property>
             <style>
               <class name="flat" />
             </style>
@@ -135,35 +146,6 @@
             </object>
           </child>
 
-          <!-- Highlighting -->
-          <child>
-            <object class="AdwPreferencesGroup">
-              <property name="title" translatable="yes">Highlighting</property>
-              <child>
-                <object class="AdwSwitchRow" id="highlight_mode_row">
-                  <property name="title" translatable="yes">Highlight-Mode</property>
-                  <property name="subtitle" translatable="yes">Fade active color</property>
-                </object>
-              </child>
-              <child>
-                <object class="AdwSpinRow" id="highlight_opacity_row">
-                  <property name="title" translatable="yes">Highlight-Opacity</property>
-                  <property name="subtitle" translatable="yes">Modify the highlight opacity (%)</property>
-                  <property name="adjustment">
-                    <object class="GtkAdjustment">
-                      <property name="lower">0</property>
-                      <property name="upper">100</property>
-                      <property name="value">50</property>
-                      <property name="step-increment">1</property>
-                    </object>
-                  </property>
-                  <property name="numeric">true</property>
-                  <property name="digits">0</property>
-                </object>
-              </child>
-            </object>
-          </child>
-
           <!-- Smooth options -->
           <child>
             <object class="AdwPreferencesGroup" id="smoothstyle_group">
@@ -243,48 +225,120 @@
               </child>
             </object>
           </child>
+        </object>
+      </child>
+    </object>
 
-          <!-- Constraints -->
+    <!-- Shaper Extra -->
+    <object class="GtkPopover" id="shaperextra_popover">
+      <child>
+        <object class="GtkBox">
+          <property name="orientation">vertical</property>
+          <property name="margin-top">6</property>
+          <property name="margin-bottom">6</property>
+          <property name="margin-start">6</property>
+          <property name="margin-end">6</property>
+          <property name="spacing">12</property>
+          <property name="width-request">300</property>
+          <child>
+            <object class="GtkBox">
+              <child>
+                <object class="GtkLabel">
+                  <property name="label" translatable="yes">Shaper Extra</property>
+                  <property name="hexpand">true</property>
+                  <property name="halign">center</property>
+                  <style>
+                    <class name="title-3" />
+                  </style>
+                </object>
+              </child>
+              <child>
+                <object class="GtkButton" id="shaperextra_popover_close_button">
+                  <property name="icon-name">window-close-symbolic</property>
+                  <style>
+                    <class name="flat" />
+                    <class name="circular" />
+                  </style>
+                </object>
+              </child>
+            </object>
+          </child>
+
+          <!-- Highlighting -->
           <child>
             <object class="AdwPreferencesGroup">
-              <property name="title" translatable="yes">Constraints</property>
+              <property name="title" translatable="yes">Highlighting</property>
               <child>
-                <object class="GtkListBox">
-                  <property name="width-request">300</property>
-                  <property name="selection-mode">none</property>
-                  <style>
-                    <class name="content" />
-                    <class name="medium" />
-                  </style>
-                  <child>
-                    <object class="AdwSwitchRow" id="constraint_enabled_row">
-                      <property name="title" translatable="yes">Enabled</property>
-                      <property name="subtitle" translatable="yes">Hold Ctrl to temporarily enable/disable
-constraints when this switch is off/on</property>
+                <object class="AdwSwitchRow" id="highlight_mode_row">
+                  <property name="title" translatable="yes">Highlight-Mode</property>
+                  <property name="subtitle" translatable="yes">Fade active color</property>
+                </object>
+              </child>
+              <child>
+                <object class="AdwSpinRow" id="highlight_opacity_row">
+                  <property name="title" translatable="yes">Highlight-Opacity</property>
+                  <property name="subtitle" translatable="yes">Modify the highlight opacity (%)</property>
+                  <property name="adjustment">
+                    <object class="GtkAdjustment">
+                      <property name="lower">0</property>
+                      <property name="upper">100</property>
+                      <property name="value">50</property>
+                      <property name="step-increment">1</property>
                     </object>
-                  </child>
+                  </property>
+                  <property name="numeric">true</property>
+                  <property name="digits">0</property>
+                </object>
+              </child>
+
+              <!-- Constraints -->
+              <child>
+                <object class="AdwPreferencesGroup">
+                  <property name="title" translatable="yes">Constraints</property>
                   <child>
-                    <object class="AdwSwitchRow" id="constraint_one_to_one_row">
-                      <property name="title" translatable="yes">1:1</property>
-                    </object>
-                  </child>
-                  <child>
-                    <object class="AdwSwitchRow" id="constraint_three_to_two_row">
-                      <property name="title" translatable="yes">3:2</property>
-                    </object>
-                  </child>
-                  <child>
-                    <object class="AdwSwitchRow" id="constraint_golden_row">
-                      <property name="title" translatable="yes">Golden Ratio (1:1.618)</property>
+                    <object class="GtkListBox">
+                      <property name="width-request">300</property>
+                      <property name="selection-mode">none</property>
+                      <style>
+                        <class name="content" />
+                        <class name="medium" />
+                      </style>
+                      <child>
+                        <object class="AdwSwitchRow" id="constraint_enabled_row">
+                          <property name="title" translatable="yes">Enabled</property>
+                          <property name="subtitle" translatable="yes">Hold Ctrl to temporarily enable/disable
+    constraints when this switch is off/on</property>
+                        </object>
+                      </child>
+                      <child>
+                        <object class="AdwSwitchRow" id="constraint_one_to_one_row">
+                          <property name="title" translatable="yes">1:1</property>
+                        </object>
+                      </child>
+                      <child>
+                        <object class="AdwSwitchRow" id="constraint_three_to_two_row">
+                          <property name="title" translatable="yes">3:2</property>
+                        </object>
+                      </child>
+                      <child>
+                        <object class="AdwSwitchRow" id="constraint_golden_row">
+                          <property name="title" translatable="yes">Golden Ratio (1:1.618)</property>
+                        </object>
+                      </child>
                     </object>
                   </child>
                 </object>
               </child>
+
             </object>
           </child>
         </object>
       </child>
     </object>
+
+
+
+
 
     <!-- Shape builder type -->
     <object class="GtkPopover" id="shapebuildertype_popover">

--- a/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
@@ -148,6 +148,32 @@
                         </object>
                       </child>
                       <child>
+                          <object class="GtkBox">
+                              <property name="orientation">horizontal</property>
+                              <property name="hexpand">true</property>
+                              <property name="margin-top">6</property>
+                              <child>
+                                  <object class="GtkButton">
+                                    <property name="sensitive">false</property>
+                                    <property name="icon-name">go-previous-view-symbolic</property>
+                                    <property name="hexpand">true</property>
+                                    <style>
+                                      <class name="raised" />
+                                    </style>
+                                  </object>
+                              </child>
+                              <child>
+                                <object class="GtkButton" id="page1_to_page2_button">
+                                  <property name="icon-name">go-next-view-symbolic</property>
+                                  <property name="hexpand">true</property>
+                                  <style>
+                                    <class name="raised" />
+                                  </style>
+                                </object>
+                              </child>
+                          </object>
+                      </child>
+                      <child>
                         <object class="GtkBox">
                           <property name="orientation">vertical</property>
                           <property name="margin-top">6</property>
@@ -275,14 +301,6 @@
                         </child>
                         </object>
                       </child>
-                      <child>
-                        <object class="GtkButton" id="page1_to_page2_button">
-                          <property name="icon-name">go-next-view-symbolic</property>
-                          <style>
-                            <class name="raised" />
-                          </style>
-                        </object>
-                      </child>
                     </object>
                   </property>
                 </object>
@@ -326,6 +344,32 @@
                             </object>
                           </child>
                         </object>
+                      </child>
+                      <child>
+                          <object class="GtkBox">
+                              <property name="orientation">horizontal</property>
+                              <property name="hexpand">true</property>
+                              <property name="margin-top">6</property>
+                              <child>
+                                  <object class="GtkButton" id="page2_to_page1_button">
+                                    <property name="icon-name">go-previous-view-symbolic</property>
+                                    <property name="hexpand">true</property>
+                                    <style>
+                                      <class name="raised" />
+                                    </style>
+                                  </object>
+                              </child>
+                              <child>
+                                <object class="GtkButton">
+                                  <property name="icon-name">go-next-view-symbolic</property>
+                                  <property name="sensitive">false</property>
+                                  <property name="hexpand">true</property>
+                                  <style>
+                                    <class name="raised" />
+                                  </style>
+                                </object>
+                              </child>
+                          </object>
                       </child>
                       <child>
                         <object class="GtkBox">
@@ -393,14 +437,6 @@
                               </child>
                             </object>
                           </child>
-                        </object>
-                      </child>
-                      <child>
-                        <object class="GtkButton" id="page2_to_page1_button">
-                          <property name="icon-name">go-previous-view-symbolic</property>
-                          <style>
-                            <class name="raised" />
-                          </style>
                         </object>
                       </child>
                     </object>

--- a/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <template class="RnShaperPage" parent="GtkWidget">
     <property name="layout-manager">
@@ -307,7 +307,7 @@
                         <object class="AdwSwitchRow" id="constraint_enabled_row">
                           <property name="title" translatable="yes">Enabled</property>
                           <property name="subtitle" translatable="yes">Hold Ctrl to temporarily enable/disable
-    constraints when this switch is off/on</property>
+constraints when this switch is off/on</property>
                         </object>
                       </child>
                       <child>
@@ -329,16 +329,11 @@
                   </child>
                 </object>
               </child>
-
             </object>
           </child>
         </object>
       </child>
     </object>
-
-
-
-
 
     <!-- Shape builder type -->
     <object class="GtkPopover" id="shapebuildertype_popover">

--- a/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
@@ -290,43 +290,33 @@
                   <property name="digits">0</property>
                 </object>
               </child>
+            </object>
+          </child>
 
-              <!-- Constraints -->
+          <!-- Constraints -->
+          <child>
+            <object class="AdwPreferencesGroup">
+              <property name="title" translatable="yes">Constraints</property>
               <child>
-                <object class="AdwPreferencesGroup">
-                  <property name="title" translatable="yes">Constraints</property>
-                  <child>
-                    <object class="GtkListBox">
-                      <property name="width-request">300</property>
-                      <property name="selection-mode">none</property>
-                      <style>
-                        <class name="content" />
-                        <class name="medium" />
-                      </style>
-                      <child>
-                        <object class="AdwSwitchRow" id="constraint_enabled_row">
-                          <property name="title" translatable="yes">Enabled</property>
-                          <property name="subtitle" translatable="yes">Hold Ctrl to temporarily enable/disable
+                <object class="AdwSwitchRow" id="constraint_enabled_row">
+                  <property name="title" translatable="yes">Enabled</property>
+                  <property name="subtitle" translatable="yes">Hold Ctrl to temporarily enable/disable
 constraints when this switch is off/on</property>
-                        </object>
-                      </child>
-                      <child>
-                        <object class="AdwSwitchRow" id="constraint_one_to_one_row">
-                          <property name="title" translatable="yes">1:1</property>
-                        </object>
-                      </child>
-                      <child>
-                        <object class="AdwSwitchRow" id="constraint_three_to_two_row">
-                          <property name="title" translatable="yes">3:2</property>
-                        </object>
-                      </child>
-                      <child>
-                        <object class="AdwSwitchRow" id="constraint_golden_row">
-                          <property name="title" translatable="yes">Golden Ratio (1:1.618)</property>
-                        </object>
-                      </child>
-                    </object>
-                  </child>
+                </object>
+              </child>
+              <child>
+                <object class="AdwSwitchRow" id="constraint_one_to_one_row">
+                  <property name="title" translatable="yes">1:1</property>
+                </object>
+              </child>
+              <child>
+                <object class="AdwSwitchRow" id="constraint_three_to_two_row">
+                  <property name="title" translatable="yes">3:2</property>
+                </object>
+              </child>
+              <child>
+                <object class="AdwSwitchRow" id="constraint_golden_row">
+                  <property name="title" translatable="yes">Golden Ratio (1:1.618)</property>
                 </object>
               </child>
             </object>

--- a/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
@@ -35,23 +35,11 @@
           </object>
         </child>
         <child>
-          <object class="GtkMenuButton" id="shapestyling_menubutton">
-            <property name="icon-name">pen-shaper-style-smooth-symbolic</property>
-            <property name="direction">left</property>
-            <property name="tooltip_text" translatable="yes">Shape Styling</property>
-            <property name="popover">shapestyling_popover</property>
-            <style>
-              <class name="flat" />
-              <class name="sidebar_action_button" />
-            </style>s
-          </object>
-        </child>
-        <child>
           <object class="GtkMenuButton" id="shaperconfig_menubutton">
             <property name="icon-name">settings-symbolic</property>
             <property name="direction">left</property>
-            <property name="tooltip_text" translatable="yes">Shaper Configuration</property>
-            <property name="popover">shaperconfig_popover</property>
+            <property name="tooltip_text" translatable="yes">Shape Configuration</property>
+            <property name="popover">tabbed_property_popover</property>
             <style>
               <class name="flat" />
             </style>
@@ -73,258 +61,6 @@
         <property name="orientation">vertical</property>
       </object>
     </child>
-
-    <!-- Shape styling -->
-    <object class="GtkPopover" id="shapestyling_popover">
-      <child>
-        <object class="GtkBox">
-          <property name="orientation">vertical</property>
-          <property name="margin-top">6</property>
-          <property name="margin-bottom">6</property>
-          <property name="margin-start">6</property>
-          <property name="margin-end">6</property>
-          <property name="spacing">12</property>
-          <property name="width-request">330</property>
-          <child>
-            <object class="GtkBox">
-              <child>
-                <object class="GtkLabel">
-                  <property name="label" translatable="yes">Shape Styling</property>
-                  <property name="hexpand">true</property>
-                  <property name="halign">center</property>
-                  <style>
-                    <class name="title-3" />
-                  </style>
-                </object>
-              </child>
-              <child>
-                <object class="GtkButton" id="shapestyling_popover_close_button">
-                  <property name="icon-name">window-close-symbolic</property>
-                  <style>
-                    <class name="flat" />
-                    <class name="circular" />
-                  </style>
-                </object>
-              </child>
-            </object>
-          </child>
-
-          <!-- Shaper Style -->
-          <child>
-            <object class="AdwPreferencesGroup">
-              <property name="title" translatable="yes">Shaper Style</property>
-              <child>
-                <object class="GtkListBox" id="shaperstyle_listbox">
-                  <property name="selection-mode">browse</property>
-                  <style>
-                    <class name="content" />
-                    <class name="large" />
-                  </style>
-                  <child>
-                    <object class="AdwActionRow" id="shaperstyle_smooth_row">
-                      <property name="title" translatable="yes">Smooth</property>
-                      <child type="prefix">
-                        <object class="GtkImage">
-                          <property name="icon-name">pen-shaper-style-smooth-symbolic</property>
-                          <property name="icon-size">large</property>
-                        </object>
-                      </child>
-                    </object>
-                  </child>
-                  <child>
-                    <object class="AdwActionRow" id="shaperstyle_rough_row">
-                      <property name="title" translatable="yes">Rough</property>
-                      <child type="prefix">
-                        <object class="GtkImage">
-                          <property name="icon-name">pen-shaper-style-rough-symbolic</property>
-                          <property name="icon-size">large</property>
-                        </object>
-                      </child>
-                    </object>
-                  </child>
-                </object>
-              </child>
-            </object>
-          </child>
-
-          <!-- Smooth options -->
-          <child>
-            <object class="AdwPreferencesGroup" id="smoothoptions_group">
-              <property name="title" translatable="yes">Smooth Options</property>
-              <child>
-                <object class="AdwComboRow" id="smoothoptions_line_cap_row">
-                  <property name="title" translatable="yes">Line Cap</property>
-                  <property name="subtitle" translatable="yes">Choose a line cap</property>
-                  <property name="model">
-                    <object class="GtkStringList">
-                      <items>
-                        <item translatable="yes">Straight</item>
-                        <item translatable="yes">Round</item>
-                      </items>
-                    </object>
-                  </property>
-                </object>
-              </child>
-              <child>
-                <object class="AdwComboRow" id="smoothoptions_line_style_row">
-                  <property name="title" translatable="yes">Line Style</property>
-                  <property name="subtitle" translatable="yes">Choose a line style</property>
-                  <property name="model">
-                    <object class="GtkStringList">
-                      <items>
-                        <item translatable="yes">Solid</item>
-                        <item translatable="yes">Dotted</item>
-                        <item translatable="yes">Dashed (narrow)</item>
-                        <item translatable="yes">Dashed (equidistant)</item>
-                        <item translatable="yes">Dashed (wide)</item>
-                      </items>
-                    </object>
-                  </property>
-                </object>
-              </child>
-            </object>
-          </child>
-
-          <!-- Rough options -->
-          <child>
-            <object class="AdwPreferencesGroup" id="roughoptions_group">
-              <property name="title" translatable="yes">Rough Options</property>
-              <child>
-                <object class="AdwComboRow" id="roughoptions_fillstyle_row">
-                  <property name="title" translatable="yes">Fill Style</property>
-                  <property name="subtitle" translatable="yes">Choose a fill style</property>
-                  <property name="model">
-                    <object class="GtkStringList">
-                      <items>
-                        <item translatable="yes">Solid</item>
-                        <item translatable="yes">Hachure</item>
-                        <item translatable="yes">Zig-Zag</item>
-                        <item translatable="yes">Zig-Zag Line</item>
-                        <item translatable="yes">Crosshatch</item>
-                        <item translatable="yes">Dots</item>
-                        <item translatable="yes">Dashed</item>
-                      </items>
-                    </object>
-                  </property>
-                </object>
-              </child>
-              <child>
-                <object class="AdwSpinRow" id="roughoptions_hachure_angle_row">
-                  <property name="title" translatable="yes">Hachure Angle</property>
-                  <property name="subtitle" translatable="yes">Set the angle of hachure fills</property>
-                  <property name="adjustment">
-                    <object class="GtkAdjustment">
-                      <property name="step-increment">2</property>
-                      <property name="upper">180.0</property>
-                      <property name="lower">-180.0</property>
-                      <property name="value">90.0</property>
-                    </object>
-                  </property>
-                  <property name="numeric">true</property>
-                  <property name="digits">0</property>
-                </object>
-              </child>
-            </object>
-          </child>
-        </object>
-      </child>
-    </object>
-
-    <!-- Shaper Config -->
-    <object class="GtkPopover" id="shaperconfig_popover">
-      <child>
-        <object class="GtkBox">
-          <property name="orientation">vertical</property>
-          <property name="margin-top">6</property>
-          <property name="margin-bottom">6</property>
-          <property name="margin-start">6</property>
-          <property name="margin-end">6</property>
-          <property name="spacing">12</property>
-          <property name="width-request">300</property>
-          <child>
-            <object class="GtkBox">
-              <child>
-                <object class="GtkLabel">
-                  <property name="label" translatable="yes">Shaper Configuration</property>
-                  <property name="hexpand">true</property>
-                  <property name="halign">center</property>
-                  <style>
-                    <class name="title-3" />
-                  </style>
-                </object>
-              </child>
-              <child>
-                <object class="GtkButton" id="shaperconfig_popover_close_button">
-                  <property name="icon-name">window-close-symbolic</property>
-                  <style>
-                    <class name="flat" />
-                    <class name="circular" />
-                  </style>
-                </object>
-              </child>
-            </object>
-          </child>
-
-          <!-- Highlighting -->
-          <child>
-            <object class="AdwPreferencesGroup">
-              <property name="title" translatable="yes">Highlighting</property>
-              <child>
-                <object class="AdwSwitchRow" id="highlight_mode_row">
-                  <property name="title" translatable="yes">Highlight-Mode</property>
-                  <property name="subtitle" translatable="yes">Fade active color</property>
-                </object>
-              </child>
-              <child>
-                <object class="AdwSpinRow" id="highlight_opacity_row">
-                  <property name="title" translatable="yes">Highlight-Opacity</property>
-                  <property name="subtitle" translatable="yes">Modify the highlight opacity (%)</property>
-                  <property name="adjustment">
-                    <object class="GtkAdjustment">
-                      <property name="lower">0</property>
-                      <property name="upper">100</property>
-                      <property name="value">50</property>
-                      <property name="step-increment">1</property>
-                    </object>
-                  </property>
-                  <property name="numeric">true</property>
-                  <property name="digits">0</property>
-                </object>
-              </child>
-            </object>
-          </child>
-
-          <!-- Constraints -->
-          <child>
-            <object class="AdwPreferencesGroup">
-              <property name="title" translatable="yes">Constraints</property>
-              <child>
-                <object class="AdwSwitchRow" id="constraint_enabled_row">
-                  <property name="title" translatable="yes">Enabled</property>
-                  <property name="subtitle" translatable="yes">Hold Ctrl to temporarily enable/disable
-constraints when this switch is off/on</property>
-                </object>
-              </child>
-              <child>
-                <object class="AdwSwitchRow" id="constraint_one_to_one_row">
-                  <property name="title" translatable="yes">1:1</property>
-                </object>
-              </child>
-              <child>
-                <object class="AdwSwitchRow" id="constraint_three_to_two_row">
-                  <property name="title" translatable="yes">3:2</property>
-                </object>
-              </child>
-              <child>
-                <object class="AdwSwitchRow" id="constraint_golden_row">
-                  <property name="title" translatable="yes">Golden Ratio (1:1.618)</property>
-                </object>
-              </child>
-            </object>
-          </child>
-        </object>
-      </child>
-    </object>
 
     <!-- Shape builder type -->
     <object class="GtkPopover" id="shapebuildertype_popover">
@@ -362,6 +98,315 @@ constraints when this switch is off/on</property>
           <child>
             <object class="RnGroupedIconPicker" id="shapebuildertype_picker">
               <property name="width-request">250</property>
+            </object>
+          </child>
+        </object>
+      </child>
+    </object>
+
+    <!-- Tabbed Shape config -->
+    <object class="GtkPopover" id="tabbed_property_popover">
+      <child>
+        <object class="AdwNavigationView" id="navigationview">
+          <property name="animate_transitions">true</property>
+          <child>
+            <object class="AdwNavigationPage" id="page1">
+              <property name="title" translatable="yes">Page 1</property>
+              <property name="tag">page-1</property>
+              <property name="child">
+                <object class="AdwToolbarView" id="toolbar_view_page1">
+                  <property name="content">
+                    <object class="GtkBox">
+                      <property name="orientation">vertical</property>
+                      <property name="margin-top">6</property>
+                      <property name="margin-bottom">6</property>
+                      <property name="margin-start">6</property>
+                      <property name="margin-end">6</property>
+                      <property name="spacing">12</property>
+                      <property name="width-request">330</property>
+                      <child>
+                        <object class="GtkBox">
+                          <child>
+                            <object class="GtkLabel">
+                              <property name="label" translatable="yes">Shape Configuration (1/2)</property>
+                              <property name="hexpand">true</property>
+                              <property name="halign">center</property>
+                              <style>
+                                <class name="title-3" />
+                              </style>
+                            </object>
+                          </child>
+                          <child>
+                            <object class="GtkButton" id="page1_popover_close_button">
+                              <property name="icon-name">window-close-symbolic</property>
+                              <style>
+                                <class name="flat" />
+                                <class name="circular" />
+                              </style>
+                            </object>
+                          </child>
+                        </object>
+                      </child>
+                      <child>
+                        <object class="GtkBox">
+                          <property name="orientation">vertical</property>
+                          <property name="margin-top">6</property>
+                          <property name="margin-bottom">6</property>
+                          <property name="margin-start">6</property>
+                          <property name="margin-end">6</property>
+                          <property name="spacing">12</property>
+                          <property name="width-request">300</property>
+                        <!-- Shaper Style -->
+                        <child>
+                          <object class="AdwPreferencesGroup">
+                            <property name="title" translatable="yes">Shaper Style</property>
+                            <child>
+                              <object class="GtkListBox" id="shaperstyle_listbox">
+                                <property name="selection-mode">browse</property>
+                                <style>
+                                  <class name="content" />
+                                  <class name="large" />
+                                </style>
+                                <child>
+                                  <object class="AdwActionRow" id="shaperstyle_smooth_row">
+                                    <property name="title" translatable="yes">Smooth</property>
+                                    <child type="prefix">
+                                      <object class="GtkImage">
+                                        <property name="icon-name">pen-shaper-style-smooth-symbolic</property>
+                                        <property name="icon-size">large</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="AdwActionRow" id="shaperstyle_rough_row">
+                                    <property name="title" translatable="yes">Rough</property>
+                                    <child type="prefix">
+                                      <object class="GtkImage">
+                                        <property name="icon-name">pen-shaper-style-rough-symbolic</property>
+                                        <property name="icon-size">large</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+
+                        <!-- Smooth options -->
+                        <child>
+                          <object class="AdwPreferencesGroup" id="smoothoptions_group">
+                            <property name="title" translatable="yes">Smooth Options</property>
+                            <child>
+                              <object class="AdwComboRow" id="smoothoptions_line_cap_row">
+                                <property name="title" translatable="yes">Line Cap</property>
+                                <property name="subtitle" translatable="yes">Choose a line cap</property>
+                                <property name="model">
+                                  <object class="GtkStringList">
+                                    <items>
+                                      <item translatable="yes">Straight</item>
+                                      <item translatable="yes">Round</item>
+                                    </items>
+                                  </object>
+                                </property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwComboRow" id="smoothoptions_line_style_row">
+                                <property name="title" translatable="yes">Line Style</property>
+                                <property name="subtitle" translatable="yes">Choose a line style</property>
+                                <property name="model">
+                                  <object class="GtkStringList">
+                                    <items>
+                                      <item translatable="yes">Solid</item>
+                                      <item translatable="yes">Dotted</item>
+                                      <item translatable="yes">Dashed (narrow)</item>
+                                      <item translatable="yes">Dashed (equidistant)</item>
+                                      <item translatable="yes">Dashed (wide)</item>
+                                    </items>
+                                  </object>
+                                </property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+
+                        <!-- Rough options -->
+                        <child>
+                          <object class="AdwPreferencesGroup" id="roughoptions_group">
+                            <property name="title" translatable="yes">Rough Options</property>
+                            <child>
+                              <object class="AdwComboRow" id="roughoptions_fillstyle_row">
+                                <property name="title" translatable="yes">Fill Style</property>
+                                <property name="subtitle" translatable="yes">Choose a fill style</property>
+                                <property name="model">
+                                  <object class="GtkStringList">
+                                    <items>
+                                      <item translatable="yes">Solid</item>
+                                      <item translatable="yes">Hachure</item>
+                                      <item translatable="yes">Zig-Zag</item>
+                                      <item translatable="yes">Zig-Zag Line</item>
+                                      <item translatable="yes">Crosshatch</item>
+                                      <item translatable="yes">Dots</item>
+                                      <item translatable="yes">Dashed</item>
+                                    </items>
+                                  </object>
+                                </property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwSpinRow" id="roughoptions_hachure_angle_row">
+                                <property name="title" translatable="yes">Hachure Angle</property>
+                                <property name="subtitle" translatable="yes">Set the angle of hachure fills</property>
+                                <property name="adjustment">
+                                  <object class="GtkAdjustment">
+                                    <property name="step-increment">2</property>
+                                    <property name="upper">180.0</property>
+                                    <property name="lower">-180.0</property>
+                                    <property name="value">90.0</property>
+                                  </object>
+                                </property>
+                                <property name="numeric">true</property>
+                                <property name="digits">0</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        </object>
+                      </child>
+                      <child>
+                        <object class="GtkButton" id="page1_to_page2_button">
+                          <property name="icon-name">go-next-view-symbolic</property>
+                          <style>
+                            <class name="raised" />
+                          </style>
+                        </object>
+                      </child>
+                    </object>
+                  </property>
+                </object>
+              </property>
+            </object>
+          </child>
+          <child>
+            <object class="AdwNavigationPage" id="page2">
+              <property name="title" translatable="yes">Page 2</property>
+              <property name="tag">page-2</property>
+              <property name="child">
+                <object class="AdwToolbarView" id="toolbar_view_page2">
+                  <property name="content">
+                    <object class="GtkBox">
+                      <property name="orientation">vertical</property>
+                      <property name="margin-top">6</property>
+                      <property name="margin-bottom">6</property>
+                      <property name="margin-start">6</property>
+                      <property name="margin-end">6</property>
+                      <property name="spacing">12</property>
+                      <property name="width-request">330</property>
+                      <child>
+                        <object class="GtkBox">
+                          <child>
+                            <object class="GtkLabel">
+                              <property name="label" translatable="yes">Shape Configuration (2/2)</property>
+                              <property name="hexpand">true</property>
+                              <property name="halign">center</property>
+                              <style>
+                                <class name="title-3" />
+                              </style>
+                            </object>
+                          </child>
+                          <child>
+                            <object class="GtkButton" id="page2_popover_close_button">
+                              <property name="icon-name">window-close-symbolic</property>
+                              <style>
+                                <class name="flat" />
+                                <class name="circular" />
+                              </style>
+                            </object>
+                          </child>
+                        </object>
+                      </child>
+                      <child>
+                        <object class="GtkBox">
+                          <property name="orientation">vertical</property>
+                          <property name="margin-top">6</property>
+                          <property name="margin-bottom">6</property>
+                          <property name="margin-start">6</property>
+                          <property name="margin-end">6</property>
+                          <property name="spacing">12</property>
+                          <property name="width-request">300</property>
+                          <!-- Highlighting -->
+                          <child>
+                            <object class="AdwPreferencesGroup">
+                              <property name="title" translatable="yes">Highlighting</property>
+                              <child>
+                                <object class="AdwSwitchRow" id="highlight_mode_row">
+                                  <property name="title" translatable="yes">Highlight-Mode</property>
+                                  <property name="subtitle" translatable="yes">Fade active color</property>
+                                </object>
+                              </child>
+                              <child>
+                                <object class="AdwSpinRow" id="highlight_opacity_row">
+                                  <property name="title" translatable="yes">Highlight-Opacity</property>
+                                  <property name="subtitle" translatable="yes">Modify the highlight opacity (%)</property>
+                                  <property name="adjustment">
+                                    <object class="GtkAdjustment">
+                                      <property name="lower">0</property>
+                                      <property name="upper">100</property>
+                                      <property name="value">50</property>
+                                      <property name="step-increment">1</property>
+                                    </object>
+                                  </property>
+                                  <property name="numeric">true</property>
+                                  <property name="digits">0</property>
+                                </object>
+                              </child>
+                            </object>
+                          </child>
+
+                          <!-- Constraints -->
+                          <child>
+                            <object class="AdwPreferencesGroup">
+                              <property name="title" translatable="yes">Constraints</property>
+                              <child>
+                                <object class="AdwSwitchRow" id="constraint_enabled_row">
+                                  <property name="title" translatable="yes">Enabled</property>
+                                  <property name="subtitle" translatable="yes">Hold Ctrl to temporarily enable/disable
+                constraints when this switch is off/on</property>
+                                </object>
+                              </child>
+                              <child>
+                                <object class="AdwSwitchRow" id="constraint_one_to_one_row">
+                                  <property name="title" translatable="yes">1:1</property>
+                                </object>
+                              </child>
+                              <child>
+                                <object class="AdwSwitchRow" id="constraint_three_to_two_row">
+                                  <property name="title" translatable="yes">3:2</property>
+                                </object>
+                              </child>
+                              <child>
+                                <object class="AdwSwitchRow" id="constraint_golden_row">
+                                  <property name="title" translatable="yes">Golden Ratio (1:1.618)</property>
+                                </object>
+                              </child>
+                            </object>
+                          </child>
+                        </object>
+                      </child>
+                      <child>
+                        <object class="GtkButton" id="page2_to_page1_button">
+                          <property name="icon-name">go-previous-view-symbolic</property>
+                          <style>
+                            <class name="raised" />
+                          </style>
+                        </object>
+                      </child>
+                    </object>
+                  </property>
+                </object>
+              </property>
             </object>
           </child>
         </object>

--- a/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
+++ b/crates/rnote-ui/data/ui/penssidebar/shaperpage.ui
@@ -107,15 +107,48 @@
     <!-- Tabbed Shape config -->
     <object class="GtkPopover" id="tabbed_property_popover">
       <child>
-        <object class="AdwNavigationView" id="navigationview">
-          <property name="animate_transitions">true</property>
-          <child>
-            <object class="AdwNavigationPage" id="page1">
-              <property name="title" translatable="yes">Page 1</property>
-              <property name="tag">page-1</property>
-              <property name="child">
-                <object class="AdwToolbarView" id="toolbar_view_page1">
-                  <property name="content">
+        <object class="AdwToolbarView">
+          <child type="top">
+            <object class="GtkBox">
+              <property name="orientation">horizontal</property>
+              <property name="hexpand">true</property>
+              <property name="margin-top">6</property>
+              <property name="margin-bottom">6</property>
+              <property name="margin-start">6</property>
+              <property name="margin-end">6</property>
+              <property name="spacing">6</property>
+              <child>
+                <object class="AdwViewSwitcher" id="switcher">
+                  <property name="stack">stack</property>
+                  <property name="policy">wide</property>
+                  <property name="hexpand">true</property>
+                </object>
+              </child>
+              <child>
+                <object class="GtkSeparator">
+                  <property name="orientation">vertical</property>
+                </object>
+              </child>
+              <child>
+                <object class="GtkButton" id="popover_close_button">
+                  <property name="icon-name">window-close-symbolic</property>
+                  <style>
+                        <class name="flat" />
+                        <class name="circular" />
+                      </style>
+                </object>
+              </child>
+            </object>
+          </child>
+          <property name="content">
+            <object class="AdwViewStack" id="stack">
+              <child>
+                <object class="AdwViewStackPage">
+                  <property name="name">page1</property>
+                  <property name="title" translatable="yes">_Style _Options</property>
+                  <property name="icon-name">settings-symbolic</property>
+                  <property name="use-underline">True</property>
+                  <property name="child">
                     <object class="GtkBox">
                       <property name="orientation">vertical</property>
                       <property name="margin-top">6</property>
@@ -124,55 +157,6 @@
                       <property name="margin-end">6</property>
                       <property name="spacing">12</property>
                       <property name="width-request">330</property>
-                      <child>
-                        <object class="GtkBox">
-                          <child>
-                            <object class="GtkLabel">
-                              <property name="label" translatable="yes">Shape Configuration (1/2)</property>
-                              <property name="hexpand">true</property>
-                              <property name="halign">center</property>
-                              <style>
-                                <class name="title-3" />
-                              </style>
-                            </object>
-                          </child>
-                          <child>
-                            <object class="GtkButton" id="page1_popover_close_button">
-                              <property name="icon-name">window-close-symbolic</property>
-                              <style>
-                                <class name="flat" />
-                                <class name="circular" />
-                              </style>
-                            </object>
-                          </child>
-                        </object>
-                      </child>
-                      <child>
-                          <object class="GtkBox">
-                              <property name="orientation">horizontal</property>
-                              <property name="hexpand">true</property>
-                              <property name="margin-top">6</property>
-                              <child>
-                                  <object class="GtkButton">
-                                    <property name="sensitive">false</property>
-                                    <property name="icon-name">go-previous-view-symbolic</property>
-                                    <property name="hexpand">true</property>
-                                    <style>
-                                      <class name="raised" />
-                                    </style>
-                                  </object>
-                              </child>
-                              <child>
-                                <object class="GtkButton" id="page1_to_page2_button">
-                                  <property name="icon-name">go-next-view-symbolic</property>
-                                  <property name="hexpand">true</property>
-                                  <style>
-                                    <class name="raised" />
-                                  </style>
-                                </object>
-                              </child>
-                          </object>
-                      </child>
                       <child>
                         <object class="GtkBox">
                           <property name="orientation">vertical</property>
@@ -182,138 +166,137 @@
                           <property name="margin-end">6</property>
                           <property name="spacing">12</property>
                           <property name="width-request">300</property>
-                        <!-- Shaper Style -->
-                        <child>
-                          <object class="AdwPreferencesGroup">
-                            <property name="title" translatable="yes">Shaper Style</property>
-                            <child>
-                              <object class="GtkListBox" id="shaperstyle_listbox">
-                                <property name="selection-mode">browse</property>
-                                <style>
-                                  <class name="content" />
-                                  <class name="large" />
-                                </style>
-                                <child>
-                                  <object class="AdwActionRow" id="shaperstyle_smooth_row">
-                                    <property name="title" translatable="yes">Smooth</property>
-                                    <child type="prefix">
-                                      <object class="GtkImage">
-                                        <property name="icon-name">pen-shaper-style-smooth-symbolic</property>
-                                        <property name="icon-size">large</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="AdwActionRow" id="shaperstyle_rough_row">
-                                    <property name="title" translatable="yes">Rough</property>
-                                    <child type="prefix">
-                                      <object class="GtkImage">
-                                        <property name="icon-name">pen-shaper-style-rough-symbolic</property>
-                                        <property name="icon-size">large</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
+                          <!-- Shaper Style -->
+                          <child>
+                            <object class="AdwPreferencesGroup">
+                              <property name="title" translatable="yes">Shaper Style</property>
+                              <child>
+                                <object class="GtkListBox" id="shaperstyle_listbox">
+                                  <property name="selection-mode">browse</property>
+                                  <style>
+                                        <class name="content" />
+                                        <class name="large" />
+                                      </style>
+                                  <child>
+                                    <object class="AdwActionRow" id="shaperstyle_smooth_row">
+                                      <property name="title" translatable="yes">Smooth</property>
+                                      <child type="prefix">
+                                        <object class="GtkImage">
+                                          <property name="icon-name">
+                                            pen-shaper-style-smooth-symbolic</property>
+                                          <property name="icon-size">large</property>
+                                        </object>
+                                      </child>
+                                    </object>
+                                  </child>
+                                  <child>
+                                    <object class="AdwActionRow" id="shaperstyle_rough_row">
+                                      <property name="title" translatable="yes">Rough</property>
+                                      <child type="prefix">
+                                        <object class="GtkImage">
+                                          <property name="icon-name">pen-shaper-style-rough-symbolic</property>
+                                          <property name="icon-size">large</property>
+                                        </object>
+                                      </child>
+                                    </object>
+                                  </child>
+                                </object>
+                              </child>
+                            </object>
+                          </child>
 
-                        <!-- Smooth options -->
-                        <child>
-                          <object class="AdwPreferencesGroup" id="smoothoptions_group">
-                            <property name="title" translatable="yes">Smooth Options</property>
-                            <child>
-                              <object class="AdwComboRow" id="smoothoptions_line_cap_row">
-                                <property name="title" translatable="yes">Line Cap</property>
-                                <property name="subtitle" translatable="yes">Choose a line cap</property>
-                                <property name="model">
-                                  <object class="GtkStringList">
-                                    <items>
-                                      <item translatable="yes">Straight</item>
-                                      <item translatable="yes">Round</item>
-                                    </items>
-                                  </object>
-                                </property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="AdwComboRow" id="smoothoptions_line_style_row">
-                                <property name="title" translatable="yes">Line Style</property>
-                                <property name="subtitle" translatable="yes">Choose a line style</property>
-                                <property name="model">
-                                  <object class="GtkStringList">
-                                    <items>
-                                      <item translatable="yes">Solid</item>
-                                      <item translatable="yes">Dotted</item>
-                                      <item translatable="yes">Dashed (narrow)</item>
-                                      <item translatable="yes">Dashed (equidistant)</item>
-                                      <item translatable="yes">Dashed (wide)</item>
-                                    </items>
-                                  </object>
-                                </property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
+                          <!-- Smooth options -->
+                          <child>
+                            <object class="AdwPreferencesGroup" id="smoothoptions_group">
+                              <property name="title" translatable="yes">Smooth Options</property>
+                              <child>
+                                <object class="AdwComboRow" id="smoothoptions_line_cap_row">
+                                  <property name="title" translatable="yes">Line Cap</property>
+                                  <property name="subtitle" translatable="yes">Choose a line cap</property>
+                                  <property name="model">
+                                    <object class="GtkStringList">
+                                      <items>
+                                        <item translatable="yes">Straight</item>
+                                        <item translatable="yes">Round</item>
+                                      </items>
+                                    </object>
+                                  </property>
+                                </object>
+                              </child>
+                              <child>
+                                <object class="AdwComboRow" id="smoothoptions_line_style_row">
+                                  <property name="title" translatable="yes">Line Style</property>
+                                  <property name="subtitle" translatable="yes">Choose a line style</property>
+                                  <property name="model">
+                                    <object class="GtkStringList">
+                                      <items>
+                                        <item translatable="yes">Solid</item>
+                                        <item translatable="yes">Dotted</item>
+                                        <item translatable="yes">Dashed (narrow)</item>
+                                        <item translatable="yes">Dashed (equidistant)</item>
+                                        <item translatable="yes">Dashed (wide)</item>
+                                      </items>
+                                    </object>
+                                  </property>
+                                </object>
+                              </child>
+                            </object>
+                          </child>
 
-                        <!-- Rough options -->
-                        <child>
-                          <object class="AdwPreferencesGroup" id="roughoptions_group">
-                            <property name="title" translatable="yes">Rough Options</property>
-                            <child>
-                              <object class="AdwComboRow" id="roughoptions_fillstyle_row">
-                                <property name="title" translatable="yes">Fill Style</property>
-                                <property name="subtitle" translatable="yes">Choose a fill style</property>
-                                <property name="model">
-                                  <object class="GtkStringList">
-                                    <items>
-                                      <item translatable="yes">Solid</item>
-                                      <item translatable="yes">Hachure</item>
-                                      <item translatable="yes">Zig-Zag</item>
-                                      <item translatable="yes">Zig-Zag Line</item>
-                                      <item translatable="yes">Crosshatch</item>
-                                      <item translatable="yes">Dots</item>
-                                      <item translatable="yes">Dashed</item>
-                                    </items>
-                                  </object>
-                                </property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="AdwSpinRow" id="roughoptions_hachure_angle_row">
-                                <property name="title" translatable="yes">Hachure Angle</property>
-                                <property name="subtitle" translatable="yes">Set the angle of hachure fills</property>
-                                <property name="adjustment">
-                                  <object class="GtkAdjustment">
-                                    <property name="step-increment">2</property>
-                                    <property name="upper">180.0</property>
-                                    <property name="lower">-180.0</property>
-                                    <property name="value">90.0</property>
-                                  </object>
-                                </property>
-                                <property name="numeric">true</property>
-                                <property name="digits">0</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
+                          <!-- Rough options -->
+                          <child>
+                            <object class="AdwPreferencesGroup" id="roughoptions_group">
+                              <property name="title" translatable="yes">Rough Options</property>
+                              <child>
+                                <object class="AdwComboRow" id="roughoptions_fillstyle_row">
+                                  <property name="title" translatable="yes">Fill Style</property>
+                                  <property name="subtitle" translatable="yes">Choose a fill style</property>
+                                  <property name="model">
+                                    <object class="GtkStringList">
+                                      <items>
+                                        <item translatable="yes">Solid</item>
+                                        <item translatable="yes">Hachure</item>
+                                        <item translatable="yes">Zig-Zag</item>
+                                        <item translatable="yes">Zig-Zag Line</item>
+                                        <item translatable="yes">Crosshatch</item>
+                                        <item translatable="yes">Dots</item>
+                                        <item translatable="yes">Dashed</item>
+                                      </items>
+                                    </object>
+                                  </property>
+                                </object>
+                              </child>
+                              <child>
+                                <object class="AdwSpinRow" id="roughoptions_hachure_angle_row">
+                                  <property name="title" translatable="yes">Hachure Angle</property>
+                                  <property name="subtitle" translatable="yes">Set the angle of hachure fills</property>
+                                  <property name="adjustment">
+                                    <object class="GtkAdjustment">
+                                      <property name="step-increment">2</property>
+                                      <property name="upper">180.0</property>
+                                      <property name="lower">-180.0</property>
+                                      <property name="value">90.0</property>
+                                    </object>
+                                  </property>
+                                  <property name="numeric">true</property>
+                                  <property name="digits">0</property>
+                                </object>
+                              </child>
+                            </object>
+                          </child>
                         </object>
                       </child>
                     </object>
                   </property>
                 </object>
-              </property>
-            </object>
-          </child>
-          <child>
-            <object class="AdwNavigationPage" id="page2">
-              <property name="title" translatable="yes">Page 2</property>
-              <property name="tag">page-2</property>
-              <property name="child">
-                <object class="AdwToolbarView" id="toolbar_view_page2">
-                  <property name="content">
+              </child>
+              <child>
+                <object class="AdwViewStackPage">
+                  <property name="name">page2</property>
+                  <property name="title" translatable="yes">_Others</property>
+                  <property name="icon-name">settings-symbolic</property>
+                  <property name="use-underline">True</property>
+                  <property name="child">
                     <object class="GtkBox">
                       <property name="orientation">vertical</property>
                       <property name="margin-top">6</property>
@@ -322,55 +305,6 @@
                       <property name="margin-end">6</property>
                       <property name="spacing">12</property>
                       <property name="width-request">330</property>
-                      <child>
-                        <object class="GtkBox">
-                          <child>
-                            <object class="GtkLabel">
-                              <property name="label" translatable="yes">Shape Configuration (2/2)</property>
-                              <property name="hexpand">true</property>
-                              <property name="halign">center</property>
-                              <style>
-                                <class name="title-3" />
-                              </style>
-                            </object>
-                          </child>
-                          <child>
-                            <object class="GtkButton" id="page2_popover_close_button">
-                              <property name="icon-name">window-close-symbolic</property>
-                              <style>
-                                <class name="flat" />
-                                <class name="circular" />
-                              </style>
-                            </object>
-                          </child>
-                        </object>
-                      </child>
-                      <child>
-                          <object class="GtkBox">
-                              <property name="orientation">horizontal</property>
-                              <property name="hexpand">true</property>
-                              <property name="margin-top">6</property>
-                              <child>
-                                  <object class="GtkButton" id="page2_to_page1_button">
-                                    <property name="icon-name">go-previous-view-symbolic</property>
-                                    <property name="hexpand">true</property>
-                                    <style>
-                                      <class name="raised" />
-                                    </style>
-                                  </object>
-                              </child>
-                              <child>
-                                <object class="GtkButton">
-                                  <property name="icon-name">go-next-view-symbolic</property>
-                                  <property name="sensitive">false</property>
-                                  <property name="hexpand">true</property>
-                                  <style>
-                                    <class name="raised" />
-                                  </style>
-                                </object>
-                              </child>
-                          </object>
-                      </child>
                       <child>
                         <object class="GtkBox">
                           <property name="orientation">vertical</property>
@@ -442,7 +376,12 @@
                     </object>
                   </property>
                 </object>
-              </property>
+              </child>
+            </object>
+          </property>
+          <child type="bottom">
+            <object class="AdwViewSwitcherBar" id="switcher_bar">
+              <property name="stack">stack</property>
             </object>
           </child>
         </object>

--- a/crates/rnote-ui/src/appwindow/imp.rs
+++ b/crates/rnote-ui/src/appwindow/imp.rs
@@ -711,6 +711,11 @@ impl RnAppWindow {
             obj.overlays()
                 .penssidebar()
                 .shaper_page()
+                .shaperextra_menubutton()
+                .set_direction(ArrowType::Right);
+            obj.overlays()
+                .penssidebar()
+                .shaper_page()
                 .shapebuildertype_menubutton()
                 .set_direction(ArrowType::Right);
             obj.overlays()

--- a/crates/rnote-ui/src/appwindow/imp.rs
+++ b/crates/rnote-ui/src/appwindow/imp.rs
@@ -706,12 +706,12 @@ impl RnAppWindow {
             obj.overlays()
                 .penssidebar()
                 .shaper_page()
-                .shapeconfig_menubutton()
+                .shapestyling_menubutton()
                 .set_direction(ArrowType::Right);
             obj.overlays()
                 .penssidebar()
                 .shaper_page()
-                .shaperextra_menubutton()
+                .shaperconfig_menubutton()
                 .set_direction(ArrowType::Right);
             obj.overlays()
                 .penssidebar()
@@ -828,7 +828,7 @@ impl RnAppWindow {
             obj.overlays()
                 .penssidebar()
                 .shaper_page()
-                .shapeconfig_menubutton()
+                .shapestyling_menubutton()
                 .set_direction(ArrowType::Left);
             obj.overlays()
                 .penssidebar()

--- a/crates/rnote-ui/src/appwindow/imp.rs
+++ b/crates/rnote-ui/src/appwindow/imp.rs
@@ -706,11 +706,6 @@ impl RnAppWindow {
             obj.overlays()
                 .penssidebar()
                 .shaper_page()
-                .shapestyling_menubutton()
-                .set_direction(ArrowType::Right);
-            obj.overlays()
-                .penssidebar()
-                .shaper_page()
                 .shaperconfig_menubutton()
                 .set_direction(ArrowType::Right);
             obj.overlays()
@@ -825,11 +820,6 @@ impl RnAppWindow {
                 .brush_page()
                 .stroke_width_picker()
                 .set_position(PositionType::Right);
-            obj.overlays()
-                .penssidebar()
-                .shaper_page()
-                .shapestyling_menubutton()
-                .set_direction(ArrowType::Left);
             obj.overlays()
                 .penssidebar()
                 .shaper_page()

--- a/crates/rnote-ui/src/penssidebar/shaperpage.rs
+++ b/crates/rnote-ui/src/penssidebar/shaperpage.rs
@@ -32,11 +32,11 @@ mod imp {
         pub(crate) shapebuildertype_picker: TemplateChild<RnGroupedIconPicker>,
 
         #[template_child]
-        pub(crate) shapeconfig_menubutton: TemplateChild<MenuButton>,
+        pub(crate) shapestyling_menubutton: TemplateChild<MenuButton>,
         #[template_child]
-        pub(crate) shapeconfig_popover: TemplateChild<Popover>,
+        pub(crate) shapestyling_popover: TemplateChild<Popover>,
         #[template_child]
-        pub(crate) shapeconfig_popover_close_button: TemplateChild<Button>,
+        pub(crate) shapestyling_popover_close_button: TemplateChild<Button>,
         #[template_child]
         pub(crate) shaperstyle_listbox: TemplateChild<ListBox>,
         #[template_child]
@@ -44,24 +44,24 @@ mod imp {
         #[template_child]
         pub(crate) shaperstyle_rough_row: TemplateChild<adw::ActionRow>,
         #[template_child]
-        pub(crate) smoothstyle_group: TemplateChild<adw::PreferencesGroup>,
+        pub(crate) smoothoptions_group: TemplateChild<adw::PreferencesGroup>,
         #[template_child]
-        pub(crate) smoothstyle_line_cap_row: TemplateChild<adw::ComboRow>,
+        pub(crate) smoothoptions_line_cap_row: TemplateChild<adw::ComboRow>,
         #[template_child]
-        pub(crate) smoothstyle_line_style_row: TemplateChild<adw::ComboRow>,
+        pub(crate) smoothoptions_line_style_row: TemplateChild<adw::ComboRow>,
         #[template_child]
-        pub(crate) roughstyle_group: TemplateChild<adw::PreferencesGroup>,
+        pub(crate) roughoptions_group: TemplateChild<adw::PreferencesGroup>,
         #[template_child]
-        pub(crate) roughstyle_fillstyle_row: TemplateChild<adw::ComboRow>,
+        pub(crate) roughoptions_fillstyle_row: TemplateChild<adw::ComboRow>,
         #[template_child]
-        pub(crate) roughstyle_hachure_angle_row: TemplateChild<adw::SpinRow>,
+        pub(crate) roughoptions_hachure_angle_row: TemplateChild<adw::SpinRow>,
 
         #[template_child]
-        pub(crate) shaperextra_menubutton: TemplateChild<MenuButton>,
+        pub(crate) shaperconfig_menubutton: TemplateChild<MenuButton>,
         #[template_child]
-        pub(crate) shaperextra_popover: TemplateChild<Popover>,
+        pub(crate) shaperconfig_popover: TemplateChild<Popover>,
         #[template_child]
-        pub(crate) shaperextra_popover_close_button: TemplateChild<Button>,
+        pub(crate) shaperconfig_popover_close_button: TemplateChild<Button>,
         #[template_child]
         pub(crate) highlight_mode_row: TemplateChild<adw::SwitchRow>,
         #[template_child]
@@ -127,12 +127,12 @@ impl RnShaperPage {
         glib::Object::new()
     }
 
-    pub(crate) fn shapeconfig_menubutton(&self) -> MenuButton {
-        self.imp().shapeconfig_menubutton.get()
+    pub(crate) fn shapestyling_menubutton(&self) -> MenuButton {
+        self.imp().shapestyling_menubutton.get()
     }
 
-    pub(crate) fn shaperextra_menubutton(&self) -> MenuButton {
-        self.imp().shaperextra_menubutton.get()
+    pub(crate) fn shaperconfig_menubutton(&self) -> MenuButton {
+        self.imp().shaperconfig_menubutton.get()
     }
 
     pub(crate) fn shapebuildertype_menubutton(&self) -> MenuButton {
@@ -167,23 +167,23 @@ impl RnShaperPage {
             .set_picked(Some(builder_type.to_icon_name()));
     }
 
-    pub(crate) fn smoothstyle_line_cap(&self) -> LineCap {
-        LineCap::try_from(self.imp().smoothstyle_line_cap_row.get().selected()).unwrap()
+    pub(crate) fn smoothoptions_line_cap(&self) -> LineCap {
+        LineCap::try_from(self.imp().smoothoptions_line_cap_row.get().selected()).unwrap()
     }
 
-    pub(crate) fn smoothstyle_line_style(&self) -> LineStyle {
-        LineStyle::try_from(self.imp().smoothstyle_line_style_row.get().selected()).unwrap()
+    pub(crate) fn smoothoptions_line_style(&self) -> LineStyle {
+        LineStyle::try_from(self.imp().smoothoptions_line_style_row.get().selected()).unwrap()
     }
 
-    pub(crate) fn roughstyle_fillstyle(&self) -> FillStyle {
-        FillStyle::try_from(self.imp().roughstyle_fillstyle_row.get().selected()).unwrap()
+    pub(crate) fn roughoptions_fillstyle(&self) -> FillStyle {
+        FillStyle::try_from(self.imp().roughoptions_fillstyle_row.get().selected()).unwrap()
     }
 
-    pub(crate) fn set_roughstyle_fillstyle(&self, fill_style: FillStyle) {
+    pub(crate) fn set_roughoptions_fillstyle(&self, fill_style: FillStyle) {
         let position = fill_style.to_u32().unwrap();
 
         self.imp()
-            .roughstyle_fillstyle_row
+            .roughoptions_fillstyle_row
             .get()
             .set_selected(position);
     }
@@ -194,26 +194,28 @@ impl RnShaperPage {
 
     pub(crate) fn init(&self, appwindow: &RnAppWindow) {
         let imp = self.imp();
-        let shapeconfig_popover = imp.shapeconfig_popover.get();
-        let shaperextra_popover = imp.shaperextra_popover.get();
+        let shapestyling_popover = imp.shapestyling_popover.get();
+        let shaperconfig_popover = imp.shaperconfig_popover.get();
         let shapebuildertype_popover = imp.shapebuildertype_popover.get();
 
         // Popovers
-        imp.shapeconfig_popover_close_button.connect_clicked(clone!(
-            #[weak]
-            shapeconfig_popover,
-            move |_| {
-                shapeconfig_popover.popdown();
-            }
-        ));
+        imp.shapestyling_popover_close_button
+            .connect_clicked(clone!(
+                #[weak]
+                shapestyling_popover,
+                move |_| {
+                    shapestyling_popover.popdown();
+                }
+            ));
 
-        imp.shaperextra_popover_close_button.connect_clicked(clone!(
-            #[weak]
-            shaperextra_popover,
-            move |_| {
-                shaperextra_popover.popdown();
-            }
-        ));
+        imp.shaperconfig_popover_close_button
+            .connect_clicked(clone!(
+                #[weak]
+                shaperconfig_popover,
+                move |_| {
+                    shaperconfig_popover.popdown();
+                }
+            ));
 
         imp.shapebuildertype_popover_close_button
             .connect_clicked(clone!(
@@ -299,8 +301,10 @@ impl RnShaperPage {
                                 .smooth_options
                                 .stroke_width;
                             let page = shaperpage.imp();
-                            page.roughstyle_group.set_visible(false);
-                            page.smoothstyle_group.set_visible(true);
+                            page.shapestyling_menubutton
+                                .set_icon_name("pen-shaper-style-smooth-symbolic");
+                            page.roughoptions_group.set_visible(false);
+                            page.smoothoptions_group.set_visible(true);
                             page.stroke_width_picker.set_stroke_width(stroke_width);
                         }
                         ShaperStyle::Rough => {
@@ -312,8 +316,10 @@ impl RnShaperPage {
                                 .rough_options
                                 .stroke_width;
                             let page = shaperpage.imp();
-                            page.smoothstyle_group.set_visible(false);
-                            page.roughstyle_group.set_visible(true);
+                            page.shapestyling_menubutton
+                                .set_icon_name("pen-shaper-style-rough-symbolic");
+                            page.smoothoptions_group.set_visible(false);
+                            page.roughoptions_group.set_visible(true);
                             page.stroke_width_picker.set_stroke_width(stroke_width);
                         }
                     }
@@ -323,7 +329,7 @@ impl RnShaperPage {
 
         // Smooth style
         // Line cap
-        imp.smoothstyle_line_cap_row
+        imp.smoothoptions_line_cap_row
             .get()
             .connect_selected_notify(clone!(
                 #[weak(rename_to=shaperpage)]
@@ -331,15 +337,15 @@ impl RnShaperPage {
                 #[weak]
                 appwindow,
                 move |_| {
-                    let line_cap = shaperpage.smoothstyle_line_cap();
+                    let line_cap = shaperpage.smoothoptions_line_cap();
 
                     // If the user has selected a straight line cap while the line style was dotted, then we update the line style to be straight
                     if line_cap == LineCap::Straight
-                        && shaperpage.smoothstyle_line_style().is_dotted()
+                        && shaperpage.smoothoptions_line_style().is_dotted()
                     {
                         shaperpage
                             .imp()
-                            .smoothstyle_line_style_row
+                            .smoothoptions_line_style_row
                             .set_selected(LineStyle::Solid.to_u32().unwrap())
                     }
                     appwindow
@@ -353,7 +359,7 @@ impl RnShaperPage {
             ));
 
         // Line style
-        imp.smoothstyle_line_style_row
+        imp.smoothoptions_line_style_row
             .get()
             .connect_selected_notify(clone!(
                 #[weak(rename_to=shaperpage)]
@@ -361,13 +367,13 @@ impl RnShaperPage {
                 #[weak]
                 appwindow,
                 move |_| {
-                    let line_style = shaperpage.smoothstyle_line_style();
+                    let line_style = shaperpage.smoothoptions_line_style();
 
                     // If the user has selected a dotted line style, then we update the line cap to be rounded
                     if line_style.is_dotted() {
                         shaperpage
                             .imp()
-                            .smoothstyle_line_cap_row
+                            .smoothoptions_line_cap_row
                             .set_selected(LineCap::Rounded.to_u32().unwrap());
                     }
                     appwindow
@@ -382,7 +388,7 @@ impl RnShaperPage {
 
         // Rough style
         // Fill style
-        imp.roughstyle_fillstyle_row
+        imp.roughoptions_fillstyle_row
             .get()
             .connect_selected_notify(clone!(
                 #[weak(rename_to=shaperpage)]
@@ -396,12 +402,12 @@ impl RnShaperPage {
                         .pens_config
                         .shaper_config
                         .rough_options
-                        .fill_style = shaperpage.roughstyle_fillstyle();
+                        .fill_style = shaperpage.roughoptions_fillstyle();
                 }
             ));
 
         // Hachure angle
-        imp.roughstyle_hachure_angle_row
+        imp.roughoptions_hachure_angle_row
             .get()
             .connect_changed(clone!(
                 #[weak]
@@ -610,14 +616,14 @@ impl RnShaperPage {
         self.set_shapebuildertype(shaper_config.builder_type);
 
         // Smooth style
-        imp.smoothstyle_line_cap_row
+        imp.smoothoptions_line_cap_row
             .set_selected(shaper_config.smooth_options.line_cap.to_u32().unwrap());
-        imp.smoothstyle_line_style_row
+        imp.smoothoptions_line_style_row
             .set_selected(shaper_config.smooth_options.line_style.to_u32().unwrap());
 
         // Rough style
-        self.set_roughstyle_fillstyle(shaper_config.rough_options.fill_style);
-        imp.roughstyle_hachure_angle_row
+        self.set_roughoptions_fillstyle(shaper_config.rough_options.fill_style);
+        imp.roughoptions_hachure_angle_row
             .set_value(shaper_config.rough_options.hachure_angle.to_degrees());
 
         // Highlighter opacity

--- a/crates/rnote-ui/src/penssidebar/shaperpage.rs
+++ b/crates/rnote-ui/src/penssidebar/shaperpage.rs
@@ -32,12 +32,6 @@ mod imp {
         pub(crate) shapebuildertype_picker: TemplateChild<RnGroupedIconPicker>,
 
         #[template_child]
-        pub(crate) shapestyling_menubutton: TemplateChild<MenuButton>,
-        #[template_child]
-        pub(crate) shapestyling_popover: TemplateChild<Popover>,
-        #[template_child]
-        pub(crate) shapestyling_popover_close_button: TemplateChild<Button>,
-        #[template_child]
         pub(crate) shaperstyle_listbox: TemplateChild<ListBox>,
         #[template_child]
         pub(crate) shaperstyle_smooth_row: TemplateChild<adw::ActionRow>,
@@ -59,10 +53,6 @@ mod imp {
         #[template_child]
         pub(crate) shaperconfig_menubutton: TemplateChild<MenuButton>,
         #[template_child]
-        pub(crate) shaperconfig_popover: TemplateChild<Popover>,
-        #[template_child]
-        pub(crate) shaperconfig_popover_close_button: TemplateChild<Button>,
-        #[template_child]
         pub(crate) highlight_mode_row: TemplateChild<adw::SwitchRow>,
         #[template_child]
         pub(crate) highlight_opacity_row: TemplateChild<adw::SpinRow>,
@@ -77,6 +67,28 @@ mod imp {
 
         #[template_child]
         pub(crate) stroke_width_picker: TemplateChild<RnStrokeWidthPicker>,
+
+        // Tabbed shaper popover properties
+        #[template_child]
+        pub(crate) navigationview: TemplateChild<adw::NavigationView>,
+        #[template_child]
+        pub(crate) tabbed_property_popover: TemplateChild<Popover>,
+        #[template_child]
+        pub(crate) page1: TemplateChild<adw::NavigationPage>,
+        #[template_child]
+        pub(crate) page2: TemplateChild<adw::NavigationPage>,
+        #[template_child]
+        pub(crate) toolbar_view_page1: TemplateChild<adw::ToolbarView>,
+        #[template_child]
+        pub(crate) toolbar_view_page2: TemplateChild<adw::ToolbarView>,
+        #[template_child]
+        pub(crate) page1_popover_close_button: TemplateChild<Button>,
+        #[template_child]
+        pub(crate) page2_popover_close_button: TemplateChild<Button>,
+        #[template_child]
+        pub(crate) page1_to_page2_button: TemplateChild<Button>,
+        #[template_child]
+        pub(crate) page2_to_page1_button: TemplateChild<Button>,
     }
 
     #[glib::object_subclass]
@@ -125,10 +137,6 @@ impl Default for RnShaperPage {
 impl RnShaperPage {
     pub(crate) fn new() -> Self {
         glib::Object::new()
-    }
-
-    pub(crate) fn shapestyling_menubutton(&self) -> MenuButton {
-        self.imp().shapestyling_menubutton.get()
     }
 
     pub(crate) fn shaperconfig_menubutton(&self) -> MenuButton {
@@ -194,28 +202,51 @@ impl RnShaperPage {
 
     pub(crate) fn init(&self, appwindow: &RnAppWindow) {
         let imp = self.imp();
-        let shapestyling_popover = imp.shapestyling_popover.get();
-        let shaperconfig_popover = imp.shaperconfig_popover.get();
         let shapebuildertype_popover = imp.shapebuildertype_popover.get();
+        let tabbedconfig_popover = imp.tabbed_property_popover.get();
+        let navigationview = imp.navigationview.get();
 
-        // Popovers
-        imp.shapestyling_popover_close_button
-            .connect_clicked(clone!(
-                #[weak]
-                shapestyling_popover,
-                move |_| {
-                    shapestyling_popover.popdown();
-                }
-            ));
+        // when closing the popover, reset to the page 1
+        // on the next opening
+        imp.tabbed_property_popover.connect_closed(clone!(
+            #[weak]
+            navigationview,
+            move |_| {
+                navigationview.pop_to_tag("page-1");
+            }
+        ));
 
-        imp.shaperconfig_popover_close_button
-            .connect_clicked(clone!(
-                #[weak]
-                shaperconfig_popover,
-                move |_| {
-                    shaperconfig_popover.popdown();
-                }
-            ));
+        imp.page1_popover_close_button.connect_clicked(clone!(
+            #[weak]
+            tabbedconfig_popover,
+            move |_| {
+                tabbedconfig_popover.popdown();
+            }
+        ));
+
+        imp.page2_popover_close_button.connect_clicked(clone!(
+            #[weak]
+            tabbedconfig_popover,
+            move |_| {
+                tabbedconfig_popover.popdown();
+            }
+        ));
+
+        imp.page1_to_page2_button.connect_clicked(clone!(
+            #[weak]
+            navigationview,
+            move |_| {
+                navigationview.push_by_tag("page-2");
+            }
+        ));
+
+        imp.page2_to_page1_button.connect_clicked(clone!(
+            #[weak]
+            navigationview,
+            move |_| {
+                navigationview.pop_to_tag("page-1");
+            }
+        ));
 
         imp.shapebuildertype_popover_close_button
             .connect_clicked(clone!(
@@ -301,8 +332,6 @@ impl RnShaperPage {
                                 .smooth_options
                                 .stroke_width;
                             let page = shaperpage.imp();
-                            page.shapestyling_menubutton
-                                .set_icon_name("pen-shaper-style-smooth-symbolic");
                             page.roughoptions_group.set_visible(false);
                             page.smoothoptions_group.set_visible(true);
                             page.stroke_width_picker.set_stroke_width(stroke_width);
@@ -316,8 +345,6 @@ impl RnShaperPage {
                                 .rough_options
                                 .stroke_width;
                             let page = shaperpage.imp();
-                            page.shapestyling_menubutton
-                                .set_icon_name("pen-shaper-style-rough-symbolic");
                             page.smoothoptions_group.set_visible(false);
                             page.roughoptions_group.set_visible(true);
                             page.stroke_width_picker.set_stroke_width(stroke_width);

--- a/crates/rnote-ui/src/penssidebar/shaperpage.rs
+++ b/crates/rnote-ui/src/penssidebar/shaperpage.rs
@@ -70,25 +70,15 @@ mod imp {
 
         // Tabbed shaper popover properties
         #[template_child]
-        pub(crate) navigationview: TemplateChild<adw::NavigationView>,
-        #[template_child]
         pub(crate) tabbed_property_popover: TemplateChild<Popover>,
         #[template_child]
-        pub(crate) page1: TemplateChild<adw::NavigationPage>,
+        pub(crate) popover_close_button: TemplateChild<Button>,
         #[template_child]
-        pub(crate) page2: TemplateChild<adw::NavigationPage>,
+        pub(crate) switcher_bar: TemplateChild<adw::ViewSwitcherBar>,
         #[template_child]
-        pub(crate) toolbar_view_page1: TemplateChild<adw::ToolbarView>,
+        pub(crate) switcher: TemplateChild<adw::ViewSwitcher>,
         #[template_child]
-        pub(crate) toolbar_view_page2: TemplateChild<adw::ToolbarView>,
-        #[template_child]
-        pub(crate) page1_popover_close_button: TemplateChild<Button>,
-        #[template_child]
-        pub(crate) page2_popover_close_button: TemplateChild<Button>,
-        #[template_child]
-        pub(crate) page1_to_page2_button: TemplateChild<Button>,
-        #[template_child]
-        pub(crate) page2_to_page1_button: TemplateChild<Button>,
+        pub(crate) stack: TemplateChild<adw::ViewStack>,
     }
 
     #[glib::object_subclass]
@@ -204,47 +194,12 @@ impl RnShaperPage {
         let imp = self.imp();
         let shapebuildertype_popover = imp.shapebuildertype_popover.get();
         let tabbedconfig_popover = imp.tabbed_property_popover.get();
-        let navigationview = imp.navigationview.get();
 
-        // when closing the popover, reset to the page 1
-        // on the next opening
-        imp.tabbed_property_popover.connect_closed(clone!(
-            #[weak]
-            navigationview,
-            move |_| {
-                navigationview.pop_to_tag("page-1");
-            }
-        ));
-
-        imp.page1_popover_close_button.connect_clicked(clone!(
+        imp.popover_close_button.connect_clicked(clone!(
             #[weak]
             tabbedconfig_popover,
             move |_| {
                 tabbedconfig_popover.popdown();
-            }
-        ));
-
-        imp.page2_popover_close_button.connect_clicked(clone!(
-            #[weak]
-            tabbedconfig_popover,
-            move |_| {
-                tabbedconfig_popover.popdown();
-            }
-        ));
-
-        imp.page1_to_page2_button.connect_clicked(clone!(
-            #[weak]
-            navigationview,
-            move |_| {
-                navigationview.push_by_tag("page-2");
-            }
-        ));
-
-        imp.page2_to_page1_button.connect_clicked(clone!(
-            #[weak]
-            navigationview,
-            move |_| {
-                navigationview.pop_to_tag("page-1");
             }
         ));
 


### PR DESCRIPTION
Follow up on https://github.com/flxzt/rnote/pull/1524 with option 2 : paged popover

<img width="732" height="874" alt="image" src="https://github.com/user-attachments/assets/934b4689-c78b-4147-9fe9-6879f6a62949" />
<img width="732" height="874" alt="image" src="https://github.com/user-attachments/assets/b93f10bb-6da8-4253-b4f5-43542d4ea4fe" />




Fixes https://github.com/flxzt/rnote/issues/1504.

Sister PR to #1808 (where option 1 : use a scrolled window was used instead)
