### PR TITLE
fix: let the cargo build script fail when cargo fails

### DIFF
--- a/build-aux/cargo_build.py
+++ b/build-aux/cargo_build.py
@@ -34,11 +34,13 @@ try:
     subprocess.run(cargo_call, shell=True, check=True)
 except CalledProcessError as e:
     print(f"cargo call failed: {e}", file=sys.stderr)
+    sys.exit(1)
 
 print(cp_call, file=sys.stderr)
 try:
     subprocess.run(cp_call, shell=True, check=True)
 except CalledProcessError as e:
     print(f"cp call failed: {e}", file=sys.stderr)
+    sys.exit(1)
 
 print("### cargo build script finished ###", file=sys.stderr)


### PR DESCRIPTION
Both `except CalledProcessError` blocks in `build-aux/cargo_build.py` only printed a message and let the script continue, so it always exited with `0`. Meson then considered the `ui-cargo-build` / `cli-cargo-build` custom targets successful even though nothing was built:

- on an incremental build the previously built binary stays in place, `just build` reports success and a subsequent `meson install` installs the stale binary
- on a clean build ninja reports a missing output instead of cargo's actual error

Adding `sys.exit(1)` to both handlers makes the failure propagate. Verified: with a failing cargo invocation the script now exits `1` instead of `0`.

Kept deliberately minimal. The shell-free alternative sketched in #1837 (`subprocess.run([...], env=...)` + `shutil.copy`, which would also drop the `env`/`cp` assumptions) changes behaviour on all platforms and seemed better left to a separate discussion.

fixes #1837

---

*Disclosure: LLM/GenAI tooling was used in preparing this change; the behaviour was reproduced and the fix verified on my machine (MSYS2 CLANGARM64, Windows 11).*
