### PR TITLE
fix: scale each imported pdf page independently to fit the document format

### DIFF
--- a/crates/rnote-engine/src/strokes/bitmapimage.rs
+++ b/crates/rnote-engine/src/strokes/bitmapimage.rs
@@ -152,12 +152,24 @@ impl BitmapImage {
             format.width() * (pdf_import_prefs.page_width_perc / 100.0)
         };
 
-        // calculate the page zoom based on the width of the first page.
-        let page_zoom = if let Some(first_page) = pages.first() {
-            page_width / first_page.render_dimensions().0 as f64
-        } else {
+        // Uniform zoom based on the widest page, keeps relative page sizes.
+        let max_intrinsic_width = page_range
+            .clone()
+            .filter_map(|page_i| pages.get(page_i))
+            .map(|page| page.render_dimensions().0 as f64)
+            .fold(0.0f64, f64::max);
+        if max_intrinsic_width <= 0.0 {
             return Ok(vec![]);
-        };
+        }
+        let page_zoom_fit = page_width / max_intrinsic_width;
+
+        // Stride for OnePerDocumentPage: start each page on a document page boundary.
+        let max_rendered_height = page_range
+            .clone()
+            .filter_map(|page_i| pages.get(page_i))
+            .map(|page| page.render_dimensions().1 as f64 * page_zoom_fit)
+            .fold(0.0f64, f64::max);
+
         let x = insert_pos[0];
         let mut y = insert_pos[1];
 
@@ -171,11 +183,11 @@ impl BitmapImage {
                     let dimensions = page.render_dimensions();
                     (dimensions.0 as f64, dimensions.1 as f64)
                 };
