### PR TITLE
fix: use the native Command modifier for shortcuts on MacOS

### DIFF
--- a/crates/rnote-compose/src/penevent.rs
+++ b/crates/rnote-compose/src/penevent.rs
@@ -85,6 +85,10 @@ pub enum KeyboardKey {
     CtrlLeft,
     /// Ctrl right.
     CtrlRight,
+    /// Meta left. This is the Command key on MacOS.
+    MetaLeft,
+    /// Meta right. This is the Command key on MacOS.
+    MetaRight,
     /// Home.
     Home,
     /// End.

--- a/crates/rnote-engine/src/pens/typewriter/penevents.rs
+++ b/crates/rnote-engine/src/pens/typewriter/penevents.rs
@@ -1057,6 +1057,8 @@ impl Typewriter {
                                 }
                                 KeyboardKey::CtrlLeft
                                 | KeyboardKey::CtrlRight
+                                | KeyboardKey::MetaLeft
+                                | KeyboardKey::MetaRight
                                 | KeyboardKey::ShiftLeft
                                 | KeyboardKey::ShiftRight => EventResult {
                                     handled: false,

--- a/crates/rnote-ui/data/ui/shortcuts.ui
+++ b/crates/rnote-ui/data/ui/shortcuts.ui
@@ -12,37 +12,37 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Show Keyboard Shortcuts</property>
-                <property name="accelerator">&lt;ctrl&gt;question</property>
+                <property name="accelerator">&lt;Primary&gt;question</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">New Window</property>
-                <property name="accelerator">&lt;ctrl&gt;n</property>
+                <property name="accelerator">&lt;Primary&gt;n</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">New Tab</property>
-                <property name="accelerator">&lt;ctrl&gt;t</property>
+                <property name="accelerator">&lt;Primary&gt;t</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Close the Active Tab</property>
-                <property name="accelerator">&lt;ctrl&gt;w</property>
+                <property name="accelerator">&lt;Primary&gt;w</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Quit the Application</property>
-                <property name="accelerator">&lt;ctrl&gt;q</property>
+                <property name="accelerator">&lt;Primary&gt;q</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Toggle Tabs Overview</property>
-                <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;o</property>
+                <property name="accelerator">&lt;Primary&gt;&lt;shift&gt;o</property>
               </object>
             </child>
             <child>
@@ -71,43 +71,43 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Switch to the 'Brush'</property>
-                <property name="accelerator">&lt;ctrl&gt;1</property>
+                <property name="accelerator">&lt;Primary&gt;1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Switch to the 'Shaper'</property>
-                <property name="accelerator">&lt;ctrl&gt;2</property>
+                <property name="accelerator">&lt;Primary&gt;2</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Switch to the 'Typewriter'</property>
-                <property name="accelerator">&lt;ctrl&gt;3</property>
+                <property name="accelerator">&lt;Primary&gt;3</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Switch to the 'Eraser'</property>
-                <property name="accelerator">&lt;ctrl&gt;4</property>
+                <property name="accelerator">&lt;Primary&gt;4</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Switch to the 'Selector'</property>
-                <property name="accelerator">&lt;ctrl&gt;5</property>
+                <property name="accelerator">&lt;Primary&gt;5</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Switch to the 'Tools'</property>
-                <property name="accelerator">&lt;ctrl&gt;6</property>
+                <property name="accelerator">&lt;Primary&gt;6</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Select Color</property>
-                <property name="accelerator">&lt;ctrl&gt;KP_1 &lt;ctrl&gt;KP_9</property>
+                <property name="accelerator">&lt;Primary&gt;KP_1 &lt;Primary&gt;KP_9</property>
               </object>
             </child>
           </object>
@@ -130,7 +130,7 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Zoom in</property>
-                <property name="accelerator">&lt;ctrl&gt;plus</property>
+                <property name="accelerator">&lt;Primary&gt;plus</property>
               </object>
             </child>
             <child>
@@ -148,7 +148,7 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Zoom out</property>
-                <property name="accelerator">&lt;ctrl&gt;minus</property>
+                <property name="accelerator">&lt;Primary&gt;minus</property>
               </object>
             </child>
             <child>
@@ -171,73 +171,73 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Open Document</property>
-                <property name="accelerator">&lt;ctrl&gt;o</property>
+                <property name="accelerator">&lt;Primary&gt;o</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Save Document</property>
-                <property name="accelerator">&lt;ctrl&gt;s</property>
+                <property name="accelerator">&lt;Primary&gt;s</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Save Document As</property>
-                <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;s</property>
+                <property name="accelerator">&lt;Primary&gt;&lt;shift&gt;s</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Snap Positions</property>
-                <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;p</property>
+                <property name="accelerator">&lt;Primary&gt;&lt;shift&gt;p</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Clear Document</property>
-                <property name="accelerator">&lt;ctrl&gt;l</property>
+                <property name="accelerator">&lt;Primary&gt;l</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Add Page (When in Fixed-Size Layout)</property>
-                <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;a</property>
+                <property name="accelerator">&lt;Primary&gt;&lt;shift&gt;a</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Remove Last Page (When in Fixed-Size Layout)</property>
-                <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;r</property>
+                <property name="accelerator">&lt;Primary&gt;&lt;shift&gt;r</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Print Document</property>
-                <property name="accelerator">&lt;ctrl&gt;p</property>
+                <property name="accelerator">&lt;Primary&gt;p</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Import File</property>
-                <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;i</property>
+                <property name="accelerator">&lt;Primary&gt;&lt;shift&gt;i</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Bold</property>
-                <property name="accelerator">&lt;ctrl&gt;b</property>
+                <property name="accelerator">&lt;Primary&gt;b</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Italic</property>
-                <property name="accelerator">&lt;ctrl&gt;i</property>
+                <property name="accelerator">&lt;Primary&gt;i</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Underline</property>
-                <property name="accelerator">&lt;ctrl&gt;u</property>
+                <property name="accelerator">&lt;Primary&gt;u</property>
               </object>
             </child>
             <child>
@@ -246,19 +246,19 @@
                 <child>
                   <object class="GtkShortcutsShortcut">
                     <property name="title" translatable="yes">Copy to Clipboard</property>
-                    <property name="accelerator">&lt;ctrl&gt;c</property>
+                    <property name="accelerator">&lt;Primary&gt;c</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkShortcutsShortcut">
                     <property name="title" translatable="yes">Cut to Clipboard</property>
-                    <property name="accelerator">&lt;ctrl&gt;x</property>
+                    <property name="accelerator">&lt;Primary&gt;x</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkShortcutsShortcut">
                     <property name="title" translatable="yes">Paste Clipboard</property>
-                    <property name="accelerator">&lt;ctrl&gt;v</property>
+                    <property name="accelerator">&lt;Primary&gt;v</property>
                   </object>
                 </child>
                 <child>
@@ -270,13 +270,13 @@
                 <child>
                   <object class="GtkShortcutsShortcut">
                     <property name="title" translatable="yes">Undo</property>
-                    <property name="accelerator">&lt;ctrl&gt;z</property>
+                    <property name="accelerator">&lt;Primary&gt;z</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkShortcutsShortcut">
                     <property name="title" translatable="yes">Redo</property>
-                    <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;z</property>
+                    <property name="accelerator">&lt;Primary&gt;&lt;shift&gt;z</property>
                   </object>
                 </child>
               </object>

--- a/crates/rnote-ui/src/app/appactions.rs
+++ b/crates/rnote-ui/src/app/appactions.rs
@@ -65,7 +65,9 @@ impl RnApp {
 
     // Accelerators / Keyboard Shortcuts
     pub(crate) fn setup_action_accels(&self) {
-        self.set_accels_for_action("app.quit", &["<Ctrl>q"]);
-        self.set_accels_for_action("app.new-window", &["<Ctrl>n"]);
+        // `<Primary>` is substituted with the platform's primary modifier,
+        // see [`crate::utils::set_accels_for_action()`].
+        crate::utils::set_accels_for_action(self, "app.quit", &["<Primary>q"]);
+        crate::utils::set_accels_for_action(self, "app.new-window", &["<Primary>n"]);
     }
 }

--- a/crates/rnote-ui/src/appwindow/actions.rs
+++ b/crates/rnote-ui/src/appwindow/actions.rs
@@ -1179,53 +1179,61 @@ impl RnAppWindow {
 
     pub(crate) fn setup_action_accels(&self) {
         let app = self.app();
+        // `<Primary>` is substituted with the platform's primary modifier,
+        // see [`crate::utils::set_accels_for_action()`].
+        let set_accels = |detailed_action_name: &str, accels: &[&str]| {
+            crate::utils::set_accels_for_action(&app, detailed_action_name, accels)
+        };
 
-        app.set_accels_for_action("win.active-tab-close", &["<Ctrl>w"]);
-        app.set_accels_for_action("win.fullscreen", &["F11"]);
-        app.set_accels_for_action("win.keyboard-shortcuts", &["<Ctrl>question"]);
-        app.set_accels_for_action("win.toggle-overview", &["<Ctrl><Shift>o"]);
-        app.set_accels_for_action("win.open-canvasmenu", &["F9"]);
-        app.set_accels_for_action("win.open-appmenu", &["F10"]);
-        app.set_accels_for_action("win.open-doc", &["<Ctrl>o"]);
-        app.set_accels_for_action("win.save-doc", &["<Ctrl>s"]);
-        app.set_accels_for_action("win.save-doc-as", &["<Ctrl><Shift>s"]);
-        app.set_accels_for_action("win.new-tab", &["<Ctrl>t"]);
-        app.set_accels_for_action("win.snap-positions", &["<Ctrl><Shift>p"]);
-        app.set_accels_for_action("win.clear-doc", &["<Ctrl>l"]);
-        app.set_accels_for_action("win.print-doc", &["<Ctrl>p"]);
-        app.set_accels_for_action("win.add-page-to-doc", &["<Ctrl><Shift>a"]);
-        app.set_accels_for_action("win.remove-page-from-doc", &["<Ctrl><Shift>r"]);
-        app.set_accels_for_action(
+        set_accels("win.active-tab-close", &["<Primary>w"]);
+        set_accels("win.fullscreen", &["F11"]);
+        set_accels("win.keyboard-shortcuts", &["<Primary>question"]);
+        set_accels("win.toggle-overview", &["<Primary><Shift>o"]);
+        set_accels("win.open-canvasmenu", &["F9"]);
+        set_accels("win.open-appmenu", &["F10"]);
+        set_accels("win.open-doc", &["<Primary>o"]);
+        set_accels("win.save-doc", &["<Primary>s"]);
+        set_accels("win.save-doc-as", &["<Primary><Shift>s"]);
+        set_accels("win.new-tab", &["<Primary>t"]);
+        set_accels("win.snap-positions", &["<Primary><Shift>p"]);
+        set_accels("win.clear-doc", &["<Primary>l"]);
+        set_accels("win.print-doc", &["<Primary>p"]);
+        set_accels("win.add-page-to-doc", &["<Primary><Shift>a"]);
+        set_accels("win.remove-page-from-doc", &["<Primary><Shift>r"]);
+        set_accels(
             "win.zoom-in",
-            &["<Ctrl>plus", "<Ctrl>equal", "<Ctrl>KP_Add"],
+            &["<Primary>plus", "<Primary>equal", "<Primary>KP_Add"],
         );
-        app.set_accels_for_action("win.zoom-reset", &["<Ctrl>0", "<Ctrl>KP_0"]);
-        app.set_accels_for_action("win.zoom-out", &["<Ctrl>minus", "<Ctrl>KP_Subtract"]);
-        app.set_accels_for_action("win.import-file", &["<Ctrl><Shift>i"]);
-        app.set_accels_for_action("win.undo", &["<Ctrl>z"]);
-        app.set_accels_for_action("win.redo", &["<Ctrl><Shift>z"]);
-        app.set_accels_for_action("win.clipboard-copy", &["<Ctrl>c"]);
-        app.set_accels_for_action("win.clipboard-cut", &["<Ctrl>x"]);
-        app.set_accels_for_action("win.clipboard-paste", &["<Ctrl>v"]);
-        app.set_accels_for_action("win.text-bold", &["<Ctrl>b"]);
-        app.set_accels_for_action("win.text-italic", &["<Ctrl>i"]);
-        app.set_accels_for_action("win.text-underline", &["<Ctrl>u"]);
-        app.set_accels_for_action("win.pen-style::brush", &["<Ctrl>1", "<Ctrl>KP_1"]);
-        app.set_accels_for_action("win.pen-style::shaper", &["<Ctrl>2", "<Ctrl>KP_2"]);
-        app.set_accels_for_action("win.pen-style::typewriter", &["<Ctrl>3", "<Ctrl>KP_3"]);
-        app.set_accels_for_action("win.pen-style::eraser", &["<Ctrl>4", "<Ctrl>KP_4"]);
-        app.set_accels_for_action("win.pen-style::selector", &["<Ctrl>5", "<Ctrl>KP_5"]);
-        app.set_accels_for_action("win.pen-style::tools", &["<Ctrl>6", "<Ctrl>KP_6"]);
+        set_accels("win.zoom-reset", &["<Primary>0", "<Primary>KP_0"]);
+        set_accels("win.zoom-out", &["<Primary>minus", "<Primary>KP_Subtract"]);
+        set_accels("win.import-file", &["<Primary><Shift>i"]);
+        set_accels("win.undo", &["<Primary>z"]);
+        set_accels("win.redo", &["<Primary><Shift>z"]);
+        set_accels("win.clipboard-copy", &["<Primary>c"]);
+        set_accels("win.clipboard-cut", &["<Primary>x"]);
+        set_accels("win.clipboard-paste", &["<Primary>v"]);
+        set_accels("win.text-bold", &["<Primary>b"]);
+        set_accels("win.text-italic", &["<Primary>i"]);
+        set_accels("win.text-underline", &["<Primary>u"]);
+        set_accels("win.pen-style::brush", &["<Primary>1", "<Primary>KP_1"]);
+        set_accels("win.pen-style::shaper", &["<Primary>2", "<Primary>KP_2"]);
+        set_accels(
+            "win.pen-style::typewriter",
+            &["<Primary>3", "<Primary>KP_3"],
+        );
+        set_accels("win.pen-style::eraser", &["<Primary>4", "<Primary>KP_4"]);
+        set_accels("win.pen-style::selector", &["<Primary>5", "<Primary>KP_5"]);
+        set_accels("win.pen-style::tools", &["<Primary>6", "<Primary>KP_6"]);
         (1..=9).for_each(|i| {
-            app.set_accels_for_action(
+            set_accels(
                 &format!("win.set-color-{i}"),
-                &[&format!("{i}"), &format!("<Ctrl>KP_{i}")],
+                &[&format!("{i}"), &format!("<Primary>KP_{i}")],
             )
         });
 
         // shortcuts for devel build
         if config::PROFILE.to_lowercase().as_str() == "devel" {
-            app.set_accels_for_action("win.visual-debug", &["<Ctrl><Shift>v"]);
+            set_accels("win.visual-debug", &["<Primary><Shift>v"]);
         }
     }
 

--- a/crates/rnote-ui/src/canvas/input.rs
+++ b/crates/rnote-ui/src/canvas/input.rs
@@ -502,6 +502,8 @@ pub(crate) fn retrieve_keyboard_key(gdk_key: gdk::Key) -> KeyboardKey {
             gdk::Key::Shift_R => KeyboardKey::ShiftRight,
             gdk::Key::Control_L => KeyboardKey::CtrlLeft,
             gdk::Key::Control_R => KeyboardKey::CtrlRight,
+            gdk::Key::Meta_L => KeyboardKey::MetaLeft,
+            gdk::Key::Meta_R => KeyboardKey::MetaRight,
             gdk::Key::Home => KeyboardKey::Home,
             gdk::Key::KP_Home => KeyboardKey::Home,
             gdk::Key::End => KeyboardKey::End,

--- a/crates/rnote-ui/src/dialogs/mod.rs
+++ b/crates/rnote-ui/src/dialogs/mod.rs
@@ -11,12 +11,12 @@ use crate::workspacebrowser::workspacesbar::RnWorkspaceRow;
 use crate::{RnIconPicker, globals};
 use adw::prelude::*;
 use gettextrs::{gettext, pgettext};
-#[allow(deprecated)]
-use gtk4::ShortcutsWindow;
 use gtk4::{
     Builder, Button, CheckButton, ColorDialogButton, FileDialog, Label, MenuButton, StringList,
     gio, glib, glib::clone,
 };
+#[allow(deprecated)]
+use gtk4::{ShortcutsShortcut, ShortcutsWindow};
 use tracing::{debug, error, warn};
 
 // About Dialog
@@ -54,6 +54,25 @@ pub(crate) fn dialog_keyboard_shortcuts(appwindow: &RnAppWindow) {
         Builder::from_resource((String::from(config::APP_IDPATH) + "ui/shortcuts.ui").as_str());
     #[allow(deprecated)]
     let dialog: ShortcutsWindow = builder.object("shortcuts_window").unwrap();
+
+    // Accelerators that are registered as application accelerators are declared in the ui file
+    // with the `<Primary>` placeholder, which has to be substituted with the platform's
+    // primary modifier. Shortcuts that are handled in the engine through `ModifierKey::KeyboardCtrl`
+    // declare `<Ctrl>` directly and are left untouched.
+    for object in builder.objects() {
+        #[allow(deprecated)]
+        let Ok(shortcut) = object.downcast::<ShortcutsShortcut>() else {
+            continue;
+        };
+        let accel = shortcut.property::<String>("accelerator");
+        if accel.contains(crate::utils::PRIMARY_MODIFIER_PLACEHOLDER) {
+            shortcut.set_property(
+                "accelerator",
+                crate::utils::substitute_primary_modifier(&accel),
+            );
+        }
+    }
+
     dialog.set_transient_for(Some(appwindow));
     dialog.present();
 }

--- a/crates/rnote-ui/src/utils.rs
+++ b/crates/rnote-ui/src/utils.rs
@@ -10,6 +10,43 @@ use std::cell::Ref;
 use std::path::{Path, PathBuf};
 use std::slice::Iter;
 
+/// Placeholder for the platform's primary modifier in accelerator strings.
+pub(crate) const PRIMARY_MODIFIER_PLACEHOLDER: &str = "<Primary>";
+
+/// The platform's primary modifier for application shortcuts,
+/// in the format expected by [`gtk4::accelerator_parse()`].
+///
+/// Gtk4 has no platform-dependent primary modifier - `<Primary>` is merely an alias for `<Ctrl>` -
+/// so it has to be substituted explicitly. On MacOS the native modifier for application
+/// shortcuts is the Command key, which Gdk reports as `<Meta>`.
+const PRIMARY_MODIFIER: &str = if cfg!(target_os = "macos") {
+    "<Meta>"
+} else {
+    "<Ctrl>"
+};
+
+/// Substitute [`PRIMARY_MODIFIER_PLACEHOLDER`] in an accelerator string
+/// with the platform's primary modifier.
+pub(crate) fn substitute_primary_modifier(accel: &str) -> String {
+    accel.replace(PRIMARY_MODIFIER_PLACEHOLDER, PRIMARY_MODIFIER)
+}
+
+/// Set the accelerators for the given action,
+/// substituting [`PRIMARY_MODIFIER_PLACEHOLDER`] with the platform's primary modifier.
+pub(crate) fn set_accels_for_action(
+    app: &impl IsA<gtk4::Application>,
+    detailed_action_name: &str,
+    accels: &[&str],
+) {
+    let accels = accels
+        .iter()
+        .map(|accel| substitute_primary_modifier(accel))
+        .collect::<Vec<String>>();
+    let accels = accels.iter().map(String::as_str).collect::<Vec<&str>>();
+    app.as_ref()
+        .set_accels_for_action(detailed_action_name, &accels);
+}
+
 /// The suffix delimiter when duplicating/renaming already existing files
 pub(crate) const FILE_DUP_SUFFIX_DELIM: &str = " - ";
 /// The suffix delimiter when duplicating/renaming already existing files for usage in a regular expression
@@ -264,4 +301,29 @@ pub(crate) fn path_walk_up_until_exists(path: impl AsRef<Path>) -> anyhow::Resul
             .ok_or_else(|| anyhow::anyhow!("Path {} has no parent", path.display()))?;
     }
     Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn substitute_primary_modifier_uses_platform_modifier() {
+        let expected = if cfg!(target_os = "macos") {
+            "<Meta><Shift>z"
+        } else {
+            "<Ctrl><Shift>z"
+        };
+        assert_eq!(substitute_primary_modifier("<Primary><Shift>z"), expected);
+    }
+
+    #[test]
+    fn substitute_primary_modifier_keeps_other_accels_intact() {
+        // accelerators without the placeholder must stay untouched on every platform
+        assert_eq!(substitute_primary_modifier("F11"), "F11");
+        assert_eq!(
+            substitute_primary_modifier("<Ctrl>ScrollUp"),
+            "<Ctrl>ScrollUp"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #663.

## Problem

On MacOS all application shortcuts are triggered with Control instead of the native
Command modifier, so Rnote does not behave like other Mac applications. This is also
inconsistent with what the app itself advertises: the MacOS menu bar shows the standard
Command accelerators (e.g. `⌘Z` for Undo), while the shortcut that actually works is
`Ctrl+Z`. As noted in the issue, this makes the shortcuts look simply broken until you
find out that Control is the modifier in use.

## Cause

Gtk4 has no platform-dependent primary accelerator modifier. `<Primary>` is merely an
alias for `<Ctrl>` (unlike in Gtk3, where it mapped to Command on MacOS), so
`setup_action_accels()` registered Control accelerators on every platform. On MacOS the
native modifier is Command, which Gdk reports as `<Meta>`.

## Fix

Accelerators are now declared with a `<Primary>` placeholder that is substituted with
`<Meta>` on MacOS and with `<Ctrl>` on all other platforms. The substitution happens in
one place in `crates/rnote-ui/src/utils.rs`; `cfg!(target_os = "macos")` is used to match
the existing platform handling in `env.rs` and `dialogs/export.rs`.

The keyboard shortcuts dialog hardcodes its accelerators in `shortcuts.ui` and does not
derive them from the registered ones, so it performs the same substitution when it is
built. Without this the dialog would keep displaying Control on MacOS while the app
reacts to Command.

To answer the question in the issue: yes, a plain remap works for all of the registered
accelerators. Everything they cover is standard on MacOS (`⌘S`, `⌘O`, `⌘T`, `⌘Z`, `⌘⇧Z`,
`⌘C`/`⌘X`/`⌘V`, `⌘B`/`⌘I`/`⌘U`, `⌘Q`, `⌘N`), including zoom (`⌘+`, `⌘-`, `⌘0`), which
follows the same convention as Safari and Preview. Accelerators without a modifier
(`F9`, `F10`, `F11`, the bare digits for the color setters) are untouched.

## What is intentionally left unchanged

Shortcuts that are not registered as application accelerators, but are handled in the
engine through `ModifierKey::KeyboardCtrl`, keep using Control on all platforms:

- zooming by scrolling (`Ctrl+ScrollUp` / `Ctrl+ScrollDown`)
- duplicating a selection (`Ctrl+D`)
- text editing in the typewriter (`Ctrl+A`, `Ctrl+←`/`→`, `Ctrl+Backspace`, `Ctrl+Home`/`End`)
- holding Control to toggle shaper constraints, and the selector / nudge modifiers

These three entries in `shortcuts.ui` therefore still declare `<Ctrl>` directly, and the
existing "Hold Ctrl ..." labels in the settings and shaper pages stay correct.

Mapping these to Command as well would mean remapping `ModifierKey::KeyboardCtrl` in
`canvas/input.rs`, which also changes the drawing-tool modifiers (shape constraints,
nudge distance, add-to-selection) and is not obviously the native behaviour in every case
— MacOS uses Option, not Command, for word-wise navigation, for instance. That felt like
a separate decision rather than something to fold into this change. Happy to follow up
with it if you would like it, either in this PR or a later one.

## Testing

Built and run on MacOS (Apple Silicon, MacOS 26, Gtk 4.22.4, libadwaita 1.9.3,
`-Dprofile=devel`), verified by hand in the running application:

Every registered accelerator was exercised and works with Command:

- `⌘C` / `⌘X` / `⌘V` copy, cut, paste
- `⌘Z` / `⌘⇧Z` undo, redo
- `⌘S` / `⌘⇧S` / `⌘O` save, save as, open
- `⌘T` / `⌘W` / `⌘N` / `⌘Q` new tab, close tab, new window, quit
- `⌘P` print, `⌘L` clear document, `⌘⇧I` import
- `⌘⇧A` / `⌘⇧R` add and remove page, `⌘⇧P` snap positions, `⌘⇧O` tabs overview
- `⌘+` / `⌘-` / `⌘0` zoom in, out, reset
- `⌘1` … `⌘6` pen styles
- `⌘B` / `⌘I` / `⌘U` text formatting
- `⌘?` keyboard shortcuts dialog, `⌘⇧V` visual debug (devel profile)

The corresponding Control shortcuts (`Ctrl+C`, `Ctrl+V`, `Ctrl+Z`, `Ctrl+S`, `Ctrl+O`,
`Ctrl+T`) no longer trigger these actions.

The engine-level shortcuts still work with Control as before: `Ctrl+ScrollUp` /
`Ctrl+ScrollDown` zooming, `Ctrl+D` duplicate, `Ctrl+A` select-all inside a text box,
`Ctrl+←` / `Ctrl+→` / `Ctrl+Backspace` word navigation and deletion, and holding Control
to toggle shaper constraints.

The keyboard shortcuts dialog displays Command for the registered accelerators and
Control for the engine-level ones.

No regressions found: typing inside text boxes, `F9` / `F10` / `F11`, the unmodified
digit keys for the color setters and `Ctrl+Space` all behave as before.

`cargo fmt --check` and `cargo clippy` are clean, and `cargo test` passes, including two
added unit tests covering the placeholder substitution on both platform branches.

The non-MacOS path was not exercised at runtime: the substitution produces exactly the
same `<Ctrl>` accelerator strings that were hardcoded before, so Linux and Windows
behaviour is unchanged by construction.

## Disclosure

An AI assistant was used while researching and preparing this change.
