### PR TITLE
fix: do not skip strokes when using the eraser

### DIFF
--- a/crates/rnote-compose/src/penpath/mod.rs
+++ b/crates/rnote-compose/src/penpath/mod.rs
@@ -158,7 +158,8 @@ impl PenPath {
             .collect()
     }
 
-    fn hitboxes_w_segs_indices(&self) -> Vec<(Option<usize>, Vec<Aabb>)> {
+    /// Returns a vector of hitboxes corresponding to each segment with their corresponding indices
+    pub fn hitboxes_w_segs_indices(&self) -> Vec<(Option<usize>, Vec<Aabb>)> {
         let mut hitboxes = Vec::with_capacity(self.segments.len());
         if self.segments.is_empty() {
             return vec![(

--- a/crates/rnote-engine/src/pens/eraser.rs
+++ b/crates/rnote-engine/src/pens/eraser.rs
@@ -60,7 +60,7 @@ impl PenBehaviour for Eraser {
 
         let event_result = match (&mut self.state, event) {
             (EraserState::Up | EraserState::Proximity { .. }, PenEvent::Down { element, .. }) => {
-                widget_flags |= erase(element, engine_view);
+                widget_flags |= erase(element, None, engine_view);
                 self.state = EraserState::Down(element);
                 EventResult {
                     handled: true,
@@ -85,7 +85,7 @@ impl PenBehaviour for Eraser {
                 progress: PenProgress::Idle,
             },
             (EraserState::Down(current_element), PenEvent::Down { element, .. }) => {
-                widget_flags |= erase(element, engine_view);
+                widget_flags |= erase(element, Some(current_element.clone()), engine_view);
                 *current_element = element;
                 EventResult {
                     handled: true,
@@ -95,7 +95,7 @@ impl PenBehaviour for Eraser {
             }
             (EraserState::Down { .. }, PenEvent::Up { element, .. }) => {
                 widget_flags |=
-                    erase(element, engine_view) | engine_view.store.record(Instant::now());
+                    erase(element, None, engine_view) | engine_view.store.record(Instant::now());
                 self.state = EraserState::Up;
                 EventResult {
                     handled: true,
@@ -220,7 +220,11 @@ impl DrawableOnDoc for Eraser {
     }
 }
 
-fn erase(element: Element, engine_view: &mut EngineViewMut) -> WidgetFlags {
+fn erase(
+    element: Element,
+    previous_element: Option<Element>,
+    engine_view: &mut EngineViewMut,
+) -> WidgetFlags {
     // the widget_flags.store_modified flag is set in the `.trash_..()` methods
     let mut widget_flags = WidgetFlags::default();
 
@@ -232,6 +236,15 @@ fn erase(element: Element, engine_view: &mut EngineViewMut) -> WidgetFlags {
                     .pens_config
                     .eraser_config
                     .eraser_bounds(element),
+                previous_element.and_then(|element| {
+                    Some(
+                        engine_view
+                            .config
+                            .pens_config
+                            .eraser_config
+                            .eraser_bounds(element),
+                    )
+                }),
                 engine_view.camera.viewport(),
             );
         }
@@ -242,6 +255,15 @@ fn erase(element: Element, engine_view: &mut EngineViewMut) -> WidgetFlags {
                     .pens_config
                     .eraser_config
                     .eraser_bounds(element),
+                previous_element.and_then(|element| {
+                    Some(
+                        engine_view
+                            .config
+                            .pens_config
+                            .eraser_config
+                            .eraser_bounds(element),
+                    )
+                }),
                 engine_view.camera.viewport(),
             );
             widget_flags |= wf;

--- a/crates/rnote-engine/src/store/trash_comp.rs
+++ b/crates/rnote-engine/src/store/trash_comp.rs
@@ -170,7 +170,7 @@ impl StrokeStore {
 
                                     // skip splits that don't have at least two segments (one's end as path start, one additional)
                                     if split_slice.len() > 1 {
-                                        split.push(split_slice.to_vec());
+                                        split.push((split_slice.to_vec(), prev));
                                     }
 
                                     prev = hit;
@@ -179,17 +179,26 @@ impl StrokeStore {
                                 // Catch the last
                                 let last_split = &brushstroke.path.segments[prev..];
                                 if last_split.len() > 1 {
-                                    split.push(last_split.to_vec());
+                                    split.push((last_split.to_vec(), prev));
                                 }
 
-                                for next_split in split {
+                                for (next_split, prev) in split {
                                     let mut next_split_iter = next_split.into_iter();
                                     let next_start = next_split_iter.next().unwrap().end();
+
+                                    let mut new_style = brushstroke.style.clone();
+                                    if let Textured(_) = new_style {
+                                        // advance the seed for the cut portion to keep the same
+                                        // visual appearance
+                                        for _ in 0..=prev {
+                                            new_style.advance_seed();
+                                        }
+                                    }
 
                                     new_strokes.push((
                                         Stroke::BrushStroke(BrushStroke::from_penpath(
                                             PenPath::new_w_segments(next_start, next_split_iter),
-                                            brushstroke.style.clone(),
+                                            new_style,
                                         )),
                                         chrono_comp.layer,
                                     ));

--- a/crates/rnote-engine/src/store/trash_comp.rs
+++ b/crates/rnote-engine/src/store/trash_comp.rs
@@ -81,6 +81,7 @@ impl StrokeStore {
     pub(crate) fn trash_colliding_strokes(
         &mut self,
         eraser_bounds: Aabb,
+        previous_eraser_bounds: Option<Aabb>,
         viewport: Aabb,
     ) -> WidgetFlags {
         let mut widget_flags = WidgetFlags::default();
@@ -129,6 +130,7 @@ impl StrokeStore {
     pub(crate) fn split_colliding_strokes(
         &mut self,
         eraser_bounds: Aabb,
+        previous_eraser_bounds: Option<Aabb>,
         viewport: Aabb,
     ) -> (Vec<StrokeKey>, WidgetFlags) {
         let mut widget_flags = WidgetFlags::default();

--- a/crates/rnote-engine/src/store/trash_comp.rs
+++ b/crates/rnote-engine/src/store/trash_comp.rs
@@ -3,8 +3,11 @@ use super::chrono_comp::StrokeLayer;
 use super::{StrokeKey, StrokeStore};
 use crate::WidgetFlags;
 use crate::strokes::{BrushStroke, Stroke};
+use geo::ConvexHull;
+use geo::intersects::Intersects;
 use p2d::bounding_volume::{Aabb, BoundingVolume};
 use rnote_compose::PenPath;
+use rnote_compose::Style::Textured;
 use rnote_compose::shapes::Shapeable;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -86,6 +89,18 @@ impl StrokeStore {
     ) -> WidgetFlags {
         let mut widget_flags = WidgetFlags::default();
 
+        let sliding_polygon = if let Some(previous_bounds) = previous_eraser_bounds {
+            Some(
+                geo::MultiPolygon::new(vec![
+                    crate::utils::p2d_aabb_to_geo_polygon(previous_bounds),
+                    crate::utils::p2d_aabb_to_geo_polygon(eraser_bounds),
+                ])
+                .convex_hull(),
+            )
+        } else {
+            None
+        };
+
         self.stroke_keys_as_rendered_intersecting_bounds(viewport)
             .into_iter()
             .for_each(|key| {
@@ -94,13 +109,31 @@ impl StrokeStore {
                 if let Some(stroke) = self.stroke_components.get(key) {
                     match stroke.as_ref() {
                         Stroke::BrushStroke(_) | Stroke::ShapeStroke(_) => {
-                            // First check if eraser even intersects stroke bounds, avoiding unnecessary work
-                            if eraser_bounds.intersects(&stroke.bounds()) {
-                                for hitbox in stroke.hitboxes().into_iter() {
-                                    if eraser_bounds.intersects(&hitbox) {
-                                        trash_current_stroke = true;
+                            let stroke_bounds = stroke.bounds();
 
-                                        break;
+                            // First check if eraser even intersects stroke bounds, avoiding unnecessary work
+                            if let Some(polygon) = &sliding_polygon {
+                                if polygon.intersects(&crate::utils::p2d_aabb_to_geo_polygon(
+                                    stroke_bounds,
+                                )) {
+                                    for hitbox in stroke.hitboxes().into_iter() {
+                                        if polygon.intersects(
+                                            &crate::utils::p2d_aabb_to_geo_polygon(hitbox),
+                                        ) {
+                                            trash_current_stroke = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            } else {
+                                // First check if eraser even intersects stroke bounds, avoiding unnecessary work
+                                if eraser_bounds.intersects(&stroke_bounds) {
+                                    for hitbox in stroke.hitboxes().into_iter() {
+                                        if eraser_bounds.intersects(&hitbox) {
+                                            trash_current_stroke = true;
+
+                                            break;
+                                        }
                                     }
                                 }
                             }
@@ -136,6 +169,18 @@ impl StrokeStore {
         let mut widget_flags = WidgetFlags::default();
         let mut modified_keys = vec![];
 
+        let sliding_polygon = if let Some(previous_bounds) = previous_eraser_bounds {
+            Some(
+                geo::MultiPolygon::new(vec![
+                    crate::utils::p2d_aabb_to_geo_polygon(previous_bounds),
+                    crate::utils::p2d_aabb_to_geo_polygon(eraser_bounds),
+                ])
+                .convex_hull(),
+            )
+        } else {
+            None
+        };
+
         let new_strokes = self
             .stroke_keys_as_rendered_intersecting_bounds(viewport)
             .into_iter()
@@ -157,13 +202,43 @@ impl StrokeStore {
 
                 match stroke {
                     Stroke::BrushStroke(brushstroke) => {
-                        if eraser_bounds.intersects(&stroke_bounds) {
+                        let intersection_test = if let Some(polygon) = &sliding_polygon {
+                            polygon
+                                .intersects(&crate::utils::p2d_aabb_to_geo_polygon(stroke_bounds))
+                        } else {
+                            eraser_bounds.intersects(&stroke_bounds)
+                        };
+
+                        if intersection_test {
                             let mut split = Vec::new();
 
-                            let mut hits = brushstroke
-                                .path
-                                .hittest(&eraser_bounds, brushstroke.style.stroke_width() * 0.5)
-                                .into_iter();
+                            let mut hits = if let Some(polygon) = &sliding_polygon {
+                                brushstroke
+                                    .path
+                                    .hitboxes_w_segs_indices()
+                                    .into_iter()
+                                    .filter_map(|(i, seg_hitboxes)| {
+                                        seg_hitboxes
+                                            .into_iter()
+                                            .any(|hitbox| {
+                                                polygon.intersects(
+                                                    &crate::utils::p2d_aabb_to_geo_polygon(
+                                                        hitbox.loosened(
+                                                            brushstroke.style.stroke_width() * 0.5,
+                                                        ),
+                                                    ),
+                                                )
+                                            })
+                                            .then_some(i?)
+                                    })
+                                    .collect::<Vec<usize>>()
+                                    .into_iter()
+                            } else {
+                                brushstroke
+                                    .path
+                                    .hittest(&eraser_bounds, brushstroke.style.stroke_width() * 0.5)
+                                    .into_iter()
+                            };
 
                             if let Some(first_hit) = hits.next() {
                                 let mut prev = first_hit;


### PR DESCRIPTION
Fixes #1247

For now I take the convex hull of the polygon containing both current and previous eraser bounds (we probably can do one helper function for this or compute a closed form hull for this case, if speed is a concern) and use it to do intersection tests with `geo` (or use the previous code for the first down eraser event)

With another fix related to #730 to keep the visual appearance of splitted textured strokes (nothing on the performance side though)