-                let width = intrinsic_width * page_zoom;
-                let height = intrinsic_height * page_zoom;
+                let width = intrinsic_width * page_zoom_fit;
+                let height = intrinsic_height * page_zoom_fit;
                 let render_settings = hayro::RenderSettings {
-                    x_scale: (pdf_import_prefs.bitmap_scalefactor * page_zoom) as f32,
-                    y_scale: (pdf_import_prefs.bitmap_scalefactor * page_zoom) as f32,
+                    x_scale: (pdf_import_prefs.bitmap_scalefactor * page_zoom_fit) as f32,
+                    y_scale: (pdf_import_prefs.bitmap_scalefactor * page_zoom_fit) as f32,
                     width: Some((pdf_import_prefs.bitmap_scalefactor * width).ceil() as u16),
                     height: Some((pdf_import_prefs.bitmap_scalefactor * height).ceil() as u16),
                     bg_color: vello_cpu::color::AlphaColor::WHITE,
@@ -189,16 +201,22 @@ impl BitmapImage {
                 let image_pos = Vector2::new(x, y);
                 let image_size = Vector2::new(width, height);
 
-                if pdf_import_prefs.adjust_document {
-                    y += height
-                } else {
-                    y += match pdf_import_prefs.page_spacing {
-                        PdfImportPageSpacing::Continuous => {
+                y += match pdf_import_prefs.page_spacing {
+                    PdfImportPageSpacing::Continuous => {
+                        if pdf_import_prefs.adjust_document {
+                            height
+                        } else {
                             height + Stroke::IMPORT_OFFSET_DEFAULT[1] * 0.5
                         }
-                        PdfImportPageSpacing::OnePerDocumentPage => format.height(),
-                    };
-                }
+                    }
+                    PdfImportPageSpacing::OnePerDocumentPage => {
+                        if pdf_import_prefs.adjust_document {
+                            max_rendered_height
+                        } else {
+                            format.height()
+                        }
+                    }
+                };
 
                 Ok((png_data, image_pos, image_size))
             })

--- a/crates/rnote-engine/src/strokes/bitmapimage.rs
+++ b/crates/rnote-engine/src/strokes/bitmapimage.rs
@@ -198,7 +198,13 @@ impl BitmapImage {
                 let pixmap = hayro::render(page, &interpreter_settings, &render_settings);
                 let png_data = pixmap.into_png()?;
 
-                let image_pos = Vector2::new(x, y);
+                // Center narrower pages within the import width when adjusting the document.
+                let page_x = if pdf_import_prefs.adjust_document {
+                    x + (page_width - width) * 0.5
+                } else {
+                    x
+                };
+                let image_pos = Vector2::new(page_x, y);
                 let image_size = Vector2::new(width, height);
 
                 y += match pdf_import_prefs.page_spacing {

--- a/crates/rnote-engine/src/strokes/vectorimage.rs
+++ b/crates/rnote-engine/src/strokes/vectorimage.rs
@@ -265,7 +265,16 @@ impl VectorImage {
                 };
                 let width = intrinsic_width * page_zoom_fit;
                 let height = intrinsic_height * page_zoom_fit;
-                let bounds = Aabb::new(Vector2::new(x, y), Vector2::new(x + width, y + height));
+                // Center narrower pages within the import width when adjusting the document.
+                let page_x = if pdf_import_prefs.adjust_document {
+                    x + (page_width - width) * 0.5
+                } else {
+                    x
+                };
+                let bounds = Aabb::new(
+                    Vector2::new(page_x, y),
+                    Vector2::new(page_x + width, y + height),
+                );
 
                 y += match pdf_import_prefs.page_spacing {
                     PdfImportPageSpacing::Continuous => {

--- a/crates/rnote-engine/src/strokes/vectorimage.rs
+++ b/crates/rnote-engine/src/strokes/vectorimage.rs
@@ -234,12 +234,24 @@ impl VectorImage {
             format.width() * (pdf_import_prefs.page_width_perc / 100.0)
         };
 
-        // calculate the page zoom based on the width of the first page.
-        let page_zoom = if let Some(first_page) = pages.first() {
-            page_width / first_page.render_dimensions().0 as f64
-        } else {
+        // Uniform zoom based on the widest page, keeps relative page sizes.
+        let max_intrinsic_width = page_range
+            .clone()
+            .filter_map(|page_i| pages.get(page_i))
+            .map(|page| page.render_dimensions().0 as f64)
+            .fold(0.0f64, f64::max);
+        if max_intrinsic_width <= 0.0 {
             return Ok(vec![]);
-        };
+        }
+        let page_zoom_fit = page_width / max_intrinsic_width;
+
+        // Stride for OnePerDocumentPage: start each page on a document page boundary.
+        let max_rendered_height = page_range
+            .clone()
+            .filter_map(|page_i| pages.get(page_i))
+            .map(|page| page.render_dimensions().1 as f64 * page_zoom_fit)
+            .fold(0.0f64, f64::max);
+
         let x = insert_pos[0];
         let mut y = insert_pos[1];
 
@@ -251,20 +263,26 @@ impl VectorImage {
                     let dimensions = page.render_dimensions();
                     (dimensions.0 as f64, dimensions.1 as f64)
                 };
-                let width = intrinsic_width * page_zoom;
-                let height = intrinsic_height * page_zoom;
+                let width = intrinsic_width * page_zoom_fit;
+                let height = intrinsic_height * page_zoom_fit;
                 let bounds = Aabb::new(Vector2::new(x, y), Vector2::new(x + width, y + height));
 
-                if pdf_import_prefs.adjust_document {
-                    y += height
-                } else {
-                    y += match pdf_import_prefs.page_spacing {
-                        PdfImportPageSpacing::Continuous => {
+                y += match pdf_import_prefs.page_spacing {
+                    PdfImportPageSpacing::Continuous => {
+                        if pdf_import_prefs.adjust_document {
+                            height
+                        } else {
                             height + Stroke::IMPORT_OFFSET_DEFAULT[1] * 0.5
                         }
-                        PdfImportPageSpacing::OnePerDocumentPage => format.height(),
-                    };
-                }
+                    }
+                    PdfImportPageSpacing::OnePerDocumentPage => {
+                        if pdf_import_prefs.adjust_document {
+                            max_rendered_height
+                        } else {
+                            format.height()
+                        }
+                    }
+                };
                 let svg_data = hayro_svg::convert(page, &interpreter_settings, &render_settings);
                 let svg = Svg { svg_data, bounds };
 

--- a/crates/rnote-ui/src/dialogs/import.rs
+++ b/crates/rnote-ui/src/dialogs/import.rs
@@ -276,11 +276,6 @@ pub(crate) async fn dialog_import_pdf_w_prefs(
         .invert_boolean()
         .sync_create()
         .build();
-    pdf_import_adjust_document_row
-        .bind_property("active", &pdf_import_page_spacing_row, "sensitive")
-        .invert_boolean()
-        .sync_create()
-        .build();
 
     let pdf_import_prefs = appwindow
         .engine_config()


### PR DESCRIPTION
Fixes #1834

When importing a PDF containing pages with different formats, such as a mix of portrait and landscape pages, the pages could become misaligned when **Adjust document** was enabled. 

This happened because all pages were scaled using the dimensions of the first page. Pages with a different format therefore did not fit correctly in the document layout.

**Changes**

- Scale each imported PDF page independently when **Adjust document** is enabled.
- Keep each page's aspect ratio while fitting it within the document format.
- Preserve the existing import behavior when **Adjust document** is disabled.
- Apply the fix to both bitmap and vector PDF imports.

**Testing**

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

The following video shows the result before and after the fix when importing a PDF with mixed page formats:

https://github.com/user-attachments/assets/9871debf-82d4-4c5b-8cc7-26482244bc84


