### PR TITLE
Auto export on save

### DIFF
--- a/crates/rnote-engine/src/document/config.rs
+++ b/crates/rnote-engine/src/document/config.rs
@@ -11,4 +11,6 @@ pub struct DocumentConfig {
     pub background: Background,
     #[serde(rename = "layout", alias = "expand_mode")]
     pub layout: Layout,
+    #[serde(rename = "auto_export_svg", default)]
+    pub auto_export_svg: bool,
 }

--- a/crates/rnote-ui/data/ui/settingspanel.ui
+++ b/crates/rnote-ui/data/ui/settingspanel.ui
@@ -441,6 +441,12 @@ gets disabled.</property>
                       </object>
                     </child>
                     <child>
+                      <object class="AdwSwitchRow" id="doc_auto_export_svg">
+                        <property name="title" translatable="yes">Auto Export SVG</property>
+                        <property name="subtitle" translatable="yes">Automatically export as [filename].svg on save</property>
+                      </object>
+                    </child>
+                    <child>
                       <object class="AdwActionRow" id="background_pattern_invert_color_row">
                         <property name="title" translatable="yes">Invert Color Brightness</property>
                         <property name="subtitle" translatable="yes">Invert the brightness of the background and pattern colors</property>

--- a/crates/rnote-ui/src/canvas/imexport.rs
+++ b/crates/rnote-ui/src/canvas/imexport.rs
@@ -264,7 +264,7 @@ impl RnCanvas {
 
         if self.engine_ref().document.config.auto_export_svg {
             self.export_doc(
-                &gio::File::for_path(filepath.with_added_extension("svg")),
+                &gio::File::for_path(filepath.with_extension("svg")),
                 crate::utils::default_file_title_for_export(Some(file.clone()), None, None),
                 Some(DocExportPrefs {
                     export_format: DocExportFormat::Svg,

--- a/crates/rnote-ui/src/canvas/imexport.rs
+++ b/crates/rnote-ui/src/canvas/imexport.rs
@@ -251,7 +251,21 @@ impl RnCanvas {
             let bytes = rnote_bytes_receiver.await??;
             // The `output_file_expect_write` should theoretically be reset to `false` by the file watcher later.
             self.set_output_file_expect_write(true);
-            crate::utils::atomic_save_to_file_future(&filepath, bytes).await
+            crate::utils::atomic_save_to_file_future(&filepath, bytes).await?;
+
+            if self.engine_ref().document.config.auto_export_svg {
+                self.export_doc(
+                    &gio::File::for_path(filepath.with_extension("svg")),
+                    crate::utils::default_file_title_for_export(Some(file.clone()), None, None),
+                    Some(DocExportPrefs {
+                        export_format: DocExportFormat::Svg,
+                        ..Default::default()
+                    }),
+                )
+                .await?
+            }
+
+            Ok(())
         };
 
         if let Err(e) = file_write_operation.await {
@@ -260,18 +274,6 @@ impl RnCanvas {
             // because we can't know for sure if the output-file watcher will be able to.
             self.set_output_file_expect_write(false);
             return Err(e);
-        }
-
-        if self.engine_ref().document.config.auto_export_svg {
-            self.export_doc(
-                &gio::File::for_path(filepath.with_extension("svg")),
-                crate::utils::default_file_title_for_export(Some(file.clone()), None, None),
-                Some(DocExportPrefs {
-                    export_format: DocExportFormat::Svg,
-                    ..Default::default()
-                }),
-            )
-            .await?;
         }
 
         debug!("Saving file has finished successfully");

--- a/crates/rnote-ui/src/canvas/imexport.rs
+++ b/crates/rnote-ui/src/canvas/imexport.rs
@@ -6,7 +6,9 @@ use gtk4::{gio, prelude::*};
 use p2d::math::Vector2;
 use rnote_compose::ext::Vector2Ext;
 use rnote_engine::WidgetFlags;
-use rnote_engine::engine::export::{DocExportPrefs, DocPagesExportPrefs, SelectionExportPrefs};
+use rnote_engine::engine::export::{
+    DocExportFormat, DocExportPrefs, DocPagesExportPrefs, SelectionExportPrefs,
+};
 use rnote_engine::engine::{EngineSnapshot, StrokeContent};
 use rnote_engine::strokes::Stroke;
 use rnote_engine::strokes::resize::ImageSizeOption;
@@ -258,6 +260,18 @@ impl RnCanvas {
             // because we can't know for sure if the output-file watcher will be able to.
             self.set_output_file_expect_write(false);
             return Err(e);
+        }
+
+        if self.engine_ref().document.config.auto_export_svg {
+            self.export_doc(
+                &gio::File::for_path(filepath.with_added_extension("svg")),
+                crate::utils::default_file_title_for_export(Some(file.clone()), None, None),
+                Some(DocExportPrefs {
+                    export_format: DocExportFormat::Svg,
+                    ..Default::default()
+                }),
+            )
+            .await?;
         }
 
         debug!("Saving file has finished successfully");

--- a/crates/rnote-ui/src/canvas/imexport.rs
+++ b/crates/rnote-ui/src/canvas/imexport.rs
@@ -262,7 +262,7 @@ impl RnCanvas {
                         ..Default::default()
                     }),
                 )
-                .await?
+                .await?;
             }
 
             Ok(())

--- a/crates/rnote-ui/src/settingspanel/mod.rs
+++ b/crates/rnote-ui/src/settingspanel/mod.rs
@@ -109,6 +109,8 @@ mod imp {
         #[template_child]
         pub(crate) doc_show_origin_indicator_row: TemplateChild<adw::SwitchRow>,
         #[template_child]
+        pub(crate) doc_auto_export_svg: TemplateChild<adw::SwitchRow>,
+        #[template_child]
         pub(crate) background_pattern_invert_color_button: TemplateChild<Button>,
         #[template_child]
         pub(crate) penshortcut_stylus_button_primary_row: TemplateChild<RnPenShortcutRow>,
@@ -465,6 +467,7 @@ impl RnSettingsPanel {
                 .config
                 .format
                 .show_origin_indicator;
+            let auto_export_svg = canvas.engine_ref().document.config.auto_export_svg;
 
             imp.doc_show_format_borders_row
                 .set_active(show_format_borders);
@@ -484,6 +487,7 @@ impl RnSettingsPanel {
             self.set_document_layout(&document_layout);
             imp.doc_show_origin_indicator_row
                 .set_active(show_origin_indicator);
+            imp.doc_auto_export_svg.set_active(auto_export_svg);
         }
     }
 
@@ -1141,6 +1145,17 @@ impl RnSettingsPanel {
                     canvas.queue_draw();
                 }
             ));
+
+        imp.doc_auto_export_svg.connect_active_notify(clone!(
+            #[weak]
+            appwindow,
+            move |row| {
+                let Some(canvas) = appwindow.active_tab_canvas() else {
+                    return;
+                };
+                canvas.engine_mut().document.config.auto_export_svg = row.is_active();
+            }
+        ));
 
         imp.background_pattern_invert_color_button
             .get()


### PR DESCRIPTION
Hey there!

I really enjoy using Rnote, however I find it very difficult to embed Rnote documents elsewhere.
Think adding a Rnote sketch to a GitHub README / any other markdown file,
or for my use case, embedding Rnote annotated PDFs into [typst](https://typst.app) documents.
To make other programs ingest Rnote documents, they first need to be exported to common file formats, manually, on every modification of the document.
Yes, one could create a CI workflow to automatically export the document using `rnote-cli`,
or set up a file system watcher to invoke `rnote-cli export` on every modification,
however that is very clunky, or just not applicable for other uses.

This pull request adds a new document-level setting, to automatically export the document as \<basename\>.svg on every save,
making it very easy to embed the document in other places, and avoids the document and export drifting out of sync.

Im not deeply familiar with the codebase and no GTK wizard, so I oriented myself on existing implementations of settings rows, hope the implementation is decent.

I would love to hear your feedback on this and my current implementation, and hopefully get a feature with this purpose added to the upstream project.

Thanks!

_This pull request was written by hand, by myself only._