### PR TITLE
Keyboard shortcuts for pen sub-styles and stroke width

### DIFF
--- a/crates/rnote-compose/src/builders/mod.rs
+++ b/crates/rnote-compose/src/builders/mod.rs
@@ -46,6 +46,8 @@ use serde::{Deserialize, Serialize};
     Clone,
     Debug,
     Default,
+    PartialEq,
+    Eq,
     Serialize,
     Deserialize,
     num_derive::FromPrimitive,

--- a/crates/rnote-ui/data/ui/shortcuts.ui
+++ b/crates/rnote-ui/data/ui/shortcuts.ui
@@ -114,6 +114,59 @@
         </child>
         <child>
           <object class="GtkShortcutsGroup">
+            <property name="title" translatable="yes">Pen Sub-Styles</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">Select the Sub-Style of the Active Pen</property>
+                <property name="accelerator">&lt;alt&gt;1 &lt;alt&gt;9</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">'Brush': Marker, Solid, Textured</property>
+                <property name="accelerator">&lt;alt&gt;1 &lt;alt&gt;3</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">'Shaper': Line, Arrow, Rectangle, Ellipse, Polyline, Polygon, Grid, Quadratic Bezier, Cubic Bezier</property>
+                <property name="accelerator">&lt;alt&gt;1 &lt;alt&gt;9</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">'Eraser': Trash Colliding Strokes, Split Colliding Strokes</property>
+                <property name="accelerator">&lt;alt&gt;1 &lt;alt&gt;2</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">'Selector': Polygon, Rectangle, Single, Intersecting Path</property>
+                <property name="accelerator">&lt;alt&gt;1 &lt;alt&gt;4</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">'Tools': Vertical Space, Offset Camera, Zoom, Laser</property>
+                <property name="accelerator">&lt;alt&gt;1 &lt;alt&gt;4</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">Increase the Stroke Width by One</property>
+                <property name="accelerator">bracketright</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">Decrease the Stroke Width by One</property>
+                <property name="accelerator">bracketleft</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
             <property name="title" translatable="yes">View</property>
             <child>
               <object class="GtkShortcutsShortcut">

--- a/crates/rnote-ui/src/appwindow/actions.rs
+++ b/crates/rnote-ui/src/appwindow/actions.rs
@@ -1,5 +1,9 @@
 // Imports
 use crate::RnApp;
+use crate::globals::{
+    STROKE_WIDTH_STEP, SUB_STYLES_BRUSH, SUB_STYLES_ERASER, SUB_STYLES_SELECTOR, SUB_STYLES_SHAPER,
+    SUB_STYLES_TOOLS,
+};
 use crate::{RnAppWindow, RnCanvas, config, dialogs};
 use gettextrs::gettext;
 use gtk4::gio::InputStream;
@@ -202,6 +206,14 @@ impl RnAppWindow {
         );
         self.add_action(&action_pen_style);
 
+        let action_sub_style =
+            gio::SimpleAction::new("sub-style", Some(&i32::static_variant_type()));
+        self.add_action(&action_sub_style);
+        let action_stroke_width_increase = gio::SimpleAction::new("stroke-width-increase", None);
+        self.add_action(&action_stroke_width_increase);
+        let action_stroke_width_decrease = gio::SimpleAction::new("stroke-width-decrease", None);
+        self.add_action(&action_stroke_width_decrease);
+
         // Open settings
         action_open_settings.connect_activate(clone!(
             #[weak(rename_to = appwindow)]
@@ -363,6 +375,35 @@ impl RnAppWindow {
                     appwindow.handle_widget_flags(widget_flags, &canvas);
                 }
                 action.set_state(&pen_style_str.to_variant());
+            }
+        ));
+
+        // Sub-style of the currently active pen
+        action_sub_style.connect_activate(clone!(
+            #[weak(rename_to=appwindow)]
+            self,
+            move |_, target| {
+                let Some(index) = target.and_then(|t| t.get::<i32>()) else {
+                    error!("Activated sub-style action with invalid target");
+                    return;
+                };
+                appwindow.apply_sub_style(index);
+            }
+        ));
+
+        action_stroke_width_increase.connect_activate(clone!(
+            #[weak(rename_to=appwindow)]
+            self,
+            move |_, _| {
+                appwindow.adjust_stroke_width(STROKE_WIDTH_STEP);
+            }
+        ));
+
+        action_stroke_width_decrease.connect_activate(clone!(
+            #[weak(rename_to=appwindow)]
+            self,
+            move |_, _| {
+                appwindow.adjust_stroke_width(-STROKE_WIDTH_STEP);
             }
         ));
 
