### PR TITLE
feat(installer): allow a per-user install mode on Windows

### DIFF
--- a/build-aux/rnote_inno.iss.in
+++ b/build-aux/rnote_inno.iss.in
@@ -33,8 +33,10 @@ OutputDir={#meson_build_root}
 OutputBaseFilename=@INSTALLER_NAME@
 SetupIconFile={#meson_source_root}\crates\rnote-ui\data\icons\rnote.ico
 UninstallDisplayIcon = {app}\bin\{#MyAppExeName}
-; Uncomment the following line to run in non administrative install mode (install for current user only.)
-;PrivilegesRequired=lowest
+; Let the user choose between an administrative (all users) and a non
+; administrative (current user only) install mode. PrivilegesRequired is left
+; at its default (admin), so "all users" stays the default choice.
+PrivilegesRequiredOverridesAllowed=dialog
 ChangesAssociations=yes
 DisableProgramGroupPage=yes
 Compression=lzma2/ultra64


### PR DESCRIPTION
Hello ! 

The Windows installer currently requires administrative privileges, which makes Rnote impossible to install on managed machines. PrivilegesRequired defaults to admin and no override is allowed, so /CURRENTUSER has no effect either.

This PR adds one directive, PrivilegesRequiredOverridesAllowed=dialog, which makes Setup show the standard "Select Setup Install Mode" dialog and enables the /ALLUSERS and /CURRENTUSER parameters. PrivilegesRequired is left at its default of admin, so "Install for all users" stays the default and nothing changes for existing users.

No other change is needed: the script already uses {autopf}, {autofonts}, {autoprograms}, {autodesktop} and Root: HKA, which resolve to their per-user equivalents in non administrative install mode. The rnote-cli PATH code already writes to HKEY_CURRENT_USER.

One caveat: per-user FontInstall requires Windows 10 1803 or newer, so the four bundled fonts would be skipped on older versions in per-user mode.