### PR TITLE
Fix stylus pointer jump 

### DIFF
--- a/crates/rnote-ui/src/canvas/input.rs
+++ b/crates/rnote-ui/src/canvas/input.rs
@@ -42,7 +42,13 @@ pub(crate) fn handle_pointer_controller_event(
     if is_stylus {
         stylus_active = gdk_event_type != gdk::EventType::ProximityOut;
     } else if stylus_active {
-        return (glib::Propagation::Proceed, pen_state, stylus_active);
+        // A deliberate mouse click hands control back to the mouse.
+        match gdk_event_type {
+            gdk::EventType::ButtonPress | gdk::EventType::ButtonRelease => {
+                stylus_active = false;
+            }
+            _ => return (glib::Propagation::Proceed, pen_state, stylus_active),
+        }
     }
 
     let mut handle_pen_event = false;

--- a/crates/rnote-ui/src/canvas/input.rs
+++ b/crates/rnote-ui/src/canvas/input.rs
@@ -18,7 +18,8 @@ pub(crate) fn handle_pointer_controller_event(
     canvas: &RnCanvas,
     event: &gdk::Event,
     mut pen_state: PenState,
-) -> (glib::Propagation, PenState) {
+    mut stylus_active: bool,
+) -> (glib::Propagation, PenState, bool) {
     let now = Instant::now();
     let mut widget_flags = WidgetFlags::default();
     let touch_drawing = canvas.touch_drawing();
@@ -32,7 +33,16 @@ pub(crate) fn handle_pointer_controller_event(
     //super::input::debug_gdk_event(event);
 
     if reject_pointer_input(event, touch_drawing) {
-        return (glib::Propagation::Proceed, pen_state);
+        return (glib::Propagation::Proceed, pen_state, stylus_active);
+    }
+
+    // GTK can deliver mouse motion events while a stylus is hovering or drawing.
+    // They must not reuse the stylus state, otherwise the pen position jumps to
+    // the last mouse position and generates an unwanted pen event.
+    if is_stylus {
+        stylus_active = gdk_event_type != gdk::EventType::ProximityOut;
+    } else if stylus_active {
+        return (glib::Propagation::Proceed, pen_state, stylus_active);
     }
 
     let mut handle_pen_event = false;
@@ -159,7 +169,7 @@ pub(crate) fn handle_pointer_controller_event(
 
     if handle_pen_event {
         let Some(elements) = retrieve_pointer_elements(canvas, now, event, backlog_policy) else {
-            return (glib::Propagation::Proceed, pen_state);
+            return (glib::Propagation::Proceed, pen_state, stylus_active);
         };
         let modifier_keys = retrieve_modifier_keys(event.modifier_state());
         let pen_mode = retrieve_pen_mode(event);
@@ -228,7 +238,7 @@ pub(crate) fn handle_pointer_controller_event(
     }
 
     canvas.emit_handle_widget_flags(widget_flags);
-    (propagation, pen_state)
+    (propagation, pen_state, stylus_active)
 }
 
 pub(crate) fn handle_key_controller_key_pressed(

--- a/crates/rnote-ui/src/canvas/mod.rs
+++ b/crates/rnote-ui/src/canvas/mod.rs
@@ -505,20 +505,26 @@ mod imp {
 
             // Pointer controller
             let pen_state = Cell::new(PenState::Up);
+            let stylus_active = Cell::new(false);
             self.pointer_controller.connect_event(clone!(
                 #[strong]
                 pen_state,
+                #[strong]
+                stylus_active,
                 #[weak(rename_to=canvas)]
                 obj,
                 #[upgrade_or]
                 glib::Propagation::Proceed,
                 move |_, event| {
-                    let (propagation, new_state) = super::input::handle_pointer_controller_event(
-                        &canvas,
-                        event,
-                        pen_state.get(),
-                    );
+                    let (propagation, new_state, new_stylus_active) =
+                        super::input::handle_pointer_controller_event(
+                            &canvas,
+                            event,
+                            pen_state.get(),
+                            stylus_active.get(),
+                        );
                     pen_state.set(new_state);
+                    stylus_active.set(new_stylus_active);
                     propagation
                 }
             ));


### PR DESCRIPTION
Fixes #1440

Related to #665 and #534

GTK can deliver mouse motion events to the canvas while a stylus is hovering or drawing. Those events were processed using the current stylus state, which could move the pointer to the mouse position and cause unwanted strokes, erasures, pans, or selections, zoom, etc.


Regarding the related issues: Both issues appear to be caused by the same underlying problem, so this PR should resolve them as well. I believe this is the case because keeping the cursor outside the canvas prevents the issue, and the lines shown in their screenshots appear to originate from the same location, which seems to be the mouse pointer position.

**Changes**
- Prevent mouse coordinates from being processed with the stylus state, which caused unwanted strokes, erasures, pans, and selections.
    - Track whether a stylus input session is active in the canvas pointer controller.
    - Ignore non-stylus pointer events while that session is active.
    
- Recover mouse input when GTK does not report the stylus leaving proximity. Without this recovery, the stylus remains active and a mouse click can move the canvas instead of drawing with the mouse.
    - Allow a deliberate mouse click to end a stale stylus session and process the click normally..


The following videos demonstrate the behavior before and after the fix:

- Before the fix:

https://github.com/user-attachments/assets/1dd3e47c-d834-4c0f-8947-428aa7d19533


- After the fix:

https://github.com/user-attachments/assets/df0512b9-74c0-4778-89ca-db154f37bb4b