@@ -1182,7 +1223,11 @@ impl RnAppWindow {
 
         app.set_accels_for_action("win.active-tab-close", &["<Ctrl>w"]);
         app.set_accels_for_action("win.fullscreen", &["F11"]);
-        app.set_accels_for_action("win.keyboard-shortcuts", &["<Ctrl>question"]);
+        app.set_accels_for_action(
+            "win.keyboard-shortcuts",
+            // `question` needs shift on most layouts, so the shifted variant is bound as well.
+            &["<Ctrl>question", "<Ctrl><Shift>question", "<Ctrl>slash"],
+        );
         app.set_accels_for_action("win.toggle-overview", &["<Ctrl><Shift>o"]);
         app.set_accels_for_action("win.open-canvasmenu", &["F9"]);
         app.set_accels_for_action("win.open-appmenu", &["F10"]);
@@ -1217,6 +1262,11 @@ impl RnAppWindow {
         app.set_accels_for_action("win.pen-style::selector", &["<Ctrl>5", "<Ctrl>KP_5"]);
         app.set_accels_for_action("win.pen-style::tools", &["<Ctrl>6", "<Ctrl>KP_6"]);
         (1..=9).for_each(|i| {
+            app.set_accels_for_action(&format!("win.sub-style({i})"), &[&format!("<Alt>{i}")])
+        });
+        app.set_accels_for_action("win.stroke-width-increase", &["bracketright"]);
+        app.set_accels_for_action("win.stroke-width-decrease", &["bracketleft"]);
+        (1..=9).for_each(|i| {
             app.set_accels_for_action(
                 &format!("win.set-color-{i}"),
                 &[&format!("{i}"), &format!("<Ctrl>KP_{i}")],
@@ -1227,6 +1277,72 @@ impl RnAppWindow {
         if config::PROFILE.to_lowercase().as_str() == "devel" {
             app.set_accels_for_action("win.visual-debug", &["<Ctrl><Shift>v"]);
         }
+    }
+
+    /// Apply the n-th (1-based) sub-style of the currently active pen.
+    ///
+    /// The sub-style is applied by driving the corresponding sidebar page, so that the widget state
+    /// and the engine config stay in sync.
+    fn apply_sub_style(&self, index: i32) {
+        let Some(canvas) = self.active_tab_canvas() else {
+            return;
+        };
+        let Ok(index) = usize::try_from(index - 1) else {
+            error!("Activated sub-style action with out of range target {index}");
+            return;
+        };
+        let penssidebar = self.overlays().penssidebar();
+
+        match canvas.engine_ref().current_pen_style_w_override() {
+            PenStyle::Brush => {
+                if let Some(style) = SUB_STYLES_BRUSH.get(index) {
+                    penssidebar.brush_page().set_brush_style(*style);
+                }
+            }
+            PenStyle::Shaper => {
+                if let Some(builder_type) = SUB_STYLES_SHAPER.get(index) {
+                    penssidebar
+                        .shaper_page()
+                        .set_shapebuildertype(*builder_type);
+                }
+            }
+            PenStyle::Eraser => {
+                if let Some(style) = SUB_STYLES_ERASER.get(index) {
+                    penssidebar.eraser_page().set_eraser_style(*style);
+                }
+            }
+            PenStyle::Selector => {
+                if let Some(style) = SUB_STYLES_SELECTOR.get(index) {
+                    penssidebar.selector_page().set_selector_style(*style);
+                }
+            }
+            PenStyle::Tools => {
+                if let Some(style) = SUB_STYLES_TOOLS.get(index) {
+                    penssidebar.tools_page().set_tool_style(*style);
+                }
+            }
+            PenStyle::Typewriter => {}
+        }
+    }
+
+    /// Change the stroke width of the currently active pen by the given delta, clamped to the range
+    /// the pen accepts. Pens without a stroke width are ignored.
+    fn adjust_stroke_width(&self, delta: f64) {
+        let Some(canvas) = self.active_tab_canvas() else {
+            return;
+        };
+        let penssidebar = self.overlays().penssidebar();
+
+        let stroke_width_picker = match canvas.engine_ref().current_pen_style_w_override() {
+            PenStyle::Brush => penssidebar.brush_page().stroke_width_picker(),
+            PenStyle::Shaper => penssidebar.shaper_page().stroke_width_picker(),
+            PenStyle::Eraser => penssidebar.eraser_page().stroke_width_picker(),
+            PenStyle::Typewriter | PenStyle::Selector | PenStyle::Tools => return,
+        };
+        let adjustment = stroke_width_picker.spinbutton().adjustment();
+        let stroke_width = (stroke_width_picker.stroke_width() + delta)
+            .clamp(adjustment.lower(), adjustment.upper());
+        stroke_width_picker.set_stroke_width(stroke_width);
     }
 
     fn clipboard_paste(&self, target_pos: Option<Vector2>) {

--- a/crates/rnote-ui/src/globals.rs
+++ b/crates/rnote-ui/src/globals.rs
@@ -1,1 +1,52 @@
+// Imports
+use rnote_compose::builders::ShapeBuilderType;
+use rnote_engine::pens::pensconfig::brushconfig::BrushStyle;
+use rnote_engine::pens::pensconfig::eraserconfig::EraserStyle;
+use rnote_engine::pens::pensconfig::selectorconfig::SelectorStyle;
+use rnote_engine::pens::pensconfig::toolsconfig::ToolStyle;
+
 pub(crate) const APP_LICENSE: gtk4::License = gtk4::License::Gpl30;
+
+/// Step size when adjusting the stroke width of the active pen with the keyboard.
+pub(crate) const STROKE_WIDTH_STEP: f64 = 1.0;
+
+/// Sub-styles of the brush pen, in the order they are reachable through the `sub-style` action.
+pub(crate) const SUB_STYLES_BRUSH: &[BrushStyle] =
+    &[BrushStyle::Marker, BrushStyle::Solid, BrushStyle::Textured];
+/// Sub-styles of the shaper pen, in the order they are reachable through the `sub-style` action.
+/// Only the most frequently used shapes are listed, the remaining ones stay sidebar-only.
+pub(crate) const SUB_STYLES_SHAPER: &[ShapeBuilderType] = &[
+    ShapeBuilderType::Line,
+    ShapeBuilderType::Arrow,
+    ShapeBuilderType::Rectangle,
+    ShapeBuilderType::Ellipse,
+    ShapeBuilderType::Polyline,
+    ShapeBuilderType::Polygon,
+    ShapeBuilderType::Grid,
+    ShapeBuilderType::QuadBez,
+    ShapeBuilderType::CubBez,
+];
+/// Sub-styles of the eraser pen, in the order they are reachable through the `sub-style` action.
+pub(crate) const SUB_STYLES_ERASER: &[EraserStyle] = &[
+    EraserStyle::TrashCollidingStrokes,
+    EraserStyle::SplitCollidingStrokes,
+];
+/// Sub-styles of the selector pen, in the order they are reachable through the `sub-style` action.
+pub(crate) const SUB_STYLES_SELECTOR: &[SelectorStyle] = &[
+    SelectorStyle::Polygon,
+    SelectorStyle::Rectangle,
+    SelectorStyle::Single,
+    SelectorStyle::IntersectingPath,
+];
+/// Sub-styles of the tools pen, in the order they are reachable through the `sub-style` action.
+pub(crate) const SUB_STYLES_TOOLS: &[ToolStyle] = &[
+    ToolStyle::VerticalSpace,
+    ToolStyle::OffsetCamera,
+    ToolStyle::Zoom,
+    ToolStyle::Laser,
+];
+
+/// The accelerator label shown to the user for the n-th (0-based) sub-style of a pen.
+pub(crate) fn sub_style_accel_label(index: usize) -> String {
+    format!("Alt+{}", index + 1)
+}

--- a/crates/rnote-ui/src/penssidebar/brushpage.rs
+++ b/crates/rnote-ui/src/penssidebar/brushpage.rs
@@ -1,4 +1,6 @@
 // Imports
+use crate::globals::sub_style_accel_label;
+use crate::utils::append_accel_to_tooltip;
 use crate::{RnAppWindow, RnStrokeWidthPicker};
 use adw::prelude::*;
 use gtk4::{
@@ -195,6 +197,17 @@ impl RnBrushPage {
 
     pub(crate) fn init(&self, appwindow: &RnAppWindow) {
         let imp = self.imp();
+
+        for (i, row) in [
+            imp.brushstyle_marker_row.get(),
+            imp.brushstyle_solid_row.get(),
+            imp.brushstyle_textured_row.get(),
+        ]
+        .iter()
+        .enumerate()
+        {
+            append_accel_to_tooltip(row, &sub_style_accel_label(i));
+        }
         let brushstyle_popover = imp.brushstyle_popover.get();
         let brushconfig_popover = imp.brushconfig_popover.get();
 

--- a/crates/rnote-ui/src/penssidebar/eraserpage.rs
+++ b/crates/rnote-ui/src/penssidebar/eraserpage.rs
@@ -1,6 +1,8 @@
 // Imports
 use crate::RnAppWindow;
 use crate::RnStrokeWidthPicker;
+use crate::globals::sub_style_accel_label;
+use crate::utils::append_accel_to_tooltip;
 use adw::prelude::*;
 use gtk4::{CompositeTemplate, ToggleButton, Widget, glib, glib::clone, subclass::prelude::*};
 use rnote_engine::pens::pensconfig::EraserConfig;
@@ -107,6 +109,16 @@ impl RnEraserPage {
 
     pub(crate) fn init(&self, appwindow: &RnAppWindow) {
         let imp = self.imp();
+
+        for (i, toggle) in [
+            imp.eraserstyle_trash_colliding_strokes_toggle.get(),
+            imp.eraserstyle_split_colliding_strokes_toggle.get(),
+        ]
+        .iter()
+        .enumerate()
+        {
+            append_accel_to_tooltip(toggle, &sub_style_accel_label(i));
+        }
 
         imp.eraserstyle_trash_colliding_strokes_toggle
             .connect_toggled(clone!(

--- a/crates/rnote-ui/src/penssidebar/selectorpage.rs
+++ b/crates/rnote-ui/src/penssidebar/selectorpage.rs
@@ -1,5 +1,7 @@
 // Imports
 use crate::RnAppWindow;
+use crate::globals::sub_style_accel_label;
+use crate::utils::append_accel_to_tooltip;
 use gtk4::{
     CompositeTemplate, ToggleButton, Widget, glib, glib::clone, prelude::*, subclass::prelude::*,
 };
@@ -101,6 +103,18 @@ impl RnSelectorPage {
 
     pub(crate) fn init(&self, appwindow: &RnAppWindow) {
         let imp = self.imp();
+
+        for (i, toggle) in [
+            imp.selectorstyle_polygon_toggle.get(),
+            imp.selectorstyle_rect_toggle.get(),
+            imp.selectorstyle_single_toggle.get(),
+            imp.selectorstyle_intersectingpath_toggle.get(),
+        ]
+        .iter()
+        .enumerate()
+        {
+            append_accel_to_tooltip(toggle, &sub_style_accel_label(i));
+        }
 
         imp.selectorstyle_polygon_toggle.connect_toggled(clone!(
             #[weak]

--- a/crates/rnote-ui/src/penssidebar/shaperpage.rs
+++ b/crates/rnote-ui/src/penssidebar/shaperpage.rs
@@ -1,4 +1,5 @@
 // Imports
+use crate::globals::{SUB_STYLES_SHAPER, sub_style_accel_label};
 use crate::{
     RnAppWindow, RnGroupedIconPicker, RnStrokeWidthPicker,
     groupediconpicker::GroupedIconPickerGroupData,
@@ -668,9 +669,20 @@ fn shape_builder_type_icons_get_groups() -> Vec<GroupedIconPickerGroupData> {
 }
 
 fn shape_builder_type_icons_to_display_name(icon_name: &str) -> String {
-    match ShapeBuilderType::from_icon_name(icon_name)
-        .expect("ShapeBuilderTypePicker failed, display name of unknown icon name requested")
-    {
+    let builder_type = ShapeBuilderType::from_icon_name(icon_name)
+        .expect("ShapeBuilderTypePicker failed, display name of unknown icon name requested");
+    let display_name = shape_builder_type_to_display_name(builder_type);
+
+    // Shapes that are reachable through the `sub-style` action get their shortcut appended, so that
+    // it is discoverable from the picker.
+    match SUB_STYLES_SHAPER.iter().position(|t| *t == builder_type) {
+        Some(i) => format!("{display_name} ({})", sub_style_accel_label(i)),
+        None => display_name,
+    }
+}
+
+fn shape_builder_type_to_display_name(builder_type: ShapeBuilderType) -> String {
+    match builder_type {
         ShapeBuilderType::Arrow => gettext("Arrow"),
         ShapeBuilderType::Line => gettext("Line"),
         ShapeBuilderType::Rectangle => gettext("Rectangle"),

--- a/crates/rnote-ui/src/penssidebar/toolspage.rs
+++ b/crates/rnote-ui/src/penssidebar/toolspage.rs
@@ -1,5 +1,7 @@
 // Imports
 use crate::RnAppWindow;
+use crate::globals::sub_style_accel_label;
+use crate::utils::append_accel_to_tooltip;
 use gtk4::{
     Button, CompositeTemplate, MenuButton, Popover, ToggleButton, Widget, glib, glib::clone,
     prelude::*, subclass::prelude::*,
@@ -117,6 +119,18 @@ impl RnToolsPage {
 
     pub(crate) fn init(&self, appwindow: &RnAppWindow) {
         let imp = self.imp();
+
+        for (i, toggle) in [
+            imp.toolstyle_verticalspace_toggle.get(),
+            imp.toolstyle_offsetcamera_toggle.get(),
+            imp.toolstyle_zoom_toggle.get(),
+            imp.toolstyle_laser_toggle.get(),
+        ]
+        .iter()
+        .enumerate()
+        {
+            append_accel_to_tooltip(toggle, &sub_style_accel_label(i));
+        }
         // for now doesn't do anything but for the close button later
         let verticalspace_popover = imp.verticalspace_popover.get();
 

--- a/crates/rnote-ui/src/utils.rs
+++ b/crates/rnote-ui/src/utils.rs
@@ -2,13 +2,24 @@
 use anyhow::Context;
 use futures::AsyncWriteExt;
 use gettextrs::pgettext;
-use gtk4::{gdk, gio, prelude::*};
+use gtk4::{Widget, gdk, gio, prelude::*};
 use palette::convert::IntoColor;
 use path_absolutize::Absolutize;
 use rnote_compose::Color;
 use std::cell::Ref;
 use std::path::{Path, PathBuf};
 use std::slice::Iter;
+
+/// Append the given accelerator label to the widget's tooltip, so that the keyboard shortcut for it
+/// is discoverable by hovering the widget.
+pub(crate) fn append_accel_to_tooltip(widget: &impl IsA<Widget>, accel_label: &str) {
+    let widget = widget.as_ref();
+    let tooltip = match widget.tooltip_text() {
+        Some(tooltip) if !tooltip.is_empty() => format!("{tooltip} ({accel_label})"),
+        _ => accel_label.to_string(),
+    };
+    widget.set_tooltip_text(Some(&tooltip));
+}
 
 /// The suffix delimiter when duplicating/renaming already existing files
 pub(crate) const FILE_DUP_SUFFIX_DELIM: &str = " - ";


### PR DESCRIPTION
## What

Adds keyboard shortcuts for the pen sub-styles and for the stroke width of the active pen.

`Ctrl+1..6` already switches the pen style, but everything below that level had no action behind it and was only reachable by clicking in the sidebar: the shaper's shape builders, the tool styles, the brush styles, and the eraser and selector styles.

**`win.sub-style`** — a new action taking a 1-based index, bound to `Alt+1..9`. It dispatches on the currently active pen, so the same keys mean "n-th sub-style of the pen I am in":

| n | Brush | Shaper | Eraser | Selector | Tools |
|---|---|---|---|---|---|
| 1 | Marker | Line | Trash colliding | Polygon | Vertical space |
| 2 | Solid | Arrow | Split colliding | Rectangle | Offset camera |
| 3 | Textured | Rectangle | | Single | Zoom |
| 4 | | Ellipse | | Intersecting path | Laser |
| 5–9 | | Polyline, Polygon, Grid, QuadBez, CubBez | | | |

**`win.stroke-width-increase` / `win.stroke-width-decrease`** — bound to `]` and `[`, changing the stroke width of the active pen by one, clamped to the range that pen accepts. Pens without a stroke width are ignored.

## Why contextual rather than one accelerator per style

The shaper alone has thirteen shape builders. Giving each style its own accelerator runs out of comfortable key combinations quickly, whereas nine contextual keys cover every pen and keep the muscle memory uniform. The four least commonly used shape builders (the coordinate systems and the ellipse with foci) remain sidebar-only.

## Discoverability

- A "Pen Sub-Styles" group in the shortcuts window.
- The accelerator is appended to the tooltips of the sub-style widgets, and the shape builder picker shows it in its labels.
- The orderings live in a single table in `globals`, used both by the action and by the labels, so the bindings and the hints cannot drift apart.

## Notes for review

- The action drives the corresponding sidebar page (`set_brush_style()`, `set_shapebuildertype()`, …) rather than writing to the engine config directly, so the widget state and the config stay in sync and the existing per-page handlers remain the single place that applies a style.
- `PartialEq`/`Eq` derived on `ShapeBuilderType` for the table lookup.
- Separately, the shortcuts window is now also bound to `Ctrl+Shift+?` and `Ctrl+/`. On layouts where `?` requires shift, the existing `Ctrl+?` accelerator never matches because the shift modifier is not part of it — on macOS the shortcuts window could not be opened by keyboard at all.
- Built and exercised on macOS (GTK 4.22, libadwaita 1.9) against Homebrew dependencies. It would be worth a check on Linux that `Alt+<digit>` does not collide with anything in a common desktop environment.
