### PR TITLE
feat: make focus mode toggleable by a pen button

### DIFF
--- a/crates/rnote-engine/src/pens/penholder.rs
+++ b/crates/rnote-engine/src/pens/penholder.rs
@@ -267,6 +267,9 @@ impl PenHolder {
                     }
                     ShortcutMode::Disabled => {}
                 },
+                ShortcutAction::ToggleFocusMode => {
+                    widget_flags.toggle_focus_mode = true;
+                }
             }
 
             propagate = EventPropagation::Stop;

--- a/crates/rnote-engine/src/pens/shortcuts.rs
+++ b/crates/rnote-engine/src/pens/shortcuts.rs
@@ -49,6 +49,9 @@ pub enum ShortcutAction {
         #[serde(rename = "mode")]
         mode: ShortcutMode,
     },
+    /// Toggle the focus mode of the appwindow.
+    #[serde(rename = "toggle_focus_mode")]
+    ToggleFocusMode,
 }
 
 /// The registered shortcut actions for the given shortcut keys.

--- a/crates/rnote-engine/src/widgetflags.rs
+++ b/crates/rnote-engine/src/widgetflags.rs
@@ -18,6 +18,8 @@ pub struct WidgetFlags {
     pub zoomed: bool,
     /// Deselect the elements of the global color picker.
     pub deselect_color_setters: bool,
+    /// Toggle the focus mode in the UI.
+    pub toggle_focus_mode: bool,
     /// Is Some when undo button visibility should be changed. Is None if should not be changed.
     pub hide_undo: Option<bool>,
     /// Is Some when redo button visibility should be changed. Is None if should not be changed.
@@ -39,6 +41,7 @@ impl Default for WidgetFlags {
             zoomed_temporarily: false,
             zoomed: false,
             deselect_color_setters: false,
+            toggle_focus_mode: false,
             hide_undo: None,
             hide_redo: None,
             enable_text_preprocessing: None,
@@ -65,6 +68,7 @@ impl std::ops::BitOrAssign for WidgetFlags {
         self.zoomed_temporarily |= rhs.zoomed_temporarily;
         self.zoomed |= rhs.zoomed;
         self.deselect_color_setters |= rhs.deselect_color_setters;
+        self.toggle_focus_mode |= rhs.toggle_focus_mode;
         if rhs.hide_undo.is_some() {
             self.hide_undo = rhs.hide_undo
         }

--- a/crates/rnote-ui/src/appwindow/mod.rs
+++ b/crates/rnote-ui/src/appwindow/mod.rs
@@ -318,6 +318,9 @@ impl RnAppWindow {
         if widget_flags.deselect_color_setters {
             self.overlays().colorpicker().deselect_setters();
         }
+        if widget_flags.toggle_focus_mode {
+            self.set_focus_mode(!self.focus_mode());
+        }
         if let Some(hide_undo) = widget_flags.hide_undo {
             self.overlays()
                 .penpicker()

--- a/crates/rnote-ui/src/settingspanel/penshortcutmodels.rs
+++ b/crates/rnote-ui/src/settingspanel/penshortcutmodels.rs
@@ -14,9 +14,9 @@ use std::str::FromStr;
 pub(crate) const FOCUS_MODE_ENTRY: &str = "focus_mode";
 
 #[derive(Debug, Clone)]
-pub(crate) struct ChangePenStyleListModel(StringList);
+pub(crate) struct PenShortcutActionListModel(StringList);
 
-impl Default for ChangePenStyleListModel {
+impl Default for PenShortcutActionListModel {
     fn default() -> Self {
         Self(StringList::new(&[
             &PenStyle::Brush.to_string(),
@@ -30,7 +30,7 @@ impl Default for ChangePenStyleListModel {
     }
 }
 
-impl Deref for ChangePenStyleListModel {
+impl Deref for PenShortcutActionListModel {
     type Target = StringList;
 
     fn deref(&self) -> &Self::Target {
@@ -38,16 +38,16 @@ impl Deref for ChangePenStyleListModel {
     }
 }
 
-impl DerefMut for ChangePenStyleListModel {
+impl DerefMut for PenShortcutActionListModel {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ChangePenStyleListFactory(SignalListItemFactory);
+pub(crate) struct PenShortcutActionListFactory(SignalListItemFactory);
 
-impl Default for ChangePenStyleListFactory {
+impl Default for PenShortcutActionListFactory {
     fn default() -> Self {
         let factory = SignalListItemFactory::new();
         factory.connect_setup(move |_factory, list_item| {
@@ -112,7 +112,7 @@ impl Default for ChangePenStyleListFactory {
     }
 }
 
-impl Deref for ChangePenStyleListFactory {
+impl Deref for PenShortcutActionListFactory {
     type Target = SignalListItemFactory;
 
     fn deref(&self) -> &Self::Target {
@@ -120,16 +120,16 @@ impl Deref for ChangePenStyleListFactory {
     }
 }
 
-impl DerefMut for ChangePenStyleListFactory {
+impl DerefMut for PenShortcutActionListFactory {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ChangePenStyleIconFactory(SignalListItemFactory);
+pub(crate) struct PenShortcutActionIconFactory(SignalListItemFactory);
 
-impl Default for ChangePenStyleIconFactory {
+impl Default for PenShortcutActionIconFactory {
     fn default() -> Self {
         let factory = SignalListItemFactory::new();
         factory.connect_setup(move |_factory, list_item| {
@@ -159,7 +159,7 @@ impl Default for ChangePenStyleIconFactory {
     }
 }
 
-impl Deref for ChangePenStyleIconFactory {
+impl Deref for PenShortcutActionIconFactory {
     type Target = SignalListItemFactory;
 
     fn deref(&self) -> &Self::Target {
@@ -167,7 +167,7 @@ impl Deref for ChangePenStyleIconFactory {
     }
 }
 
-impl DerefMut for ChangePenStyleIconFactory {
+impl DerefMut for PenShortcutActionIconFactory {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }

--- a/crates/rnote-ui/src/settingspanel/penshortcutmodels.rs
+++ b/crates/rnote-ui/src/settingspanel/penshortcutmodels.rs
@@ -9,6 +9,10 @@ use rnote_engine::pens::PenStyle;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
+/// Marker string for the extra "focus mode" entry in the pen shortcut picker.
+/// Chosen to not collide with any `PenStyle` string representation.
+pub(crate) const FOCUS_MODE_ENTRY: &str = "focus_mode";
+
 #[derive(Debug, Clone)]
 pub(crate) struct ChangePenStyleListModel(StringList);
 
@@ -21,6 +25,7 @@ impl Default for ChangePenStyleListModel {
             &PenStyle::Eraser.to_string(),
             &PenStyle::Selector.to_string(),
             &PenStyle::Tools.to_string(),
+            FOCUS_MODE_ENTRY,
         ]))
     }
 }
@@ -63,28 +68,32 @@ impl Default for ChangePenStyleListFactory {
         });
         factory.connect_bind(move |_factory, list_item| {
             let list_item = list_item.downcast_ref::<ListItem>().unwrap();
-            let pen_style = PenStyle::from_str(
-                &list_item
-                    .item()
-                    .unwrap()
-                    .downcast::<StringObject>()
-                    .unwrap()
-                    .string(),
-            )
-            .unwrap();
+            let item_string = list_item
+                .item()
+                .unwrap()
+                .downcast::<StringObject>()
+                .unwrap()
+                .string();
             let item_box = list_item.child().unwrap().downcast::<gtk4::Box>().unwrap();
+
+            let (label, icon_name) = if item_string == FOCUS_MODE_ENTRY {
+                (gettext("Focus mode"), String::from("focus-mode-symbolic"))
+            } else {
+                let pen_style = PenStyle::from_str(&item_string).unwrap();
+                let label = match pen_style {
+                    PenStyle::Brush => gettext("Brush"),
+                    PenStyle::Shaper => gettext("Shaper"),
+                    PenStyle::Typewriter => gettext("Typewriter"),
+                    PenStyle::Eraser => gettext("Eraser"),
+                    PenStyle::Selector => gettext("Selector"),
+                    PenStyle::Tools => gettext("Tools"),
+                };
+                (label, pen_style.icon_name())
+            };
 
             let mut child = item_box.first_child();
             while let Some(ref next_child) = child {
                 if next_child.type_() == Label::static_type() {
-                    let label = match pen_style {
-                        PenStyle::Brush => gettext("Brush"),
-                        PenStyle::Shaper => gettext("Shaper"),
-                        PenStyle::Typewriter => gettext("Typewriter"),
-                        PenStyle::Eraser => gettext("Eraser"),
-                        PenStyle::Selector => gettext("Selector"),
-                        PenStyle::Tools => gettext("Tools"),
-                    };
                     next_child
                         .downcast_ref::<Label>()
                         .unwrap()
@@ -93,7 +102,7 @@ impl Default for ChangePenStyleListFactory {
                     next_child
                         .downcast_ref::<Image>()
                         .unwrap()
-                        .set_icon_name(Some(pen_style.icon_name().as_str()));
+                        .set_icon_name(Some(icon_name.as_str()));
                 }
 
                 child = next_child.next_sibling();
@@ -131,20 +140,20 @@ impl Default for ChangePenStyleIconFactory {
         });
         factory.connect_bind(move |_factory, list_item| {
             let list_item = list_item.downcast_ref::<ListItem>().unwrap();
-            let pen_style = PenStyle::from_str(
-                &list_item
-                    .item()
-                    .unwrap()
-                    .downcast::<StringObject>()
-                    .unwrap()
-                    .string(),
-            )
-            .unwrap();
-            let image = list_item.child().unwrap().downcast::<Image>().unwrap();
-            image
-                .downcast_ref::<Image>()
+            let item_string = list_item
+                .item()
                 .unwrap()
-                .set_icon_name(Some(pen_style.icon_name().as_str()));
+                .downcast::<StringObject>()
+                .unwrap()
+                .string();
+            let image = list_item.child().unwrap().downcast::<Image>().unwrap();
+
+            let icon_name = if item_string == FOCUS_MODE_ENTRY {
+                String::from("focus-mode-symbolic")
+            } else {
+                PenStyle::from_str(&item_string).unwrap().icon_name()
+            };
+            image.set_icon_name(Some(icon_name.as_str()));
         });
         Self(factory)
     }

--- a/crates/rnote-ui/src/settingspanel/penshortcutmodels.rs
+++ b/crates/rnote-ui/src/settingspanel/penshortcutmodels.rs
@@ -12,6 +12,7 @@ use std::str::FromStr;
 /// Marker string for the extra "focus mode" entry in the pen shortcut picker.
 /// Chosen to not collide with any `PenStyle` string representation.
 pub(crate) const FOCUS_MODE_ENTRY: &str = "focus_mode";
+pub(crate) const FOCUS_MODE_ICON_NAME: &str = "focus-mode-symbolic";
 
 #[derive(Debug, Clone)]
 pub(crate) struct PenShortcutActionListModel(StringList);
@@ -77,7 +78,7 @@ impl Default for PenShortcutActionListFactory {
             let item_box = list_item.child().unwrap().downcast::<gtk4::Box>().unwrap();
 
             let (label, icon_name) = if item_string == FOCUS_MODE_ENTRY {
-                (gettext("Focus mode"), String::from("focus-mode-symbolic"))
+                (gettext("Focus mode"), String::from(FOCUS_MODE_ICON_NAME))
             } else {
                 let pen_style = PenStyle::from_str(&item_string).unwrap();
                 let label = match pen_style {
@@ -149,7 +150,7 @@ impl Default for PenShortcutActionIconFactory {
             let image = list_item.child().unwrap().downcast::<Image>().unwrap();
 
             let icon_name = if item_string == FOCUS_MODE_ENTRY {
-                String::from("focus-mode-symbolic")
+                String::from(FOCUS_MODE_ICON_NAME)
             } else {
                 PenStyle::from_str(&item_string).unwrap().icon_name()
             };

--- a/crates/rnote-ui/src/settingspanel/penshortcutrow.rs
+++ b/crates/rnote-ui/src/settingspanel/penshortcutrow.rs
@@ -77,7 +77,7 @@ mod imp {
                     row.imp().mode_dropdown.set_visible(true);
                     let mode = match previous_action {
                         ShortcutAction::ChangePenStyle { mode, .. } => mode,
-                        _ => ShortcutMode::Temporary,
+                        ShortcutAction::ToggleFocusMode => ShortcutMode::Temporary,
                     };
                     *row.imp().action.borrow_mut() = ShortcutAction::ChangePenStyle {
                         style: row.selected_pen_style().unwrap(),
@@ -96,7 +96,7 @@ mod imp {
                         ShortcutAction::ChangePenStyle { mode, .. } => {
                             *mode = penshortcutrow.shortcut_mode();
                         }
-                        _ => {}
+                        ShortcutAction::ToggleFocusMode => {}
                     }
                     penshortcutrow.emit_by_name::<()>("action-changed", &[]);
                 }

--- a/crates/rnote-ui/src/settingspanel/penshortcutrow.rs
+++ b/crates/rnote-ui/src/settingspanel/penshortcutrow.rs
@@ -1,6 +1,6 @@
 // Imports
 use super::penshortcutmodels::{
-    ChangePenStyleIconFactory, ChangePenStyleListFactory, ChangePenStyleListModel,
+    ChangePenStyleIconFactory, ChangePenStyleListFactory, ChangePenStyleListModel, FOCUS_MODE_ENTRY,
 };
 use adw::{prelude::*, subclass::prelude::*};
 use gtk4::{CompositeTemplate, DropDown, ListBoxRow, Widget, glib, glib::clone, glib::subclass::*};
@@ -67,13 +67,23 @@ mod imp {
             obj.set_factory(Some(&*icon_factory));
 
             obj.connect_selected_item_notify(move |row| {
-                let new_pen_style = row.pen_style();
+                let previous_action = row.action();
 
-                match &mut *row.imp().action.borrow_mut() {
-                    ShortcutAction::ChangePenStyle { style, .. } => {
-                        *style = new_pen_style;
-                    }
+                if row.selected_is_focus_mode() {
+                    row.imp().mode_dropdown.set_visible(false);
+                    *row.imp().action.borrow_mut() = ShortcutAction::ToggleFocusMode;
+                } else {
+                    row.imp().mode_dropdown.set_visible(true);
+                    let mode = match previous_action {
+                        ShortcutAction::ChangePenStyle { mode, .. } => mode,
+                        _ => ShortcutMode::Temporary,
+                    };
+                    *row.imp().action.borrow_mut() = ShortcutAction::ChangePenStyle {
+                        style: row.selected_pen_style().unwrap(),
+                        mode,
+                    };
                 }
+
                 row.emit_by_name::<()>("action-changed", &[]);
             });
 
@@ -85,6 +95,7 @@ mod imp {
                         ShortcutAction::ChangePenStyle { mode, .. } => {
                             *mode = penshortcutrow.shortcut_mode();
                         }
+                        _ => {}
                     }
                     penshortcutrow.emit_by_name::<()>("action-changed", &[]);
                 }
@@ -150,8 +161,20 @@ impl RnPenShortcutRow {
         self.emit_by_name::<()>("action-changed", &[]);
     }
 
-    pub(crate) fn pen_style(&self) -> PenStyle {
-        PenStyle::try_from(self.selected()).unwrap()
+    pub(crate) fn selected_is_focus_mode(&self) -> bool {
+        self.imp()
+            .changepenstyle_model
+            .string(self.selected())
+            .is_some_and(|string| string == FOCUS_MODE_ENTRY)
+    }
+
+    fn focus_mode_index(&self) -> Option<u32> {
+        let index = self.imp().changepenstyle_model.find(FOCUS_MODE_ENTRY);
+        (index != u32::MAX).then_some(index)
+    }
+
+    pub(crate) fn selected_pen_style(&self) -> Option<PenStyle> {
+        PenStyle::try_from(self.selected()).ok()
     }
 
     pub(crate) fn set_pen_style(&self, style: PenStyle) {
@@ -173,6 +196,13 @@ impl RnPenShortcutRow {
             ShortcutAction::ChangePenStyle { style, mode } => {
                 self.set_pen_style(style);
                 self.set_shortcut_mode(mode);
+                self.imp().mode_dropdown.set_visible(true);
+            }
+            ShortcutAction::ToggleFocusMode => {
+                if let Some(index) = self.focus_mode_index() {
+                    self.set_selected(index);
+                }
+                self.imp().mode_dropdown.set_visible(false);
             }
         }
     }

--- a/crates/rnote-ui/src/settingspanel/penshortcutrow.rs
+++ b/crates/rnote-ui/src/settingspanel/penshortcutrow.rs
@@ -11,6 +11,7 @@ use rnote_engine::pens::PenStyle;
 use rnote_engine::pens::shortcuts::ShortcutAction;
 use rnote_engine::pens::shortcuts::ShortcutMode;
 use std::cell::RefCell;
+use std::str::FromStr;
 
 mod imp {
     use super::*;
@@ -175,11 +176,21 @@ impl RnPenShortcutRow {
     }
 
     pub(crate) fn selected_pen_style(&self) -> Option<PenStyle> {
-        PenStyle::try_from(self.selected()).ok()
+        self.imp()
+            .shortcut_actions_model
+            .string(self.selected())
+            .and_then(|string| PenStyle::from_str(&string).ok())
+    }
+
+    fn style_index(&self, style: PenStyle) -> Option<u32> {
+        let index = self.imp().shortcut_actions_model.find(&style.to_string());
+        (index != u32::MAX).then_some(index)
     }
 
     pub(crate) fn set_pen_style(&self, style: PenStyle) {
-        self.set_selected(style.to_u32().unwrap())
+        if let Some(index) = self.style_index(style) {
+            self.set_selected(index);
+        }
     }
 
     pub(crate) fn shortcut_mode(&self) -> ShortcutMode {

--- a/crates/rnote-ui/src/settingspanel/penshortcutrow.rs
+++ b/crates/rnote-ui/src/settingspanel/penshortcutrow.rs
@@ -1,6 +1,7 @@
 // Imports
 use super::penshortcutmodels::{
-    ChangePenStyleIconFactory, ChangePenStyleListFactory, ChangePenStyleListModel, FOCUS_MODE_ENTRY,
+    FOCUS_MODE_ENTRY, PenShortcutActionIconFactory, PenShortcutActionListFactory,
+    PenShortcutActionListModel,
 };
 use adw::{prelude::*, subclass::prelude::*};
 use gtk4::{CompositeTemplate, DropDown, ListBoxRow, Widget, glib, glib::clone, glib::subclass::*};
@@ -18,7 +19,7 @@ mod imp {
     #[template(resource = "/com/github/flxzt/rnote/ui/penshortcutrow.ui")]
     pub(crate) struct RnPenShortcutRow {
         pub(crate) action: RefCell<ShortcutAction>,
-        pub(crate) changepenstyle_model: ChangePenStyleListModel,
+        pub(crate) shortcut_actions_model: PenShortcutActionListModel,
 
         #[template_child]
         pub(crate) mode_dropdown: TemplateChild<DropDown>,
@@ -31,7 +32,7 @@ mod imp {
                     style: PenStyle::Eraser,
                     mode: ShortcutMode::Temporary,
                 }),
-                changepenstyle_model: ChangePenStyleListModel::default(),
+                shortcut_actions_model: PenShortcutActionListModel::default(),
 
                 mode_dropdown: TemplateChild::default(),
             }
@@ -59,10 +60,10 @@ mod imp {
             self.parent_constructed();
             let obj = self.obj();
 
-            let list_factory = ChangePenStyleListFactory::default();
-            let icon_factory = ChangePenStyleIconFactory::default();
+            let list_factory = PenShortcutActionListFactory::default();
+            let icon_factory = PenShortcutActionIconFactory::default();
 
-            obj.set_model(Some(&*self.changepenstyle_model));
+            obj.set_model(Some(&*self.shortcut_actions_model));
             obj.set_list_factory(Some(&*list_factory));
             obj.set_factory(Some(&*icon_factory));
 
@@ -163,13 +164,13 @@ impl RnPenShortcutRow {
 
     pub(crate) fn selected_is_focus_mode(&self) -> bool {
         self.imp()
-            .changepenstyle_model
+            .shortcut_actions_model
             .string(self.selected())
             .is_some_and(|string| string == FOCUS_MODE_ENTRY)
     }
 
     fn focus_mode_index(&self) -> Option<u32> {
-        let index = self.imp().changepenstyle_model.find(FOCUS_MODE_ENTRY);
+        let index = self.imp().shortcut_actions_model.find(FOCUS_MODE_ENTRY);
         (index != u32::MAX).then_some(index)
     }
 


### PR DESCRIPTION
Closes #1785

Adds a new `ShortcutAction` so any pen shortcut key (stylus buttons, drawing pad buttons, touch two-finger long press,keyboard Ctrl+Space, …) can be bound to toggle the app's focus mode from the existing pen shortcut settings, without changing any default shortcuts.

**Changes**

Engine (`rnote-engine`)

* Added a new `ShortcutAction` to toggle **Focus mode**.
* Added a flag to let the UI know when Focus mode needs to be changed.

UI (`rnote-ui`)

* Added **“Focus mode”** to the list of available pen shortcut actions, using the existing icon.
* Renamed a few internal components to reflect that the list now contains both pen actions and Focus mode.

**Testing**

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings` (no warnings)
- `cargo test --workspace`
- `meson compile ui-cargo-clippy -C _mesonbuild`
- `meson compile cli-cargo-clippy -C _mesonbuild`
- `meson test -C _mesonbuild` (3/3 OK)
- Manual: bound a pen shortcut to "Focus mode" and verified that focus mode
  toggles and the shortcut remains configured after reopening the settings.

https://github.com/user-attachments/assets/ee4f0662-3495-4d5b-974d-37c9b50d7b3c


**Disclosure**
This implementation was created with the assistance of an LLM.